### PR TITLE
Import task cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,6 @@ Run an import task:
 thor import:start
 ```
 
-Use the `--district` flag to indicate your school district or charter organization. File formats and storage are configured in `app/importers/settings/settings.rb`.
-
 So far, Student Insights can import CSV and JSON and can fetch data from AWS and SFTP. To import a new flat file type, write a new data transformer: `app/importers/data_transformers`. To import from a new storage location, write a new client: `app/importers/clients`.
 
 ### LDAP

--- a/app/helpers/import_task_report.rb
+++ b/app/helpers/import_task_report.rb
@@ -4,6 +4,7 @@ class ImportTaskReport
 
   def initialize(models_for_report)
     @models_for_report = models_for_report
+    @initial_counts_hash = compute_initial_counts
   end
 
   ## INITIAL REPORT ##
@@ -20,7 +21,7 @@ class ImportTaskReport
     end
   end
 
-  def initial_counts_hash
+  def compute_initial_counts
     models_for_report.map do |klass|
       [ klass.to_s, klass.count ]
     end.to_h
@@ -30,14 +31,14 @@ class ImportTaskReport
 
   def print_final_report
     puts; puts; puts "=== FINAL DATABASE COUNTS ==="
-    puts; puts end_of_task_report(initial_counts_hash)
+    puts; puts end_of_task_report
     puts; puts; puts "=== BY SCHOOL ==="
     puts by_school_report
   end
 
-  def end_of_task_report(initial_counts_hash)
+  def end_of_task_report
     models_for_report.map do |klass|
-      initial_count = initial_counts_hash[klass.to_s]
+      initial_count = @initial_counts_hash[klass.to_s]
       end_of_task_report_for_klass(klass, initial_count)
     end
   end
@@ -67,11 +68,7 @@ class ImportTaskReport
   end
 
   def diff_report_for_class(klass_diff)
-    "(#{diff_sign(klass_diff)}#{humanize_count(klass_diff)})"
-  end
-
-  def diff_sign(klass_diff)
-    klass_diff >= 0 ? '+' : '-'
+    "(#{klass_diff >= 0 ? '+' : '-' }#{humanize_count(klass_diff)})"
   end
 
   def humanize_class_name(klass)

--- a/app/importers/bulk_attendance_importer.rb
+++ b/app/importers/bulk_attendance_importer.rb
@@ -6,7 +6,6 @@ class BulkAttendanceImporter
 
     # Optional
     @school_scope = options["school"]
-    @recent_only = options["recent_only"]
     @first_time = options["first_time"]
   end
 

--- a/app/importers/bulk_attendance_importer.rb
+++ b/app/importers/bulk_attendance_importer.rb
@@ -5,9 +5,9 @@ class BulkAttendanceImporter
     @client = options[:client]
 
     # Optional
-    @school_scope = options[:school_scope]
-    @recent_only = options[:recent_only]
-    @first_time = options[:first_time]
+    @school_scope = options["school"]
+    @recent_only = options["recent_only"]
+    @first_time = options["first_time"]
   end
 
   def remote_file_name

--- a/app/importers/importer.rb
+++ b/app/importers/importer.rb
@@ -5,7 +5,6 @@ class Importer
                                     # import_row => method for importing each row
                   :client,
                   :school_scope,
-                  :recent_only,
                   :first_time
 
   attr_accessor   :current_file_importer
@@ -17,7 +16,6 @@ class Importer
 
     # Optional
     @school_scope = options[:school_scope]    # Array of school local IDs
-    @recent_only = options[:recent_only]
     @first_time = options[:first_time]
 
     # Just for testing convenience, otherwise set internally

--- a/app/importers/settings/kipp_nj_importers.rb
+++ b/app/importers/settings/kipp_nj_importers.rb
@@ -1,11 +1,10 @@
 class KippNjImporters
 
-  attr_reader :school_scope, :first_time, :recent_only
+  attr_reader :school_scope, :first_time
 
   def initialize(options = {})
     @school_scope = options[:school_scope]
     @first_time = options[:first_time]
-    @recent_only = options[:recent_only]
   end
 
   def aws_credentials
@@ -20,7 +19,6 @@ class KippNjImporters
   def options
     {
       school_scope: @school_scope,
-      recent_only: @recent_only,
       first_time: @first_time,
       data_transformer: JsonTransformer.new,
       client: AwsAdapter.new(credentials: aws_credentials),

--- a/app/importers/settings/somerville_star_importers.rb
+++ b/app/importers/settings/somerville_star_importers.rb
@@ -3,7 +3,6 @@ class SomervilleStarImporters
   def initialize(options = {})
     @school_scope = options["school"]
     @first_time = options["first_time"]
-    @recent_only = options["recent_only"]
   end
 
   def sftp_credentials
@@ -17,7 +16,6 @@ class SomervilleStarImporters
   def options
     {
       school_scope: @school_scope,
-      recent_only: @recent_only,
       first_time: @first_time,
       client: SftpClient.new(credentials: sftp_credentials),
       data_transformer: CsvTransformer.new,

--- a/app/importers/settings/somerville_star_importers.rb
+++ b/app/importers/settings/somerville_star_importers.rb
@@ -1,9 +1,9 @@
 class SomervilleStarImporters
 
   def initialize(options = {})
-    @school_scope = options[:school_scope]
-    @first_time = options[:first_time]
-    @recent_only = options[:recent_only]
+    @school_scope = options["school"]
+    @first_time = options["first_time"]
+    @recent_only = options["recent_only"]
   end
 
   def sftp_credentials

--- a/app/importers/settings/somerville_x2_importers.rb
+++ b/app/importers/settings/somerville_x2_importers.rb
@@ -1,9 +1,9 @@
 class SomervilleX2Importers
 
   def initialize(options = {})
-    @school_scope = options[:school_scope]
-    @first_time = options[:first_time]
-    @recent_only = options[:recent_only]
+    @school_scope = options["school"]
+    @first_time = options["first_time"]
+    @recent_only = options["recent_only"]
   end
 
   def sftp_credentials

--- a/app/importers/settings/somerville_x2_importers.rb
+++ b/app/importers/settings/somerville_x2_importers.rb
@@ -3,7 +3,6 @@ class SomervilleX2Importers
   def initialize(options = {})
     @school_scope = options["school"]
     @first_time = options["first_time"]
-    @recent_only = options["recent_only"]
   end
 
   def sftp_credentials
@@ -17,7 +16,6 @@ class SomervilleX2Importers
   def base_options
     {
       school_scope: @school_scope,
-      recent_only: @recent_only,
       first_time: @first_time,
       client: SftpClient.new(credentials: sftp_credentials)
     }

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -27,8 +27,6 @@ class Import < Thor
 
     report.print_initial_report
 
-    initial_counts_hash = report.initial_counts_hash    # Store initial values so we can diff later
-
     # Create Somerville schools from seed file if they are missing
 
     School.seed_somerville_schools if School.count == 0
@@ -51,8 +49,10 @@ class Import < Thor
     # X2 importers to come first because they are the sole source of truth about students.
     # STAR importers don't import students, they only import STAR results.
 
-    importers = [ SomervilleX2Importers.new(importer_options).importer,
-                  SomervilleStarImporters.new(importer_options).importer ].flatten
+    importers = [
+      SomervilleX2Importers.new(importer_options).importer,
+      SomervilleStarImporters.new(importer_options).importer
+    ].flatten
 
     importers.each do |i|
       begin

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -40,18 +40,12 @@ class Import < Thor
       end
     end
 
-    importer_options = {
-      school_scope: options["school"],
-      first_time: options["first_time"],
-      recent_only: options["recent_only"]
-    }
-
     # X2 importers to come first because they are the sole source of truth about students.
     # STAR importers don't import students, they only import STAR results.
 
     importers = [
-      SomervilleX2Importers.new(importer_options).importer,
-      SomervilleStarImporters.new(importer_options).importer
+      SomervilleX2Importers.new(options).importer,
+      SomervilleStarImporters.new(options).importer
     ].flatten
 
     importers.each do |i|

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -13,24 +13,16 @@ class Import < Thor
 
     # Kick up a new report helper object
     report = ImportTaskReport.new([
-      Student,
-      StudentAssessment,
-      DisciplineIncident,
-      Absence,
-      Tardy,
-      Educator,
-      School
+      Student, StudentAssessment, DisciplineIncident, Absence, Tardy, Educator, School
     ])
 
     report.print_initial_report
 
     # Create Somerville schools from seed file if they are missing
-
     School.seed_somerville_schools if School.count == 0
 
     # Make sure school exists in database if school scope is set and refers
     # to a particular school. No need to check if scope is all elementary schools.
-
     if options["school"].present? && options["school"] != ["ELEM"]
       options["school"].map do |school_local_id|
         School.find_by_local_id!(school_local_id)
@@ -39,7 +31,6 @@ class Import < Thor
 
     # X2 importers to come first because they are the sole source of truth about students.
     # STAR importers don't import students, they only import STAR results.
-
     importers = [
       SomervilleX2Importers.new(options).importer,
       SomervilleStarImporters.new(options).importer
@@ -56,7 +47,6 @@ class Import < Thor
     Student.update_risk_levels
     Student.update_student_school_years
     Student.update_recent_student_assessments
-
     Homeroom.destroy_empty_homerooms
 
     report.print_final_report

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -7,9 +7,6 @@ class Import < Thor
   method_option :first_time,
     type: :boolean,
     desc: "Fill up an empty database"
-  method_option :recent_only,
-    type: :boolean,
-    desc: "For data update, only look at recent rows"
 
   def start
     require './config/environment'

--- a/spec/importers/settings/kipp_nj_importer_spec.rb
+++ b/spec/importers/settings/kipp_nj_importer_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe KippNjImporters do
 
     context 'with no options' do
       let(:options) { {} }
-      it 'returns importer with no school_scope, first_time, or recent_only' do
+      it 'returns importer with no school_scope or first_time flag' do
         expect(importer.school_scope).to be_nil
-        expect(importer.recent_only).to be_nil
         expect(importer.first_time).to be_nil
       end
     end

--- a/spec/importers/settings/somerville_x2_importers_spec.rb
+++ b/spec/importers/settings/somerville_x2_importers_spec.rb
@@ -21,9 +21,8 @@ RSpec.describe SomervilleX2Importers do
         expect(client.credentials[:user]).to eq('totes valid user')
         expect(client.credentials[:key_data]).to eq('totes valid key')
       end
-      it 'returns importer with no school_scope, first_time, or recent_only' do
+      it 'returns importer with no school_scope or first_time flag' do
         expect(importer.school_scope).to be_nil
-        expect(importer.recent_only).to be_nil
         expect(importer.first_time).to be_nil
       end
     end

--- a/spec/importers/settings/somerville_x2_importers_spec.rb
+++ b/spec/importers/settings/somerville_x2_importers_spec.rb
@@ -30,14 +30,14 @@ RSpec.describe SomervilleX2Importers do
 
     context 'with school scope' do
       let(:school) { School.create }
-      let(:options) { { school_scope: school } }
+      let(:options) { { "school" => school } }
       it 'returns importer with school_scope' do
         expect(importer.school_scope).to eq school
       end
     end
 
     context 'with first time setting' do
-      let(:options) { { first_time: true } }
+      let(:options) { { "first_time" => true } }
       it 'returns first time importer' do
         expect(importer).to be_a Array
         expect(importer.first).to be_a Importer


### PR DESCRIPTION
## What's new

* Fix object count diffs in import task report
* Deprecate `--district` flag: only working in 1 district at this point
* Remove `--recent-only` flag: not a real thing yet