### PR TITLE
Fix handling of nil Educator.grade_level_access in authorization code

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -8,7 +8,7 @@ class StudentsController < ApplicationController
   def authorize!
     student = Student.find(params[:id])
     educator = current_educator
-    raise Exceptions::EducatorNotAuthorized unless educator.is_authorized_for_student(student)educator
+    raise Exceptions::EducatorNotAuthorized unless educator.is_authorized_for_student(student)
   end
 
   def show

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -8,19 +8,7 @@ class StudentsController < ApplicationController
   def authorize!
     student = Student.find(params[:id])
     educator = current_educator
-
-    raise Exceptions::EducatorNotAuthorized if educator.restricted_to_sped_students &&
-                                               !(student.program_assigned.in? ['Sp Ed', 'SEIP'])
-
-    raise Exceptions::EducatorNotAuthorized if educator.restricted_to_english_language_learners &&
-                                               student.limited_english_proficiency == 'Fluent'
-    allowed_conditions = [
-      educator.schoolwide_access,                       # <= Schoolwide admin
-      student.grade.in?(educator.grade_level_access),   # <= Grade level access
-      student.in?(educator.students)                    # <= Homeroom level access
-    ]
-
-    raise Exceptions::EducatorNotAuthorized unless allowed_conditions.any?
+    raise Exceptions::EducatorNotAuthorized unless educator.is_authorized_for_student(student)educator
   end
 
   def show

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -20,12 +20,12 @@ class Educator < ActiveRecord::Base
   # This method is the source of truth for whether an educator is authorized to view information about a particular
   # student.
   def is_authorized_for_student(student)
-    return false if educator.restricted_to_sped_students && !(student.program_assigned.in? ['Sp Ed', 'SEIP'])
-    return false if educator.restricted_to_english_language_learners && student.limited_english_proficiency == 'Fluent'
-    
-    return true if educator.schoolwide_access? # Schoolwide admin
-    return true if educator.has_access_to_grade_levels? && student.grade.in?(educator.grade_level_access) # Grade level access
-    return true if student.in?(educator.students) # Homeroom level access
+    return false if self.restricted_to_sped_students && !(student.program_assigned.in? ['Sp Ed', 'SEIP'])
+    return false if self.restricted_to_english_language_learners && student.limited_english_proficiency == 'Fluent'
+
+    return true if self.schoolwide_access? # Schoolwide admin
+    return true if self.has_access_to_grade_levels? && student.grade.in?(self.grade_level_access) # Grade level access
+    return true if student.in?(self.students) # Homeroom level access
     false
   end
 

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -17,6 +17,18 @@ class Educator < ActiveRecord::Base
   validates :email, presence: true, uniqueness: true
   validates :local_id, presence: true, uniqueness: true
 
+  # This method is the source of truth for whether an educator is authorized to view information about a particular
+  # student.
+  def is_authorized_for_student(student)
+    return false if educator.restricted_to_sped_students && !(student.program_assigned.in? ['Sp Ed', 'SEIP'])
+    return false if educator.restricted_to_english_language_learners && student.limited_english_proficiency == 'Fluent'
+    
+    return true if educator.schoolwide_access? # Schoolwide admin
+    return true if educator.has_access_to_grade_levels? && student.grade.in?(educator.grade_level_access) # Grade level access
+    return true if student.in?(educator.students) # Homeroom level access
+    false
+  end
+
   def students_for_school_overview(*additional_includes)
     return [] unless school.present?
 

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -97,6 +97,19 @@ describe StudentsController, :type => :controller do
           end
         end
 
+        context 'educator has schoolwide access but grade_level_access is nil' do
+          let(:educator) { FactoryGirl.create(:educator, {
+            grade_level_access: nil,
+            schoolwide_access: true,
+            restricted_to_sped_students: false
+          }) }
+
+          it 'succeeds without an exception' do
+            make_request({ student_id: student.id, format: :html })
+            expect(response).to be_success
+          end
+        end
+
         context 'educator has some grade level access but for the wrong grade' do
           let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['KF']) }
 


### PR DESCRIPTION
This is causing exceptions in production now for two users, Jill and our dev user.

@alexsoble There may be an opportunity to address this with validations during import or on the model too, I didn't look at that here though.