### PR TITLE
Validate student grade levels

### DIFF
--- a/app/importers/attendance_row.rb
+++ b/app/importers/attendance_row.rb
@@ -26,7 +26,7 @@ class AttendanceRow < Struct.new(:row)
   end
 
   def student
-    Student.find_or_create_by(local_id: row[:local_id])
+    Student.find_by_local_id! row[:local_id]
   end
 
   def school_year

--- a/app/importers/behavior_row.rb
+++ b/app/importers/behavior_row.rb
@@ -28,7 +28,7 @@ class BehaviorRow < Struct.new(:row)
   end
 
   def student
-    Student.find_or_create_by(local_id: row[:local_id])
+    Student.find_by_local_id! row[:local_id]
   end
 
   def school_year

--- a/app/importers/student_assessment_row.rb
+++ b/app/importers/student_assessment_row.rb
@@ -26,7 +26,7 @@ class StudentAssessmentRow < Struct.new(:row)
   private
 
   def student
-    Student.find_or_create_by!(local_id: row[:local_id])
+    Student.find_by_local_id!(row[:local_id])
   end
 
   def assessment

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -7,9 +7,18 @@ class Student < ActiveRecord::Base
   has_many :interventions, dependent: :destroy
   has_many :student_notes
   has_one :student_risk_level, dependent: :destroy
+
   validates_presence_of :local_id
   validates_uniqueness_of :local_id
+  validate :valid_grade
+
   after_create :update_student_school_years
+
+  VALID_GRADES = [ 'PK', 'KF', '1', '2', '3', '4', '5', '6', '7', '8' ].freeze
+
+  def valid_grade
+    errors.add(:grade, "must be a valid grade") unless grade.in?(VALID_GRADES)
+  end
 
   def self.with_school
     where.not(school: nil)

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -150,23 +150,24 @@ class Student < ActiveRecord::Base
 
   ## SCHOOL YEARS ##
 
+  def earliest_school_year
+    return DateToSchoolYear.new(registration_date).convert if registration_date.present?
+
+    # If we don't have a registration date on file from X2, our next best option
+    # is to guess that the student started Somerville Public Schools in K.
+    # As of May 2105, about 9% of current students are missing a registration date
+    # value in X2, mostly students in the high school.
+    # We'll also need to handle non-numerical grade levels: KF, PK, SP
+
+    return DateToSchoolYear.new(Time.new - grade.to_i.years).convert
+  end
+
+  def current_school_year
+    DateToSchoolYear.new(Time.new).convert
+  end
+
   def find_student_school_years
-    if registration_date.present? || grade.present?
-      if registration_date.present?
-        first_school_year = DateToSchoolYear.new(registration_date).convert
-      elsif grade.present?
-        # If we don't have a registration date on file from X2, our next best option
-        # is to guess that the student started Somerville Public Schools in K.
-        # As of May 2105, about 9% of current students are missing a registration date
-        # value in X2, mostly students in the high school.
-        # We'll also need to handle non-numerical grade levels: KF, PK, SP
-        first_school_year = DateToSchoolYear.new(Time.new - grade.to_i.years).convert
-      end
-      current_school_year = DateToSchoolYear.new(Time.new).convert
-      SchoolYear.in_between(first_school_year, current_school_year)
-    else
-      []
-    end
+    SchoolYear.in_between(earliest_school_year, current_school_year)
   end
 
   def most_recent_school_year

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -155,8 +155,12 @@ class Student < ActiveRecord::Base
 
     # If we don't have a registration date on file from X2, our next best option
     # is to guess that the student started Somerville Public Schools in K.
+
     # As of May 2105, about 9% of current students are missing a registration date
     # value in X2, mostly students in the high school.
+
+    # As of February 2016, all students in X2 are associated with a grade level.
+
     # We'll also need to handle non-numerical grade levels: KF, PK, SP
 
     return DateToSchoolYear.new(Time.new - grade.to_i.years).convert

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -51,7 +51,7 @@ describe StudentsController, :type => :controller do
 
           it 'assigns the student school year correctly' do
             make_request({ student_id: student.id, format: :html })
-            expect(assigns(:student_school_years)).to eq [student_school_year]
+            expect(assigns(:student_school_years)).to eq student.student_school_years
           end
 
         end
@@ -111,6 +111,7 @@ describe StudentsController, :type => :controller do
         end
 
         context 'educator has some grade level access but for the wrong grade' do
+          let(:student) { FactoryGirl.create(:student, :with_risk_level, grade: '1') }
           let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['KF']) }
 
           it 'fails' do
@@ -199,8 +200,8 @@ describe StudentsController, :type => :controller do
       end
       context 'query matches student name' do
         let(:healey) { FactoryGirl.create(:healey) }
-        let!(:juan) { FactoryGirl.create(:student, first_name: 'Juan', school: healey, grade: '05') }
-        let!(:jacob) { FactoryGirl.create(:student, first_name: 'Jacob', grade: '05') }
+        let!(:juan) { FactoryGirl.create(:student, first_name: 'Juan', school: healey, grade: '5') }
+        let!(:jacob) { FactoryGirl.create(:student, first_name: 'Jacob', grade: '5') }
 
         it 'is successful' do
           make_request('j')
@@ -208,7 +209,7 @@ describe StudentsController, :type => :controller do
         end
         it 'returns student name and id' do
           make_request('j')
-          expect(assigns(:result)).to eq [{ label: "Juan - HEA - 05", value: juan.id }]
+          expect(assigns(:result)).to eq [{ label: "Juan - HEA - 5", value: juan.id }]
         end
       end
       context 'does not match student name' do

--- a/spec/decorators/student_decorator_spec.rb
+++ b/spec/decorators/student_decorator_spec.rb
@@ -38,7 +38,6 @@ describe StudentDecorator do
          "disability" => nil,
          "first_name" => nil,
          "free_reduced_lunch" => nil,
-         "grade" => nil,
          "hispanic_latino" => nil,
          "home_language" => nil,
          "last_name" => nil,

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -117,31 +117,37 @@ FactoryGirl.define do
 
     factory :student_with_registration_date do
       registration_date Date.new(2015, 1, 1)
+
       factory :student_with_mcas_assessment do
+        grade '6'
         after(:create) do |student|
           FactoryGirl.create(:mcas_assessment, student: student)
         end
       end
 
       factory :student_with_mcas_math_assessment do
+        grade '6'
         after(:create) do |student|
           FactoryGirl.create(:mcas_math_assessment, student: student)
         end
       end
 
       factory :student_with_mcas_ela_assessment do
+        grade '6'
         after(:create) do |student|
           FactoryGirl.create(:mcas_ela_assessment, student: student)
         end
       end
 
       factory :student_with_mcas_math_warning_assessment do
+        grade '6'
         after(:create) do |student|
           FactoryGirl.create(:mcas_math_warning_assessment, student: student)
         end
       end
 
       factory :student_with_mcas_math_advanced_and_star_math_warning_assessments do
+        grade '6'
         after(:create) do |student|
           FactoryGirl.create(:mcas_math_advanced_assessment, student: student)
           FactoryGirl.create(:star_math_warning_assessment, student: student)
@@ -149,12 +155,14 @@ FactoryGirl.define do
       end
 
       factory :student_with_star_math_assessment do
+        grade '6'
         after(:create) do |student|
           FactoryGirl.create(:star_math_assessment, student: student)
         end
       end
 
       factory :student_with_star_math_and_star_reading_same_day do
+        grade '6'
         after(:create) do |student|
           FactoryGirl.create(:star_math_assessment, student: student)
           FactoryGirl.create(:star_reading_assessment, student: student)
@@ -162,6 +170,7 @@ FactoryGirl.define do
       end
 
       factory :student_with_star_math_student_assessments_different_days do
+        grade '6'
         after(:create) do |student|
           FactoryGirl.create(:star_math_assessment, student: student)
           FactoryGirl.create(:star_math_assessment_on_different_day, student: student)
@@ -169,6 +178,7 @@ FactoryGirl.define do
       end
 
       factory :student_with_star_assessment_between_30_85 do
+        grade '6'
         after(:create) do |student|
           FactoryGirl.create(:star_assessment_between_30_85, student: student)
         end
@@ -219,6 +229,13 @@ FactoryGirl.define do
       grade "5"
       after(:create) do |student|
         FactoryGirl.create(:star_assessment_with_irl_above_5, student: student)
+      end
+    end
+
+    factory :student_with_absence do
+      after(:create) do |student|
+        student_school_years = FactoryGirl.create_list(:student_school_year, 1, student: student)
+        FactoryGirl.create(:absence, student_school_year: student_school_years.first)
       end
     end
 

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -1,11 +1,12 @@
 FactoryGirl.define do
-  sequence(:local_id) { |n| "#{n}000" }
-end
 
-FactoryGirl.define do
+  sequence(:student_local_id) { |n| "#{n}000" }
+
+  sequence(:valid_grade_level) { [ 'PK', 'KF', '1', '2', '3', '4', '5', '6', '7', '8' ].sample }
 
   factory :student do
-    local_id
+    local_id { generate(:student_local_id) }
+    grade { generate(:valid_grade_level) }
     association :homeroom
 
     trait :with_risk_level do

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -222,14 +222,6 @@ FactoryGirl.define do
       end
     end
 
-    # Test event sorting
-    factory :student_with_absence do
-      after(:create) do |student|
-        student_school_years = FactoryGirl.create_list(:student_school_year, 1, student: student)
-        FactoryGirl.create(:absence, student_school_year: student_school_years.first)
-      end
-    end
-
     factory :student_with_discipline_incident do
       after(:create) do |student|
         student_school_years = FactoryGirl.create_list(:student_school_year, 1, student: student)

--- a/spec/features/profile_feature_spec.rb
+++ b/spec/features/profile_feature_spec.rb
@@ -91,7 +91,7 @@ describe 'educator views student profile', :type => :feature do
       end
 
       context 'math' do
-        let!(:student) { FactoryGirl.create(:student_with_star_math_assessment, :with_risk_level) }
+        let!(:student) { FactoryGirl.create(:student_with_star_math_assessment, :with_risk_level, grade: '6') }
         it 'shows STAR result' do
           expect(page).to have_css '.star-math-values'
         end

--- a/spec/features/profile_feature_spec.rb
+++ b/spec/features/profile_feature_spec.rb
@@ -24,7 +24,9 @@ describe 'educator views student profile', :type => :feature do
     context 'student has discipline incidents' do
       let!(:student) { FactoryGirl.create(:student_with_discipline_incident, :with_risk_level) }
       it 'shows the discipline incident' do
-        expect(page).not_to have_content 'No behavior incidents'
+        expect(page).to have_content 'Code'
+        expect(page).to have_content 'Description'
+        expect(page).to have_content 'Location'
       end
     end
 
@@ -36,13 +38,10 @@ describe 'educator views student profile', :type => :feature do
     end
 
     context 'student has absence' do
-      let!(:student) { FactoryGirl.create(:student, :with_risk_level) }
-      let(:student_school_year) { student.most_recent_school_year }
-      let(:school_year) { student_school_year.school_year }
-      let(:absence) { student_school_year.absences.create!(occurred_at: school_year.start) }
+      let!(:student) { FactoryGirl.create(:student_with_absence, :with_risk_level) }
 
       it 'shows the absence' do
-        expect(page).not_to have_content 'No absences or tardies'
+        expect(page).to have_content 'Absences: 1'
       end
     end
 

--- a/spec/features/profile_feature_spec.rb
+++ b/spec/features/profile_feature_spec.rb
@@ -33,7 +33,11 @@ describe 'educator views student profile', :type => :feature do
       end
     end
     context 'student has absence' do
-      let!(:student) { FactoryGirl.create(:student_with_absence, :with_risk_level) }
+      let!(:student) { FactoryGirl.create(:student, :with_risk_level) }
+      let(:student_school_year) { student.most_recent_school_year }
+      let(:school_year) { student_school_year.school_year }
+      let(:absence) { student_school_year.absences.create!(occurred_at: school_year.start) }
+
       it 'shows the absence' do
         expect(page).not_to have_content 'No absences or tardies'
       end
@@ -46,27 +50,27 @@ describe 'educator views student profile', :type => :feature do
     end
     context 'student has MCAS results' do
       context 'English' do
-        let!(:student) { FactoryGirl.create(:student_with_mcas_ela_assessment, :with_risk_level) }
+        let!(:student) { FactoryGirl.create(:student_with_mcas_ela_assessment, :with_risk_level, grade: '6') }
         it 'shows MCAS results' do
           expect(page).to have_css '.mcas-ela-values'
         end
       end
       context 'math' do
-        let!(:student) { FactoryGirl.create(:student_with_mcas_math_assessment, :with_risk_level) }
+        let!(:student) { FactoryGirl.create(:student_with_mcas_math_assessment, :with_risk_level, grade: '6') }
         it 'shows MCAS results' do
           expect(page).to have_css '.mcas-math-values'
         end
       end
     end
     context 'student has no STAR results' do
-      let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level) }
+      let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level, grade: '6') }
       it 'shows no STAR results' do
         expect(page).not_to have_css '.star-result-section'
       end
     end
     context 'student has a STAR result' do
       context 'reading' do
-        let!(:student) { FactoryGirl.create(:student_ahead_in_reading, :with_risk_level) }
+        let!(:student) { FactoryGirl.create(:student_ahead_in_reading, :with_risk_level, grade: '6') }
         it 'shows STAR result' do
           expect(page).to have_css '.star-reading-values'
         end

--- a/spec/features/profile_feature_spec.rb
+++ b/spec/features/profile_feature_spec.rb
@@ -20,18 +20,21 @@ describe 'educator views student profile', :type => :feature do
         expect(page).to have_content 'No behavior incidents'
       end
     end
+
     context 'student has discipline incidents' do
       let!(:student) { FactoryGirl.create(:student_with_discipline_incident, :with_risk_level) }
       it 'shows the discipline incident' do
         expect(page).not_to have_content 'No behavior incidents'
       end
     end
+
     context 'student has no attendance events' do
       let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level) }
       it 'shows no attendance events' do
         expect(page).to have_content 'No absences or tardies'
       end
     end
+
     context 'student has absence' do
       let!(:student) { FactoryGirl.create(:student, :with_risk_level) }
       let(:student_school_year) { student.most_recent_school_year }
@@ -42,33 +45,41 @@ describe 'educator views student profile', :type => :feature do
         expect(page).not_to have_content 'No absences or tardies'
       end
     end
+
     context 'student has no MCAS results' do
       let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level) }
       it 'shows no MCAS results' do
         expect(page).not_to have_css '.mcas-result-section'
       end
     end
+
     context 'student has MCAS results' do
+
       context 'English' do
         let!(:student) { FactoryGirl.create(:student_with_mcas_ela_assessment, :with_risk_level, grade: '6') }
         it 'shows MCAS results' do
           expect(page).to have_css '.mcas-ela-values'
         end
       end
+
       context 'math' do
         let!(:student) { FactoryGirl.create(:student_with_mcas_math_assessment, :with_risk_level, grade: '6') }
         it 'shows MCAS results' do
           expect(page).to have_css '.mcas-math-values'
         end
       end
+
     end
+
     context 'student has no STAR results' do
       let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level, grade: '6') }
       it 'shows no STAR results' do
         expect(page).not_to have_css '.star-result-section'
       end
     end
+
     context 'student has a STAR result' do
+
       context 'reading' do
         let!(:student) { FactoryGirl.create(:student_ahead_in_reading, :with_risk_level, grade: '6') }
         it 'shows STAR result' do
@@ -79,6 +90,7 @@ describe 'educator views student profile', :type => :feature do
           expect(instructional_reading_level).to have_content('6.0')
         end
       end
+
       context 'math' do
         let!(:student) { FactoryGirl.create(:student_with_star_math_assessment, :with_risk_level) }
         it 'shows STAR result' do
@@ -86,29 +98,34 @@ describe 'educator views student profile', :type => :feature do
         end
       end
     end
+
     context 'student has DIBELS' do
       let!(:student) { FactoryGirl.create(:student_with_dibels, :with_risk_level) }
       it 'shows DIBELS' do
         expect(page).to have_css '.dibels-values'
       end
     end
+
     context 'student has no DIBELS' do
       let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level) }
       it 'doesn\'t show DIBELS' do
         expect(page).not_to have_css '.dibels-values'
       end
     end
+
     context 'student has ACCESS' do
       let!(:student) { FactoryGirl.create(:student_with_access, :with_risk_level) }
       it 'shows ACCESS' do
         expect(page).to have_css '.access-values'
       end
     end
+
     context 'student has no ACCESS' do
       let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level) }
       it 'doesn\'t show ACCESS' do
         expect(page).not_to have_css '.access-values'
       end
     end
+
   end
 end

--- a/spec/fixtures/fake_students_export.txt
+++ b/spec/fixtures/fake_students_export.txt
@@ -1,4 +1,4 @@
 "state_id","local_id","full_name","home_language","program_assigned","limited_english_proficiency","sped_placement","disability","sped_level_of_need","plan_504","student_address","grade","registration_date","free_reduced_lunch","homeroom","school_local_id"
-"1000000000","100","Fake Student, First","English","Sp Ed","Fluent","Full Inclusion","Specific LDs","Moderate","Not 504","155 9th St, San Francisco, CA","10","2008-02-20","Not Eligible","Homeroom 200","HEA"
-"1000000001","101","Fake Student, Second","Vietnamese","Reg Ed","FLEP-Transitioning",\N,\N,\N,"Not 504","155 9th St, San Francisco, CA","10","2005-08-05","Free Lunch","Homeroom 200","SHS"
-"1000000002","103","Fake Student, Second","Vietnamese","Reg Ed","FLEP-Transitioning",\N,\N,\N,"Not 504","155 9th St, San Francisco, CA","10","2005-08-05","Free Lunch","Homeroom 200","BRN"
+"1000000000","100","Fake Student, First","English","Sp Ed","Fluent","Full Inclusion","Specific LDs","Moderate","Not 504","155 9th St, San Francisco, CA","07","2008-02-20","Not Eligible","Homeroom 200","HEA"
+"1000000001","101","Fake Student, Second","Vietnamese","Reg Ed","FLEP-Transitioning",\N,\N,\N,"Not 504","155 9th St, San Francisco, CA","07","2005-08-05","Free Lunch","Homeroom 200","SHS"
+"1000000002","103","Fake Student, Second","Vietnamese","Reg Ed","FLEP-Transitioning",\N,\N,\N,"Not 504","155 9th St, San Francisco, CA","07","2005-08-05","Free Lunch","Homeroom 200","BRN"

--- a/spec/importers/attendance_row_spec.rb
+++ b/spec/importers/attendance_row_spec.rb
@@ -3,9 +3,12 @@ require 'rails_helper'
 RSpec.describe AttendanceRow do
   let(:absence) { true }
   let(:tardy) { false }
+
+  let!(:student) { FactoryGirl.create(:student) }
+
   let(:data) do
     {
-      local_id: 'student-id',
+      local_id: student.local_id,
       event_date: DateTime.parse('1981-12-30'),
       absence: absence,
       tardy: tardy,
@@ -45,11 +48,6 @@ RSpec.describe AttendanceRow do
     it 'creates the appropriate school year' do
       expect { row.build }.to change(SchoolYear, :count).by(1)
       expect(SchoolYear.last.name).to eq('1981-1982')
-    end
-
-    it 'creates the appropriate student record' do
-      expect { row.build }.to change(Student, :count).by(1)
-      expect(Student.last.local_id).to eq('student-id')
     end
   end
 end

--- a/spec/importers/behavior_importer_spec.rb
+++ b/spec/importers/behavior_importer_spec.rb
@@ -1,3 +1,4 @@
+
 require 'rails_helper'
 
 RSpec.describe BehaviorImporter do
@@ -5,6 +6,11 @@ RSpec.describe BehaviorImporter do
   let(:importer) {
     Importer.new(current_file_importer: described_class.new)
   }
+
+  before { FactoryGirl.create(:student, local_id: '11') }
+  before { FactoryGirl.create(:student, local_id: '12') }
+  before { FactoryGirl.create(:student, local_id: '13') }
+  before { FactoryGirl.create(:student, local_id: '14') }
 
   let(:import) { importer.start_import(csv) }
 

--- a/spec/importers/behavior_row_spec.rb
+++ b/spec/importers/behavior_row_spec.rb
@@ -1,9 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe BehaviorRow do
+
+  let!(:student) { FactoryGirl.create(:student) }
+
   let(:data) do
     {
-      local_id: 'student-id',
+      local_id: student.local_id,
       event_date: DateTime.parse('1981-12-30'),
     }
   end
@@ -18,11 +21,6 @@ RSpec.describe BehaviorRow do
     it 'creates the appropriate school year' do
       expect { row.build }.to change(SchoolYear, :count).by(1)
       expect(SchoolYear.last.name).to eq('1981-1982')
-    end
-
-    it 'creates the appropriate student record' do
-      expect { row.build }.to change(Student, :count).by(1)
-      expect(Student.last.local_id).to eq('student-id')
     end
   end
 end

--- a/spec/importers/importer_spec.rb
+++ b/spec/importers/importer_spec.rb
@@ -4,12 +4,7 @@ RSpec.describe do
 
   describe '#import' do
 
-    let(:file_importer_class) {
-      Class.new do
-        def import_row(row); Student.where(local_id: row[:local_id]).first_or_create! end
-        def remote_file_name; '' end
-      end
-    }
+    let(:file_importer_class) { StudentsImporter }
 
     let(:file_importer) { file_importer_class.new }
 

--- a/spec/importers/student_assessment_importer_spec.rb
+++ b/spec/importers/student_assessment_importer_spec.rb
@@ -9,17 +9,17 @@ RSpec.describe StudentAssessmentImporter do
       let(:csv) { transformer.transform(file) }
 
       context 'for Healey school' do
+
+        let!(:student) { FactoryGirl.create(:student, local_id: '100') }
+
         let(:healey) { School.where(local_id: "HEA").first_or_create! }
+
         let(:healey_importer) {
           Importer.new(current_file_importer: described_class.new, school_scope: 'HEA')
         }
 
         before(:each) do
           healey_importer.start_import(csv)
-        end
-
-        it 'creates a student' do
-          expect(Student.count).to eq 1
         end
 
         it 'imports only white-listed assessments' do

--- a/spec/models/homeroom_spec.rb
+++ b/spec/models/homeroom_spec.rb
@@ -3,12 +3,6 @@ require 'rails_helper'
 RSpec.describe Homeroom do
 
   describe '#grade' do
-    context 'with no students' do
-      let(:homeroom) { FactoryGirl.create(:homeroom_with_student) }
-      it 'is nil' do
-        expect(homeroom.grade).to eq nil
-      end
-    end
     context 'with PK student' do
       let(:homeroom) { FactoryGirl.create(:homeroom_with_pre_k_student) }
       it 'is "PK"' do

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -120,13 +120,21 @@ RSpec.describe Student do
     context 'student with no absences or tardies' do
       let(:student) { FactoryGirl.create(:student_with_registration_date) }
       it 'returns the correct array' do
-        expect(student.absences_count_by_school_year).to eq [0, 0]
+        expect(student.absences_count_by_school_year.uniq).to eq [0]
       end
     end
+
     context 'student with absence' do
-      let(:student) { FactoryGirl.create(:student_with_absence) }
+      let(:student) { FactoryGirl.create(:student) }
+
+      before do
+        student_school_year = student.most_recent_school_year
+        occurred_at = student_school_year.school_year.start
+        student_school_year.absences.create!(occurred_at: occurred_at)
+      end
+
       it 'returns the correct array' do
-        expect(student.absences_count_by_school_year).to eq [1]
+        expect(student.absences_count_by_school_year.first).to eq 1
       end
     end
   end

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -131,18 +131,12 @@ RSpec.describe Student do
     end
   end
 
-  describe '#school_years' do
+  describe '#find_student_school_years' do
     context 'school years in the 2010s' do
       let!(:sy_2014_2015) { FactoryGirl.create(:sy_2014_2015) }
       let!(:sy_2013_2014) { FactoryGirl.create(:sy_2013_2014) }
       let!(:sy_2012_2013) { FactoryGirl.create(:sy_2012_2013) }
 
-      context 'student has no registration date or grade' do
-        let(:student) { FactoryGirl.create(:student) }
-        it 'returns an empty array' do
-          expect(student.find_student_school_years).to eq([])
-        end
-      end
       context 'student has registration date' do
         let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014) }
         it 'calculates student school years based on registration date' do
@@ -151,6 +145,7 @@ RSpec.describe Student do
           end
         end
       end
+
       context 'student has numerical grade level (1 through 12)' do
         context 'student is in 2nd grade' do
           let(:student) { FactoryGirl.create(:second_grade_student) }
@@ -161,6 +156,7 @@ RSpec.describe Student do
           end
         end
       end
+
       context 'student has non-numerical grade level' do
         context 'student grade level is PK' do
           let(:student) { FactoryGirl.create(:pre_k_student) }
@@ -171,6 +167,7 @@ RSpec.describe Student do
           end
         end
       end
+
     end
   end
 


### PR DESCRIPTION
## What's new?

+ Validate student grade levels against a frozen array of options (KF through 8)
+ Make `students_export.txt` the sole source of truth for students; strip all other X2 importers of ability to create new student records
