### PR TITLE
Make importers more verbose about how many rows they have dropped

### DIFF
--- a/app/importers/importer.rb
+++ b/app/importers/importer.rb
@@ -28,7 +28,7 @@ class Importer
       file = @client.read_file(file_importer.remote_file_name)
 
       pre_cleanup_csv = CSV.parse(file, headers: true)
-      puts; puts "#{pre_cleanup_csv.size} rows of data in #{file_importer.remote_file_name} pre-cleanup"
+      puts; puts; puts "#{pre_cleanup_csv.size} rows of data in #{file_importer.remote_file_name} pre-cleanup"
 
       data = file_importer.data_transformer.transform(file)
       puts "#{data.size} rows of data in #{file_importer.remote_file_name} post-cleanup"

--- a/app/importers/importer.rb
+++ b/app/importers/importer.rb
@@ -26,7 +26,13 @@ class Importer
     file_importers.each do |file_importer|
       @current_file_importer = file_importer
       file = @client.read_file(file_importer.remote_file_name)
+
+      pre_cleanup_csv = CSV.parse(file, headers: true)
+      puts; puts "#{pre_cleanup_csv.size} rows of data in #{file_importer.remote_file_name} pre-cleanup"
+
       data = file_importer.data_transformer.transform(file)
+      puts "#{data.size} rows of data in #{file_importer.remote_file_name} post-cleanup"
+
       start_import(data)
     end
   end


### PR DESCRIPTION
## How many rows are being dropped due to dirty data?

Logs from X2 export process: 

```
STUDENTS: NONE
5019 rows of data in students_export.txt pre-cleanup
5019 rows of data in students_export.txt post-cleanup

ASSESSMENTS: NONE
133110 rows of data in assessment_export.txt pre-cleanup
133110 rows of data in assessment_export.txt post-cleanup

BEHAVIOR: 2 ROWS
9413 rows of data in behavior_export.txt pre-cleanup
9411 rows of data in behavior_export.txt post-cleanup

EDUCATORS: NONE
639 rows of data in educators_export.txt pre-cleanup
639 rows of data in educators_export.txt post-cleanup

ATTENDANCE: 470 ROWS
414713 rows of data in attendance_export.txt pre-cleanup
414243 rows of data in attendance_export.txt post-cleanup
```

___NOTE:___  In this context "dirty data" means data that contains either:

+ dates that can't be parsed OR 
+ boolean values that can't be parsed.