### PR TITLE
Fix bug in demo data with assessment generators not tracking state

### DIFF
--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -73,32 +73,32 @@ class FakeStudent
     }
   end
 
-  def x2_assessment_generators
+  def create_x2_assessment_generators(student)
     [
-      FakeMcasMathResultGenerator.new(@student),
-      FakeMcasElaResultGenerator.new(@student),
-      FakeDibelsResultGenerator.new(@student),
-      FakeAccessResultGenerator.new(@student)
+      FakeMcasMathResultGenerator.new(student),
+      FakeMcasElaResultGenerator.new(student),
+      FakeDibelsResultGenerator.new(student),
+      FakeAccessResultGenerator.new(student)
     ]
   end
 
-  def star_assessment_generators
+  def create_star_assessment_generators(student)
     [
-      FakeStarMathResultGenerator.new(@student),
-      FakeStarReadingResultGenerator.new(@student)
+      FakeStarMathResultGenerator.new(student),
+      FakeStarReadingResultGenerator.new(student)
     ]
   end
 
   def add_student_assessments
-    5.times do
-      x2_assessment_generators.each do |assessment|
-        StudentAssessment.new(assessment.next).save
+    create_x2_assessment_generators(@student).each do |assessment_generator|
+      5.times do
+        StudentAssessment.new(assessment_generator.next).save
       end
     end
 
-    12.times do
-     star_assessment_generators.each do |assessment|
-        StudentAssessment.new(assessment.next).save
+    create_star_assessment_generators(@student).each do |assessment_generator|
+      12.times do
+        StudentAssessment.new(assessment_generator.next).save
       end
     end
   end


### PR DESCRIPTION
I ran into this working on the new profile page; locally there are students with MCAS Math assessments on the same date.  The problem is that the assessment generator classes are stateful (so they don't generate assessment dates for the same year), but new generator instances are created for each call in `FakeStudent`.  This re-uses the same instances so the stateful parts of the assessment generators work as expected.

This may affect other generators, this only addresses student assessments for now.