### PR TITLE
Student profile - add 'none' for read-only notes and interventions

### DIFF
--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -51,13 +51,6 @@
       collapsedNote: {
         maxHeight: '2em',
         overflowY: 'hidden'
-      },
-      addButton: {
-        fontSize: 24,
-        outline: '1px solid black',
-        padding: '0px 5px',
-        marginLeft: 10,
-
       }
     },
 
@@ -81,18 +74,12 @@
     render: function() {
       return dom.div({ className: 'InterventionsDetails', style: this.styles.container },
         dom.div({ style: this.styles.notesContainer },
-          dom.div({ style: this.styles.title},
-            'Notes',
-            dom.span({ style: this.styles.addButton }, '+')
-          ),
-          this.props.notes.map(this.renderNote)
+          dom.div({ style: this.styles.title}, 'Notes'),
+          (this.props.notes.length === 0) ? 'No notes' : this.props.notes.map(this.renderNote)
         ),
         dom.div({ style: this.styles.interventionsContainer },
-          dom.div({ style: this.styles.title},
-            'Interventions',
-            dom.span({ style: this.styles.addButton }, '+')
-          ),
-          this.props.student.interventions.map(this.renderIntervention)
+          dom.div({ style: this.styles.title}, 'Interventions'),
+          (this.props.student.interventions.length === 0) ? 'No interventions' : this.props.student.interventions.map(this.renderIntervention)
         )
       );
     },


### PR DESCRIPTION
Also removes placeholder "add" buttons to make clear this is read-only at the moment.

Before:
<img width="1243" alt="screen shot 2016-02-09 at 5 41 50 pm" src="https://cloud.githubusercontent.com/assets/1056957/12933129/8ad0df46-cf54-11e5-9484-2cbdf8888958.png">


After:
<img width="1211" alt="screen shot 2016-02-09 at 5 41 31 pm" src="https://cloud.githubusercontent.com/assets/1056957/12933120/770b5838-cf54-11e5-93dd-e28300699d26.png">
