### PR TITLE
Sort allowed_homerooms array in spec before comparing

### DIFF
--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Educator do
       let!(:homeroom_103) { FactoryGirl.create(:homeroom, grade: '2') }
 
       it 'returns all homerooms' do
-        expect(educator.allowed_homerooms).to eq [homeroom_101, homeroom_102, homeroom_103]
+        expect(educator.allowed_homerooms.sort).to eq [homeroom_101, homeroom_102, homeroom_103].sort
       end
     end
 


### PR DESCRIPTION
## Notes

+ This fails every once in a while, not sure why
+ Not important because order of `educator.allowed_homerooms` doesn't matter, we just test inclusion