### PR TITLE
Expect absences/tardies to come in as 1s and 0s from X2

### DIFF
--- a/app/importers/attendance_row.rb
+++ b/app/importers/attendance_row.rb
@@ -20,8 +20,8 @@ class AttendanceRow < Struct.new(:row)
   private
 
   def attendance_event_class
-    return student_school_year.absences if row[:absence]
-    return student_school_year.tardies if row[:tardy]
+    return student_school_year.absences if row[:absence].to_i == 1
+    return student_school_year.tardies if row[:tardy].to_i == 1
     NullRelation.new
   end
 

--- a/spec/importers/attendance_importer_spec.rb
+++ b/spec/importers/attendance_importer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AttendanceImporter do
       let!(:student_school_year) { StudentSchoolYear.create(student: student, school_year: school_year) }
 
       context 'row with absence' do
-        let(:row) { { event_date: date, local_id: '1', absence: true, tardy: false } }
+        let(:row) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
 
         it 'creates an absence' do
           expect { described_class.new.import_row(row) }.to change { Absence.count }.by 1
@@ -53,8 +53,8 @@ RSpec.describe AttendanceImporter do
         StudentSchoolYear.create(student: kristen, school_year: school_year)
       end
 
-      let(:row_for_edwin) { { event_date: date, local_id: '1', absence: true, tardy: false } }
-      let(:row_for_kristen) { { event_date: date, local_id: '2', absence: true, tardy: false } }
+      let(:row_for_edwin) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
+      let(:row_for_kristen) { { event_date: date, local_id: '2', absence: '1', tardy: '0' } }
 
       it 'creates an absence for each student' do
         expect {
@@ -71,8 +71,8 @@ RSpec.describe AttendanceImporter do
       let(:school_year) { DateToSchoolYear.new(date).convert }
       let!(:student_school_year) { StudentSchoolYear.create(student: student, school_year: school_year) }
 
-      let(:first_row) { { event_date: date, local_id: '1', absence: true, tardy: false } }
-      let(:second_row) { { event_date: date, local_id: '1', absence: true, tardy: false } }
+      let(:first_row) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
+      let(:second_row) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
 
       it 'creates an absence' do
         expect {
@@ -89,10 +89,10 @@ RSpec.describe AttendanceImporter do
       let(:school_year) { DateToSchoolYear.new(date).convert }
       let!(:student_school_year) { StudentSchoolYear.create(student: student, school_year: school_year) }
 
-      let(:first_row) { { event_date: date, local_id: '1', absence: true, tardy: false } }
-      let(:second_row) { { event_date: date + 1.day, local_id: '1', absence: true, tardy: false } }
-      let(:third_row) { { event_date: date + 2.days, local_id: '1', absence: true, tardy: false } }
-      let(:fourth_row) { { event_date: date + 3.days, local_id: '1', absence: true, tardy: false } }
+      let(:first_row) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
+      let(:second_row) { { event_date: date + 1.day, local_id: '1', absence: '1', tardy: '0' } }
+      let(:third_row) { { event_date: date + 2.days, local_id: '1', absence: '1', tardy: '0' } }
+      let(:fourth_row) { { event_date: date + 3.days, local_id: '1', absence: '1', tardy: '0' } }
 
       it 'creates multiple absences' do
         importer = described_class.new

--- a/spec/importers/attendance_row_spec.rb
+++ b/spec/importers/attendance_row_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe AttendanceRow do
-  let(:absence) { true }
-  let(:tardy) { false }
+  let(:absence) { '1' }
+  let(:tardy) { '0' }
 
   let!(:student) { FactoryGirl.create(:student) }
 
@@ -25,8 +25,8 @@ RSpec.describe AttendanceRow do
     end
 
     context 'when the row is a tardy' do
-      let(:absence) { false }
-      let(:tardy) { true }
+      let(:absence) { '0' }
+      let(:tardy) { '1' }
 
       it 'saves a tardy' do
         expect { row.build.save! }.to change(Tardy, :count).by(1)
@@ -34,7 +34,7 @@ RSpec.describe AttendanceRow do
     end
 
     context 'when the row is neither absence nor tardy' do
-      let(:absence) { false }
+      let(:absence) { '0' }
 
       it 'does not save an absence' do
         expect { row.build.save! }.not_to change(Absence, :count)


### PR DESCRIPTION
## Notes 

+ Our old code was calling `AttendanceEvent.create(absence: row[:absence])` ...
+ ... which auto-coerced the integers into booleans.
+ Now that we're not assigning object attributes directly we get no automatic coercion!