### PR TITLE
Fix bug with test setup not being update for FakeNoteGenerator

### DIFF
--- a/spec/demo_data/fake_student_spec.rb
+++ b/spec/demo_data/fake_student_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe FakeStudent do
 
   let!(:school) { FactoryGirl.create(:school) }
   let!(:homeroom) { FactoryGirl.create(:homeroom) }
+  before { FactoryGirl.create(:educator, :admin) }
 
   before do
     InterventionType.seed_somerville_intervention_types


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/studentinsights/studentinsights/pull/45, which now expects that there is an admin Educator in the db when running the fake seed generators for local development and test.