### PR TITLE
Fix bugs with attendance and behavior charts on v2 profile

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -47,6 +47,7 @@
 // pages:
 //= require_tree ./student
 //= require ./student_profile_v2/highcharts_wrapper
+//= require ./student_profile_v2/scales
 //= require_tree ./student_profile_v2
 //= require_tree ./roster
 //= require_tree ./school_overview

--- a/app/assets/javascripts/student_profile_v2/attendance_details.js
+++ b/app/assets/javascripts/student_profile_v2/attendance_details.js
@@ -3,7 +3,9 @@
   var dom = window.shared.ReactHelpers.dom;
   var createEl = window.shared.ReactHelpers.createEl;
   var merge = window.shared.ReactHelpers.merge;
+
   var HighchartsWrapper = window.shared.HighchartsWrapper;
+  var Scales = window.shared.Scales;
 
   var AttendanceDetails = window.shared.AttendanceDetails = React.createClass({
     displayName: 'AttendanceDetails',
@@ -45,14 +47,15 @@
     },
 
     renderDisciplineIncidents: function() {
+      var range = Scales.disciplineIncidents.valueRange;
       return createEl(HighchartsWrapper, merge(this.baseOptions(), {
         title: {
           text: 'Discipline incidents, last 4 years',
           align: 'left'
         },
         yAxis: {
-          min: 0,
-          max: 6
+          min: range[0],
+          max: range[1]
         },
         series: [{
           name: 'Events per school year',
@@ -67,12 +70,16 @@
           text: 'Absences and Tardies, last 4 years',
           align: 'left'
         },
+        yAxis: {
+          min: _.min([Scales.absences.valueRange[0], Scales.tardies.valueRange[0]]),
+          max: _.max([Scales.absences.valueRange[1], Scales.tardies.valueRange[1]])
+        },
         series: [{
-          name: 'Absences per school year',
-          data: this.quadsToPairs(this.props.cumulativeAbsences)
-        }, {
           name: 'Tardies per school year',
           data: this.quadsToPairs(this.props.cumulativeTardies)
+        }, {
+          name: 'Absences per school year',
+          data: this.quadsToPairs(this.props.cumulativeAbsences)
         }]
       }));
     },
@@ -106,11 +113,7 @@
           plotLines: this.x_axis_bands,
           min: timestampRange.min,
           max: timestampRange.max
-        }),
-        yAxis: {
-          min: 0,
-          max: 20
-        }
+        })
       });
     },
 

--- a/app/assets/javascripts/student_profile_v2/quad_converter.js
+++ b/app/assets/javascripts/student_profile_v2/quad_converter.js
@@ -1,0 +1,64 @@
+(function() {
+  window.shared || (window.shared = {});
+
+  var QuadConverter = window.shared.QuadConverter = {
+    // Fills in data points for start of the school year (8/15) and for current day.
+    // Also collapses multiple events on the same day.
+    // TODO(kr) should extract this, simplify and test it more thoroughly
+    convert: function(attendanceEvents, nowDate, dateRange) {
+      var currentYearStart = this.schoolYearStart(moment(nowDate));
+      var schoolYearStarts = this.allSchoolYearStarts(dateRange);
+      var sortedAttendanceEvents = _.sortBy(attendanceEvents, 'occurred_at');
+
+      var quads = [];
+      schoolYearStarts.sort().forEach(function(schoolYearStart) {
+        var yearAttendanceEvents = sortedAttendanceEvents.filter(function(attendanceEvent) {
+          return this.schoolYearStart(moment(attendanceEvent.occurred_at)) === schoolYearStart;
+        }, this);
+        var cumulativeEventQuads = this.toCumulativeQuads(yearAttendanceEvents);
+        var startOfYearQuad = [schoolYearStart, 8, 15, 0];
+        quads.push(startOfYearQuad);
+        cumulativeEventQuads.forEach(function(cumulativeQuad) { quads.push(cumulativeQuad); });
+        var lastValue = (cumulativeEventQuads.length === 0) ? 0 : _.last(cumulativeEventQuads)[3];
+        if (schoolYearStart === currentYearStart) {
+          quads.push([nowDate.getFullYear(), nowDate.getMonth() + 1, nowDate.getDate(), lastValue]);
+        }
+      }, this);
+
+      return _.sortBy(quads, function(quad) { return new Date(quad[0], quad[1], quad[2]) });
+    },
+
+    schoolYearStart: function(eventMoment) {
+      var year = eventMoment.year();
+      var startOfSchoolYear = moment(new Date(year, 7, 15));
+      var isEventDuringFall = eventMoment.clone().diff(startOfSchoolYear, 'days') > 0;
+      return (isEventDuringFall) ? year : year - 1;
+    },
+
+    allSchoolYearStarts: function(dateRange) {
+      var schoolYearStarts = dateRange.map(function(date) {
+        return this.schoolYearStart(moment(date));
+      }, this);
+      return _.range(schoolYearStarts[0], schoolYearStarts[1] + 1);
+    },
+
+    toCumulativeQuads: function(yearAttendanceEvents) {
+      var cumulativeValue = 0;
+      var quads = [];
+      _.sortBy(yearAttendanceEvents, 'occurred_at').forEach(function(attendanceEvent) {
+        var occurrenceDate = moment(attendanceEvent.occurred_at).toDate();
+        cumulativeValue = cumulativeValue + 1;
+        
+        // collapse consecutive events on the same day
+        var lastQuad = _.last(quads);
+        if (lastQuad && lastQuad[0] === occurrenceDate.getFullYear() && lastQuad[1] === occurrenceDate.getMonth() + 1 && lastQuad[2] === occurrenceDate.getDate()) {
+          lastQuad[3] = cumulativeValue;
+        } else {
+          quads.push([occurrenceDate.getFullYear(), occurrenceDate.getMonth() + 1, occurrenceDate.getDate(), cumulativeValue]);
+        }
+      });
+
+      return quads;
+    }
+  };
+})();

--- a/app/assets/javascripts/student_profile_v2/scales.js
+++ b/app/assets/javascripts/student_profile_v2/scales.js
@@ -1,0 +1,22 @@
+(function() {
+  window.shared || (window.shared = {});
+
+  var Scales = window.shared.Scales = {
+    mcas: {
+      valueRange: [200, 300],
+      threshold: 240
+    },
+    disciplineIncidents: {
+      valueRange: [0, 6],
+      threshold: 3
+    },
+    absences: {
+      valueRange: [0, 20],
+      threshold: 10
+    },
+    tardies: {
+      valueRange: [0, 40],
+      threshold: 20
+    }
+  };
+})();

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -91,22 +91,27 @@ class StudentsController < ApplicationController
   # TODO(kr) this is placeholder fixture data for now, to test design prototypes on the v2 student profile
   # page
   def student_feed(student)
-    fixture_educator_id = 12
-    v2_notes = [
-      { version: 'v2', id: 42, profile_v2_note_type_id: 1, educator_id: fixture_educator_id, date_recorded: '2016-02-09T20:56:51.638Z', text: 'Call parent in for a meeting.' },
-      { version: 'v2', id: 43, profile_v2_note_type_id: 2, educator_id: fixture_educator_id, date_recorded: '2016-02-03T20:56:51.638Z', text: 'Attendance has improved, will schedule a meeting with the family to talk about counseling needs.' }
-    ]
+    {
+      v1_notes: student.student_notes.map { |note| serialize_student_note(note) },
+      v1_interventions: student.interventions.map { |intervention| serialize_intervention(intervention) },
+      v2_notes: if Rails.env.development? then v2_notes_fixture else [] end,
+      v2_services: if Rails.env.development? then v2_services_fixture else [] end
+    }
+  end
 
-    v2_services = [
+  def v2_services_fixture
+    fixture_educator_id = 1
+    [
       { version: 'v2', id: 133, profile_v2_service_type_id: 1, recorded_by_educator_id: fixture_educator_id, assigned_to_educator_id: fixture_educator_id, start_date: '2016-02-09T20:56:51.638Z', end_date: nil, text: 'Working on goals' },
       { version: 'v2', id: 134, profile_v2_service_type_id: 1, recorded_by_educator_id: fixture_educator_id, assigned_to_educator_id: fixture_educator_id, start_date: '2016-02-09T20:56:51.638Z', end_date: nil, text: ''  }
     ]
+  end
 
-    {
-      v1_notes: student.student_notes.map { |note| serialize_student_note(note) },
-      v2_notes: v2_notes,
-      v1_interventions: student.interventions.map { |intervention| serialize_intervention(intervention) },
-      v2_services: v2_services
-    }
+  def v2_notes_fixture
+    fixture_educator_id = 1
+    [
+      { version: 'v2', id: 42, profile_v2_note_type_id: 1, educator_id: fixture_educator_id, date_recorded: '2016-02-09T20:56:51.638Z', text: 'Call parent in for a meeting.' },
+      { version: 'v2', id: 43, profile_v2_note_type_id: 2, educator_id: fixture_educator_id, date_recorded: '2016-02-03T20:56:51.638Z', text: 'Attendance has improved, will schedule a meeting with the family to talk about counseling needs.' }
+    ]
   end
 end

--- a/spec/javascripts/student_profile_v2/quad_converter_spec.js
+++ b/spec/javascripts/student_profile_v2/quad_converter_spec.js
@@ -1,0 +1,45 @@
+describe('QuadConverter', function() {
+  var QuadConverter = window.shared.QuadConverter;
+
+  describe('#schoolYearStart', function() {
+    it('aligns to school year', function() {
+      expect(QuadConverter.schoolYearStart(moment('2013-09-12'))).toEqual(2013);
+      expect(QuadConverter.schoolYearStart(moment('2014-05-12'))).toEqual(2013);
+      expect(QuadConverter.schoolYearStart(moment('2014-08-19'))).toEqual(2014);
+      expect(QuadConverter.schoolYearStart(moment('2014-11-19'))).toEqual(2014);
+    });
+  });
+
+  describe('#convert', function() {
+    it('returns the expected javascript date', function() {
+      var now = new Date('Wed Feb 10 2016 22:11:26 GMT-0500 (EST)');
+      var dateRange = [moment(now).subtract(1, 'year').toDate(), now];
+      var attendanceEvents = [
+        {'occurred_at':'2015-12-22T00:00:00.000Z'},
+        {'occurred_at':'2015-12-21T00:00:00.000Z'},
+        {'occurred_at':'2015-12-08T00:00:00.000Z'},
+        {'occurred_at':'2015-10-16T00:00:00.000Z'},
+        {'occurred_at':'2015-10-14T00:00:00.000Z'},
+        {'occurred_at':'2015-10-08T00:00:00.000Z'},
+        {'occurred_at':'2015-10-07T00:00:00.000Z'},
+        {'occurred_at':'2015-10-06T00:00:00.000Z'},
+        {'occurred_at':'2015-09-23T00:00:00.000Z'},
+        {'occurred_at':'2015-09-22T00:00:00.000Z'},
+        {'occurred_at':'2015-09-21T00:00:00.000Z'},
+        {'occurred_at':'2015-09-18T00:00:00.000Z'},
+        {'occurred_at':'2015-09-17T00:00:00.000Z'},
+        {'occurred_at':'2015-09-15T00:00:00.000Z'},
+        {'occurred_at':'2015-09-08T00:00:00.000'}
+      ];
+      var quads = QuadConverter.convert(attendanceEvents, now, dateRange);
+      expect(quads[0]).toEqual([2014, 8, 15, 0]);
+      expect(quads[1]).toEqual([2015, 8, 15, 0]);
+      expect(quads[2]).toEqual([2015, 9, 8, 1]);
+      expect(quads.length).toEqual(2 + attendanceEvents.length + 1);
+      expect(_.last(quads)[3]).toEqual(15);
+
+      var values = quads.map(function(quad) { return quad[3]; });
+      expect(values).toEqual(_.sortBy(values));
+    });
+  });
+});


### PR DESCRIPTION
Extract code converting between lists of events and cumulative counts, add some minimal tests and fix a bug in computing school year alignment.

Also factor out the definition of chart scales, which is re-used by the sparklines and larger charts on the profile v2 page.