### PR TITLE
Profile v2 - Tweaks for user testing tomorrow

### DIFF
--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -342,14 +342,14 @@
         ),
         dom.div({ style: { marginTop: 20 } }, 'When did they start?'),
         dom.input({ className: 'datepicker', style: { fontSize: 14, padding: 5, width: '50%' }, defaultValue: moment().format('MM/DD/YYYY') }),
-        dom.div({ style: { marginTop: 15 } }, 'Any other context?'),
-        dom.textarea({
-          rows: 3,
-          style: styles.recordServiceTextArea,
-          // ref: function(ref) { this.takeNotesTextAreaRef = ref; }.bind(this),
-          value: this.state.serviceText,
-          onChange: this.onRecordServiceTextChanged
-        }),
+        // dom.div({ style: { marginTop: 15 } }, 'Any other context?'),
+        // dom.textarea({
+        //   rows: 3,
+        //   style: styles.recordServiceTextArea,
+        //   // ref: function(ref) { this.takeNotesTextAreaRef = ref; }.bind(this),
+        //   value: this.state.serviceText,
+        //   onChange: this.onRecordServiceTextChanged
+        // }),
         dom.div({},
           dom.button({
             style: merge(styles.recordServiceButton, {
@@ -369,9 +369,11 @@
     },
 
     renderEducatorSelect: function() {
-      // TODO(kr) convert to names, are those in Aspen?
       var options = _.values(this.props.educatorsIndex).map(function(educator) {
-        return { value: educator.id, label: educator.email.split('@')[0] };
+        var name = (educator.full_name !== null)
+          ? educator.full_name
+          : educator.email.split('@')[0];
+        return { value: educator.id, label: name };
       });
 
       return createEl(ReactSelect, {

--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -350,7 +350,7 @@
         //   value: this.state.serviceText,
         //   onChange: this.onRecordServiceTextChanged
         // }),
-        dom.div({},
+        dom.div({ style: { marginTop: 15 } },
           dom.button({
             style: merge(styles.recordServiceButton, {
               background: '#ccc' // TODO(kr) (this.state.serviceTypeId === null) ? '#ccc' : undefined

--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -353,9 +353,9 @@
         dom.div({},
           dom.button({
             style: merge(styles.recordServiceButton, {
-              background: (this.state.serviceTypeId === null) ? '#ccc' : undefined
+              background: '#ccc' // TODO(kr) (this.state.serviceTypeId === null) ? '#ccc' : undefined
             }),
-            disabled: (this.state.serviceTypeId === null),
+            disabled: true, // TODO(kr) (this.state.serviceTypeId === null),
             className: 'btn',
             onClick: this.onCancelRecordServiceClicked // TODO(kr) non-functional
           }, 'Record service'),
@@ -369,10 +369,10 @@
     },
 
     renderEducatorSelect: function() {
-      var options = [
-        { value: 1, label: 'Jill Geiser' },
-        { value: 2, label: 'Uri Harel' }
-      ];
+      // TODO(kr) convert to names, are those in Aspen?
+      var options = _.values(this.props.educatorsIndex).map(function(educator) {
+        return { value: educator.id, label: educator.email.split('@')[0] };
+      });
 
       return createEl(ReactSelect, {
         name: 'assigned-educator-select',

--- a/app/assets/stylesheets/student.scss
+++ b/app/assets/stylesheets/student.scss
@@ -127,6 +127,18 @@
   border-radius: 8px;
 }
 
+#profile-v2-link {
+  float: right;
+  display: inline;
+  position: relative;
+  padding: 3px 15px;
+  margin-top: 18px;
+  border-radius: 4px;
+  background-color: $white;
+  color: $gray;
+  border: 1px solid $light-line;
+}
+
 #export-button {
   float: right;
   display: inline;

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -2,6 +2,7 @@
     <div id="roster-back">
       <%= link_to "< Back to roster for #{@student.homeroom.name}", @roster_url %>
     </div>
+    <%= link_to 'Profile v2 prototype', profile_student_path(@student), id: 'profile-v2-link' %>
     <div id="export">
       <%= link_to 'Export', @csv_url, method: "get", id: 'export-button' %>
     </div>


### PR DESCRIPTION
…ecord service button

This is part of the student profile v2 page: https://github.com/studentinsights/studentinsights/issues/5.

This PR adds a button for navigating from profile v1 to profile v2.  It's red to stick out and indicate that it's a prototype, and this is really only intended to be used for user testing tomorrow.

<img width="1273" alt="screen shot 2016-02-11 at 7 31 27 pm" src="https://cloud.githubusercontent.com/assets/1056957/12995546/3983f026-d0f6-11e5-9b4e-b7c4a267b09a.png">

It also disables the "Record service" button, since saving doesn't work yet, but updates the list of educators there to be real names (or email addresses if there's no full_name set), instead of previous fixture data.

<img width="596" alt="screen shot 2016-02-11 at 7 36 55 pm" src="https://cloud.githubusercontent.com/assets/1056957/12995637/e3c66230-d0f6-11e5-85bd-eb1c0f40ad90.png">
