### PR TITLE
Profile v2 - add event note type badge in list

### DIFF
--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -56,6 +56,15 @@
       fontWeight: 'bold',
       display: 'inline-block'
     },
+    badge: {
+      display: 'inline-block',
+      background: '#eee',
+      outline: '3px solid #eee',
+      width: '8em',
+      textAlign: 'center',
+      marginLeft: 10,
+      marginRight: 10
+    },
     educator: {
       paddingLeft: 5,
       display: 'inline-block'
@@ -239,9 +248,20 @@
     renderNoteHeader: function(header) {
       return dom.div({},
         dom.span({ style: styles.date }, header.noteMoment.format('MMMM D, YYYY')),
-        '|',
+        header.badge,
         dom.span({ style: styles.educator }, header.educatorEmail)
       );
+    },
+
+    renderEventNoteTypeBadge: function(eventNoteTypeId) {
+      switch (eventNoteTypeId) {
+        case 1: return dom.span({ style: styles.badge }, 'SST meeting');
+        case 2: return dom.span({ style: styles.badge }, 'MTSS meeting');
+        case 3: return dom.span({ style: styles.badge }, 'Family');
+        case 5: return dom.span({ style: styles.badge }, 'Something else');
+      }
+
+      return null;
     },
 
     renderV2Note: function(note) {
@@ -252,6 +272,7 @@
       },
         this.renderNoteHeader({
           noteMoment: moment(note.date_recorded),
+          badge: this.renderEventNoteTypeBadge(note.event_note_type_id),
           educatorEmail: educatorEmail
         }),
         dom.div({ style: { whiteSpace: 'pre-wrap' } },
@@ -267,6 +288,7 @@
       },
         this.renderNoteHeader({
           noteMoment: moment(note.created_at_timestamp),
+          badge: dom.span({ style: styles.badge }, 'Older note'),
           educatorEmail: note.educator_email
         }),
         dom.div({ style: { whiteSpace: 'pre-wrap' } },

--- a/app/assets/javascripts/student_profile_v2/take_notes.js
+++ b/app/assets/javascripts/student_profile_v2/take_notes.js
@@ -107,8 +107,7 @@
             this.renderNoteButton('MTSS meeting', 2)
           ),
           dom.div({ style: { flex: 1 } },
-            this.renderNoteButton('Parent conversation', 3),
-            this.renderNoteButton('51a filing', 4)
+            this.renderNoteButton('Family conversation', 3)
           ),
           dom.div({ style: { flex: 'auto' } },
             this.renderNoteButton('Something else', 5) 

--- a/app/models/event_note_type.rb
+++ b/app/models/event_note_type.rb
@@ -5,7 +5,7 @@ class EventNoteType < ActiveRecord::Base
       { id: 300, name: 'SST Meeting' },
       { id: 301, name: 'MTSS Meeting' },
       { id: 302, name: 'Parent conversation' },
-      { id: 303, name: '51a filing' },
+      { id: 303, name: '51a filing' }, # TODO(kr) deprecated
       { id: 304, name: 'Something else' }
     ])
   end

--- a/app/models/intervention_type.rb
+++ b/app/models/intervention_type.rb
@@ -1,3 +1,4 @@
+# TODO(kr) deprecated
 class InterventionType < ActiveRecord::Base
   has_many :interventions
 


### PR DESCRIPTION
Add in badge showing event note type, and also change "Parent conversation" to "Family conversation."

<img width="656" alt="screen shot 2016-02-15 at 3 06 34 pm" src="https://cloud.githubusercontent.com/assets/1056957/13059083/cde14de8-d3f5-11e5-90e9-66b6a9dfbac2.png">

Also add some deprecation comments for interventions and 51a event_note_type, which will be moved to services.