### PR TITLE
Profile v2 - remove 51a filing event note type, will move to service

### DIFF
--- a/app/models/event_note_type.rb
+++ b/app/models/event_note_type.rb
@@ -5,7 +5,6 @@ class EventNoteType < ActiveRecord::Base
       { id: 300, name: 'SST Meeting' },
       { id: 301, name: 'MTSS Meeting' },
       { id: 302, name: 'Parent conversation' },
-      { id: 303, name: '51a filing' }, # TODO(kr) deprecated
       { id: 304, name: 'Something else' }
     ])
   end

--- a/db/migrate/20160215200930_remove_51a_event_note_type.rb
+++ b/db/migrate/20160215200930_remove_51a_event_note_type.rb
@@ -1,0 +1,7 @@
+class Remove51aEventNoteType < ActiveRecord::Migration
+  def change
+    # This type is being removed, and this will be capture as a 'service' instead.
+    # See also EventNoteType#seed_somerville_event_note_types
+    EventNoteType.find(303).destroy!
+  end
+end

--- a/db/migrate/20160215200930_remove_51a_event_note_type.rb
+++ b/db/migrate/20160215200930_remove_51a_event_note_type.rb
@@ -2,6 +2,9 @@ class Remove51aEventNoteType < ActiveRecord::Migration
   def change
     # This type is being removed, and this will be capture as a 'service' instead.
     # See also EventNoteType#seed_somerville_event_note_types
-    EventNoteType.find(303).destroy!
+    begin
+      EventNoteType.find(303).destroy!
+    rescue ActiveRecord::RecordNotFound
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160211143535) do
+ActiveRecord::Schema.define(version: 20160215200930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Removing the event note type and UI choice:

<img width="637" alt="screen shot 2016-02-15 at 3 12 17 pm" src="https://cloud.githubusercontent.com/assets/1056957/13059204/85feea5c-d3f6-11e5-88c1-7233b4b579d5.png">
