### PR TITLE
Remove counter_cache from attendance events

### DIFF
--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -1,4 +1,4 @@
 class Absence < ActiveRecord::Base
-  belongs_to :student_school_year, counter_cache: true
+  belongs_to :student_school_year
   validates_presence_of :student_school_year, :occurred_at
 end

--- a/app/models/discipline_incident.rb
+++ b/app/models/discipline_incident.rb
@@ -1,4 +1,4 @@
 class DisciplineIncident < ActiveRecord::Base
-  belongs_to :student_school_year, counter_cache: true
+  belongs_to :student_school_year
   validates_presence_of :student_school_year, :occurred_at
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -122,18 +122,6 @@ class Student < ActiveRecord::Base
     end
   end
 
-  def absences_count_by_school_year
-    student_school_years.map(&:absences_count)
-  end
-
-  def tardies_count_by_school_year
-    student_school_years.map(&:tardies_count)
-  end
-
-  def discipline_incidents_count_by_school_year
-    student_school_years.map(&:discipline_incidents_count)
-  end
-
   def serialized_student_data
     {
       student: self,
@@ -142,9 +130,9 @@ class Student < ActiveRecord::Base
       star_reading_results: star_reading_results,
       mcas_math_results: mcas_math_results,
       mcas_ela_results: mcas_ela_results,
-      absences_count_by_school_year: absences_count_by_school_year,
-      tardies_count_by_school_year: tardies_count_by_school_year,
-      discipline_incidents_by_school_year: discipline_incidents_count_by_school_year,
+      absences_count_by_school_year: student_school_years.map {|year| year.absences.length },
+      tardies_count_by_school_year: student_school_years.map {|year| year.tardies.length },
+      discipline_incidents_by_school_year: student_school_years.map {|year| year.discipline_incidents.length },
       school_year_names: student_school_years.pluck(:name),
       interventions: interventions
     }

--- a/app/models/tardy.rb
+++ b/app/models/tardy.rb
@@ -1,4 +1,4 @@
 class Tardy < ActiveRecord::Base
-  belongs_to :student_school_year, counter_cache: true
+  belongs_to :student_school_year
   validates_presence_of :student_school_year, :occurred_at
 end

--- a/db/migrate/20160215212215_remove_school_year_attendance_counter_columns.rb
+++ b/db/migrate/20160215212215_remove_school_year_attendance_counter_columns.rb
@@ -1,0 +1,7 @@
+class RemoveSchoolYearAttendanceCounterColumns < ActiveRecord::Migration
+  def change
+    remove_column :student_school_years, :tardies_count
+    remove_column :student_school_years, :absences_count
+    remove_column :student_school_years, :discipline_incidents_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160215200930) do
+ActiveRecord::Schema.define(version: 20160215212215) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -219,13 +219,10 @@ ActiveRecord::Schema.define(version: 20160215200930) do
   end
 
   create_table "student_school_years", force: true do |t|
-    t.integer  "student_id",                             null: false
-    t.integer  "school_year_id",                         null: false
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
-    t.integer  "tardies_count",              default: 0
-    t.integer  "absences_count",             default: 0
-    t.integer  "discipline_incidents_count", default: 0
+    t.integer  "student_id",     null: false
+    t.integer  "school_year_id", null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
   end
 
   add_index "student_school_years", ["student_id", "school_year_id"], name: "index_student_school_years_on_student_id_and_school_year_id", unique: true, using: :btree

--- a/spec/importers/attendance_importer_spec.rb
+++ b/spec/importers/attendance_importer_spec.rb
@@ -27,16 +27,16 @@ RSpec.describe AttendanceImporter do
           }.to change { Absence.count }.by 1
         end
 
-        it 'increments the student school year absence counter cache by 1' do
+        it 'increments the student school year absences by 1' do
           expect {
             described_class.new.import_row(row)
-          }.to change { StudentSchoolYear.last.absences_count }.by 1
+          }.to change { StudentSchoolYear.last.absences.size }.by 1
         end
 
-        it 'does not increment the student school year tardies counter cache' do
+        it 'does not increment the student school year tardies' do
           expect {
             described_class.new.import_row(row)
-          }.to change { StudentSchoolYear.last.tardies_count }.by 0
+          }.to change { StudentSchoolYear.last.tardies.size }.by 0
         end
       end
     end

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -116,29 +116,6 @@ RSpec.describe Student do
     end
   end
 
-  describe '#absences_count_by_school_year' do
-    context 'student with no absences or tardies' do
-      let(:student) { FactoryGirl.create(:student_with_registration_date) }
-      it 'returns the correct array' do
-        expect(student.absences_count_by_school_year.uniq).to eq [0]
-      end
-    end
-
-    context 'student with absence' do
-      let(:student) { FactoryGirl.create(:student) }
-
-      before do
-        student_school_year = student.most_recent_school_year
-        occurred_at = student_school_year.school_year.start
-        student_school_year.absences.create!(occurred_at: occurred_at)
-      end
-
-      it 'returns the correct array' do
-        expect(student.absences_count_by_school_year.first).to eq 1
-      end
-    end
-  end
-
   describe '#find_student_school_years' do
     context 'school years in the 2010s' do
       let!(:sy_2014_2015) { FactoryGirl.create(:sy_2014_2015) }


### PR DESCRIPTION
This removes the use of `counter_cache` on attendance models to fix a bug in yearly counts for discipline events, absences and tardies that affects the v1 profile page.  This may be related to https://github.com/studentinsights/studentinsights/issues/4 -  I only focused on the immediate problem here though and didn't dig further.

I think the root bug here is from a misunderstanding about how `counter_cache` works.  The work in https://github.com/studentinsights/studentinsights/commit/b7aba340fbec0079e65fac9218de44548645b061 created models for `Tardy`, etc. and added `counter_cache` options to them, along with the the corresponding columns to the `StudentSchoolYear` model.  But the migration to add these columns set the default counters to 0.  Adding `counter_cache` only adds hooks to the ActiveRecord lifecycle events to increment and decrement this column (http://guides.rubyonrails.org/association_basics.html#counter-cache), and on its own it won't do anything smart to set the initial value if there are existing associations.  So as a result the `counter_cache` columns all under-count.  I think in order to do a refactoring like this in the future, we'd need to read the current counts and set them as the default value in the migration code.

Relatedly, I discovered that calling `student.most_recent_school_year.absences.size` on a collection with `counter_cache: true` will lead to reading the value from the counter cache.  So in order to see the inconsistency in the database you have to use `.length` to load all the rows and count them, or `.count` to explicitly issue a count query.  I was using student 422 as a test case.

```
irb(main):049:0> student.most_recent_school_year.absences.size
=> 0
irb(main):050:0> student.most_recent_school_year.absences.count
=> 9
irb(main):051:0> student.most_recent_school_year.absences.length
=> 0
irb(main):053:0> student.most_recent_school_year.absences_count
=> 9
```

From an engineering perspective, this was counter-intuitive to me (and I assume to @alexsoble too).  If we want to precompute values for performance, I think it'd be better to do this in the nightly import process or in a separate precompute task so that the dataflow stays explicitly one-way.

From a product perspective, the UI features on the profile v1 page that rely on this are showing inaccurate data in production now, so this will fix that.  I'm not sure the optimization to precompute the counts here has much product impact - for a single school year this should be scanning at most ~180 rows at the end of the school year.  Right now, the median absences is 3 and median tardies is 1.

Also, the charts on the profile v1 page (that this optimization was intended to serve), is geared towards seeing attendance events over several years, which isn't super important for SST/MTSS meetings.  It's deprecated and we're actively building the v2 profile page, so it makes more sense to fix forward.  The attendance, tardies and discipline data on the v2 profile page is unaffected by this bug and already working in production, so there's no net feature loss.