### PR TITLE
Fix UI bug with recorded_at field name in EventNote

### DIFF
--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -268,6 +268,7 @@
       var educatorEmail = this.props.educatorsIndex[note.educator_id].email;
       return dom.div({
         key: ['v2', note.id].join(),
+        className: 'note',
         style: styles.note
       },
         this.renderNoteHeader({
@@ -284,6 +285,7 @@
     renderV1Note: function(note) {
       return dom.div({
         key: note.id,
+        className: 'note',
         style: styles.note
       },
         this.renderNoteHeader({

--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -233,7 +233,7 @@
 
     renderNotes: function() {
       var v1Notes = this.props.feed.v1_notes.map(function(note) { return merge(note, { version: 'v1', sort_timestamp: note.created_at_timestamp }); });
-      var v2Notes = this.props.feed.event_notes.map(function(note) { return merge(note, { version: 'v2', sort_timestamp: note.date_recorded }); });
+      var v2Notes = this.props.feed.event_notes.map(function(note) { return merge(note, { version: 'v2', sort_timestamp: note.recorded_at }); });
       // TODO(kr) v1 interventions as notes
       // TODO(kr) v1 interventions progress notes as notes
       var mergedNotes = _.sortBy(v1Notes.concat(v2Notes), 'sort_timestamp').reverse();
@@ -271,7 +271,7 @@
         style: styles.note
       },
         this.renderNoteHeader({
-          noteMoment: moment(note.date_recorded),
+          noteMoment: moment(note.recorded_at),
           badge: this.renderEventNoteTypeBadge(note.event_note_type_id),
           educatorEmail: educatorEmail
         }),

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -27,3 +27,4 @@
 // For more information: http://github.com/modeset/teaspoon
 
 //= require support/jasmine-jquery
+//= require support/spec_sugar

--- a/spec/javascripts/student_profile_v2/fixtures.js
+++ b/spec/javascripts/student_profile_v2/fixtures.js
@@ -1,8 +1,27 @@
 (function() {
   window.shared || (window.shared = {});
-  window.shared.Fixtures = {};
+  var Fixtures = window.shared.Fixtures = {};
   
+  // assuming static time for specs
   window.shared.Fixtures.nowMoment = moment('2016-02-11T10:15:00');
+
+  var currentEducator = window.shared.Fixtures.currentEducator = {
+    "id": 1,
+    "email": "demo@example.com",
+    "created_at": "2016-02-11T14:41:36.284Z",
+    "updated_at": "2016-02-11T15:38:22.288Z",
+    "admin": true,
+    "phone": null,
+    "full_name": null,
+    "state_id": null,
+    "local_id": "350",
+    "staff_type": null,
+    "school_id": 1,
+    "schoolwide_access": true,
+    "grade_level_access": [],
+    "restricted_to_sped_students": false,
+    "restricted_to_english_language_learners": false
+  };
 
   window.shared.Fixtures.studentProfile = {
     "student": {
@@ -809,23 +828,7 @@
         "restricted_to_english_language_learners": false
       }
     },
-    "currentEducator": {
-      "id": 1,
-      "email": "demo@example.com",
-      "created_at": "2016-02-11T14:41:36.284Z",
-      "updated_at": "2016-02-11T15:38:22.288Z",
-      "admin": true,
-      "phone": null,
-      "full_name": null,
-      "state_id": null,
-      "local_id": "350",
-      "staff_type": null,
-      "school_id": 1,
-      "schoolwide_access": true,
-      "grade_level_access": [],
-      "restricted_to_sped_students": false,
-      "restricted_to_english_language_learners": false
-    },
+    "currentEducator": Fixtures.currentEducator,
     "chartData": {
       "star_series_math_percentile": [
         [

--- a/spec/javascripts/student_profile_v2/page_container_spec.js
+++ b/spec/javascripts/student_profile_v2/page_container_spec.js
@@ -5,34 +5,11 @@ describe('PageContainer', function() {
   var createEl = window.shared.ReactHelpers.createEl;
   var merge = window.shared.ReactHelpers.merge;
 
-  var Simulate = React.addons.TestUtils.Simulate;
+  var SpecSugar = window.shared.SpecSugar;
   var PageContainer = window.shared.PageContainer;    
   var Fixtures = window.shared.Fixtures;
 
   var helpers = {
-    withTestEl: function(description, testsFn) {
-      return describe(description, function() {
-        beforeEach(function() {
-          this.testEl = $('<div id="test-el" />').get(0);
-          $('body').append(this.testEl);
-        });
-
-        afterEach(function() {
-          $(this.testEl).remove();
-        });
-
-        testsFn.call(this);
-      });
-    },
-
-    // Update the text value of an input or textarea, and simulate the React
-    // change event.
-    changeTextValue: function($el, value) {
-      $el.val(value);
-      Simulate.change($el.get(0));
-      return undefined;
-    },
-
     findColumns: function(el) {
       return $(el).find('.summary-container > div');
     },
@@ -55,13 +32,13 @@ describe('PageContainer', function() {
 
     takeNotesAndSave: function(el, typeName, text) {
       $(el).find('.btn.take-notes').click();
-      helpers.changeTextValue($(el).find('textarea'), 'hello!');
+      SpecSugar.changeTextValue($(el).find('textarea'), 'hello!');
       $(el).find('.btn.note-type:contains(SST meeting)').click();
       $(el).find('.btn.save').click();
     }
   };
 
-  helpers.withTestEl('high-level integration tests', function() {
+  SpecSugar.withTestEl('high-level integration tests', function() {
     it('renders everything on the happy path', function() {
       var el = this.testEl;
       helpers.renderInto(el);

--- a/spec/javascripts/student_profile_v2/take_notes_spec.js
+++ b/spec/javascripts/student_profile_v2/take_notes_spec.js
@@ -1,0 +1,43 @@
+//= require ./fixtures
+
+describe('TakeNotes', function() {
+  var dom = window.shared.ReactHelpers.dom;
+  var createEl = window.shared.ReactHelpers.createEl;
+  var merge = window.shared.ReactHelpers.merge;
+
+  var TakeNotes = window.shared.TakeNotes;
+  var SpecSugar = window.shared.SpecSugar;
+  var Fixtures = window.shared.Fixtures;
+  var eventNotesFixture = [{"id":4,"student_id":24,"educator_id":1,"event_note_type_id":1,"text":"cool!","recorded_at":"2016-02-15T18:42:45.937Z","created_at":"2016-02-15T18:42:45.943Z","updated_at":"2016-02-15T18:42:45.943Z"},{"id":5,"student_id":24,"educator_id":1,"event_note_type_id":3,"text":"this tiss thie this tiss thie this tiss thie this tiss thie this tiss thie this tiss thie this tiss thie ","recorded_at":"2016-02-15T20:01:02.086Z","created_at":"2016-02-15T20:01:02.087Z","updated_at":"2016-02-15T20:01:02.087Z"},{"id":6,"student_id":24,"educator_id":1,"event_note_type_id":5,"text":"okay!","recorded_at":"2016-02-15T20:03:28.232Z","created_at":"2016-02-15T20:03:28.233Z","updated_at":"2016-02-15T20:03:28.233Z"},{"id":7,"student_id":24,"educator_id":1,"event_note_type_id":2,"text":"yep :)","recorded_at":"2016-02-15T20:03:36.699Z","created_at":"2016-02-15T20:03:36.700Z","updated_at":"2016-02-15T20:03:36.700Z"}];
+
+  var helpers = {
+    // findColumns: function(el) {
+    //   return $(el).find('.summary-container > div');
+    // },
+
+    renderInto: function(el, props) {
+      var mergedProps = merge(props || {}, {
+        nowMoment: Fixtures.nowMoment,
+        currentEducator: Fixtures.currentEducator,
+        onSave: jasmine.createSpy('onSave'),
+        onCancel: jasmine.createSpy('onCancel'),
+        requestState: null
+      });
+      return ReactDOM.render(createEl(TakeNotes, mergedProps), el);
+    }
+  };
+
+  SpecSugar.withTestEl('high-level integration tests', function() {
+    it('renders note-taking area', function() {
+      var el = this.testEl;
+      helpers.renderInto(el);
+
+      expect(el).toContainText('February 11, 2016');
+      expect(el).toContainText('demo@example.com');
+      expect($(el).find('textarea').length).toEqual(1);
+      expect($(el).find('.btn.note-type').length).toEqual(4);
+      expect($(el).find('.btn.save').length).toEqual(1);
+      expect($(el).find('.btn.cancel').length).toEqual(1);
+    });
+  });
+});

--- a/spec/javascripts/support/spec_sugar.js
+++ b/spec/javascripts/support/spec_sugar.js
@@ -1,0 +1,30 @@
+(function() {
+  window.shared || (window.shared = {});
+  var Simulate = React.addons.TestUtils.Simulate;
+
+  /* Sugar for common test setup and interactions */  
+  var SpecSugar = window.shared.SpecSugar = {
+    withTestEl: function(description, testsFn) {
+      return describe(description, function() {
+        beforeEach(function() {
+          this.testEl = $('<div id="test-el" />').get(0);
+          $('body').append(this.testEl);
+        });
+
+        afterEach(function() {
+          $(this.testEl).remove();
+        });
+
+        testsFn.call(this);
+      });
+    },
+
+    // Update the text value of an input or textarea, and simulate the React
+    // change event.
+    changeTextValue: function($el, value) {
+      $el.val(value);
+      Simulate.change($el.get(0));
+      return undefined;
+    }
+  };
+})();


### PR DESCRIPTION
The field name was changed, so all dates were showing today.

This shows the bug:
<img width="637" alt="screen shot 2016-02-15 at 4 52 41 pm" src="https://cloud.githubusercontent.com/assets/1056957/13061218/a08c1d96-d404-11e5-81df-5517ae6cefd5.png">
