### PR TITLE
Profile v2 - Fix UI bug in staff names in interventions column, factor out Educator rendering

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -47,6 +47,7 @@
 // student profile page v2:
 // components:
   //= require ./student/profile_charts/profile_chart_settings
+  //= require ./student_profile_v2/educator
   //= require ./student_profile_v2/highcharts_wrapper
   //= require ./student_profile_v2/sparkline
   //= require ./student_profile_v2/scales

--- a/app/assets/javascripts/student_profile_v2/educator.js
+++ b/app/assets/javascripts/student_profile_v2/educator.js
@@ -4,20 +4,30 @@
   var createEl = window.shared.ReactHelpers.createEl;
   var merge = window.shared.ReactHelpers.merge;
 
+  var PropTypes = window.shared.PropTypes;
+
+  /*
+  Canonical display of an educator, showing their name as a link to email them.
+  */
   var Educator = window.shared.Educator = React.createClass({
     displayName: 'Educator',
-    
+
     propTypes: {
-      educatorsIndex: React.PropTypes.object.isRequired,
-      educatorId: React.PropTypes.number.isRequired
+      educator: React.PropTypes.shape({
+        full_name: PropTypes.nullable(React.PropTypes.string.isRequired),
+        email: React.PropTypes.string.isRequired
+      }).isRequired
     },
 
     render: function() {
-      var educator = this.props.educatorsIndex[this.props.educatorId];
+      var educator = this.props.educator;
       var educatorName = (educator.full_name !== null)
         ? educator.full_name
         : educator.email.split('@')[0] + '@';
-      return dom.a({ href: 'mailto:' + educator.email }, educatorName);
+      return dom.a({
+        className: 'Educator',
+        href: 'mailto:' + educator.email
+      }, educatorName);
     }
   });
 })();

--- a/app/assets/javascripts/student_profile_v2/educator.js
+++ b/app/assets/javascripts/student_profile_v2/educator.js
@@ -1,0 +1,21 @@
+(function() {
+  window.shared || (window.shared = {});
+  var dom = window.shared.ReactHelpers.dom;
+  var createEl = window.shared.ReactHelpers.createEl;
+  var merge = window.shared.ReactHelpers.merge;
+
+  var Educator = window.shared.Educator = React.createClass({
+    propTypes: {
+      educatorsIndex: React.PropTypes.object.isRequired,
+      educatorId: React.PropTypes.number.isRequired
+    },
+
+    render: function() {
+      var educator = this.props.educatorsIndex[this.props.educatorId];
+      var educatorName = (educator.full_name !== null)
+        ? educator.full_name
+        : educator.email.split('@')[0] + '@';
+      return dom.a({ href: 'mailto:' + educator.email }, educatorName);
+    }
+  });
+})();

--- a/app/assets/javascripts/student_profile_v2/educator.js
+++ b/app/assets/javascripts/student_profile_v2/educator.js
@@ -5,6 +5,8 @@
   var merge = window.shared.ReactHelpers.merge;
 
   var Educator = window.shared.Educator = React.createClass({
+    displayName: 'Educator',
+    
     propTypes: {
       educatorsIndex: React.PropTypes.object.isRequired,
       educatorId: React.PropTypes.number.isRequired

--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -273,8 +273,7 @@
           noteMoment: moment(note.recorded_at),
           badge: this.renderEventNoteTypeBadge(note.event_note_type_id),
           educatorEl: createEl(Educator, {
-            educatorsIndex: this.props.educatorsIndex,
-            educatorId: note.educator_id
+            educator: this.props.educatorsIndex[note.educator_id]
           })
         }),
         dom.div({ style: { whiteSpace: 'pre-wrap' } },
@@ -293,8 +292,7 @@
           noteMoment: moment(note.created_at_timestamp),
           badge: dom.span({ style: styles.badge }, 'Older note'),
           educatorEl: createEl(Educator, {
-            educatorsIndex: this.props.educatorsIndex,
-            educatorId: note.educator_id
+            educator: this.props.educatorsIndex[note.educator_id]
           })
         }),
         dom.div({ style: { whiteSpace: 'pre-wrap' } },

--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -4,6 +4,7 @@
   var createEl = window.shared.ReactHelpers.createEl;
   var merge = window.shared.ReactHelpers.merge;
   
+  var Educator = window.shared.Educator;
   var ReactSelect = window.Select;
   var datepickerOptions = window.datepicker_options;
   var TakeNotes = window.shared.TakeNotes;
@@ -121,6 +122,8 @@
   var InterventionsDetails = window.shared.InterventionsDetails = React.createClass({
     propTypes: {
       interventionTypesIndex: React.PropTypes.object.isRequired,
+      currentEducator: React.PropTypes.object.isRequired,
+      mergedNotes: React.PropTypes.array.isRequired,
       actions: PropTypes.actions.isRequired
     },
 
@@ -232,11 +235,7 @@
     },
 
     renderNotes: function() {
-      var v1Notes = this.props.feed.v1_notes.map(function(note) { return merge(note, { version: 'v1', sort_timestamp: note.created_at_timestamp }); });
-      var v2Notes = this.props.feed.event_notes.map(function(note) { return merge(note, { version: 'v2', sort_timestamp: note.recorded_at }); });
-      // TODO(kr) v1 interventions as notes
-      // TODO(kr) v1 interventions progress notes as notes
-      var mergedNotes = _.sortBy(v1Notes.concat(v2Notes), 'sort_timestamp').reverse();
+      var mergedNotes = this.props.mergedNotes;
       return dom.div({}, (mergedNotes.length === 0) ? dom.div({ style: styles.noItems }, 'No notes') : mergedNotes.map(function(note) {
         switch (note.version) {
           case 'v1': return this.renderV1Note(note);
@@ -249,7 +248,7 @@
       return dom.div({},
         dom.span({ style: styles.date }, header.noteMoment.format('MMMM D, YYYY')),
         header.badge,
-        dom.span({ style: styles.educator }, header.educatorEmail)
+        dom.span({ style: styles.educator }, header.educatorEl)
       );
     },
 
@@ -265,7 +264,6 @@
     },
 
     renderV2Note: function(note) {
-      var educatorEmail = this.props.educatorsIndex[note.educator_id].email;
       return dom.div({
         key: ['v2', note.id].join(),
         className: 'note',
@@ -274,7 +272,10 @@
         this.renderNoteHeader({
           noteMoment: moment(note.recorded_at),
           badge: this.renderEventNoteTypeBadge(note.event_note_type_id),
-          educatorEmail: educatorEmail
+          educatorEl: createEl(Educator, {
+            educatorsIndex: this.props.educatorsIndex,
+            educatorId: note.educator_id
+          })
         }),
         dom.div({ style: { whiteSpace: 'pre-wrap' } },
           dom.div({ style: styles.expandedNote }, note.text)
@@ -291,7 +292,10 @@
         this.renderNoteHeader({
           noteMoment: moment(note.created_at_timestamp),
           badge: dom.span({ style: styles.badge }, 'Older note'),
-          educatorEmail: note.educator_email
+          educatorEl: createEl(Educator, {
+            educatorsIndex: this.props.educatorsIndex,
+            educatorId: note.educator_id
+          })
         }),
         dom.div({ style: { whiteSpace: 'pre-wrap' } },
           dom.div({ style: styles.expandedNote }, note.content)

--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -287,11 +287,9 @@
       var mergedNotes = this.mergedNotes();
       var educatorIds = _.unique(_.pluck(mergedNotes, 'educator_id'));
       var elements = educatorIds.slice(0, limit).map(function(educatorId) {
-        return createEl(Educator, {
-          educatorsIndex: this.props.educatorsIndex,
-          educatorId: educatorId
-        });
+        return createEl(Educator, { educator: this.props.educatorsIndex[educatorId] });
       }, this);
+      
       if (educatorIds.length > limit) elements.push(dom.span({}, '+ ' + (educatorIds.length - limit) + ' more'));
       return createEl(SummaryList, {
         title: 'Staff',

--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -11,6 +11,7 @@
   var SummaryList = window.shared.SummaryList;
   var QuadConverter = window.shared.QuadConverter;
   var Scales = window.shared.Scales;
+  var Educator = window.shared.Educator;
 
   var ProfileDetails = window.shared.ProfileDetails;
   var ELADetails = window.shared.ELADetails;
@@ -119,6 +120,15 @@
       return (columnKey === this.props.selectedColumnKey) ? styles.selectedColumn : {};
     },
 
+    // Merges data from event_notes, services and deprecated tables (notes, interventions).
+    mergedNotes: function() {
+      var v1Notes = this.props.feed.v1_notes.map(function(note) { return merge(note, { version: 'v1', sort_timestamp: note.created_at_timestamp }); });
+      var v2Notes = this.props.feed.event_notes.map(function(note) { return merge(note, { version: 'v2', sort_timestamp: note.recorded_at }); });
+      // TODO(kr) v1 interventions as notes
+      // TODO(kr) v1 interventions progress notes as notes
+      return _.sortBy(v1Notes.concat(v2Notes), 'sort_timestamp').reverse();
+    },
+
     render: function() {
       return dom.div({ className: 'StudentProfileV2Page', style: styles.page },
         this.renderSaveStatus(),
@@ -165,15 +175,16 @@
             disciplineIncidents: attendanceData.discipline_incidents
           });
         case 'interventions':
-          return createEl(InterventionsDetails, _.pick(this.props,
+          return createEl(InterventionsDetails, merge(_.pick(this.props,
             'currentEducator',
             'student',
-            'feed',
             'interventionTypesIndex',
             'educatorsIndex',
             'actions',
             'requests'
-          ));
+          ), {
+            mergedNotes: this.mergedNotes()
+          }));
       }
       return null;
     },
@@ -228,7 +239,7 @@
       }, this.padElements(styles.summaryWrapper, [
         this.renderPlacement(student),
         this.renderInterventions(student),
-        this.renderNotes(student)
+        this.renderStaff(student)
       ]));
     },
 
@@ -271,14 +282,17 @@
       });
     },
 
-    renderNotes: function(student) {
-      // TODO(kr) revisit design and factoring here to support new notes, sort recency
+    renderStaff: function(student) {
       var limit = 3;
-      var educatorEmails = _.unique(_.pluck(this.props.feed.v1_notes, 'educator_email'));
-      var elements = educatorEmails.slice(0, limit).map(function(educatorEmail) {
-        return dom.span({ key: educatorEmails }, educatorEmails);
+      var mergedNotes = this.mergedNotes();
+      var educatorIds = _.unique(_.pluck(mergedNotes, 'educator_id'));
+      var elements = educatorIds.slice(0, limit).map(function(educatorId) {
+        return createEl(Educator, {
+          educatorsIndex: this.props.educatorsIndex,
+          educatorId: educatorId
+        });
       }, this);
-      if (educatorEmails.length > limit) elements.push(dom.span({}, '+ ' + (educatorEmails.length - limit) + ' more'));
+      if (educatorIds.length > limit) elements.push(dom.span({}, '+ ' + (educatorIds.length - limit) + ' more'));
       return createEl(SummaryList, {
         title: 'Staff',
         elements: elements

--- a/app/helpers/serialize_data_helper.rb
+++ b/app/helpers/serialize_data_helper.rb
@@ -28,6 +28,7 @@ module SerializeDataHelper
     {
       id: student_note.id,
       content: student_note.content,
+      educator_id: student_note.educator.id,
       educator_email: student_note.educator.email,
       created_at_timestamp: student_note.created_at,
       created_at: student_note.created_at.strftime('%B %e, %Y')

--- a/spec/javascripts/student_profile_v2/fixtures.js
+++ b/spec/javascripts/student_profile_v2/fixtures.js
@@ -340,6 +340,7 @@
         "id": 19,
         "content": "We talked with an outside therapist.",
         "educator_email": "demo@example.com",
+        "educator_id":1,
         "created_at_timestamp": "2016-02-11T14:41:52.857Z",
         "created_at": "February 11, 2016"
       },
@@ -347,6 +348,7 @@
         "id": 20,
         "content": "We talked with the family.",
         "educator_email": "demo@example.com",
+        "educator_id":1,
         "created_at_timestamp": "2016-02-11T14:41:52.861Z",
         "created_at": "February 11, 2016"
       },
@@ -354,6 +356,7 @@
         "id": 21,
         "content": "We talked with an outside therapist.",
         "educator_email": "demo@example.com",
+        "educator_id":1,
         "created_at_timestamp": "2016-02-11T14:41:52.864Z",
         "created_at": "February 11, 2016"
       },
@@ -361,6 +364,7 @@
         "id": 22,
         "content": "We talked with an outside therapist.",
         "educator_email": "demo@example.com",
+        "educator_id":1,
         "created_at_timestamp": "2016-02-11T14:41:52.868Z",
         "created_at": "February 11, 2016"
       },
@@ -368,6 +372,7 @@
         "id": 23,
         "content": "We talked with an outside therapist.",
         "educator_email": "demo@example.com",
+        "educator_id":1,
         "created_at_timestamp": "2016-02-11T14:41:52.872Z",
         "created_at": "February 11, 2016"
       },
@@ -375,6 +380,7 @@
         "id": 24,
         "content": "We talked with the family.",
         "educator_email": "demo@example.com",
+        "educator_id":1,
         "created_at_timestamp": "2016-02-11T14:41:52.875Z",
         "created_at": "February 11, 2016"
       },
@@ -382,6 +388,7 @@
         "id": 25,
         "content": "We talked with the family.",
         "educator_email": "demo@example.com",
+        "educator_id":1,
         "created_at_timestamp": "2016-02-11T14:41:52.879Z",
         "created_at": "February 11, 2016"
       }
@@ -550,6 +557,7 @@
           "id": 19,
           "content": "We talked with an outside therapist.",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "created_at_timestamp": "2016-02-11T14:41:52.857Z",
           "created_at": "February 11, 2016"
         },
@@ -557,6 +565,7 @@
           "id": 20,
           "content": "We talked with the family.",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "created_at_timestamp": "2016-02-11T14:41:52.861Z",
           "created_at": "February 11, 2016"
         },
@@ -564,6 +573,7 @@
           "id": 21,
           "content": "We talked with an outside therapist.",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "created_at_timestamp": "2016-02-11T14:41:52.864Z",
           "created_at": "February 11, 2016"
         },
@@ -571,6 +581,7 @@
           "id": 22,
           "content": "We talked with an outside therapist.",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "created_at_timestamp": "2016-02-11T14:41:52.868Z",
           "created_at": "February 11, 2016"
         },
@@ -578,6 +589,7 @@
           "id": 23,
           "content": "We talked with an outside therapist.",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "created_at_timestamp": "2016-02-11T14:41:52.872Z",
           "created_at": "February 11, 2016"
         },
@@ -585,6 +597,7 @@
           "id": 24,
           "content": "We talked with the family.",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "created_at_timestamp": "2016-02-11T14:41:52.875Z",
           "created_at": "February 11, 2016"
         },
@@ -592,6 +605,7 @@
           "id": 25,
           "content": "We talked with the family.",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "created_at_timestamp": "2016-02-11T14:41:52.879Z",
           "created_at": "February 11, 2016"
         }
@@ -605,6 +619,7 @@
           "start_date": "October  1, 2010",
           "end_date": "October 15, 2010",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -615,6 +630,7 @@
           "start_date": "November 26, 2010",
           "end_date": "December 10, 2010",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -625,6 +641,7 @@
           "start_date": "January 12, 2011",
           "end_date": "January 26, 2011",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -635,6 +652,7 @@
           "start_date": "February 21, 2011",
           "end_date": "March  7, 2011",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -645,6 +663,7 @@
           "start_date": "April  5, 2011",
           "end_date": "April 19, 2011",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -655,6 +674,7 @@
           "start_date": "May 11, 2011",
           "end_date": "May 25, 2011",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -665,6 +685,7 @@
           "start_date": "June 30, 2011",
           "end_date": "July 14, 2011",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -675,6 +696,7 @@
           "start_date": "July 31, 2011",
           "end_date": "August 14, 2011",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -685,6 +707,7 @@
           "start_date": "September 18, 2011",
           "end_date": "October  2, 2011",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -695,6 +718,7 @@
           "start_date": "October 18, 2011",
           "end_date": "November  1, 2011",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -705,6 +729,7 @@
           "start_date": "December 12, 2011",
           "end_date": "December 26, 2011",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -715,6 +740,7 @@
           "start_date": "February  8, 2012",
           "end_date": "February 22, 2012",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -725,6 +751,7 @@
           "start_date": "April  7, 2012",
           "end_date": "April 21, 2012",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -735,6 +762,7 @@
           "start_date": "May 24, 2012",
           "end_date": "June  7, 2012",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -745,6 +773,7 @@
           "start_date": "July  2, 2012",
           "end_date": "July 16, 2012",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -755,6 +784,7 @@
           "start_date": "August 21, 2012",
           "end_date": "September  4, 2012",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         },
         {
@@ -765,6 +795,7 @@
           "start_date": "October 13, 2012",
           "end_date": "October 27, 2012",
           "educator_email": "demo@example.com",
+          "educator_id":1,
           "progress_notes": []
         }
       ],

--- a/spec/javascripts/student_profile_v2/take_notes_spec.js
+++ b/spec/javascripts/student_profile_v2/take_notes_spec.js
@@ -11,10 +11,6 @@ describe('TakeNotes', function() {
   var eventNotesFixture = [{"id":4,"student_id":24,"educator_id":1,"event_note_type_id":1,"text":"cool!","recorded_at":"2016-02-15T18:42:45.937Z","created_at":"2016-02-15T18:42:45.943Z","updated_at":"2016-02-15T18:42:45.943Z"},{"id":5,"student_id":24,"educator_id":1,"event_note_type_id":3,"text":"this tiss thie this tiss thie this tiss thie this tiss thie this tiss thie this tiss thie this tiss thie ","recorded_at":"2016-02-15T20:01:02.086Z","created_at":"2016-02-15T20:01:02.087Z","updated_at":"2016-02-15T20:01:02.087Z"},{"id":6,"student_id":24,"educator_id":1,"event_note_type_id":5,"text":"okay!","recorded_at":"2016-02-15T20:03:28.232Z","created_at":"2016-02-15T20:03:28.233Z","updated_at":"2016-02-15T20:03:28.233Z"},{"id":7,"student_id":24,"educator_id":1,"event_note_type_id":2,"text":"yep :)","recorded_at":"2016-02-15T20:03:36.699Z","created_at":"2016-02-15T20:03:36.700Z","updated_at":"2016-02-15T20:03:36.700Z"}];
 
   var helpers = {
-    // findColumns: function(el) {
-    //   return $(el).find('.summary-container > div');
-    // },
-
     renderInto: function(el, props) {
       var mergedProps = merge(props || {}, {
         nowMoment: Fixtures.nowMoment,


### PR DESCRIPTION
This consolidates codes for merging v1 and v2 notes together (still unfinished, but now in one place).  It also factors out rendering of an `Educator` to show their name and fallback to email if it's not available.  Also renders it as a `mailto` link.

 Before:
<img width="351" alt="screen shot 2016-02-15 at 5 56 05 pm" src="https://cloud.githubusercontent.com/assets/1056957/13062540/6b5d58f2-d40d-11e5-8d3d-65c15991af34.png">

Also before, raw educator emails used in notes:
<img width="646" alt="screen shot 2016-02-15 at 5 56 08 pm" src="https://cloud.githubusercontent.com/assets/1056957/13062542/735aed62-d40d-11e5-99c7-f8f05b7bf3c2.png">

After:
<img width="346" alt="screen shot 2016-02-15 at 5 43 43 pm" src="https://cloud.githubusercontent.com/assets/1056957/13062528/57b007c8-d40d-11e5-9fe5-bd2ccfd1e8fc.png">

<img width="647" alt="screen shot 2016-02-15 at 5 43 40 pm" src="https://cloud.githubusercontent.com/assets/1056957/13062527/562bc798-d40d-11e5-979a-12bbb6481ba6.png">
