### PR TITLE
Fix bug with attendance data point ordering, switch everything to UTC

### DIFF
--- a/app/assets/javascripts/school_overview/school_overview_page.js
+++ b/app/assets/javascripts/school_overview/school_overview_page.js
@@ -278,7 +278,7 @@
         ].join(',');
       });
       var csvText = [header].concat(rows).join('\n');
-      var dateText = moment().format('YYYY-MM-DD');
+      var dateText = moment.utc().format('YYYY-MM-DD');
       var filtersText = (this.activeFiltersIdentifier().length === 0) ? '' : ' (' + this.activeFiltersIdentifier() + ')';
       var filename = 'Students on ' + dateText + filtersText + '.csv';
 

--- a/app/assets/javascripts/school_star/star_reading_page.js
+++ b/app/assets/javascripts/school_star/star_reading_page.js
@@ -94,7 +94,7 @@ $(function() {
 
         // only include students with recent assessments
         var recentAssessment = _.findLast(assessmentsByDate, function(assessment) {
-          var takenDaysAgo = moment(dateNow).diff(assessment.date_taken, 'days');
+          var takenDaysAgo = moment.utc(dateNow).diff(assessment.date_taken, 'days');
           return (takenDaysAgo < recentThresholdInDays && _.isNumber(assessment.percentile_rank));
         });
         if (recentAssessment === undefined) return null;
@@ -300,8 +300,8 @@ $(function() {
     },
 
     quarterDate: function(date) {
-      var anchor = moment('2000-09-01');
-      var monthsAfter = moment(date).diff(anchor, 'months');
+      var anchor = moment.utc('2000-09-01');
+      var monthsAfter = moment.utc(date).diff(anchor, 'months');
       var quartersAfter = Math.floor(monthsAfter / 3);
       return anchor.add(quartersAfter * 3, 'months').toDate();
     },
@@ -419,7 +419,7 @@ $(function() {
       var assessments = this.flattenedAssessments(students);
 
       // bucket by school quarters
-      var anchorMoment = moment('2000-09-01');
+      var anchorMoment = moment.utc('2000-09-01');
       var buckets = _.pairs(_.groupBy(assessments, function(result) {
         return this.quarterDate(new Date(result.date_taken)).getTime();
       }, this));

--- a/app/assets/javascripts/student_profile_v2/attendance_details.js
+++ b/app/assets/javascripts/student_profile_v2/attendance_details.js
@@ -30,7 +30,7 @@
     // since that's easy to miss and misinterpret.
     timestampRange: function() {
       return {
-        min: moment(this.props.now).subtract(this.props.intervalBack[0], this.props.intervalBack[1]).toDate().getTime(),
+        min: moment.utc(this.props.now).subtract(this.props.intervalBack[0], this.props.intervalBack[1]).toDate().getTime(),
         max: this.props.now.getTime()
       };
     },

--- a/app/assets/javascripts/student_profile_v2/attendance_details.js
+++ b/app/assets/javascripts/student_profile_v2/attendance_details.js
@@ -19,7 +19,7 @@
 
     getDefaultProps: function() {
       return {
-        now: new Date(),
+        now: moment.utc().toDate(),
         intervalBack: [4, 'years']
       };
     },

--- a/app/assets/javascripts/student_profile_v2/ela_details.js
+++ b/app/assets/javascripts/student_profile_v2/ela_details.js
@@ -29,7 +29,7 @@
 
     getDefaultProps: function() {
       return {
-        now: new Date(),
+        now: moment.utc().toDate(),
         intervalBack: [4, 'years']
       };
     },

--- a/app/assets/javascripts/student_profile_v2/ela_details.js
+++ b/app/assets/javascripts/student_profile_v2/ela_details.js
@@ -40,7 +40,7 @@
     // since that's easy to miss and misinterpret.
     timestampRange: function() {
       return {
-        min: moment(this.props.now).subtract(this.props.intervalBack[0], this.props.intervalBack[1]).toDate().getTime(),
+        min: moment.utc(this.props.now).subtract(this.props.intervalBack[0], this.props.intervalBack[1]).toDate().getTime(),
         max: this.props.now.getTime()
       };
     },

--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -214,7 +214,7 @@
     renderTakeNotesSection: function() {
       if (this.state.isTakingNotes || this.props.requests.saveNotes !== null) {
         return createEl(TakeNotes, {
-          nowMoment: moment(), // TODO(kr) thread through
+          nowMoment: moment.utc(), // TODO(kr) thread through
           currentEducator: this.props.currentEducator,
           onSave: this.onSaveNotes,
           onCancel: this.onCancelNotes,
@@ -272,7 +272,7 @@
         style: styles.note
       },
         this.renderNoteHeader({
-          noteMoment: moment(note.recorded_at),
+          noteMoment: moment.utc(note.recorded_at),
           badge: this.renderEventNoteTypeBadge(note.event_note_type_id),
           educatorEmail: educatorEmail
         }),
@@ -289,7 +289,7 @@
         style: styles.note
       },
         this.renderNoteHeader({
-          noteMoment: moment(note.created_at_timestamp),
+          noteMoment: moment.utc(note.created_at_timestamp),
           badge: dom.span({ style: styles.badge }, 'Older note'),
           educatorEmail: note.educator_email
         }),
@@ -362,10 +362,10 @@
           dom.div({}, 'Who is working with ' + this.props.student.first_name + '?'),
           dom.div({ style: { width: '50%' } }, this.renderEducatorSelect())
           // dom.span({ style: { fontSize: 12, color: '#666', marginLeft: 5, marginRight: 5 } }, ' starting on '),
-          // dom.input({ style: { fontSize: 14 }, defaultValue: moment().format('MM/DD/YYYY') })
+          // dom.input({ style: { fontSize: 14 }, defaultValue: moment.utc().format('MM/DD/YYYY') })
         ),
         dom.div({ style: { marginTop: 20 } }, 'When did they start?'),
-        dom.input({ className: 'datepicker', style: { fontSize: 14, padding: 5, width: '50%' }, defaultValue: moment().format('MM/DD/YYYY') }),
+        dom.input({ className: 'datepicker', style: { fontSize: 14, padding: 5, width: '50%' }, defaultValue: moment.utc().format('MM/DD/YYYY') }),
         // dom.div({ style: { marginTop: 15 } }, 'Any other context?'),
         // dom.textarea({
         //   rows: 3,
@@ -433,7 +433,7 @@
     // allow editing, fixup.  'no longer active'
     renderIntervention: function(intervention) {
       var interventionText = this.props.interventionTypesIndex[intervention.intervention_type_id].name;
-      var daysText = moment(intervention.start_date).fromNow(true);
+      var daysText = moment.utc(intervention.start_date).fromNow(true);
       var educatorEmail = this.props.educatorsIndex[intervention.educator_id].email;
       return dom.div({
         key: intervention.id,
@@ -445,7 +445,7 @@
             dom.div({}, 'With ' + educatorEmail),
             dom.div({},
               'Since ',
-              moment(intervention.start_date).format('MMMM D, YYYY'),
+              moment.utc(intervention.start_date).format('MMMM D, YYYY'),
               dom.span({ style: styles.daysAgo }, daysText)
             )
           )

--- a/app/assets/javascripts/student_profile_v2/main.js
+++ b/app/assets/javascripts/student_profile_v2/main.js
@@ -9,7 +9,7 @@ $(function() {
 
   // entry point, reading static bootstrapped data from the page
   ReactDOM.render(createEl(PageContainer, {
-    nowMomentFn: function() { return moment(); },
+    nowMomentFn: function() { return moment.utc(); },
     serializedData: $('#serialized-data').data(),
     queryParams: parseQueryString(window.location.search)
   }), document.getElementById('main'));

--- a/app/assets/javascripts/student_profile_v2/quad_converter.js
+++ b/app/assets/javascripts/student_profile_v2/quad_converter.js
@@ -6,16 +6,16 @@
     // Also collapses multiple events on the same day.
     // TODO(kr) should extract this, simplify and test it more thoroughly
     convert: function(attendanceEvents, nowDate, dateRange) {
-      var currentYearStart = this.schoolYearStart(moment(nowDate));
-      var schoolYearStarts = this.allSchoolYearStarts(dateRange);
+      var currentYearStart = this.schoolYearStart(moment.utc(nowDate));
+      var schoolYearStarts = this._allSchoolYearStarts(dateRange);
       var sortedAttendanceEvents = _.sortBy(attendanceEvents, 'occurred_at');
 
       var quads = [];
       schoolYearStarts.sort().forEach(function(schoolYearStart) {
         var yearAttendanceEvents = sortedAttendanceEvents.filter(function(attendanceEvent) {
-          return this.schoolYearStart(moment(attendanceEvent.occurred_at)) === schoolYearStart;
+          return this.schoolYearStart(moment.utc(attendanceEvent.occurred_at)) === schoolYearStart;
         }, this);
-        var cumulativeEventQuads = this.toCumulativeQuads(yearAttendanceEvents);
+        var cumulativeEventQuads = this._toCumulativeQuads(yearAttendanceEvents);
         var startOfYearQuad = [schoolYearStart, 8, 15, 0];
         quads.push(startOfYearQuad);
         cumulativeEventQuads.forEach(function(cumulativeQuad) { quads.push(cumulativeQuad); });
@@ -30,23 +30,23 @@
 
     schoolYearStart: function(eventMoment) {
       var year = eventMoment.year();
-      var startOfSchoolYear = moment(new Date(year, 7, 15));
+      var startOfSchoolYear = moment.utc(new Date(year, 7, 15));
       var isEventDuringFall = eventMoment.clone().diff(startOfSchoolYear, 'days') > 0;
       return (isEventDuringFall) ? year : year - 1;
     },
 
-    allSchoolYearStarts: function(dateRange) {
+    _allSchoolYearStarts: function(dateRange) {
       var schoolYearStarts = dateRange.map(function(date) {
-        return this.schoolYearStart(moment(date));
+        return this.schoolYearStart(moment.utc(date));
       }, this);
       return _.range(schoolYearStarts[0], schoolYearStarts[1] + 1);
     },
 
-    toCumulativeQuads: function(yearAttendanceEvents) {
+    _toCumulativeQuads: function(yearAttendanceEvents) {
       var cumulativeValue = 0;
       var quads = [];
       _.sortBy(yearAttendanceEvents, 'occurred_at').forEach(function(attendanceEvent) {
-        var occurrenceDate = moment(attendanceEvent.occurred_at).toDate();
+        var occurrenceDate = moment.utc(attendanceEvent.occurred_at).toDate();
         cumulativeValue = cumulativeValue + 1;
         
         // collapse consecutive events on the same day

--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -258,7 +258,7 @@
       var sortedInterventions = _.sortBy(student.interventions, 'start_date').reverse();
       var elements = sortedInterventions.slice(0, limit).map(function(intervention) {
         var interventionText = this.props.interventionTypesIndex[intervention.intervention_type_id].name;
-        var daysText = moment(intervention.start_date).from(this.props.nowMomentFn(), true);
+        var daysText = moment.utc(intervention.start_date).from(this.props.nowMomentFn(), true);
         return dom.span({ key: intervention.id },
           dom.span({}, interventionText),
           dom.span({ style: { opacity: 0.25, paddingLeft: 10 } }, daysText)

--- a/spec/javascripts/student_profile_v2/quad_converter_spec.js
+++ b/spec/javascripts/student_profile_v2/quad_converter_spec.js
@@ -12,8 +12,8 @@ describe('QuadConverter', function() {
 
   describe('#convert', function() {
     it('returns the expected javascript date', function() {
-      var now = new Date('Wed Feb 10 2016 22:11:26 GMT-0500 (EST)');
-      var dateRange = [moment(now).subtract(1, 'year').toDate(), now];
+      var now = new Date('Wed Feb 10 2016 22:11:26 GMT-0500 (GMT)');
+      var dateRange = [moment.utc((now).subtract(1, 'year').toDate(), now];
       var attendanceEvents = [
         {'occurred_at':'2015-12-22T00:00:00.000Z'},
         {'occurred_at':'2015-12-21T00:00:00.000Z'},
@@ -38,6 +38,21 @@ describe('QuadConverter', function() {
       expect(quads.length).toEqual(2 + attendanceEvents.length + 1);
       expect(_.last(quads)[3]).toEqual(15);
 
+      var values = quads.map(function(quad) { return quad[3]; });
+      expect(values).toEqual(_.sortBy(values));
+    });
+
+    it('always sorts by date', function() {
+      var now = new Date('Mon Feb 15 2016 18:19:55 GMT-0500 (GMT)');
+      var dateRange = [moment(now).subtract(1, 'year').toDate(), now];
+      var tardyEvents = [{"id":16910,"student_school_year_id":304,"occurred_at":"2016-02-11T00:00:00.000Z"},{"id":16871,"student_school_year_id":304,"occurred_at":"2016-02-10T00:00:00.000Z"},{"id":16628,"student_school_year_id":304,"occurred_at":"2016-02-04T00:00:00.000Z"},{"id":16627,"student_school_year_id":304,"occurred_at":"2016-02-02T00:00:00.000Z"},{"id":16626,"student_school_year_id":304,"occurred_at":"2016-02-01T00:00:00.000Z"},{"id":16547,"student_school_year_id":304,"occurred_at":"2016-01-25T00:00:00.000Z"},{"id":16381,"student_school_year_id":304,"occurred_at":"2016-01-19T00:00:00.000Z"},{"id":16207,"student_school_year_id":304,"occurred_at":"2016-01-12T00:00:00.000Z"},{"id":16206,"student_school_year_id":304,"occurred_at":"2016-01-11T00:00:00.000Z"},{"id":15959,"student_school_year_id":304,"occurred_at":"2015-12-23T00:00:00.000Z"},{"id":15958,"student_school_year_id":304,"occurred_at":"2015-12-22T00:00:00.000Z"},{"id":15732,"student_school_year_id":304,"occurred_at":"2015-12-11T00:00:00.000Z"},{"id":15731,"student_school_year_id":304,"occurred_at":"2015-12-10T00:00:00.000Z"},{"id":15708,"student_school_year_id":304,"occurred_at":"2015-12-09T00:00:00.000Z"},{"id":15671,"student_school_year_id":304,"occurred_at":"2015-12-08T00:00:00.000Z"},{"id":15636,"student_school_year_id":304,"occurred_at":"2015-12-07T00:00:00.000Z"},{"id":15604,"student_school_year_id":304,"occurred_at":"2015-12-04T00:00:00.000Z"},{"id":15527,"student_school_year_id":304,"occurred_at":"2015-12-02T00:00:00.000Z"},{"id":15468,"student_school_year_id":304,"occurred_at":"2015-11-30T00:00:00.000Z"},{"id":15397,"student_school_year_id":304,"occurred_at":"2015-11-23T00:00:00.000Z"},{"id":15258,"student_school_year_id":304,"occurred_at":"2015-11-16T00:00:00.000Z"},{"id":15234,"student_school_year_id":304,"occurred_at":"2015-11-13T00:00:00.000Z"},{"id":15105,"student_school_year_id":304,"occurred_at":"2015-11-04T00:00:00.000Z"},{"id":15064,"student_school_year_id":304,"occurred_at":"2015-10-30T00:00:00.000Z"},{"id":15031,"student_school_year_id":304,"occurred_at":"2015-10-29T00:00:00.000Z"},{"id":14992,"student_school_year_id":304,"occurred_at":"2015-10-28T00:00:00.000Z"},{"id":14908,"student_school_year_id":304,"occurred_at":"2015-10-23T00:00:00.000Z"},{"id":14727,"student_school_year_id":304,"occurred_at":"2015-10-15T00:00:00.000Z"},{"id":14700,"student_school_year_id":304,"occurred_at":"2015-10-14T00:00:00.000Z"},{"id":14598,"student_school_year_id":304,"occurred_at":"2015-10-07T00:00:00.000Z"},{"id":14563,"student_school_year_id":304,"occurred_at":"2015-10-06T00:00:00.000Z"},{"id":14378,"student_school_year_id":304,"occurred_at":"2015-09-25T00:00:00.000Z"},{"id":14297,"student_school_year_id":304,"occurred_at":"2015-09-22T00:00:00.000Z"},{"id":14276,"student_school_year_id":304,"occurred_at":"2015-09-21T00:00:00.000Z"},{"id":14238,"student_school_year_id":304,"occurred_at":"2015-09-17T00:00:00.000Z"},{"id":14161,"student_school_year_id":304,"occurred_at":"2015-09-14T00:00:00.000Z"},{"id":14112,"student_school_year_id":304,"occurred_at":"2015-09-10T00:00:00.000Z"},{"id":14092,"student_school_year_id":304,"occurred_at":"2015-09-09T00:00:00.000Z"},{"id":14062,"student_school_year_id":304,"occurred_at":"2015-09-04T00:00:00.000Z"},{"id":14052,"student_school_year_id":304,"occurred_at":"2015-09-03T00:00:00.000Z"}];
+      var quads = QuadConverter.convert(tardyEvents, now, dateRange);
+
+      var dates = quads.map(function(quad) {
+        var dateString = [quad[0], quad[1], quad[2]].join('-');
+        return moment.utc(dateString, 'YYYY-M-D').toDate();
+      });
+      expect(dates).toEqual(_.sortBy(dates));
       var values = quads.map(function(quad) { return quad[3]; });
       expect(values).toEqual(_.sortBy(values));
     });


### PR DESCRIPTION
This came up from a Highcharts errors about date ordering in the attendance section of the v2 profile for student 32.  Root cause is using UTC in some places and not all, so this swaps all dates to UTC and adds some specs verifying this works as expected.