### PR TITLE
Fix MCAS "Math" VS. "Mathematics"

### DIFF
--- a/app/csv_exporters/student_profile_csv_exporter.rb
+++ b/app/csv_exporters/student_profile_csv_exporter.rb
@@ -20,8 +20,8 @@ class StudentProfileCsvExporter < Struct.new :student
     end
   end
 
-  def mcas_math_results
-    student.mcas_math_results.map do |result|
+  def mcas_mathematics_results
+    student.mcas_mathematics_results.map do |result|
       [
         result.date_taken,
         result.scale_score,
@@ -78,11 +78,11 @@ class StudentProfileCsvExporter < Struct.new :student
       csv << ['School Year', 'Number of Discipline Incidents']
       school_years_and_discipline_incidents.each { |row| csv << row }
 
-      if mcas_math_results.present?
+      if mcas_mathematics_results.present?
         csv << []
-        csv << ["MCAS Math"]
+        csv << ["MCAS Mathematics"]
         csv << ['Date', 'Scale Score', 'Growth', 'Performance Level']
-        mcas_math_results.each { |row| csv << row }
+        mcas_mathematics_results.each { |row| csv << row }
       end
 
       if mcas_ela_results.present?

--- a/app/demo_data/fake_access_result_generator.rb
+++ b/app/demo_data/fake_access_result_generator.rb
@@ -5,9 +5,13 @@ class FakeAccessResultGenerator
     @student = student
   end
 
+  def access_assessment_id
+    @assessment_id ||= Assessment.find_by_family('ACCESS').id
+  end
+
   def next
     {
-      assessment_id: Assessment.access.id,
+      assessment_id: access_assessment_id,
       date_taken: DateTime.new(@dates.pop, 5, 15),
       scale_score: rand(300..400),
       performance_level: rand(10),

--- a/app/demo_data/fake_dibels_result_generator.rb
+++ b/app/demo_data/fake_dibels_result_generator.rb
@@ -5,9 +5,13 @@ class FakeDibelsResultGenerator
     @student = student
   end
 
+  def dibels_assessment_id
+    @assessment_id ||= Assessment.find_by_family('DIBELS').id
+  end
+
   def next
     {
-      assessment_id: Assessment.dibels.id,
+      assessment_id: dibels_assessment_id,
       date_taken: DateTime.new(@dates.pop, 5, 15),
       performance_level: ["Intensive", "Strategic", "Core", "Benchmark", "CORE", nil].sample,
       student_id: @student.id

--- a/app/demo_data/fake_mcas_ela_result_generator.rb
+++ b/app/demo_data/fake_mcas_ela_result_generator.rb
@@ -5,9 +5,13 @@ class FakeMcasElaResultGenerator
     @student = student
   end
 
+  def mcas_ela_assessment_id
+    @assessment_id ||= Assessment.find_by_family_and_subject('MCAS', 'ELA').id
+  end
+
   def next
     {
-      assessment_id: Assessment.mcas_ela.id,
+      assessment_id: mcas_ela_assessment_id,
       date_taken: DateTime.new(@dates.pop, 5, 15),
       scale_score: rand(200..280),
       performance_level: ["W", "NI", "P", "A", nil].sample,

--- a/app/demo_data/fake_mcas_math_result_generator.rb
+++ b/app/demo_data/fake_mcas_math_result_generator.rb
@@ -5,9 +5,13 @@ class FakeMcasMathResultGenerator
     @student = student
   end
 
+  def mcas_mathematics_assessment_id
+    @assessment_id ||= Assessment.find_by_family_and_subject('MCAS', 'Mathematics').id
+  end
+
   def next
     {
-      assessment_id: Assessment.mcas_math.id,
+      assessment_id: mcas_mathematics_assessment_id,
       date_taken: DateTime.new(@dates.pop, 5, 15),
       scale_score: rand(200..280),
       performance_level: ["W", "NI", "P", "A", nil].sample,

--- a/app/demo_data/fake_star_math_result_generator.rb
+++ b/app/demo_data/fake_star_math_result_generator.rb
@@ -6,13 +6,17 @@ class FakeStarMathResultGenerator
     @student = student
   end
 
+  def star_math_assessment_id
+    @assessment_id ||= Assessment.find_by_family_and_subject('STAR', 'Math').id
+  end
+
   def next
     @math_percentile += rand(-15..15)
     @math_percentile = [0, @math_percentile, 100].sort[1]
     @test_date += rand(30..60)  # days
 
     return {
-      assessment_id: Assessment.star_math.id,
+      assessment_id: star_math_assessment_id,
       date_taken: @test_date,
       percentile_rank: @math_percentile,
       student_id: @student.id

--- a/app/demo_data/fake_star_reading_result_generator.rb
+++ b/app/demo_data/fake_star_reading_result_generator.rb
@@ -7,6 +7,10 @@ class FakeStarReadingResultGenerator
     @reading_percentile = rand(10..99)
   end
 
+  def star_reading_assessment_id
+    @assessment_id ||= Assessment.find_by_family_and_subject('STAR', 'Reading').id
+  end
+
   def next
     @reading_percentile += rand(-15..15)
     @reading_percentile = [0, @reading_percentile, 100].sort[1]
@@ -14,7 +18,7 @@ class FakeStarReadingResultGenerator
     @test_date += rand(30..60)  # days
 
     return {
-      assessment_id: Assessment.star_reading.id,
+      assessment_id: star_reading_assessment_id,
       date_taken: @test_date,
       percentile_rank: @reading_percentile,
       instructional_reading_level: @instructional_reading_level,

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -1,6 +1,13 @@
 class Assessment < ActiveRecord::Base
   has_many :student_assessments, dependent: :destroy
   has_many :students, through: :student_assessments
+  validate :valid_mcas_subject
+  VALID_MCAS_SUBJECTS = [ 'ELA', 'Mathematics', 'Science', 'Arts', 'Technology' ].freeze
+
+  def valid_mcas_subject
+    errors.add(:subject, "must be a valid MCAS subject") if family == 'MCAS' &&
+                                                            !subject.in?(VALID_MCAS_SUBJECTS)
+  end
 
   def self.seed_somerville_assessments
     Assessment.create!([

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -1,5 +1,5 @@
 class Assessment < ActiveRecord::Base
-  has_many :student_assessments
+  has_many :student_assessments, dependent: :destroy
   has_many :students, through: :student_assessments
 
   def self.seed_somerville_assessments

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -13,28 +13,4 @@ class Assessment < ActiveRecord::Base
     ])
   end
 
-  def self.mcas_ela; where(family: "MCAS", subject: "ELA").last end
-
-  def self.mcas_math; where(family: "MCAS", subject: "Mathematics").last end
-
-  def self.star_math; where(family: "STAR", subject: "Math").last end
-
-  def self.star_reading; where(family: "STAR", subject: "Reading").last end
-
-  def self.map_test; where(family: "MAP").last end
-
-  def self.dibels; where(family: "DIBELS").last end
-
-  def self.access; where(family: "ACCESS").last end
-
-  def self.math; where(subject: "Mathematics").all end
-
-  def self.mcas; where(family: "MCAS").all end
-
-  def self.star; where(family: "STAR").all end
-
-  def self.ela; where(subject: "ELA").all end
-
-  def self.reading; where(subject: "Reading").all end
-
 end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -4,7 +4,7 @@ class Assessment < ActiveRecord::Base
 
   def self.seed_somerville_assessments
     Assessment.create!([
-      { family: "MCAS", subject: "Math" },
+      { family: "MCAS", subject: "Mathematics" },
       { family: "MCAS", subject: "ELA" },
       { family: "STAR", subject: "Math" },
       { family: "STAR", subject: "Reading" },
@@ -15,7 +15,7 @@ class Assessment < ActiveRecord::Base
 
   def self.mcas_ela; where(family: "MCAS", subject: "ELA").last end
 
-  def self.mcas_math; where(family: "MCAS", subject: "Math").last end
+  def self.mcas_math; where(family: "MCAS", subject: "Mathematics").last end
 
   def self.star_math; where(family: "STAR", subject: "Math").last end
 
@@ -27,7 +27,7 @@ class Assessment < ActiveRecord::Base
 
   def self.access; where(family: "ACCESS").last end
 
-  def self.math; where(subject: "Math").all end
+  def self.math; where(subject: "Mathematics").all end
 
   def self.mcas; where(family: "MCAS").all end
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -63,8 +63,8 @@ class Student < ActiveRecord::Base
         .order_by_date_taken_asc
   end
 
-  def mcas_math_results
-    ordered_results_by_family_and_subject("MCAS", "Math")
+  def mcas_mathematics_results
+    ordered_results_by_family_and_subject("MCAS", "Mathematics")
   end
 
   def mcas_ela_results
@@ -87,8 +87,8 @@ class Student < ActiveRecord::Base
     ordered_results_by_family("ACCESS")
   end
 
-  def latest_mcas_math
-    latest_result_by_family_and_subject("MCAS", "Math") || MissingStudentAssessment.new
+  def latest_mcas_mathematics
+    latest_result_by_family_and_subject("MCAS", "Mathematics") || MissingStudentAssessment.new
   end
 
   def latest_mcas_ela
@@ -105,11 +105,11 @@ class Student < ActiveRecord::Base
 
   def update_recent_student_assessments
     update_attributes({
-      most_recent_mcas_math_growth: latest_mcas_math.growth_percentile,
+      most_recent_mcas_math_growth: latest_mcas_mathematics.growth_percentile,
       most_recent_mcas_ela_growth: latest_mcas_ela.growth_percentile,
-      most_recent_mcas_math_performance: latest_mcas_math.performance_level,
+      most_recent_mcas_math_performance: latest_mcas_mathematics.performance_level,
       most_recent_mcas_ela_performance: latest_mcas_ela.performance_level,
-      most_recent_mcas_math_scaled: latest_mcas_math.scale_score,
+      most_recent_mcas_math_scaled: latest_mcas_mathematics.scale_score,
       most_recent_mcas_ela_scaled: latest_mcas_ela.scale_score,
       most_recent_star_reading_percentile: latest_star_reading.percentile_rank,
       most_recent_star_math_percentile: latest_star_math.percentile_rank
@@ -128,7 +128,7 @@ class Student < ActiveRecord::Base
       student_assessments: student_assessments,
       star_math_results: star_math_results,
       star_reading_results: star_reading_results,
-      mcas_math_results: mcas_math_results,
+      mcas_mathematics_results: mcas_mathematics_results,
       mcas_ela_results: mcas_ela_results,
       absences_count_by_school_year: student_school_years.map {|year| year.absences.length },
       tardies_count_by_school_year: student_school_years.map {|year| year.tardies.length },

--- a/app/models/student_risk_level.rb
+++ b/app/models/student_risk_level.rb
@@ -5,7 +5,7 @@ class StudentRiskLevel < ActiveRecord::Base
 
   # Use most recent assessments to calculate risk
   def mcas_math
-    student.latest_result_by_family_and_subject("MCAS", "Math") || MissingStudentAssessment.new
+    student.latest_result_by_family_and_subject("MCAS", "Mathematics") || MissingStudentAssessment.new
   end
 
   def star_math

--- a/app/models/student_school_year.rb
+++ b/app/models/student_school_year.rb
@@ -9,9 +9,9 @@ class StudentSchoolYear < ActiveRecord::Base
   delegate :name, to: :school_year
   default_scope { joins(:school_year).order('school_years.start DESC') }
 
-  def mcas_math_result
+  def mcas_mathematics_result
     student_assessments.order_by_date_taken_asc
-                       .by_family_and_subject("MCAS", "Math")
+                       .by_family_and_subject("MCAS", "Mathematics")
                        .last
   end
 

--- a/app/views/students/_school_year_box.html.erb
+++ b/app/views/students/_school_year_box.html.erb
@@ -4,7 +4,7 @@
       <h1><%= school_year.name %></h1>
     </div>
 
-    <% if school_year.mcas_math_result.present? || school_year.mcas_ela_result.present?  # Since there is only one MCAS result per student per year %>
+    <% if school_year.mcas_mathematics_result.present? || school_year.mcas_ela_result.present?  # Since there is only one MCAS result per student per year %>
       <div class="section mcas-result-section">
         <h2 class="section-header">MCAS</h2>
         <% if school_year.mcas_ela_result.present? %>
@@ -18,14 +18,14 @@
             </div>
           </div>
         <% end %>
-        <% if school_year.mcas_math_result.present? %>
+        <% if school_year.mcas_mathematics_result.present? %>
           <h3 class="assessment-type">Math</h3>
           <div class="assessment-dark-background mcas-math-values">
             <div class="values">
-              <p>Performance: <strong><%= school_year.mcas_math_result.decorate.performance_level %></strong></p>
+              <p>Performance: <strong><%= school_year.mcas_mathematics_result.decorate.performance_level %></strong></p>
             </div>
             <div class="values">
-              <p>Scaled Score: <strong><%= school_year.mcas_math_result.decorate.scale_score %></strong></p>
+              <p>Scaled Score: <strong><%= school_year.mcas_mathematics_result.decorate.scale_score %></strong></p>
             </div>
           </div>
         <% end %>

--- a/db/migrate/20160216183740_remove_incorrect_mcas_math_assessment.rb
+++ b/db/migrate/20160216183740_remove_incorrect_mcas_math_assessment.rb
@@ -1,0 +1,10 @@
+class RemoveIncorrectMcasMathAssessment < ActiveRecord::Migration
+  def change
+    # "MCAS Math" => incorrect
+    # "MCAS Mathematics" => correct
+    begin
+      Assessment.find_by_family_and_subject("MCAS", "Math").destroy!
+    rescue ActiveRecord::RecordNotFound
+    end
+  end
+end

--- a/db/migrate/20160216183740_remove_incorrect_mcas_math_assessment.rb
+++ b/db/migrate/20160216183740_remove_incorrect_mcas_math_assessment.rb
@@ -3,7 +3,8 @@ class RemoveIncorrectMcasMathAssessment < ActiveRecord::Migration
     # "MCAS Math" => incorrect
     # "MCAS Mathematics" => correct
     begin
-      Assessment.find_by_family_and_subject("MCAS", "Math").destroy!
+      incorrect = Assessment.find_by_family_and_subject("MCAS", "Math")
+      incorrect.destroy! unless incorrect.nil?
     rescue ActiveRecord::RecordNotFound
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160215212215) do
+ActiveRecord::Schema.define(version: 20160216183740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
       family "MCAS"
     end
     trait :math do
-      subject "Math"
+      subject "Mathematics"
     end
     trait :reading do
       subject "Reading"

--- a/spec/factories/student_assessments.rb
+++ b/spec/factories/student_assessments.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     association :student
     factory :mcas_assessment do
       factory :mcas_math_assessment do
-        association :assessment, subject: "Math", family: "MCAS"
+        association :assessment, subject: "Mathematics", family: "MCAS"
         factory :mcas_math_warning_assessment do
           performance_level "W"
         end

--- a/spec/features/export_profile_feature_spec.rb
+++ b/spec/features/export_profile_feature_spec.rb
@@ -118,7 +118,7 @@ describe 'export profile', :type => :feature do
           [ "School Year", "Number of Discipline Incidents" ],
           [ "2014-2015", "0" ],
           [],
-          [ "MCAS Math" ],
+          [ "MCAS Mathematics" ],
           [ "Date", "Scale Score", "Growth", "Performance Level" ],
           [ "2015-06-19 00:00:00 UTC", nil, nil, "W" ]
         ]

--- a/spec/fixtures/fake_x2_assessments.csv
+++ b/spec/fixtures/fake_x2_assessments.csv
@@ -1,7 +1,7 @@
 'local_id','school_local_id','assessment_date','assessment_scale_score','assessment_performance_level','assessment_growth','assessment_name','assessment_subject','assessment_test'
 "100","HEA","2014-05-01","222.00","NI","70","MCAS 2014 English Language Arts","ELA","MCAS"
 "100","HEA","2014-05-02","222.00","NI","70",\N,\N,"MAP: Reading 2-5 Common Core 2010 V2"
-"100","HEA","2014-05-01","214.00","W","baf","MCAS 2014 Mathematics","Math","MCAS"
+"100","HEA","2014-05-01","214.00","W","baf","MCAS 2014 Mathematics","Mathematics","MCAS"
 "100","HEA","2014-05-01",\N,\N,\N,\N,"GRADE","GRADE"
 "100","HEA","2008-09-22",\N,"Benchmark","NWF: 90,ORF: 70","DIBELS SY09 Admin #1","DIBELS","DIBELS"
 "100","HEA","2014-01-01","368.00","4.2",\N,"WIDA-ACCESS 2014 Winter Writing","ELL","WIDA-ACCESS"

--- a/spec/importers/student_assessment_importer_spec.rb
+++ b/spec/importers/student_assessment_importer_spec.rb
@@ -29,14 +29,14 @@ RSpec.describe StudentAssessmentImporter do
         context 'MCAS' do
           let(:assessments) { Assessment.where(family: "MCAS") }
 
-          it 'creates MCAS Math and ELA assessments' do
+          it 'creates MCAS Mathematics and ELA assessments' do
             expect(assessments.count).to eq 2
             expect(assessments.first.subject).to eq "ELA"
-            expect(assessments.last.subject).to eq "Math"
+            expect(assessments.last.subject).to eq "Mathematics"
           end
           context 'Math' do
             it 'sets the scaled scores and performance levels, growth percentiles correctly' do
-              mcas_assessment = assessments.where(subject: "Math").first
+              mcas_assessment = Assessment.find_by_family_and_subject('MCAS', 'Mathematics')
               mcas_student_assessment = mcas_assessment.student_assessments.last
               expect(mcas_student_assessment.scale_score).to eq(214)
               expect(mcas_student_assessment.performance_level).to eq('W')

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Assessment, type: :model do
+
+  context 'MCAS' do
+    context 'valid subject' do
+      let(:assessment) { FactoryGirl.build(:assessment, family: 'MCAS', subject: 'Mathematics') }
+      it 'is valid' do
+        expect(assessment).to be_valid
+      end
+    end
+    context 'invalid subject' do
+      let(:assessment) { FactoryGirl.build(:assessment, family: 'MCAS', subject: 'Math') }
+      it 'is invalid' do
+        expect(assessment).to be_invalid
+      end
+    end
+  end
+
+end

--- a/spec/models/student_assessment_spec.rb
+++ b/spec/models/student_assessment_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe StudentAssessment, :type => :model do
+RSpec.describe StudentAssessment, type: :model do
 
   describe '.by_family_and_subject' do
     let!(:student_assessment) { FactoryGirl.create(:student_assessment, assessment: assessment) }
@@ -13,7 +13,7 @@ RSpec.describe StudentAssessment, :type => :model do
         end
       end
       context 'there are MCAS reading student assessments' do
-        let(:assessment) { FactoryGirl.create(:assessment, :mcas, :reading) }
+        let(:assessment) { FactoryGirl.create(:assessment, :mcas, :ela) }
         it 'returns an empty association' do
           expect(result).to be_empty
         end

--- a/spec/models/student_assessment_spec.rb
+++ b/spec/models/student_assessment_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe StudentAssessment, :type => :model do
   describe '.by_family_and_subject' do
     let!(:student_assessment) { FactoryGirl.create(:student_assessment, assessment: assessment) }
     context 'MCAS & math' do
-      let(:result) { StudentAssessment.by_family_and_subject("MCAS", "Math") }
+      let(:result) { StudentAssessment.by_family_and_subject("MCAS", "Mathematics") }
       context 'there are only MCAS math student assessments' do
         let(:assessment) { FactoryGirl.create(:assessment, :mcas, :math) }
         it 'returns the MCAS and math student assessments' do

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -27,12 +27,6 @@ RSpec.describe Student do
             date_taken: Date.today - 1.year,
           )
         }
-        context 'when the student has an MCAS result but not in Math' do
-          let(:assessment_subject) { "Tacos" }
-          it 'returns nil' do
-            expect(result).to be_nil
-          end
-        end
         context 'when the student has a Math result but not MCAS' do
           let(:assessment_family) { "Doc's Special Exam" }
           it 'returns nil' do

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe Student do
   describe '#latest_result_by_family_and_subject' do
     let(:student) { FactoryGirl.create(:student) }
     let(:assessment_family) { "MCAS" }
-    let(:assessment_subject) { "Math" }
+    let(:assessment_subject) { "Mathematics" }
     let(:assessment) { Assessment.create!(
         family: assessment_family,
         subject: assessment_subject
       )
     }
-    let(:result) { student.latest_result_by_family_and_subject("MCAS", "Math") }
+    let(:result) { student.latest_result_by_family_and_subject("MCAS", "Mathematics") }
 
     context 'MCAS Math' do
       context 'when the student has no student assessment results' do
@@ -64,8 +64,8 @@ RSpec.describe Student do
 
   describe '#ordered_results_by_family_and_subject' do
     let(:student) { FactoryGirl.create(:student) }
-    let!(:mcas_math) { Assessment.create!(family: "MCAS", subject: "Math") }
-    let(:result) { student.ordered_results_by_family_and_subject("MCAS", "Math") }
+    let!(:mcas_math) { Assessment.create!(family: "MCAS", subject: "Mathematics") }
+    let(:result) { student.ordered_results_by_family_and_subject("MCAS", "Mathematics") }
 
     context 'when the student has no MCAS Math result' do
       it 'returns an empty set' do


### PR DESCRIPTION
## Notes

+ Migration for deleting MCAS "Math" assessment and its student assessment results
+ Make sure all queries point to MCAS assessment with subject "Mathematics"
+ Validate MCAS assessment subject names
