### PR TITLE
Fix STAR "Math" VS. "Mathematics"

### DIFF
--- a/app/demo_data/fake_star_math_result_generator.rb
+++ b/app/demo_data/fake_star_math_result_generator.rb
@@ -6,8 +6,8 @@ class FakeStarMathResultGenerator
     @student = student
   end
 
-  def star_math_assessment_id
-    @assessment_id ||= Assessment.find_by_family_and_subject('STAR', 'Math').id
+  def star_math_assessment
+    @assessment ||= Assessment.find_by_family_and_subject('STAR', 'Mathematics')
   end
 
   def next
@@ -16,7 +16,7 @@ class FakeStarMathResultGenerator
     @test_date += rand(30..60)  # days
 
     return {
-      assessment_id: star_math_assessment_id,
+      assessment: star_math_assessment,
       date_taken: @test_date,
       percentile_rank: @math_percentile,
       student_id: @student.id

--- a/app/demo_data/fake_star_reading_result_generator.rb
+++ b/app/demo_data/fake_star_reading_result_generator.rb
@@ -7,8 +7,8 @@ class FakeStarReadingResultGenerator
     @reading_percentile = rand(10..99)
   end
 
-  def star_reading_assessment_id
-    @assessment_id ||= Assessment.find_by_family_and_subject('STAR', 'Reading').id
+  def star_reading_assessment
+    @assessment ||= Assessment.find_by_family_and_subject('STAR', 'Reading')
   end
 
   def next
@@ -18,7 +18,7 @@ class FakeStarReadingResultGenerator
     @test_date += rand(30..60)  # days
 
     return {
-      assessment_id: star_reading_assessment_id,
+      assessment: star_reading_assessment,
       date_taken: @test_date,
       percentile_rank: @reading_percentile,
       instructional_reading_level: @instructional_reading_level,

--- a/app/helpers/import_task_report.rb
+++ b/app/helpers/import_task_report.rb
@@ -34,6 +34,7 @@ class ImportTaskReport
     puts; puts end_of_task_report
     puts; puts; puts "=== BY SCHOOL ==="
     puts by_school_report
+    puts; puts assessments_report
   end
 
   def end_of_task_report
@@ -58,6 +59,18 @@ class ImportTaskReport
           count_report_for_class(klass, count)
         end
       ]
+    end
+  end
+
+  def assessments_report
+    headers = [
+                'Assessments:',
+                'Family | Subject | Count',
+                '--- | --- | ---',
+                ''
+              ]
+    headers << Assessment.all.sort_by(&:family).map do |assessment|
+      "#{assessment.family} | #{assessment.subject} | #{assessment.student_assessments.count}"
     end
   end
 

--- a/app/importers/settings/kipp_nj_importers.rb
+++ b/app/importers/settings/kipp_nj_importers.rb
@@ -29,12 +29,10 @@ class KippNjImporters
   def file_importers
     if @first_time
       [ StudentsImporter.new,
-        StudentAssessmentImporter.new,
         BehaviorImporter.new,
         BulkAttendanceImporter.new ] # Use bulk attendance importer for first-time import
     else
       [ StudentsImporter.new,
-        StudentAssessmentImporter.new,
         BehaviorImporter.new,
         AttendanceImporter.new ]
     end

--- a/app/importers/settings/somerville_x2_importers.rb
+++ b/app/importers/settings/somerville_x2_importers.rb
@@ -24,7 +24,7 @@ class SomervilleX2Importers
   def file_importers
     [
       StudentsImporter.new,
-      StudentAssessmentImporter.new,
+      X2AssessmentImporter.new,
       BehaviorImporter.new,
       EducatorsImporter.new,
     ]

--- a/app/importers/star_math_importer.rb
+++ b/app/importers/star_math_importer.rb
@@ -8,8 +8,8 @@ class StarMathImporter
     StarMathCsvTransformer.new
   end
 
-  def assessment
-    Assessment.where(family: "STAR", subject: "Math").first_or_create!
+  def star_mathematics_assessment
+    @assessment ||= Assessment.where(family: "STAR", subject: "Mathematics").first_or_create!
   end
 
   def import_row(row)
@@ -21,7 +21,7 @@ class StarMathImporter
     star_assessment = StudentAssessment.where({
       student_id: student.id,
       date_taken: date_taken,
-      assessment_id: assessment.id
+      assessment: star_mathematics_assessment
     }).first_or_create!
 
     star_assessment.update_attributes({percentile_rank: row[:percentile_rank]})

--- a/app/importers/star_reading_importer.rb
+++ b/app/importers/star_reading_importer.rb
@@ -8,8 +8,8 @@ class StarReadingImporter
     StarReadingCsvTransformer.new
   end
 
-  def assessment
-    Assessment.where(family: "STAR", subject: "Reading").first_or_create!
+  def star_reading_assessment
+    @assessment ||= Assessment.where(family: "STAR", subject: "Reading").first_or_create!
   end
 
   def import_row(row)
@@ -21,7 +21,7 @@ class StarReadingImporter
     star_assessment = StudentAssessment.where({
       student_id: student.id,
       date_taken: date_taken,
-      assessment_id: assessment.id
+      assessment: star_reading_assessment
     }).first_or_create!
 
     star_assessment.update_attributes({

--- a/app/importers/student_assessment_importer.rb
+++ b/app/importers/student_assessment_importer.rb
@@ -1,5 +1,5 @@
 class StudentAssessmentImporter
-  WHITELIST = Regexp.union(/ACCESS/, /WIDA-ACCESS/, /DIBELS/, /MCAS/, /MAP/, /MELA-O/, /MEPA/, /STAR/).freeze
+  WHITELIST = Regexp.union(/ACCESS/, /WIDA-ACCESS/, /DIBELS/, /MCAS/, /MAP/, /MELA-O/, /MEPA/).freeze
 
   def remote_file_name
     # Expects a CSV with the following headers, transformed to symbols by CsvTransformer during import:

--- a/app/importers/x2_assessment_importer.rb
+++ b/app/importers/x2_assessment_importer.rb
@@ -1,4 +1,6 @@
-class StudentAssessmentImporter
+class X2AssessmentImporter
+  # Aspen X2 is the name of Somerville's Student Information System.
+
   WHITELIST = Regexp.union(/ACCESS/, /WIDA-ACCESS/, /DIBELS/, /MCAS/, /MAP/, /MELA-O/, /MEPA/).freeze
 
   def remote_file_name
@@ -17,7 +19,7 @@ class StudentAssessmentImporter
 
   def import_row(row)
     return unless row[:assessment_test].match(WHITELIST)
-    StudentAssessmentRow.build(row).save!
+    X2AssessmentRow.build(row).save!
   end
 
 end

--- a/app/importers/x2_assessment_row.rb
+++ b/app/importers/x2_assessment_row.rb
@@ -1,4 +1,4 @@
-class StudentAssessmentRow < Struct.new(:row)
+class X2AssessmentRow < Struct.new(:row)
 
   def self.build(row)
     new(row).build

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -13,7 +13,7 @@ class Assessment < ActiveRecord::Base
     Assessment.create!([
       { family: "MCAS", subject: "Mathematics" },
       { family: "MCAS", subject: "ELA" },
-      { family: "STAR", subject: "Math" },
+      { family: "STAR", subject: "Mathematics" },
       { family: "STAR", subject: "Reading" },
       { family: "ACCESS" },
       { family: "DIBELS" }

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -1,12 +1,19 @@
 class Assessment < ActiveRecord::Base
   has_many :student_assessments, dependent: :destroy
   has_many :students, through: :student_assessments
-  validate :valid_mcas_subject
+  validate :valid_mcas_subject, :valid_star_subject
+
   VALID_MCAS_SUBJECTS = [ 'ELA', 'Mathematics', 'Science', 'Arts', 'Technology' ].freeze
+  VALID_STAR_SUBJECTS = [ 'Mathematics', 'Reading' ].freeze
 
   def valid_mcas_subject
     errors.add(:subject, "must be a valid MCAS subject") if family == 'MCAS' &&
                                                             !subject.in?(VALID_MCAS_SUBJECTS)
+  end
+
+  def valid_star_subject
+    errors.add(:subject, "must be a valid STAR subject") if family == 'STAR' &&
+                                                            !subject.in?(VALID_STAR_SUBJECTS)
   end
 
   def self.seed_somerville_assessments

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -76,7 +76,7 @@ class Student < ActiveRecord::Base
   end
 
   def star_math_results
-    ordered_results_by_family_and_subject("STAR", "Math")
+    ordered_results_by_family_and_subject("STAR", "Mathematics")
   end
 
   def dibels
@@ -95,8 +95,8 @@ class Student < ActiveRecord::Base
     latest_result_by_family_and_subject("MCAS", "ELA") || MissingStudentAssessment.new
   end
 
-  def latest_star_math
-    latest_result_by_family_and_subject("STAR", "Math") || MissingStudentAssessment.new
+  def latest_star_mathematics
+    latest_result_by_family_and_subject("STAR", "Mathematics") || MissingStudentAssessment.new
   end
 
   def latest_star_reading
@@ -112,7 +112,7 @@ class Student < ActiveRecord::Base
       most_recent_mcas_math_scaled: latest_mcas_mathematics.scale_score,
       most_recent_mcas_ela_scaled: latest_mcas_ela.scale_score,
       most_recent_star_reading_percentile: latest_star_reading.percentile_rank,
-      most_recent_star_math_percentile: latest_star_math.percentile_rank
+      most_recent_star_math_percentile: latest_star_mathematics.percentile_rank
     })
   end
 

--- a/app/models/student_risk_level.rb
+++ b/app/models/student_risk_level.rb
@@ -9,7 +9,7 @@ class StudentRiskLevel < ActiveRecord::Base
   end
 
   def star_math
-    student.latest_result_by_family_and_subject("STAR", "Math") || MissingStudentAssessment.new
+    student.latest_result_by_family_and_subject("STAR", "Mathematics") || MissingStudentAssessment.new
   end
 
   def mcas_ela
@@ -17,7 +17,7 @@ class StudentRiskLevel < ActiveRecord::Base
   end
 
   def star_reading
-    student.latest_result_by_family_and_subject("STAR", "ELA") || MissingStudentAssessment.new
+    student.latest_result_by_family_and_subject("STAR", "Reading") || MissingStudentAssessment.new
   end
 
   def mcas_or_star_at_level(this_level)

--- a/app/views/students/_school_year_box.html.erb
+++ b/app/views/students/_school_year_box.html.erb
@@ -40,7 +40,7 @@
           <div class="assessment-dark-background">
             <% results.each do |r| %>
               <div class="star-values">
-                <% if r.assessment.subject == "Math" %>
+                <% if r.assessment.subject == "Mathematics" %>
                   <div class="values star-math-values">
                     <p>Math percentile: <strong><%= r.decorate.percentile_rank %></strong></p>
                   </div>

--- a/db/migrate/20160216220143_remove_incorrect_star_math_assessment.rb
+++ b/db/migrate/20160216220143_remove_incorrect_star_math_assessment.rb
@@ -1,0 +1,14 @@
+class RemoveIncorrectStarMathAssessment < ActiveRecord::Migration
+  def change
+    # "STAR Math" => incorrect
+    # "STAR Mathematics" => correct
+    begin
+      incorrect = Assessment.find_by_family_and_subject("STAR", "Math")
+      unless incorrect.nil?
+        incorrect.destroy!
+        Student.update_recent_student_assessments
+      end
+    rescue ActiveRecord::RecordNotFound
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160216183740) do
+ActiveRecord::Schema.define(version: 20160216220143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/student_assessments.rb
+++ b/spec/factories/student_assessments.rb
@@ -30,7 +30,7 @@ FactoryGirl.define do
       end
       factory :star_assessment do
         factory :star_math_assessment do
-          association :assessment, subject: "Math", family: "STAR"
+          association :assessment, subject: "Mathematics", family: "STAR"
           factory :star_math_warning_assessment do
             percentile_rank 8
           end

--- a/spec/importers/settings/somerville_x2_importers_spec.rb
+++ b/spec/importers/settings/somerville_x2_importers_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SomervilleX2Importers do
     let(:file_importers) { importer.file_importers }
     it 'returns an array of importers' do
       expect(file_importers).to include(a_kind_of(StudentsImporter))
-      expect(file_importers).to include(a_kind_of(StudentAssessmentImporter))
+      expect(file_importers).to include(a_kind_of(X2AssessmentImporter))
       expect(file_importers).to include(a_kind_of(BehaviorImporter))
       expect(file_importers).to include(a_kind_of(EducatorsImporter))
     end

--- a/spec/importers/star_math_importer_spec.rb
+++ b/spec/importers/star_math_importer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe StarMathImporter do
             student_assessment = StudentAssessment.last
             assessment = student_assessment.assessment
             expect(assessment.family).to eq "STAR"
-            expect(assessment.subject).to eq "Math"
+            expect(assessment.subject).to eq "Mathematics"
           end
           it 'sets math percentile rank correctly' do
             math_importer.start_import(csv)

--- a/spec/importers/x2_assessment_importer_spec.rb
+++ b/spec/importers/x2_assessment_importer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe StudentAssessmentImporter do
+RSpec.describe X2AssessmentImporter do
 
   describe '#import' do
     context 'with good data' do

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -17,4 +17,19 @@ RSpec.describe Assessment, type: :model do
     end
   end
 
+  context 'STAR' do
+    context 'valid subject' do
+      let(:assessment) { FactoryGirl.build(:assessment, family: 'STAR', subject: 'Mathematics') }
+      it 'is valid' do
+        expect(assessment).to be_valid
+      end
+    end
+    context 'invalid subject' do
+      let(:assessment) { FactoryGirl.build(:assessment, family: 'STAR', subject: 'Math') }
+      it 'is invalid' do
+        expect(assessment).to be_invalid
+      end
+    end
+  end
+
 end

--- a/spec/models/student_assessment_spec.rb
+++ b/spec/models/student_assessment_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe StudentAssessment, type: :model do
         end
       end
       context 'there are no ACCESS student assessments' do
-        let(:assessment) { FactoryGirl.create(:assessment, :star) }
+        let(:assessment) { FactoryGirl.create(:assessment, :star, :math) }
         it 'returns an empty association' do
           expect(StudentAssessment.by_family("ACCESS")).to be_empty
         end


### PR DESCRIPTION
## Notes

+ No more importing information about STAR from X2 Aspen

+ STAR's SFTP server is the only source of truth about STAR assessments
  + Aspen X2 was storing these assessments with the subject "Math"
  + The same information was coming in from STAR's SFTP server with the subject "Mathematics"

+ Use only "Mathematics", validate STAR subjects as either "Reading" or "Mathematics"