### PR TITLE
Fix bug with matching first and last name in searchbar

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -109,7 +109,7 @@ class StudentsController < ApplicationController
     students_with_scores.sort_by {|ss| -1 * ss[:score] }.map {|ss| ss[:student] }
   end
 
-  # range: [0, 1]
+  # range: [0.0, 1.0]
   def calculate_student_score(student, search_tokens)
     student_tokens = [student.first_name, student.last_name].compact
     
@@ -118,6 +118,7 @@ class StudentsController < ApplicationController
       student_tokens.each do |student_token|
         if search_token.upcase == student_token[0..search_token.length - 1].upcase
           search_token_scores << 1
+          break
         end
       end
     end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -85,19 +85,12 @@ class StudentsController < ApplicationController
   end
 
   def names
-    @q = params[:q].upcase
-    @length = @q.length
-
-    @matches = Student.with_school.select do |s|
-      first_name = s.first_name[0..@length - 1].upcase if s.first_name.present?
-      last_name = s.last_name[0..@length - 1].upcase if s.last_name.present?
-      first_name == @q || last_name == @q
-    end
-
-    @result = @matches.map { |student| student.decorate.presentation_for_autocomplete }
+    q = params[:q]
+    sorted_students = search_and_score(q, Student.with_school)
+    @sorted_results = sorted_students.map {|student| student.decorate.presentation_for_autocomplete }
 
     respond_to do |format|
-      format.json { render json: @result }
+      format.json { render json: @sorted_results }
     end
   end
 
@@ -105,6 +98,33 @@ class StudentsController < ApplicationController
   def not_authorized
     redirect_to not_authorized_path
   end
+
+  def search_and_score(query, students)
+    search_tokens = query.split(' ')
+    students_with_scores = students.flat_map do |student|
+      score = calculate_student_score(student, search_tokens)
+      if score > 0 then [{ student: student, score: score }] else [] end
+    end
+
+    students_with_scores.sort_by {|ss| -1 * ss[:score] }.map {|ss| ss[:student] }
+  end
+
+  # range: [0, 1]
+  def calculate_student_score(student, search_tokens)
+    student_tokens = [student.first_name, student.last_name].compact
+    
+    search_token_scores = []
+    search_tokens.each do |search_token|
+      student_tokens.each do |student_token|
+        if search_token.upcase == student_token[0..search_token.length - 1].upcase
+          search_token_scores << 1
+        end
+      end
+    end
+    
+    (search_token_scores.sum.to_f / search_tokens.length)
+  end
+
 
   # TODO(kr) this is placeholder fixture data for now, to test design prototypes on the v2 student profile
   # page

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -309,7 +309,7 @@ describe StudentsController, :type => :controller do
   describe '#calculate_student_score' do
     context 'happy path' do
       let(:search_tokens) { ['don', 'kenob'] }
-      it 'is 0.9 when no matches' do
+      it 'is 0.0 when no matches' do
         result = controller.send(:calculate_student_score, Student.new(first_name: 'Mickey', last_name: 'Mouse'), search_tokens)
         expect(result).to eq 0.0
       end

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -307,26 +307,36 @@ describe StudentsController, :type => :controller do
   end
 
   describe '#calculate_student_score' do
-    let(:search_tokens) { ['don', 'kenob'] }
+    context 'happy path' do
+      let(:search_tokens) { ['don', 'kenob'] }
+      it 'is 0.9 when no matches' do
+        result = controller.send(:calculate_student_score, Student.new(first_name: 'Mickey', last_name: 'Mouse'), search_tokens)
+        expect(result).to eq 0.0
+      end
 
-    it 'is 0.9 when no matches' do
-      result = controller.send(:calculate_student_score, Student.new(first_name: 'Mickey', last_name: 'Mouse'), search_tokens)
-      expect(result).to eq 0.0
+      it 'is 0.5 when first name only matches' do
+        result = controller.send(:calculate_student_score, Student.new(first_name: 'Donald', last_name: 'Mouse'), search_tokens)
+        expect(result).to eq 0.5
+      end
+
+      it 'is 0.5 when last name only matches' do
+        result = controller.send(:calculate_student_score, Student.new(first_name: 'zzz', last_name: 'Kenobiliiii'), search_tokens)
+        expect(result).to eq 0.5
+      end
+
+      it 'is 1.0 when both names match' do
+        result = controller.send(:calculate_student_score, Student.new(first_name: 'Donald', last_name: 'Kenobi'), search_tokens)
+        expect(result).to eq 1.0
+      end
     end
 
-    it 'is 0.5 when first name only matches' do
-      result = controller.send(:calculate_student_score, Student.new(first_name: 'Donald', last_name: 'Mouse'), search_tokens)
-      expect(result).to eq 0.5
-    end
-
-    it 'is 0.5 when last name only matches' do
-      result = controller.send(:calculate_student_score, Student.new(first_name: 'zzz', last_name: 'Kenobiliiii'), search_tokens)
-      expect(result).to eq 0.5
-    end
-
-    it 'is 1.0 when both names match' do
-      result = controller.send(:calculate_student_score, Student.new(first_name: 'Donald', last_name: 'Kenobi'), search_tokens)
-      expect(result).to eq 1.0
+    it 'works for bug test case' do
+      search_tokens = ['al','p']
+      aladdin_score = controller.send(:calculate_student_score, Student.new(first_name: 'Aladdin', last_name: 'Poppins'), search_tokens)
+      pluto_score = controller.send(:calculate_student_score, Student.new(first_name: 'Pluto', last_name: 'Poppins'), search_tokens)
+      expect(aladdin_score).to be > pluto_score
+      expect(aladdin_score).to eq 1
+      expect(pluto_score).to eq 0.5
     end
   end
 end

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -283,7 +283,7 @@ describe StudentsController, :type => :controller do
         end
         it 'returns student name and id' do
           make_request('j')
-          expect(assigns(:result)).to eq [{ label: "Juan - HEA - 5", value: juan.id }]
+          expect(assigns(:sorted_results)).to eq [{ label: "Juan - HEA - 5", value: juan.id }]
         end
       end
       context 'does not match student name' do
@@ -293,7 +293,7 @@ describe StudentsController, :type => :controller do
         end
         it 'returns an empty array' do
           make_request('j')
-          expect(assigns(:result)).to eq []
+          expect(assigns(:sorted_results)).to eq []
         end
       end
     end
@@ -303,6 +303,30 @@ describe StudentsController, :type => :controller do
         expect(response.status).to eq 401
         expect(response.body).to include "You need to sign in before continuing."
       end
+    end
+  end
+
+  describe '#calculate_student_score' do
+    let(:search_tokens) { ['don', 'kenob'] }
+
+    it 'is 0.9 when no matches' do
+      result = controller.send(:calculate_student_score, Student.new(first_name: 'Mickey', last_name: 'Mouse'), search_tokens)
+      expect(result).to eq 0.0
+    end
+
+    it 'is 0.5 when first name only matches' do
+      result = controller.send(:calculate_student_score, Student.new(first_name: 'Donald', last_name: 'Mouse'), search_tokens)
+      expect(result).to eq 0.5
+    end
+
+    it 'is 0.5 when last name only matches' do
+      result = controller.send(:calculate_student_score, Student.new(first_name: 'zzz', last_name: 'Kenobiliiii'), search_tokens)
+      expect(result).to eq 0.5
+    end
+
+    it 'is 1.0 when both names match' do
+      result = controller.send(:calculate_student_score, Student.new(first_name: 'Donald', last_name: 'Kenobi'), search_tokens)
+      expect(result).to eq 1.0
     end
   end
 end


### PR DESCRIPTION
This came in a @codeforboston user testing session yesterday, with help from some awesome Northeastern user interaction students.

Spaces in names weren't being handled correctly.  If you tried to disambiguate a first name with multiple matches by typing the last name, you'll get no matches back.  This fixes that with a slightly smarter match algorithm and adds test cases demonstrating the behavior.