### PR TITLE
Minimal fix for viewing MCAS math data in UI

### DIFF
--- a/app/charts/student_profile_chart.rb
+++ b/app/charts/student_profile_chart.rb
@@ -42,9 +42,9 @@ class StudentProfileChart < Struct.new :data
     {
       star_series_math_percentile: percentile_ranks_to_highcharts(data[:star_math_results]),
       star_series_reading_percentile: percentile_ranks_to_highcharts(data[:star_reading_results]),
-      mcas_series_math_scaled: scale_scores_to_highcharts(data[:mcas_math_results]),
+      mcas_series_math_scaled: scale_scores_to_highcharts(data[:mcas_mathematics_results]),
       mcas_series_ela_scaled: scale_scores_to_highcharts(data[:mcas_ela_results]),
-      mcas_series_math_growth: growth_percentiles_to_highcharts(data[:mcas_math_results]),
+      mcas_series_math_growth: growth_percentiles_to_highcharts(data[:mcas_mathematics_results]),
       mcas_series_ela_growth: growth_percentiles_to_highcharts(data[:mcas_ela_results]),
       interventions: interventions_to_highcharts,
       behavior_series: reverse_for_highcharts(data[:discipline_incidents_by_school_year]),


### PR DESCRIPTION
This is leading to MCAS charts not having data on student profile v1 and v2 pages, so this makes the minimal fix to get it working again.  Will rename the UI code to 'mathematics' to simplify, and add some related tests after confirming this fixes the problem.