### PR TITLE
Profile v2 - extend sparklines to 2 years, add vertical markers for start of school year

### DIFF
--- a/app/assets/javascripts/student_profile_v2/main.js
+++ b/app/assets/javascripts/student_profile_v2/main.js
@@ -8,9 +8,10 @@ $(function() {
   var parseQueryString = window.shared.parseQueryString;
 
   // entry point, reading static bootstrapped data from the page
+  var serializedData = $('#serialized-data').data();
   ReactDOM.render(createEl(PageContainer, {
     nowMomentFn: function() { return moment.utc(); },
-    serializedData: $('#serialized-data').data(),
+    serializedData: serializedData,
     queryParams: parseQueryString(window.location.search)
   }), document.getElementById('main'));
 });

--- a/app/assets/javascripts/student_profile_v2/sparkline.js
+++ b/app/assets/javascripts/student_profile_v2/sparkline.js
@@ -85,7 +85,7 @@
           x2: x(yearStartDate),
           y1: y.range()[0],
           y2: y.range()[1],
-          stroke: '#999'
+          stroke: '#ccc'
         });
       });
     },

--- a/app/assets/javascripts/student_profile_v2/sparkline.js
+++ b/app/assets/javascripts/student_profile_v2/sparkline.js
@@ -47,13 +47,14 @@
           width: this.props.width
         },
           dom.line({
-            x1: padding,
-            x2: this.props.width,
+            x1: x.range()[0],
+            x2: x.range()[1],
             y1: y(this.props.thresholdValue),
             y2: y(this.props.thresholdValue),
             stroke: '#ccc',
             strokeDasharray: 5
           }),
+          this.renderYearStarts(padding, x, y),
           dom.path({
             d: lineGenerator(this.props.quads),
             stroke: lineColor,
@@ -71,6 +72,22 @@
           })
         )
       );
+    },
+
+    // TODO(kr) check start of school year
+    renderYearStarts: function(padding, x, y) {
+      var years = _.range(this.props.dateRange[0].getFullYear(), this.props.dateRange[1].getFullYear());
+      return years.map(function(year) {
+        var yearStartDate = moment.utc([year, 8, 15].join('-'), 'YYYY-M-D').toDate();
+        return dom.line({
+          key: year,
+          x1: x(yearStartDate),
+          x2: x(yearStartDate),
+          y1: y.range()[0],
+          y2: y.range()[1],
+          stroke: '#999'
+        });
+      });
     },
 
     delta: function(quads) {

--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -113,7 +113,7 @@
 
     dateRange: function() {
       var nowMoment = this.props.nowMomentFn();
-      return [nowMoment.clone().subtract(1, 'year').toDate(), nowMoment.toDate()];
+      return [nowMoment.clone().subtract(2, 'year').toDate(), nowMoment.toDate()];
     },
 
     selectedColumnStyles: function(columnKey) {


### PR DESCRIPTION
This could use some visual design iterations, but I think we need some minimal anchoring here to show the time frame relative to the charts below.  For now starting with just a vertical line at the start of each school year, which we can generalize to other charts too.

Before:
<img width="632" alt="screen shot 2016-02-17 at 4 32 27 pm" src="https://cloud.githubusercontent.com/assets/1056957/13125572/4754aea0-d594-11e5-95e9-322d9925f6eb.png">

After:
<img width="640" alt="screen shot 2016-02-17 at 4 34 44 pm" src="https://cloud.githubusercontent.com/assets/1056957/13125595/6b357f70-d594-11e5-9fca-9728f0321ce6.png">
