### PR TITLE
Refactor serialized_student_data out of model and into StudentProfileChart

### DIFF
--- a/app/charts/student_profile_chart.rb
+++ b/app/charts/student_profile_chart.rb
@@ -1,8 +1,8 @@
-class StudentProfileChart < Struct.new :data
+class StudentProfileChart < Struct.new :student
 
   def interventions_to_highcharts
-    return if data[:interventions].blank?
-    data[:interventions].with_start_and_end_dates.map do |intervention|
+    return if student.interventions.blank?
+    student.interventions.with_start_and_end_dates.map do |intervention|
       intervention.to_highcharts
     end
   end
@@ -39,6 +39,7 @@ class StudentProfileChart < Struct.new :data
   end
 
   def chart_data
+    data = serialize_student_for_profile_chart(student)
     {
       star_series_math_percentile: percentile_ranks_to_highcharts(data[:star_math_results]),
       star_series_reading_percentile: percentile_ranks_to_highcharts(data[:star_reading_results]),
@@ -55,4 +56,19 @@ class StudentProfileChart < Struct.new :data
     }
   end
 
+  def serialize_student_for_profile_chart(student)
+    {
+      student: student,
+      student_assessments: student.student_assessments,
+      star_math_results: student.star_math_results,
+      star_reading_results: student.star_reading_results,
+      mcas_mathematics_results: student.mcas_mathematics_results,
+      mcas_ela_results: student.mcas_ela_results,
+      absences_count_by_school_year: student.student_school_years.map {|year| year.absences.length },
+      tardies_count_by_school_year: student.student_school_years.map {|year| year.tardies.length },
+      discipline_incidents_by_school_year: student.student_school_years.map {|year| year.discipline_incidents.length },
+      school_year_names: student.student_school_years.pluck(:name),
+      interventions: student.interventions
+    }
+  end
 end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -14,7 +14,7 @@ class StudentsController < ApplicationController
   def show
     @student = Student.find(params[:id]).decorate
     @chart_start = params[:chart_start] || "mcas-growth"
-    @chart_data = StudentProfileChart.new(serialize_student_for_profile(@student)).chart_data
+    @chart_data = StudentProfileChart.new(@student).chart_data
 
     @student_risk_level = @student.student_risk_level.decorate
 
@@ -48,7 +48,7 @@ class StudentsController < ApplicationController
   # TODO(kr) can simplify chart_data later
   def profile
     student = Student.find(params[:id])
-    chart_data = StudentProfileChart.new(serialize_student_for_profile(student)).chart_data
+    chart_data = StudentProfileChart.new(student).chart_data
     @serialized_data = {
       current_educator: current_educator,
       student: student.serialized_data,

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -13,10 +13,8 @@ class StudentsController < ApplicationController
 
   def show
     @student = Student.find(params[:id]).decorate
-    @serialized_student_data = @student.serialized_student_data
-
     @chart_start = params[:chart_start] || "mcas-growth"
-    @chart_data = StudentProfileChart.new(@serialized_student_data).chart_data
+    @chart_data = StudentProfileChart.new(serialize_student_for_profile(@student)).chart_data
 
     @student_risk_level = @student.student_risk_level.decorate
 
@@ -50,12 +48,13 @@ class StudentsController < ApplicationController
   # TODO(kr) can simplify chart_data later
   def profile
     student = Student.find(params[:id])
+    chart_data = StudentProfileChart.new(serialize_student_for_profile(student)).chart_data
     @serialized_data = {
       current_educator: current_educator,
       student: student.serialized_data,
       notes: student.student_notes.map { |note| serialize_student_note(note) },
       feed: student_feed(student),
-      chart_data: StudentProfileChart.new(student.serialized_student_data).chart_data,
+      chart_data: chart_data,
       intervention_types_index: intervention_types_index,
       educators_index: educators_index,
       attendance_data: {
@@ -126,6 +125,21 @@ class StudentsController < ApplicationController
     (search_token_scores.sum.to_f / search_tokens.length)
   end
 
+  def serialize_student_for_profile(student)
+    {
+      student: student,
+      student_assessments: student.student_assessments,
+      star_math_results: student.star_math_results,
+      star_reading_results: student.star_reading_results,
+      mcas_mathematics_results: student.mcas_mathematics_results,
+      mcas_ela_results: student.mcas_ela_results,
+      absences_count_by_school_year: student.student_school_years.map {|year| year.absences.length },
+      tardies_count_by_school_year: student.student_school_years.map {|year| year.tardies.length },
+      discipline_incidents_by_school_year: student.student_school_years.map {|year| year.discipline_incidents.length },
+      school_year_names: student.student_school_years.pluck(:name),
+      interventions: student.interventions
+    }
+  end
 
   # TODO(kr) this is placeholder fixture data for now, to test design prototypes on the v2 student profile
   # page

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -122,22 +122,6 @@ class Student < ActiveRecord::Base
     end
   end
 
-  def serialized_student_data
-    {
-      student: self,
-      student_assessments: student_assessments,
-      star_math_results: star_math_results,
-      star_reading_results: star_reading_results,
-      mcas_mathematics_results: mcas_mathematics_results,
-      mcas_ela_results: mcas_ela_results,
-      absences_count_by_school_year: student_school_years.map {|year| year.absences.length },
-      tardies_count_by_school_year: student_school_years.map {|year| year.tardies.length },
-      discipline_incidents_by_school_year: student_school_years.map {|year| year.discipline_incidents.length },
-      school_year_names: student_school_years.pluck(:name),
-      interventions: interventions
-    }
-  end
-
   def self.with_mcas_math
     where.not(most_recent_mcas_math_performance: nil)
   end

--- a/spec/charts/student_profile_chart_spec.rb
+++ b/spec/charts/student_profile_chart_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe StudentProfileChart do
   describe '#chart_data' do
     let(:student) { FactoryGirl.create(:student) }
     it 'has the expected keys' do
-      chart_data = StudentProfileChart.new(student.serialized_student_data).chart_data
+      chart_data = StudentProfileChart.new(student).chart_data
       expect(chart_data.keys).to eq([
         :star_series_math_percentile,
         :star_series_reading_percentile,

--- a/spec/charts/student_profile_chart_spec.rb
+++ b/spec/charts/student_profile_chart_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe StudentProfileChart do
   describe '#chart_data' do
     let(:student) { FactoryGirl.create(:student) }
     it 'has the expected keys' do
-      puts student.serialized_student_data.to_json
       chart_data = StudentProfileChart.new(student.serialized_student_data).chart_data
       expect(chart_data.keys).to eq([
         :star_series_math_percentile,


### PR DESCRIPTION
There's already instance and class methods called `serialize_data` on the `Student` model, so this one's a bit confusing.  It's only used to grab some fields for use in `StudentProfileChart`, so this moves it there and isolates it, and we can simplify that code on its own later.