### PR TITLE
Fix mistake with MCAS ELA import

### DIFF
--- a/app/importers/mcas_row.rb
+++ b/app/importers/mcas_row.rb
@@ -1,13 +1,10 @@
 class McasRow < Struct.new :row
-  SUBJECT_WHITELIST = ['Mathematics', 'ELA']
 
   def self.build(row)
     new(row).build
   end
 
   def build
-    return NullRow.new unless row[:assessment_subject].in? SUBJECT_WHITELIST
-
     student_assessment = StudentAssessment.find_or_initialize_by(
       student: student,
       assessment: assessment,
@@ -29,8 +26,16 @@ class McasRow < Struct.new :row
     Student.find_by_local_id!(row[:local_id])
   end
 
+  def subject
+    if "English Language Arts".in?(row[:assessment_name])
+      'ELA'
+    else
+      row[:assessment_subject]
+    end
+  end
+
   def assessment
-    Assessment.find_or_create_by!(subject: row[:assessment_subject], family: 'MCAS')
+    Assessment.find_or_create_by!(subject: subject, family: 'MCAS')
   end
 
 end

--- a/app/importers/null_row.rb
+++ b/app/importers/null_row.rb
@@ -1,4 +1,0 @@
-class NullRow
-  def save!; end
-end
-

--- a/spec/importers/mcas_row_spec.rb
+++ b/spec/importers/mcas_row_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe McasRow do
       {
         assessment_test: 'MCAS',
         assessment_subject: 'Mathematics',
+        assessment_name: 'MCAS 2016 Mathematics',
         local_id: student.local_id,
         assessment_date: Date.today
       }
@@ -27,19 +28,24 @@ RSpec.describe McasRow do
 
   end
 
-  context 'MCAS Arts' do
+  context 'MCAS English Language Arts' do
     let(:row) {
       {
         assessment_test: 'MCAS',
         assessment_subject: 'Arts',
+        assessment_name: 'MCAS 2016 English Language Arts',
         local_id: student.local_id,
         assessment_date: Date.today
       }
     }
 
-    it 'does not create an assessment or student assessment result' do
-      expect(Assessment.count).to eq 0
-      expect(StudentAssessment.count).to eq 0
+    it 'creates an assessment' do
+      expect(Assessment.count).to eq 1
+      expect(StudentAssessment.count).to eq 1
+    end
+
+    it 'sets the correct subject' do
+      expect(Assessment.last.subject).to eq 'ELA'
     end
   end
 


### PR DESCRIPTION
## Notes

+ `assessment_export.sql` incorrectly codes `ASD_SUBJECT` because it naively assumes subject strings are 1 word; that does not hold for 'English Language Arts'
+ `assessment_export.sql` incorrectly parses English Language Arts to have subject == Arts
+ Stop looking at `ASD_SUBJECT` (which is created by our SQL script and is poor quality) and only use the original `ASD_NAME`
+ Set MCAS subject to ELA when `ASD_NAME` includes string English Language Arts
+ #82, #1