### PR TITLE
Allow developer to specify which X2 files to import

### DIFF
--- a/app/importers/settings/somerville_x2_importers.rb
+++ b/app/importers/settings/somerville_x2_importers.rb
@@ -6,6 +6,7 @@ class SomervilleX2Importers
   def initialize(options = {})
     @school_scope = options["school"]
     @first_time = options["first_time"]
+    @x2_file_importers = options["x2_file_importers"]
   end
 
   def base_options
@@ -16,21 +17,38 @@ class SomervilleX2Importers
     }
   end
 
+  def self.file_importer_options
+    {
+      'students' => StudentsImporter,
+      'assessments' => X2AssessmentImporter,
+      'behavior' => BehaviorImporter,
+      'educators' => EducatorsImporter,
+      'attendance' => AttendanceImporter,
+    }
+  end
+
+  def self.file_importer_names
+    self.file_importer_options.keys
+  end
+
   def file_importers
-    importers = [
-      StudentsImporter,
-      X2AssessmentImporter,
-      BehaviorImporter,
-      EducatorsImporter,
-    ]
-    importers << AttendanceImporter unless @first_time
-    importers
+    @x2_file_importers.map do |importer_option|
+      unless importer_option == 'attendance' && @first_time
+        SomervilleX2Importers.file_importer_options.fetch(importer_option)
+      end
+    end.compact.uniq
   end
 
   def importer
     importer_set = [Importer.new(base_options)]
-    importer_set << BulkAttendanceImporter.new(base_options) if @first_time
+    importer_set << BulkAttendanceImporter.new(base_options) if include_bulk_attendance?
     importer_set
+  end
+
+  private
+
+  def include_bulk_attendance?
+    @first_time && @x2_file_importers.include?('attendance')
   end
 
 end

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -1,6 +1,11 @@
 require 'thor'
 require_relative '../../app/importers/settings/somerville_star_importers'
 require_relative '../../app/importers/settings/somerville_x2_importers'
+require_relative '../../app/importers/students_importer'
+require_relative '../../app/importers/x2_assessment_importer'
+require_relative '../../app/importers/behavior_importer'
+require_relative '../../app/importers/educators_importer'
+require_relative '../../app/importers/attendance_importer'
 
 class Import
   class Start < Thor::Group
@@ -24,8 +29,12 @@ class Import
       desc: "Fill up an empty database"
     class_option :source,
       type: :array,
-      default: ["x2", "star"],
+      default: SOURCE_IMPORTERS.keys,
       desc: "Import data from the specified source: #{SOURCE_IMPORTERS.keys}"
+    class_option :x2_file_importers,
+      type: :array,
+      default: SomervilleX2Importers.file_importer_names,
+      desc: "Import data from the specified files: #{SomervilleX2Importers.file_importer_names}"
 
     no_commands do
       def report

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -22,6 +22,7 @@ class Import
 
     class_option :school,
       type: :array,
+      default: ['HEA'],
       aliases: "-s",
       desc: "Scope by school local IDs; use ELEM to import all elementary schools"
     class_option :first_time,

--- a/spec/importers/settings/somerville_x2_importers_spec.rb
+++ b/spec/importers/settings/somerville_x2_importers_spec.rb
@@ -2,7 +2,15 @@ require 'rails_helper'
 
 RSpec.describe SomervilleX2Importers do
   let(:first_time) { nil }
-  let(:options) { { "first_time" => first_time } }
+  let(:x2_file_importers) { ["students", "assessments", "behavior", "educators", "attendance"] }
+
+  let(:options) {
+    {
+      "first_time" => first_time,
+      "x2_file_importers" => x2_file_importers
+    }
+  }
+
   let(:importer_factory) { SomervilleX2Importers.new(options) }
   before { allow(SftpClient).to receive(:for_x2) }
 
@@ -15,22 +23,78 @@ RSpec.describe SomervilleX2Importers do
 
   describe '#file_importers' do
     it 'returns an default set of importers' do
-      expect(importer_factory.file_importers).to eq([
-        StudentsImporter,
-        X2AssessmentImporter,
-        BehaviorImporter,
-        EducatorsImporter,
-        AttendanceImporter
-      ])
+      expect(importer_factory.file_importers).to eq [
+        StudentsImporter, X2AssessmentImporter, BehaviorImporter, EducatorsImporter, AttendanceImporter
+      ]
     end
 
     context 'when factorying importers for a first-time import' do
       let(:first_time) { true }
-
       it 'does not include the attendance importer' do
-        expect(importer_factory.file_importers).not_to include(AttendanceImporter)
+        expect(importer_factory.file_importers).to eq [
+          StudentsImporter, X2AssessmentImporter, BehaviorImporter, EducatorsImporter
+        ]
       end
     end
+
+    context 'when passed non-default options' do
+
+      context 'when passed an empty array' do
+        let(:x2_file_importers) { [] }
+        it 'returns an empty array' do
+          expect(importer_factory.file_importers).to eq []
+        end
+      end
+
+      context 'when passed a single valid x2 file importer name' do
+        let(:x2_file_importers) { ['students'] }
+        it 'returns an array containing the specified importer' do
+          expect(importer_factory.file_importers).to eq [StudentsImporter]
+        end
+      end
+
+      context 'when passed duplicate x2 file importer names' do
+        let(:x2_file_importers) { ['students', 'students'] }
+        it 'returns an array containing the specified importer' do
+          expect(importer_factory.file_importers).to eq [StudentsImporter]
+        end
+      end
+
+      context 'when passed different valid x2 file importer names' do
+        let(:x2_file_importers) { ['students', 'assessments'] }
+        it 'returns an array containing the specified importers' do
+          expect(importer_factory.file_importers).to eq [StudentsImporter, X2AssessmentImporter]
+        end
+      end
+
+      context 'when passed an invalid x2 file importer name' do
+        let(:x2_file_importers) { ['mud'] }
+        it 'throws an error' do
+          expect { importer_factory.file_importers }.to raise_error KeyError
+        end
+      end
+
+    end
+  end
+
+  describe '#importer' do
+
+    context 'default' do
+      it 'returns one generic importer' do
+        expect(importer_factory.importer.size).to eq 1
+        expect(importer_factory.importer.first).to be_a Importer
+      end
+    end
+
+    context 'first time import' do
+      let(:first_time) { true }
+      it 'returns one generic importer and one bulk attendance importer' do
+        expect(importer_factory.importer.size).to eq 2
+        expect(importer_factory.importer.first).to be_a Importer
+        expect(importer_factory.importer.second).to be_a BulkAttendanceImporter
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
## New developer powers:

Import only students file from X2:

`thor import:start --source x2 --x2-file-importers students`

Import students, assessments, and behavior from X2:

`thor import:start --source x2 --x2-file-importers students assessments behavior`

Import from all sources and files:

`thor import:start`