### PR TITLE
Improve dates for generated STAR assessment data

### DIFF
--- a/app/demo_data/fake_star_math_result_generator.rb
+++ b/app/demo_data/fake_star_math_result_generator.rb
@@ -1,9 +1,10 @@
 class FakeStarMathResultGenerator
 
-  def initialize(student)
-    @test_date = DateTime.new(2010, 9, 1)
-    @math_percentile = rand(10..99)
+  def initialize(student, options = {})
     @student = student
+    @test_date = options[:start_date] || DateTime.new(2010, 9, 1)
+    @star_period_days = options[:star_period_days] || 90
+    @math_percentile = rand(10..99)
   end
 
   def star_math_assessment
@@ -13,7 +14,7 @@ class FakeStarMathResultGenerator
   def next
     @math_percentile += rand(-15..15)
     @math_percentile = [0, @math_percentile, 100].sort[1]
-    @test_date += rand(30..60)  # days
+    @test_date += @star_period_days + rand(-10..10)  # days
 
     return {
       assessment: star_math_assessment,

--- a/app/demo_data/fake_star_reading_result_generator.rb
+++ b/app/demo_data/fake_star_reading_result_generator.rb
@@ -1,8 +1,8 @@
 class FakeStarReadingResultGenerator
-
-  def initialize(student)
-    @test_date = DateTime.new(2010, 9, 1)
+  def initialize(student, options)
     @student = student
+    @test_date = options[:start_date] || DateTime.new(2010, 9, 1)
+    @star_period_days = options[:star_period_days] || 90
     @instructional_reading_level = @student.grade.to_f
     @reading_percentile = rand(10..99)
   end
@@ -15,7 +15,7 @@ class FakeStarReadingResultGenerator
     @reading_percentile += rand(-15..15)
     @reading_percentile = [0, @reading_percentile, 100].sort[1]
     @instructional_reading_level += rand(-1..1)
-    @test_date += rand(30..60)  # days
+    @test_date += @star_period_days + rand(-10..10)  # days
 
     return {
       assessment: star_reading_assessment,

--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -6,7 +6,8 @@ class FakeStudent
     add_discipline_incidents
     add_interventions
     add_notes
-    add_student_assessments
+    add_student_assessments_from_x2
+    add_student_assessments_from_star
     homeroom.students << @student
   end
 
@@ -84,23 +85,36 @@ class FakeStudent
     ]
   end
 
-  def create_star_assessment_generators(student)
-    [
-      FakeStarMathResultGenerator.new(student),
-      FakeStarReadingResultGenerator.new(student)
-    ]
+  def create_star_assessment_generators(student, options)
+    
   end
 
-  def add_student_assessments
+  def add_student_assessments_from_x2
     create_x2_assessment_generators(@student).each do |assessment_generator|
       5.times do
         StudentAssessment.new(assessment_generator.next).save
       end
     end
+  end
 
-    create_star_assessment_generators(@student).each do |assessment_generator|
-      12.times do
-        StudentAssessment.new(assessment_generator.next).save
+  def add_student_assessments_from_star
+    # Define semi-realistic date ranges for STAR assessments
+    start_date = DateTime.new(2010, 9, 1)
+    star_period_days = 90
+    now = DateTime.now
+    assessment_count = (now - start_date).to_i / star_period_days
+    options = {
+      start_date: start_date,
+      star_period_days: star_period_days
+    }    
+
+    generators = [
+      FakeStarMathResultGenerator.new(@student, options),
+      FakeStarReadingResultGenerator.new(@student, options)
+    ]
+    generators.each do |star_assessment_generator|
+      assessment_count.times do
+        StudentAssessment.new(star_assessment_generator.next).save
       end
     end
   end


### PR DESCRIPTION
The scripts generating fake STAR demo for local development and the demo site didn't create any recent data.  Updated that to be a bit more realistic, in support of development on the v2 profile page, which currently shows no STAR data on sparklines for any students.

Before:
<img width="1271" alt="screen shot 2016-02-22 at 11 33 14 am" src="https://cloud.githubusercontent.com/assets/1056957/13224773/13f23efc-d958-11e5-95c4-fa713805c1f1.png">


After:
<img width="1270" alt="screen shot 2016-02-22 at 11 31 11 am" src="https://cloud.githubusercontent.com/assets/1056957/13224731/e40103b8-d957-11e5-9959-7667d6e77ac7.png">


Thanks @erose!