### PR TITLE
Newsfeed

### DIFF
--- a/app/assets/javascripts/student_profile_v2/profile_details.js
+++ b/app/assets/javascripts/student_profile_v2/profile_details.js
@@ -5,8 +5,77 @@
   var merge = window.shared.ReactHelpers.merge;
 
   var ProfileDetails = window.shared.ProfileDetails = React.createClass({
+    displayName: 'ProfileDetails',
+
+    propTypes: {
+        student: React.PropTypes.object,
+        chartData: React.PropTypes.object,
+        attendanceData: React.PropTypes.object
+    },
+
+    getEvents: function(){
+      // Returns a list of {type: ..., date: ..., value: ...} pairs, sorted by date of occurrence.
+      var events = [];
+
+      _.each(this.props.attendanceData.tardies, function(obj){
+        events.push({type: 'Tardy', date: Date.parse(obj.occurred_at), data: null});
+      });
+      _.each(this.props.attendanceData.absences, function(obj){
+        events.push({type: 'Absence', date: Date.parse(obj.occurred_at), data: null});
+      });
+      _.each(this.props.chartData.mcas_series_ela_scaled, function(quad){
+        var year = quad[0], month = quad[1], day = quad[2], score = quad[3];
+        events.push({type: 'MCAS ELA Score', date: new Date(year, month, day), data: score});
+      });
+      _.each(this.props.chartData.mcas_series_math_scaled, function(quad){
+        var year = quad[0], month = quad[1], day = quad[2], score = quad[3];
+        events.push({type: 'MCAS Math Score', date: new Date(year, month, day), data: score});
+      });
+      _.each(this.props.chartData.star_series_reading_percentile, function(quad){
+        var year = quad[0], month = quad[1], day = quad[2], score = quad[3];
+        events.push({type: 'STAR Reading Percentile', date: new Date(year, month, day), data: score});
+      });
+      _.each(this.props.chartData.star_series_math_percentile, function(quad){
+        var year = quad[0], month = quad[1], day = quad[2], score = quad[3];
+        events.push({type: 'STAR Math Percentile', date: new Date(year, month, day), data: score});
+      });
+      // var discipline_incidents = this.props.attendanceData.discipline_incidents;
+
+      return _.sortBy(events, 'date').reverse();
+    },
+    getDescription: function(obj){
+      var name = this.props.student.first_name;
+      if (obj.type === 'Tardy'){
+        return name + ' was tardy.'
+      }
+      else if (obj.type === 'Absence'){
+        return name + ' was absent.'
+      }
+      else if (obj.type === 'MCAS ELA Score'){
+        return name + ' scored a ' + obj.data.toString() + ' on the ELA section of the MCAS.' 
+      }
+      else if (obj.type === 'MCAS Math Score'){
+        return name + ' scored a ' + obj.data.toString() + ' on the Math section of the MCAS.' 
+      }
+      else if (obj.type === 'STAR Reading Percentile'){
+        return name + ' scored a ' + obj.data.toString() + '% on the Reading section of STAR.' 
+      }
+      else if (obj.type === 'STAR Math Percentile'){
+        return name + ' scored a ' + obj.data.toString() + '% on the Math section of STAR.' 
+      }
+    },
+
     render: function() {
-      return dom.div({}, 'profile');
+      var self = this;
+      return dom.div({},
+        createEl("ul", null,
+          this.getEvents().map(function(obj){
+            return createEl("li", null,
+              moment(obj.date).format("MMMM Do, YYYY") + ": " + self.getDescription(obj)
+            );
+          })
+        )
+      );
     }
   });
 })();

--- a/app/assets/javascripts/student_profile_v2/profile_details.js
+++ b/app/assets/javascripts/student_profile_v2/profile_details.js
@@ -15,63 +15,57 @@
 
     getEvents: function(){
       // Returns a list of {type: ..., date: ..., value: ...} pairs, sorted by date of occurrence.
+      var name = this.props.student.first_name;
       var events = [];
 
       _.each(this.props.attendanceData.tardies, function(obj){
-        events.push({type: 'Tardy', date: Date.parse(obj.occurred_at), data: null});
+        events.push({
+          message: name + ' was tardy.', date: Date.parse(obj.occurred_at)
+        });
       });
       _.each(this.props.attendanceData.absences, function(obj){
-        events.push({type: 'Absence', date: Date.parse(obj.occurred_at), data: null});
+        events.push({
+          message: name + ' was absent.', date: Date.parse(obj.occurred_at)
+        });
       });
       _.each(this.props.chartData.mcas_series_ela_scaled, function(quad){
         var year = quad[0], month = quad[1], day = quad[2], score = quad[3];
-        events.push({type: 'MCAS ELA Score', date: new Date(year, month, day), data: score});
+        events.push({
+          message: name + ' scored a ' + score + ' on the ELA section of the MCAS.',
+          date: new Date(year, month, day)
+        });
       });
       _.each(this.props.chartData.mcas_series_math_scaled, function(quad){
         var year = quad[0], month = quad[1], day = quad[2], score = quad[3];
-        events.push({type: 'MCAS Math Score', date: new Date(year, month, day), data: score});
+        events.push({
+          message: name + ' scored a ' + score + ' on the Math section of the MCAS.',
+          date: new Date(year, month, day)
+        });
       });
       _.each(this.props.chartData.star_series_reading_percentile, function(quad){
         var year = quad[0], month = quad[1], day = quad[2], score = quad[3];
-        events.push({type: 'STAR Reading Percentile', date: new Date(year, month, day), data: score});
+        events.push({
+          message: name + ' scored a ' + score + '% on the Reading section of STAR.',
+          date: new Date(year, month, day)
+        });
       });
       _.each(this.props.chartData.star_series_math_percentile, function(quad){
         var year = quad[0], month = quad[1], day = quad[2], score = quad[3];
-        events.push({type: 'STAR Math Percentile', date: new Date(year, month, day), data: score});
+        events.push({
+          message: name + ' scored a ' + score + '% on the Math section of STAR.',
+          date: new Date(year, month, day)
+        });
       });
-      // var discipline_incidents = this.props.attendanceData.discipline_incidents;
-
+      // TODO: incorporate discipline incidents.
       return _.sortBy(events, 'date').reverse();
-    },
-    getDescription: function(obj){
-      var name = this.props.student.first_name;
-      if (obj.type === 'Tardy'){
-        return name + ' was tardy.'
-      }
-      else if (obj.type === 'Absence'){
-        return name + ' was absent.'
-      }
-      else if (obj.type === 'MCAS ELA Score'){
-        return name + ' scored a ' + obj.data.toString() + ' on the ELA section of the MCAS.' 
-      }
-      else if (obj.type === 'MCAS Math Score'){
-        return name + ' scored a ' + obj.data.toString() + ' on the Math section of the MCAS.' 
-      }
-      else if (obj.type === 'STAR Reading Percentile'){
-        return name + ' scored a ' + obj.data.toString() + '% on the Reading section of STAR.' 
-      }
-      else if (obj.type === 'STAR Math Percentile'){
-        return name + ' scored a ' + obj.data.toString() + '% on the Math section of STAR.' 
-      }
     },
 
     render: function() {
-      var self = this;
       return dom.div({},
-        createEl("ul", null,
+        dom.ul({},
           this.getEvents().map(function(obj){
-            return createEl("li", null,
-              moment(obj.date).format("MMMM Do, YYYY") + ": " + self.getDescription(obj)
+            return dom.li({},
+              moment(obj.date).format("MMMM Do, YYYY") + ": " + obj.message
             );
           })
         )

--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -153,9 +153,15 @@
 
     renderSectionDetails: function() {
       switch (this.props.selectedColumnKey) {
-        case 'profile': return createEl(ProfileDetails, {});
-        case 'ela': return createEl(ELADetails, { chartData: this.props.chartData });
-        case 'math': return createEl(MathDetails, { chartData: this.props.chartData });
+        case 'profile': return createEl(ProfileDetails,
+          {
+            chartData: this.props.chartData,
+            attendanceData: this.props.attendanceData,
+            student: this.props.student
+          }
+        );
+        case 'ela': return createEl(ELADetails, {chartData: this.props.chartData});
+        case 'math': return createEl(MathDetails, {chartData: this.props.chartData});
         case 'attendance':
           var attendanceData = this.props.attendanceData;
           return createEl(AttendanceDetails, {


### PR DESCRIPTION
Bare-bones implementation of a newsfeed on profile v2, which displays events sorted chronologically, where an "event" is an:
  * absence
  * tardy
  * Math or ELA score on the MCAS or STAR test

Each event consists of:
  * its date of occurrence
  * a short description string with the student's name

e.g. "Monday, February 12th, 2016: Aladdin was tardy" or "Tuesday, April 15th, 2016: Aladdin scored a 37% on the Math section of the MCAS."

![screen shot 2016-02-23 at 3 48 00 pm](https://cloud.githubusercontent.com/assets/1514487/13266193/de769136-da44-11e5-8771-3582a8987ecd.png)
