### PR TITLE
Add username to database.yml, fixing issue on Eric's Gentoo build

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -6,6 +6,7 @@ development:
   pool: 5
   database: student_insights_development
   host: localhost
+  username: postgres
 
 test:
   adapter: postgresql


### PR DESCRIPTION
This resolved a problem on @sentientmachine's Gentoo setup, where it appears Rails was taking the OS username.