### PR TITLE
Profile v2 - include risk level when serializing student data, move serialization to controller

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -25,23 +25,6 @@ class Student < ActiveRecord::Base
     where.not(school: nil)
   end
 
-  def serialized_data
-    as_json.merge({
-      interventions: interventions.as_json,
-      absences_count: most_recent_school_year.absences.count,
-      tardies_count: most_recent_school_year.tardies.count,
-      school_name: try(:school).try(:name),
-      homeroom_name: try(:homeroom).try(:name),
-      discipline_incidents_count: most_recent_school_year.discipline_incidents.count
-    })
-  end
-
-  def self.serialized_data
-    includes(:interventions).map do |student|
-      student.serialized_data
-    end
-  end
-
   ## STUDENT ASSESSMENT RESULTS ##
 
   def latest_result_by_family_and_subject(family_name, subject_name)

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -306,6 +306,22 @@ describe StudentsController, :type => :controller do
     end
   end
 
+  describe '#serialize_student_for_profile' do
+    it 'returns a hash with the additional keys that UI code expects' do
+      student = FactoryGirl.create(:student)
+      serialized_student = controller.send(:serialize_student_for_profile, student)
+      expect(serialized_student.keys).to include(*[
+        'interventions',
+        'student_risk_level',
+        'absences_count',
+        'tardies_count',
+        'school_name',
+        'homeroom_name',
+        'discipline_incidents_count'
+      ])
+    end
+  end
+
   describe '#calculate_student_score' do
     context 'happy path' do
       let(:search_tokens) { ['don', 'kenob'] }


### PR DESCRIPTION
This is part of https://github.com/studentinsights/studentinsights/pull/5.

This adds in data needed for https://github.com/studentinsights/studentinsights/pull/108.  It removes the generic-seeming `serialize_data` method from the `Student` model, since it's only used by `students#profile`.  It moves the method into the controller and adds a spec.  This also revealed an older dead method in the controller that is now removed.
