### PR TITLE
Fix React warning on profile timeline list

### DIFF
--- a/app/assets/javascripts/student_profile_v2/profile_details.js
+++ b/app/assets/javascripts/student_profile_v2/profile_details.js
@@ -64,7 +64,8 @@
       return dom.div({},
         dom.ul({},
           this.getEvents().map(function(obj){
-            return dom.li({},
+            var key = [obj.date, obj.message].join();
+            return dom.li({ key: key },
               moment(obj.date).format("MMMM Do, YYYY") + ": " + obj.message
             );
           })


### PR DESCRIPTION
@erose I should have noticed this in https://github.com/studentinsights/studentinsights/pull/105, my bad!

There's a warning from React on the development console:
<img width="1033" alt="screen shot 2016-02-24 at 9 41 14 am" src="https://cloud.githubusercontent.com/assets/1056957/13289152/f7d9518e-dadc-11e5-9907-8471dbfd98df.png">

It's coming from this line:
<img width="532" alt="screen shot 2016-02-24 at 9 41 24 am" src="https://cloud.githubusercontent.com/assets/1056957/13289161/fd857572-dadc-11e5-9d61-775ab1c6dc21.png">

The way React works is that you describe what you want the DOM to look like in `render`, and then React figures out how to update the DOM when `render` returns different values.  The process of figuring out what parts of the DOM need to update is called [reconciliation](https://facebook.github.io/react/docs/reconciliation.html).  It comes up here because when there's a list of items, React needs a hint as to how to uniquely identify the items in the list.  That's what the warning up above is saying.

In this case, there's not a true unique ID, but the combination of the date and message should be unique in almost all cases.  Alternately, we could thread in the `type` and the `id` for that entity to get a true primary key, but I think this is good enough for now.