### PR TITLE
Profile v2 - Rename fields in services fixtures

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -138,22 +138,31 @@ class StudentsController < ApplicationController
     (search_token_scores.sum.to_f / search_tokens.length)
   end
 
-  # TODO(kr) this is placeholder fixture data for now, to test design prototypes on the v2 student profile
+  # TODO(kr) this has some placeholder fixture data for now, to test design prototypes on the v2 student profile
   # page
   def student_feed(student)
     {
-      v1_notes: student.student_notes.map { |note| serialize_student_note(note) },
-      v1_interventions: student.interventions.map { |intervention| serialize_intervention(intervention) },
       event_notes: student.event_notes,
-      v2_services: if Rails.env.development? then v2_services_fixture else [] end
+      services: if Rails.env.development? then services_fixture else [] end,
+      v1_notes: student.student_notes.map { |note| serialize_student_note(note) },
+      v1_interventions: student.interventions.map { |intervention| serialize_intervention(intervention) }
     }
   end
 
-  def v2_services_fixture
+  def services_fixture
     fixture_educator_id = 1
-    [
-      { version: 'v2', id: 133, profile_v2_service_type_id: 1, recorded_by_educator_id: fixture_educator_id, assigned_to_educator_id: fixture_educator_id, start_date: '2016-02-09T20:56:51.638Z', end_date: nil, text: 'Working on goals' },
-      { version: 'v2', id: 134, profile_v2_service_type_id: 1, recorded_by_educator_id: fixture_educator_id, assigned_to_educator_id: fixture_educator_id, start_date: '2016-02-09T20:56:51.638Z', end_date: nil, text: ''  }
-    ]
+    [{
+      id: 133,
+      service_type_id: 1,
+      recorded_by_educator_id: fixture_educator_id,
+      assigned_to_educator_id: fixture_educator_id,
+      date_started: '2016-02-09'
+    }, {
+      id: 134,
+      service_type_id: 1,
+      recorded_by_educator_id: fixture_educator_id,
+      assigned_to_educator_id: fixture_educator_id,
+      date_started: '2016-02-08'
+    }]
   end
 end

--- a/spec/javascripts/student_profile_v2/fixtures.js
+++ b/spec/javascripts/student_profile_v2/fixtures.js
@@ -800,26 +800,20 @@
         }
       ],
       "event_notes": [{"id":1,"student_id":6,"educator_id":1,"event_note_type_id":3,"text":"okay!","recorded_at":"2016-02-11T21:28:02.102Z","created_at":"2016-02-11T21:28:02.103Z","updated_at":"2016-02-11T21:28:02.103Z"},{"id":2,"student_id":6,"educator_id":1,"event_note_type_id":3,"text":"cool!","recorded_at":"2016-02-11T21:29:18.166Z","created_at":"2016-02-11T21:29:18.167Z","updated_at":"2016-02-11T21:29:18.167Z"},{"id":3,"student_id":6,"educator_id":1,"event_note_type_id":1,"text":"sweet","recorded_at":"2016-02-11T21:29:30.287Z","created_at":"2016-02-11T21:29:30.288Z","updated_at":"2016-02-11T21:29:30.288Z"}],
-      "v2_services": [
+      "services": [
         {
-          "version": "v2",
           "id": 133,
-          "profile_v2_service_type_id": 1,
+          "service_type_id": 1,
           "recorded_by_educator_id": 1,
           "assigned_to_educator_id": 1,
-          "start_date": "2016-02-09T20:56:51.638Z",
-          "end_date": null,
-          "text": "Working on goals"
+          "date_started": "2016-02-09"
         },
         {
-          "version": "v2",
           "id": 134,
-          "profile_v2_service_type_id": 1,
+          "service_type_id": 1,
           "recorded_by_educator_id": 1,
           "assigned_to_educator_id": 1,
-          "start_date": "2016-02-09T20:56:51.638Z",
-          "end_date": null,
-          "text": ""
+          "date_started": "2016-02-09"
         }
       ]
     },


### PR DESCRIPTION
Rename draft fields to something that matches the current UI.

@BWieber You can use this as a starting point for the new models in https://github.com/studentinsights/studentinsights/issues/115.  But if you find that you end up needing to use different field names for some reason, it's easy to change the controller code and UI code to match later too.