### PR TITLE
Cross-browser styling fixes: layout, SVG overflow and profile v2 buttons

### DIFF
--- a/app/assets/javascripts/student_profile_v2/academic_summary.js
+++ b/app/assets/javascripts/student_profile_v2/academic_summary.js
@@ -5,6 +5,19 @@
   var merge = window.shared.ReactHelpers.merge;
   var PropTypes = window.shared.PropTypes;
 
+  var styles = {
+    caption: {
+      marginRight: 5
+    },
+    value: {
+      fontWeight: 'bold'
+    },
+    sparklineContainer: {
+      paddingLeft: 15,
+      paddingRight: 15
+    }
+  };
+  
   var AcademicSummary = window.shared.AcademicSummary = React.createClass({
     displayName: 'AcademicSummary',
 
@@ -14,22 +27,13 @@
       sparkline: React.PropTypes.element.isRequired
     },
 
-    // TODO(kr) statics?
-    styles: {
-      caption: {
-        marginRight: 5
-      },
-      value: {
-        fontWeight: 'bold'
-      }
-    },
-
     render: function() {
-      var styles = this.styles;
       return dom.div({ className: 'AcademicSummary' },
-        dom.span({ style: styles.caption }, this.props.caption + ':'),
-        dom.span({ style: styles.value }, (this.props.value === undefined) ? 'none' : this.props.value),
-        dom.div({}, this.props.sparkline)
+        dom.div({},
+          dom.span({ style: styles.caption }, this.props.caption + ':'),
+          dom.span({ style: styles.value }, (this.props.value === undefined) ? 'none' : this.props.value)
+        ),
+        dom.div({ style: styles.sparklineContainer }, this.props.sparkline)
       );
     }
   });

--- a/app/assets/javascripts/student_profile_v2/academic_summary.js
+++ b/app/assets/javascripts/student_profile_v2/academic_summary.js
@@ -15,6 +15,9 @@
     sparklineContainer: {
       paddingLeft: 15,
       paddingRight: 15
+    },
+    textContainer: {
+      paddingBottom: 5
     }
   };
   
@@ -29,7 +32,7 @@
 
     render: function() {
       return dom.div({ className: 'AcademicSummary' },
-        dom.div({},
+        dom.div({ style: styles.textContainer },
           dom.span({ style: styles.caption }, this.props.caption + ':'),
           dom.span({ style: styles.value }, (this.props.value === undefined) ? 'none' : this.props.value)
         ),

--- a/app/assets/javascripts/student_profile_v2/record_service.js
+++ b/app/assets/javascripts/student_profile_v2/record_service.js
@@ -24,8 +24,9 @@
     },
     serviceButton: {
       background: '#eee', // override CSS
-      color: 'black',
-      // shrinking:
+      color: 'black'
+    },
+    buttonWidth: {
       width: '12em',
       fontSize: 12,
       padding: 8
@@ -92,16 +93,16 @@
     renderWhichService: function() {
       return dom.div({}, 
         dom.div({ style: { marginBottom: 5 } }, 'Which service?'),
-        dom.div({ style: { display: 'flex' } },
-          dom.div({ style: { flex: 1 } },
+        dom.div({ style: { display: 'flex', justifyContent: 'flex-start' } },
+          dom.div({ style: styles.buttonWidth },
             this.renderServiceButton(505),
             this.renderServiceButton(506)
           ),
-          dom.div({ style: { flex: 1 } },
+          dom.div({ style: styles.buttonWidth },
             this.renderServiceButton(507),
             this.renderServiceButton(508)
           ),
-          dom.div({ style: { flex: 'auto' } },
+          dom.div({ style: styles.buttonWidth },
             this.renderServiceButton(502),
             this.renderServiceButton(503),
             this.renderServiceButton(504)
@@ -129,10 +130,9 @@
         className: 'btn service-type',
         onClick: this.onServiceClicked.bind(this, serviceTypeId),
         tabIndex: -1,
-        style: merge(styles.serviceButton, {
+        style: merge(styles.serviceButton, styles.buttonWidth, {
           background: color,
           opacity: (this.state.serviceTypeId === null || this.state.serviceTypeId === serviceTypeId) ? 1 : 0.25,
-          outline: 0,
           border: (this.state.serviceTypeId === serviceTypeId)
             ? '4px solid rgba(49, 119, 201, 0.75)'
             : '4px solid white'

--- a/app/assets/javascripts/student_profile_v2/sparkline.js
+++ b/app/assets/javascripts/student_profile_v2/sparkline.js
@@ -41,7 +41,7 @@
         .interpolate('linear');
 
       var lineColor = color(this.delta(this.props.quads));
-      return dom.div({ className: 'Sparkline' },
+      return dom.div({ className: 'Sparkline', style: { overflow: 'hidden' }},
         dom.svg({
           height: this.props.height,
           width: this.props.width

--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -23,24 +23,23 @@
 
   // define page component
   var styles = {
-    page: {
-      marginLeft: 20,
-      marginRight: 20
-    },
     summaryContainer: {
       display: 'flex',
       flexDirection: 'row',
-      background: '#eee'
+      background: '#eee',
+      marginLeft: 20,
+      marginRight: 20
     },
     detailsContainer: {
       margin: 30
     },
     academicColumn: {
       textAlign: 'center',
-      flex: 3
+      flex: 1,
+      maxWidth: 220
     },
     column: {
-      flex: 4,
+      flex: 1,
       padding: 15,
       cursor: 'pointer'
     },
@@ -121,7 +120,7 @@
     },
 
     render: function() {
-      return dom.div({ className: 'StudentProfileV2Page', style: styles.page },
+      return dom.div({ className: 'StudentProfileV2Page' },
         this.renderSaveStatus(),
         createEl(StudentProfileHeader, { student: this.props.student }),
         dom.div({ className: 'summary-container', style: styles.summaryContainer },

--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -40,13 +40,13 @@
       flex: 3
     },
     column: {
-      flex: 5,
-      padding: 20,
+      flex: 4,
+      padding: 15,
       cursor: 'pointer'
     },
     selectedColumn: {
       border: '5px solid rgba(49, 119, 201, 0.64)',
-      padding: 15
+      padding: 10
     },
     summaryWrapper: {
       paddingBottom: 10

--- a/app/assets/stylesheets/overall.scss
+++ b/app/assets/stylesheets/overall.scss
@@ -13,6 +13,7 @@
 }
 
 body {
+  min-width: 1024px;
 }
 
 .info-area {


### PR DESCRIPTION
Bunch of improvements here, tested locally on Safari.  The actual issue is IE compatibility, so I'll test those on browserstack on the demo site after merging.

#### IE11 in browserstack, before:
<img width="1255" alt="screen shot 2016-02-25 at 12 59 33 pm" src="https://cloud.githubusercontent.com/assets/1056957/13330323/6669160e-dbc6-11e5-9eb2-e3337bb13fd9.png">
<img width="1199" alt="screen shot 2016-02-25 at 12 59 49 pm" src="https://cloud.githubusercontent.com/assets/1056957/13330325/680ea712-dbc6-11e5-9fe7-e9b3f6767ffe.png">


#### Safari before, SVG paths overflowing:
<img width="1076" alt="screen shot 2016-02-25 at 1 17 50 pm" src="https://cloud.githubusercontent.com/assets/1056957/13330155/7e4cd28e-dbc5-11e5-9965-85c15209fe67.png">

#### Safari after, no overflow:
<img width="1009" alt="screen shot 2016-02-25 at 1 21 51 pm" src="https://cloud.githubusercontent.com/assets/1056957/13330315/5a29591c-dbc6-11e5-825a-346e536987df.png">

#### Safari after, columns for buttons fixed width:
<img width="961" alt="screen shot 2016-02-25 at 1 34 09 pm" src="https://cloud.githubusercontent.com/assets/1056957/13330340/786b1e9c-dbc6-11e5-812f-9a00b68164b2.png">

#### Safari/Chrome after, showing changes in profile v2 layout flexing:
<img width="1014" alt="screen shot 2016-02-25 at 1 46 45 pm" src="https://cloud.githubusercontent.com/assets/1056957/13330302/4a66b7fe-dbc6-11e5-93d5-2bb398792df6.png">
<img width="1429" alt="screen shot 2016-02-25 at 1 46 50 pm" src="https://cloud.githubusercontent.com/assets/1056957/13330306/4d983236-dbc6-11e5-8753-438b5e1d553d.png">