### PR TITLE
Remove unused MCAS assessment subjects

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -3,7 +3,7 @@ class Assessment < ActiveRecord::Base
   has_many :students, through: :student_assessments
   validate :has_valid_subject
 
-  VALID_MCAS_SUBJECTS = [ 'ELA', 'Mathematics', 'Science', 'Arts', 'Technology' ].freeze
+  VALID_MCAS_SUBJECTS = [ 'ELA', 'Mathematics' ].freeze
   VALID_STAR_SUBJECTS = [ 'Mathematics', 'Reading' ].freeze
 
   def has_valid_subject

--- a/db/migrate/20160226145922_remove_mcas_assessment_subjects_not_being_used.rb
+++ b/db/migrate/20160226145922_remove_mcas_assessment_subjects_not_being_used.rb
@@ -1,0 +1,5 @@
+class RemoveMcasAssessmentSubjectsNotBeingUsed < ActiveRecord::Migration
+  def change
+    Assessment.where(family: 'MCAS', subject: ['Science', 'Arts', 'Technology']).destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160217010342) do
+ActiveRecord::Schema.define(version: 20160226145922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
## Notes

* MCAS Science and Technology results are not being surfaced anywhere in the application at the moment, so we don't need to keep that data around the app
* MCAS "Arts" is vestigial from a string parsing error — should really refer to "English Language Arts" so no point in keeping this around