### PR TITLE
Profile v2 - UI read path for rendering services and notes for deprecated tables

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -46,6 +46,7 @@
 
 // student profile page v2:
 // components:
+  //= require ./student_profile_v2/service_color
   //= require ./student/profile_charts/profile_chart_settings
   //= require ./student_profile_v2/educator
   //= require ./student_profile_v2/highcharts_wrapper
@@ -58,7 +59,6 @@
   //= require ./student_profile_v2/summary_list
   //= require ./student_profile_v2/profileChart.js
   //= require ./student_profile_v2/student_profile_header
-  //= require ./student_profile_v2/service_color
 // details:
   //= require ./student_profile_v2/profile_details
   //= require ./student_profile_v2/attendance_details

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -55,6 +55,7 @@
   //= require ./student_profile_v2/quad_converter
   //= require ./student_profile_v2/academic_summary
   //= require ./student_profile_v2/take_notes
+  //= require ./student_profile_v2/notes_list
   //= require ./student_profile_v2/record_service
   //= require ./student_profile_v2/summary_list
   //= require ./student_profile_v2/profileChart.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -58,6 +58,7 @@
   //= require ./student_profile_v2/summary_list
   //= require ./student_profile_v2/profileChart.js
   //= require ./student_profile_v2/student_profile_header
+  //= require ./student_profile_v2/service_color
 // details:
   //= require ./student_profile_v2/profile_details
   //= require ./student_profile_v2/attendance_details

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -48,6 +48,7 @@
 // components:
   //= require ./student_profile_v2/service_color
   //= require ./student/profile_charts/profile_chart_settings
+  //= require ./student_profile_v2/feed_helpers
   //= require ./student_profile_v2/educator
   //= require ./student_profile_v2/highcharts_wrapper
   //= require ./student_profile_v2/sparkline

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -57,6 +57,7 @@
   //= require ./student_profile_v2/academic_summary
   //= require ./student_profile_v2/take_notes
   //= require ./student_profile_v2/notes_list
+  //= require ./student_profile_v2/services_list
   //= require ./student_profile_v2/record_service
   //= require ./student_profile_v2/summary_list
   //= require ./student_profile_v2/profileChart.js

--- a/app/assets/javascripts/helpers/prop_types.js
+++ b/app/assets/javascripts/helpers/prop_types.js
@@ -22,6 +22,17 @@
     }),
     api: React.PropTypes.shape({
       saveNotes: React.PropTypes.func.isRequired
+    }),
+
+    // The feed of all notes and data entered in Student Insights for
+    // a student.
+    feed: React.PropTypes.shape({
+      event_notes: React.PropTypes.array.isRequired,
+      services: React.PropTypes.array.isRequired,
+      deprecated: React.PropTypes.shape({
+        notes: React.PropTypes.array.isRequired,
+        interventions: React.PropTypes.array.isRequired
+      })
     })
   };
 })();

--- a/app/assets/javascripts/student_profile_v2/feed_helpers.js
+++ b/app/assets/javascripts/student_profile_v2/feed_helpers.js
@@ -1,0 +1,57 @@
+(function() {
+  window.shared || (window.shared = {});
+  var merge = window.shared.ReactHelpers.merge;
+
+  /*
+  Functions for transforming the feed data structure that holds
+  all notes and services for a student.
+  */
+  var FeedHelpers = window.shared.FeedHelpers = {
+    // Merges data from event_notes, services and deprecated tables (notes, interventions).
+    mergedNotes: function(feed) {
+      var deprecatedNotes = feed.deprecated.notes.map(function(deprecatedNote) {
+        return merge(deprecatedNote, {
+          type: 'deprecated_notes',
+          sort_timestamp: deprecatedNote.created_at_timestamp
+        });
+      });
+      var deprecatedInterventions = feed.deprecated.interventions.map(function(intervention) {
+        return merge(intervention, {
+          type: 'deprecated_interventions',
+          sort_timestamp: intervention.updated_at
+        });
+      });
+      var deprecatedProgressNotes = _.flatten(feed.deprecated.interventions.map(function(intervention) {
+        return intervention.progress_notes.map(function(progressNote) {
+          return merge(progressNote, {
+            type: 'deprecated_progress_notes',
+            sort_timestamp: progressNote.updated_at,
+            intervention: intervention
+          });
+        });
+      }));
+      var eventNotes = feed.event_notes.map(function(eventNote) {
+        return merge(eventNote, {
+          type: 'event_notes',
+          sort_timestamp: eventNote.recorded_at
+        });
+      });
+
+      var mergedNotes = eventNotes.concat.apply(eventNotes, [
+        deprecatedNotes,
+        deprecatedInterventions,
+        deprecatedProgressNotes
+      ]);
+      return _.sortBy(mergedNotes, 'sort_timestamp').reverse();
+    },
+
+    // Returns a list of all educatorIds that are active for the student,
+    // based on the feed.
+    allEducatorIds: function(feed) {
+      var mergedNotes = FeedHelpers.mergedNotes(feed);
+      var idsFromNotes = _.pluck(mergedNotes, 'educator_id');
+      var idsFromServices = _.pluck(feed.services, 'assigned_to_educator_id');
+      return _.unique(idsFromNotes.concat(idsFromServices));
+    }
+  };
+})();

--- a/app/assets/javascripts/student_profile_v2/feed_helpers.js
+++ b/app/assets/javascripts/student_profile_v2/feed_helpers.js
@@ -42,7 +42,7 @@
         deprecatedInterventions,
         deprecatedProgressNotes
       ]);
-      return _.sortBy(mergedNotes, 'sort_timestamp').reverse();
+      return _.sortBy(mergedNotes, 'sort_timestamp');
     },
 
     // Returns a list of all educatorIds that are active for the student,

--- a/app/assets/javascripts/student_profile_v2/feed_helpers.js
+++ b/app/assets/javascripts/student_profile_v2/feed_helpers.js
@@ -18,7 +18,7 @@
       var deprecatedInterventions = feed.deprecated.interventions.map(function(intervention) {
         return merge(intervention, {
           type: 'deprecated_interventions',
-          sort_timestamp: intervention.updated_at
+          sort_timestamp: intervention.start_date_timestamp
         });
       });
       var deprecatedProgressNotes = _.flatten(feed.deprecated.interventions.map(function(intervention) {
@@ -42,7 +42,7 @@
         deprecatedInterventions,
         deprecatedProgressNotes
       ]);
-      return _.sortBy(mergedNotes, 'sort_timestamp');
+      return _.sortBy(mergedNotes, 'sort_timestamp').reverse();
     },
 
     // Returns a list of all educatorIds that are active for the student,

--- a/app/assets/javascripts/student_profile_v2/feed_helpers.js
+++ b/app/assets/javascripts/student_profile_v2/feed_helpers.js
@@ -25,7 +25,7 @@
         return intervention.progress_notes.map(function(progressNote) {
           return merge(progressNote, {
             type: 'deprecated_progress_notes',
-            sort_timestamp: progressNote.updated_at,
+            sort_timestamp: progressNote.created_at_timestamp,
             intervention: intervention
           });
         });

--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -10,6 +10,7 @@
   var PropTypes = window.shared.PropTypes;
   var serviceColor = window.shared.serviceColor;
 
+  // TODO(kr) need to clean these all out
   var styles = {
     container: {
       display: 'flex'
@@ -76,7 +77,7 @@
       marginTop: 10,
       marginBottom: 10
     },
-    intervention: {
+    service: {
       border: '1px solid #eee',
       padding: 15,
       marginTop: 10,
@@ -252,7 +253,7 @@
     renderDeprecatedIntervention: function(deprecatedIntervention) {
       return createEl(NoteHeader, {
         key: ['deprecated_intervention', deprecatedIntervention.id].join(),
-        noteMoment: moment.utc(deprecatedIntervention.start_date),
+        noteMoment: moment.utc(deprecatedIntervention.start_date_timestamp),
         badge: dom.span({ style: styles.badge }, 'Older intervention'),
         educatorId: deprecatedIntervention.educator_id,
         content: _.compact([deprecatedIntervention.name, deprecatedIntervention.comment, deprecatedIntervention.goal]).join('\n'),

--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -6,6 +6,7 @@
   
   var Educator = window.shared.Educator;
   var TakeNotes = window.shared.TakeNotes;
+  var NotesList = window.shared.NotesList;
   var RecordService = window.shared.RecordService;
   var PropTypes = window.shared.PropTypes;
   var serviceColor = window.shared.serviceColor;
@@ -32,9 +33,6 @@
     interventionsContainer: {
       flex: 1
     },
-    noItems: {
-      margin: 10
-    },
     inlineBlock: {
       display: 'inline-block'
     },
@@ -53,30 +51,6 @@
       padding: 10,
       paddingLeft: 0
     },
-    date: {
-      paddingRight: 10,
-      fontWeight: 'bold',
-      display: 'inline-block'
-    },
-    badge: {
-      display: 'inline-block',
-      background: '#eee',
-      outline: '3px solid #eee',
-      width: '10em',
-      textAlign: 'center',
-      marginLeft: 10,
-      marginRight: 10
-    },
-    educator: {
-      paddingLeft: 5,
-      display: 'inline-block'
-    },
-    note: {
-      border: '1px solid #eee',
-      padding: 15,
-      marginTop: 10,
-      marginBottom: 10
-    },
     service: {
       border: '1px solid #eee',
       padding: 15,
@@ -88,9 +62,6 @@
       background: '#eee',
       marginLeft: 10
     },
-    noteText: {
-      marginTop: 5
-    },
     discontinue: {
       background: 'white',
       opacity: 0.5,
@@ -100,29 +71,12 @@
   };
 
 
-  // TODO(kr) extract, simplify styles
-  //props: {key, noteMoment, badge, educator_id, content}
-  var NoteHeader = React.createClass({
-    render: function() {
-      var header = this.props; // TODO(kr)
-      return dom.div({
-        className: 'note',
-        style: styles.note
-      },
-        dom.div({}, 
-          dom.span({ style: styles.date }, header.noteMoment.format('MMMM D, YYYY')),
-          header.badge,
-          dom.span({ style: styles.educator }, createEl(Educator, {
-            educator: this.props.educatorsIndex[header.educatorId]
-          }))
-        ),
-        dom.div({ style: { whiteSpace: 'pre-wrap' } },
-          dom.div({ style: styles.noteText }, header.content)
-        )
-      );
-    }
-  });
 
+  /*
+  The bottom region of the page, showing notes about the student, services
+  they are receiving, and allowing users to enter new information about
+  these as well.
+  */
   var InterventionsDetails = window.shared.InterventionsDetails = React.createClass({
     propTypes: {
       interventionTypesIndex: React.PropTypes.object.isRequired,
@@ -171,7 +125,10 @@
         dom.div({ style: styles.notesContainer },
           dom.h4({ style: styles.title}, 'Notes'),
           this.renderTakeNotesSection(),
-          this.renderNotes()
+          createEl(NotesList, {
+            mergedNotes: this.props.mergedNotes,
+            educatorsIndex: this.props.educatorsIndex
+          })
         ),
         dom.div({ style: styles.interventionsContainer },
           dom.h4({ style: styles.title}, 'Services'),
@@ -201,70 +158,6 @@
           onClick: this.onClickTakeNotes
         }, 'Take notes')
       );
-    },
-
-    renderNotes: function() {
-      var mergedNotes = this.props.mergedNotes;
-      return dom.div({}, (mergedNotes.length === 0) ? dom.div({ style: styles.noItems }, 'No notes') : mergedNotes.map(function(mergedNote) {
-        switch (mergedNote.type) {
-          case 'event_notes': return this.renderEventNote(mergedNote);
-          case 'deprecated_notes': return this.renderDeprecatedNote(mergedNote);
-          case 'deprecated_interventions': return this.renderDeprecatedIntervention(mergedNote);
-          case 'deprecated_progress_notes': return this.renderDeprecatedProgressNote(mergedNote);
-        }
-      }, this));
-    },
-
-    renderEventNoteTypeBadge: function(eventNoteTypeId) {
-      switch (eventNoteTypeId) {
-        case 1: return dom.span({ style: styles.badge }, 'SST meeting');
-        case 2: return dom.span({ style: styles.badge }, 'MTSS meeting');
-        case 3: return dom.span({ style: styles.badge }, 'Family');
-        case 5: return dom.span({ style: styles.badge }, 'Something else');
-      }
-
-      return null;
-    },
-
-    renderEventNote: function(eventNote) {
-      return createEl(NoteHeader, {
-        key: ['event_note', eventNote.id].join(),
-        noteMoment: moment.utc(eventNote.recorded_at),
-        badge: this.renderEventNoteTypeBadge(eventNote.event_note_type_id),
-        educatorId: eventNote.educator_id,
-        content: eventNote.text,
-        educatorsIndex: this.props.educatorsIndex
-      });
-    },
-
-    renderDeprecatedNote: function(deprecatedNote) {
-      return createEl(NoteHeader, {
-        key: ['deprecated_note', deprecatedNote.id].join(),
-        noteMoment: moment.utc(deprecatedNote.created_at_timestamp),
-        badge: dom.span({ style: styles.badge }, 'Older note'),
-        educatorId: deprecatedNote.educator_id,
-        content: deprecatedNote.content,
-        educatorsIndex: this.props.educatorsIndex
-      });
-    },
-
-    // TODO(kr) support custom intervention type
-    // This assumes that the `end_date` field is not accurate enough to be worth splitting
-    // this out into two note entries.
-    renderDeprecatedIntervention: function(deprecatedIntervention) {
-      return createEl(NoteHeader, {
-        key: ['deprecated_intervention', deprecatedIntervention.id].join(),
-        noteMoment: moment.utc(deprecatedIntervention.start_date_timestamp),
-        badge: dom.span({ style: styles.badge }, 'Older intervention'),
-        educatorId: deprecatedIntervention.educator_id,
-        content: _.compact([deprecatedIntervention.name, deprecatedIntervention.comment, deprecatedIntervention.goal]).join('\n'),
-        educatorsIndex: this.props.educatorsIndex
-      });
-    },
-
-    // TODO(kr) not done!
-    renderDeprecatedProgressNote: function(deprecatedProgressNote) {
-      return null;
     },
 
     renderRecordServiceSection: function() {

--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -100,7 +100,8 @@
   };
 
 
-  //{key, noteMoment, badge, educator_id, content}
+  // TODO(kr) extract, simplify styles
+  //props: {key, noteMoment, badge, educator_id, content}
   var NoteHeader = React.createClass({
     render: function() {
       var header = this.props; // TODO(kr)

--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -83,9 +83,9 @@
       serviceTypesIndex: React.PropTypes.object.isRequired,
       educatorsIndex: React.PropTypes.object.isRequired,
       currentEducator: React.PropTypes.object.isRequired,
+      actions: PropTypes.actions.isRequired,
 
-      mergedNotes: React.PropTypes.array.isRequired,
-      actions: PropTypes.actions.isRequired
+      feed: PropTypes.feed.isRequired
     },
 
     getInitialState: function() {
@@ -126,7 +126,7 @@
           dom.h4({ style: styles.title}, 'Notes'),
           this.renderTakeNotesSection(),
           createEl(NotesList, {
-            mergedNotes: this.props.mergedNotes,
+            feed: this.props.feed,
             educatorsIndex: this.props.educatorsIndex
           })
         ),

--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -132,8 +132,8 @@
       if (this.state.isAddingService) {
         return createEl(RecordService, {
           studentFirstName: this.props.student.first_name,
-          onSave: this.onSaveNotes,
-          onCancel: this.onCancelNotes,
+          onSave: this.onSaveRecordService,
+          onCancel: this.onCancelRecordService,
           requestState: this.props.requests.saveNotes,
 
           nowMoment: moment.utc(), // TODO(kr) thread through

--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -5,11 +5,11 @@
   var merge = window.shared.ReactHelpers.merge;
 
   var Educator = window.shared.Educator;
+  var PropTypes = window.shared.PropTypes;
   var TakeNotes = window.shared.TakeNotes;
   var NotesList = window.shared.NotesList;
+  var ServicesList = window.shared.ServicesList;
   var RecordService = window.shared.RecordService;
-  var PropTypes = window.shared.PropTypes;
-  var serviceColor = window.shared.serviceColor;
 
   // TODO(kr) need to clean these all out
   var styles = {
@@ -32,27 +32,6 @@
       color: 'black',
       padding: 10,
       paddingLeft: 0
-    },
-
-    service: {
-      border: '1px solid #eee',
-      padding: 15,
-      marginTop: 10,
-      marginBottom: 10
-    },
-    userText: {
-      whiteSpace: 'pre-wrap'
-    },
-    daysAgo: {
-      opacity: 0.25,
-      paddingLeft: 10,
-      display: 'inline-block'
-    },
-    discontinue: {
-      background: 'white',
-      opacity: 0.5,
-      border: '1px solid #ccc',
-      color: '#666'
     }
   };
 
@@ -119,9 +98,11 @@
         dom.div({ style: styles.servicesContainer },
           dom.h4({ style: styles.title}, 'Services'),
           dom.div({ style: styles.addServiceContainer }, this.renderRecordServiceSection()),
-          (this.props.feed.services.length === 0)
-            ? dom.div({ style: styles.noItems }, 'No services')
-            : this.renderServices()
+          createEl(ServicesList, {
+            services: this.props.feed.services,
+            educatorsIndex: this.props.educatorsIndex,
+            serviceTypesIndex: this.props.serviceTypesIndex
+          })
         )
       );
     },
@@ -166,41 +147,6 @@
         className: 'btn record-service',
         onClick: this.onClickRecordService
       }, 'Record service')
-    },
-
-    renderServices: function() {
-      var sortedInterventions = _.sortBy(this.props.feed.services, 'date_started').reverse();
-      return sortedInterventions.map(this.renderService);
-    },
-
-    // TODO(kr) allow editing, fixup.  'no longer active'
-    // TODO(kr) for now, going with ignoring older data we could interpret to be here,
-    // for end-user simplicity.  Start with fresh data.
-    renderService: function(service) {
-      var serviceText = this.props.serviceTypesIndex[service.service_type_id].name;
-      var momentStarted = moment.utc(service.date_started);
-      var educatorEmail = this.props.educatorsIndex[service.assigned_to_educator_id].email;
-      return dom.div({
-        key: service.id,
-        style: merge(styles.service, { background: serviceColor(service.service_type_id) })
-      },
-        dom.div({ style: { display: 'flex' } },
-          dom.div({ style: { flex: 1 } },
-            dom.div({ style: { fontWeight: 'bold' } }, serviceText),
-            dom.div({}, 'With ' + educatorEmail),
-            dom.div({},
-              'Since ',
-              momentStarted.format('MMMM D, YYYY'),
-              dom.span({ style: styles.daysAgo }, momentStarted.fromNow(true))
-            )
-          )
-          // TODO(kr) re-enable
-          // dom.div({},
-          //   dom.button({ className: 'btn', style: styles.discontinue }, 'Discontinue')
-          // )
-        ),
-        dom.div({ style: merge(styles.userText, { paddingTop: 15 }) }, service.comment)
-      );
     }
   });
 })();

--- a/app/assets/javascripts/student_profile_v2/interventions_details.js
+++ b/app/assets/javascripts/student_profile_v2/interventions_details.js
@@ -3,7 +3,7 @@
   var dom = window.shared.ReactHelpers.dom;
   var createEl = window.shared.ReactHelpers.createEl;
   var merge = window.shared.ReactHelpers.merge;
-  
+
   var Educator = window.shared.Educator;
   var TakeNotes = window.shared.TakeNotes;
   var NotesList = window.shared.NotesList;
@@ -20,29 +20,11 @@
       flex: 1,
       marginRight: 20
     },
-    dialog: {
-      border: '1px solid #ccc',
-      borderRadius: 2,
-      padding: 20,
-      marginBottom: 20,
-      marginTop: 10
+    servicesContainer: {
+      flex: 1
     },
     addServiceContainer: {
       marginTop: 10
-    },
-    interventionsContainer: {
-      flex: 1
-    },
-    inlineBlock: {
-      display: 'inline-block'
-    },
-    userText: {
-      whiteSpace: 'pre-wrap'
-    },
-    daysAgo: {
-      opacity: 0.25,
-      paddingLeft: 10,
-      display: 'inline-block'
     },
     title: {
       borderBottom: '1px solid #333',
@@ -51,16 +33,20 @@
       padding: 10,
       paddingLeft: 0
     },
+
     service: {
       border: '1px solid #eee',
       padding: 15,
       marginTop: 10,
       marginBottom: 10
     },
-    cancelTakeNotesButton: { // overidding CSS
-      color: 'black',
-      background: '#eee',
-      marginLeft: 10
+    userText: {
+      whiteSpace: 'pre-wrap'
+    },
+    daysAgo: {
+      opacity: 0.25,
+      paddingLeft: 10,
+      display: 'inline-block'
     },
     discontinue: {
       background: 'white',
@@ -130,7 +116,7 @@
             educatorsIndex: this.props.educatorsIndex
           })
         ),
-        dom.div({ style: styles.interventionsContainer },
+        dom.div({ style: styles.servicesContainer },
           dom.h4({ style: styles.title}, 'Services'),
           dom.div({ style: styles.addServiceContainer }, this.renderRecordServiceSection()),
           (this.props.feed.services.length === 0)

--- a/app/assets/javascripts/student_profile_v2/notes_list.js
+++ b/app/assets/javascripts/student_profile_v2/notes_list.js
@@ -5,6 +5,8 @@
   var merge = window.shared.ReactHelpers.merge;
   
   var Educator = window.shared.Educator;
+  var PropTypes = window.shared.PropTypes;
+  var FeedHelpers = window.shared.FeedHelpers;
   var moment = window.moment;
 
   var styles = {
@@ -71,12 +73,12 @@
   //noItems, badge
   var NotesList = window.shared.NotesList = React.createClass({
     propTypes: {
-      mergedNotes: React.PropTypes.array.isRequired,
+      feed: PropTypes.feed.isRequired,
       educatorsIndex: React.PropTypes.object.isRequired
     },
 
     render: function() {
-      var mergedNotes = this.props.mergedNotes;
+      var mergedNotes = FeedHelpers.mergedNotes(this.props.feed);
       return dom.div({}, (mergedNotes.length === 0) ? dom.div({ style: styles.noItems }, 'No notes') : mergedNotes.map(function(mergedNote) {
         switch (mergedNote.type) {
           case 'event_notes': return this.renderEventNote(mergedNote);

--- a/app/assets/javascripts/student_profile_v2/notes_list.js
+++ b/app/assets/javascripts/student_profile_v2/notes_list.js
@@ -1,0 +1,142 @@
+(function() {
+  window.shared || (window.shared = {});
+  var dom = window.shared.ReactHelpers.dom;
+  var createEl = window.shared.ReactHelpers.createEl;
+  var merge = window.shared.ReactHelpers.merge;
+  
+  var Educator = window.shared.Educator;
+  var moment = window.moment;
+
+  var styles = {
+    noItems: {
+      margin: 10
+    },
+    note: {
+      border: '1px solid #eee',
+      padding: 15,
+      marginTop: 10,
+      marginBottom: 10
+    },
+    badge: {
+      display: 'inline-block',
+      background: '#eee',
+      outline: '3px solid #eee',
+      width: '10em',
+      textAlign: 'center',
+      marginLeft: 10,
+      marginRight: 10
+    },
+    date: {
+      paddingRight: 10,
+      fontWeight: 'bold',
+      display: 'inline-block'
+    },
+    educator: {
+      paddingLeft: 5,
+      display: 'inline-block'
+    },
+    noteText: {
+      marginTop: 5
+    }
+  };
+
+  // This renders a single card for a 
+  var NoteCard = React.createClass({
+    propTypes: {
+      noteMoment: React.PropTypes.instanceOf(moment).isRequired,
+      educatorId: React.PropTypes.number.isRequired,
+      badge: React.PropTypes.element.isRequired,
+      text: React.PropTypes.string.isRequired
+    },
+
+    render: function() {
+      return dom.div({
+        className: 'note',
+        style: styles.note
+      },
+        dom.div({}, 
+          dom.span({ style: styles.date }, this.props.noteMoment.format('MMMM D, YYYY')),
+          this.props.badge,
+          dom.span({ style: styles.educator }, createEl(Educator, {
+            educator: this.props.educatorsIndex[this.props.educatorId]
+          }))
+        ),
+        dom.div({ style: { whiteSpace: 'pre-wrap' } },
+          dom.div({ style: styles.noteText }, this.props.text)
+        )
+      );
+    }
+  });
+
+  //noItems, badge
+  var NotesList = window.shared.NotesList = React.createClass({
+    propTypes: {
+      mergedNotes: React.PropTypes.array.isRequired,
+      educatorsIndex: React.PropTypes.object.isRequired
+    },
+
+    render: function() {
+      var mergedNotes = this.props.mergedNotes;
+      return dom.div({}, (mergedNotes.length === 0) ? dom.div({ style: styles.noItems }, 'No notes') : mergedNotes.map(function(mergedNote) {
+        switch (mergedNote.type) {
+          case 'event_notes': return this.renderEventNote(mergedNote);
+          case 'deprecated_notes': return this.renderDeprecatedNote(mergedNote);
+          case 'deprecated_interventions': return this.renderDeprecatedIntervention(mergedNote);
+          case 'deprecated_progress_notes': return this.renderDeprecatedProgressNote(mergedNote);
+        }
+      }, this));
+    },
+
+    renderEventNoteTypeBadge: function(eventNoteTypeId) {
+      switch (eventNoteTypeId) {
+        case 1: return dom.span({ style: styles.badge }, 'SST meeting');
+        case 2: return dom.span({ style: styles.badge }, 'MTSS meeting');
+        case 3: return dom.span({ style: styles.badge }, 'Family');
+        case 5: return dom.span({ style: styles.badge }, 'Something else');
+      }
+
+      return null;
+    },
+
+    renderEventNote: function(eventNote) {
+      return createEl(NoteCard, {
+        key: ['event_note', eventNote.id].join(),
+        noteMoment: moment.utc(eventNote.recorded_at),
+        badge: this.renderEventNoteTypeBadge(eventNote.event_note_type_id),
+        educatorId: eventNote.educator_id,
+        text: eventNote.text,
+        educatorsIndex: this.props.educatorsIndex
+      });
+    },
+
+    renderDeprecatedNote: function(deprecatedNote) {
+      return createEl(NoteCard, {
+        key: ['deprecated_note', deprecatedNote.id].join(),
+        noteMoment: moment.utc(deprecatedNote.created_at_timestamp),
+        badge: dom.span({ style: styles.badge }, 'Older note'),
+        educatorId: deprecatedNote.educator_id,
+        text: deprecatedNote.content,
+        educatorsIndex: this.props.educatorsIndex
+      });
+    },
+
+    // TODO(kr) support custom intervention type
+    // This assumes that the `end_date` field is not accurate enough to be worth splitting
+    // this out into two note entries.
+    renderDeprecatedIntervention: function(deprecatedIntervention) {
+      return createEl(NoteCard, {
+        key: ['deprecated_intervention', deprecatedIntervention.id].join(),
+        noteMoment: moment.utc(deprecatedIntervention.start_date_timestamp),
+        badge: dom.span({ style: styles.badge }, 'Older intervention'),
+        educatorId: deprecatedIntervention.educator_id,
+        text: _.compact([deprecatedIntervention.name, deprecatedIntervention.comment, deprecatedIntervention.goal]).join('\n'),
+        educatorsIndex: this.props.educatorsIndex
+      });
+    },
+
+    // TODO(kr) not done!
+    renderDeprecatedProgressNote: function(deprecatedProgressNote) {
+      return null;
+    }
+  });
+})();

--- a/app/assets/javascripts/student_profile_v2/notes_list.js
+++ b/app/assets/javascripts/student_profile_v2/notes_list.js
@@ -19,6 +19,12 @@
       marginTop: 10,
       marginBottom: 10
     },
+    date: {
+      display: 'inline-block',
+      width: '11em',
+      paddingRight: 10,
+      fontWeight: 'bold'
+    },
     badge: {
       display: 'inline-block',
       background: '#eee',
@@ -27,11 +33,6 @@
       textAlign: 'center',
       marginLeft: 10,
       marginRight: 10
-    },
-    date: {
-      paddingRight: 10,
-      fontWeight: 'bold',
-      display: 'inline-block'
     },
     educator: {
       paddingLeft: 5,
@@ -121,7 +122,7 @@
       return createEl(NoteCard, {
         key: ['deprecated_note', deprecatedNote.id].join(),
         noteMoment: moment.utc(deprecatedNote.created_at_timestamp),
-        badge: dom.span({ style: styles.badge }, 'Older note'),
+        badge: dom.span({ style: styles.badge }, 'Old note'),
         educatorId: deprecatedNote.educator_id,
         text: deprecatedNote.content,
         educatorsIndex: this.props.educatorsIndex
@@ -135,16 +136,22 @@
       return createEl(NoteCard, {
         key: ['deprecated_intervention', deprecatedIntervention.id].join(),
         noteMoment: moment.utc(deprecatedIntervention.start_date_timestamp),
-        badge: dom.span({ style: styles.badge }, 'Older intervention'),
+        badge: dom.span({ style: styles.badge }, 'Old intervention'),
         educatorId: deprecatedIntervention.educator_id,
         text: _.compact([deprecatedIntervention.name, deprecatedIntervention.comment, deprecatedIntervention.goal]).join('\n'),
         educatorsIndex: this.props.educatorsIndex
       });
     },
 
-    // TODO(kr) not done!
     renderDeprecatedProgressNote: function(deprecatedProgressNote) {
-      return null;
+      return createEl(NoteCard, {
+        key: ['deprecated_progress_note', deprecatedProgressNote.id].join(),
+        noteMoment: moment.utc(deprecatedProgressNote.created_at_timestamp),
+        badge: dom.span({ style: styles.badge }, 'Old progress note'),
+        educatorId: deprecatedProgressNote.educator_id,
+        text: _.compact([deprecatedProgressNote.intervention.name, deprecatedProgressNote.content]).join('\n'),
+        educatorsIndex: this.props.educatorsIndex
+      });
     }
   });
 })();

--- a/app/assets/javascripts/student_profile_v2/notes_list.js
+++ b/app/assets/javascripts/student_profile_v2/notes_list.js
@@ -42,7 +42,7 @@
     }
   };
 
-  // This renders a single card for a 
+  // This renders a single card for a Note of any type.
   var NoteCard = React.createClass({
     propTypes: {
       noteMoment: React.PropTypes.instanceOf(moment).isRequired,
@@ -70,8 +70,12 @@
     }
   });
 
-  //noItems, badge
+  /*
+  Renders the list of notes.
+  */
   var NotesList = window.shared.NotesList = React.createClass({
+    displayName: 'NotesList',
+
     propTypes: {
       feed: PropTypes.feed.isRequired,
       educatorsIndex: React.PropTypes.object.isRequired
@@ -79,7 +83,7 @@
 
     render: function() {
       var mergedNotes = FeedHelpers.mergedNotes(this.props.feed);
-      return dom.div({}, (mergedNotes.length === 0) ? dom.div({ style: styles.noItems }, 'No notes') : mergedNotes.map(function(mergedNote) {
+      return dom.div({ className: 'NotesList' }, (mergedNotes.length === 0) ? dom.div({ style: styles.noItems }, 'No notes') : mergedNotes.map(function(mergedNote) {
         switch (mergedNote.type) {
           case 'event_notes': return this.renderEventNote(mergedNote);
           case 'deprecated_notes': return this.renderDeprecatedNote(mergedNote);

--- a/app/assets/javascripts/student_profile_v2/notes_list.js
+++ b/app/assets/javascripts/student_profile_v2/notes_list.js
@@ -44,6 +44,8 @@
 
   // This renders a single card for a Note of any type.
   var NoteCard = React.createClass({
+    displayName: 'NoteCard',
+
     propTypes: {
       noteMoment: React.PropTypes.instanceOf(moment).isRequired,
       educatorId: React.PropTypes.number.isRequired,
@@ -53,11 +55,11 @@
 
     render: function() {
       return dom.div({
-        className: 'note',
+        className: 'NoteCard',
         style: styles.note
       },
         dom.div({}, 
-          dom.span({ style: styles.date }, this.props.noteMoment.format('MMMM D, YYYY')),
+          dom.span({ className: 'date', style: styles.date }, this.props.noteMoment.format('MMMM D, YYYY')),
           this.props.badge,
           dom.span({ style: styles.educator }, createEl(Educator, {
             educator: this.props.educatorsIndex[this.props.educatorId]

--- a/app/assets/javascripts/student_profile_v2/record_service.js
+++ b/app/assets/javascripts/student_profile_v2/record_service.js
@@ -7,6 +7,7 @@
   var PropTypes = window.shared.PropTypes;
   var ReactSelect = window.Select;
   var datepickerOptions = window.datepicker_options;
+  var serviceColor = window.shared.serviceColor;
 
   var styles = {
     dialog: {
@@ -112,19 +113,8 @@
     },
 
     renderServiceButton: function(serviceTypeId, options) {
-      var serviceNameMap = {
-        502: 'Attendance Officer',
-        503: 'Attendance Contract',
-        504: 'Behavior Contract',
-        505: 'Counseling, in-house',
-        506: 'Counseling, outside',
-        507: 'Reading intervention',
-        508: 'Math intervention'
-      };
-      var serviceType = this.props.serviceTypesIndex[serviceTypeId];
-      // TODO(kr) update default value here after merging server-side migrations
-      var serviceText = serviceNameMap[serviceTypeId] || 'Unknown service';
-      var color = this.serviceColor(serviceTypeId);
+      var serviceText = this.props.serviceTypesIndex[serviceTypeId].name;
+      var color = serviceColor(serviceTypeId);
 
       return dom.button({
         className: 'btn service-type',
@@ -138,19 +128,6 @@
             : '4px solid white'
         })
       }, serviceText);
-    },
-
-    serviceColor: function(serviceTypeId) {
-      var map = {
-       507: '#ffe7d6',
-       502: '#e8fce8',
-       503: '#e8fce8',
-       504: '#e8fce8',
-       505: '#eee',
-       506: '#eee',
-       508: '#e8e9fc'
-      };
-      return map[serviceTypeId] || null;
     },
 
     renderEducatorSelect: function() {

--- a/app/assets/javascripts/student_profile_v2/service_color.js
+++ b/app/assets/javascripts/student_profile_v2/service_color.js
@@ -1,0 +1,17 @@
+(function() {
+  window.shared || (window.shared = {});
+  
+  // Map service_type_id to a themed color.
+  var serviceColor = window.shared.serviceColor = function(serviceTypeId) {
+    var map = {
+     507: '#ffe7d6',
+     502: '#e8fce8',
+     503: '#e8fce8',
+     504: '#e8fce8',
+     505: '#eee',
+     506: '#eee',
+     508: '#e8e9fc'
+    };
+    return map[serviceTypeId] || null;
+  };
+})();

--- a/app/assets/javascripts/student_profile_v2/service_color.js
+++ b/app/assets/javascripts/student_profile_v2/service_color.js
@@ -1,16 +1,23 @@
 (function() {
   window.shared || (window.shared = {});
   
+  var Colors = {
+    purple: '#e8e9fc',
+    orange: '#ffe7d6',
+    green: '#e8fce8',
+    gray: '#eee'
+  };
+
   // Map service_type_id to a themed color.
   var serviceColor = window.shared.serviceColor = function(serviceTypeId) {
     var map = {
-     507: '#ffe7d6',
-     502: '#e8fce8',
-     503: '#e8fce8',
-     504: '#e8fce8',
-     505: '#eee',
-     506: '#eee',
-     508: '#e8e9fc'
+     507: Colors.orange,
+     502: Colors.green,
+     503: Colors.green,
+     504: Colors.green,
+     505: Colors.gray,
+     506: Colors.gray,
+     508: Colors.purple
     };
     return map[serviceTypeId] || null;
   };

--- a/app/assets/javascripts/student_profile_v2/services_list.js
+++ b/app/assets/javascripts/student_profile_v2/services_list.js
@@ -1,0 +1,90 @@
+(function() {
+  window.shared || (window.shared = {});
+  var dom = window.shared.ReactHelpers.dom;
+  var createEl = window.shared.ReactHelpers.createEl;
+  var merge = window.shared.ReactHelpers.merge;
+  
+  var Educator = window.shared.Educator;
+  var serviceColor = window.shared.serviceColor;
+  var moment = window.moment;
+
+  var styles = {
+    noItems: {
+      margin: 10
+    },
+    service: {
+      border: '1px solid #eee',
+      padding: 15,
+      marginTop: 10,
+      marginBottom: 10
+    },
+    userText: {
+      whiteSpace: 'pre-wrap'
+    },
+    daysAgo: {
+      opacity: 0.25,
+      paddingLeft: 10,
+      display: 'inline-block'
+    },
+    discontinue: {
+      background: 'white',
+      opacity: 0.5,
+      border: '1px solid #ccc',
+      color: '#666'
+    }
+  };
+
+
+  /*
+  Renders the list of services.
+  */
+  var ServicesList = window.shared.ServicesList = React.createClass({
+    displayName: 'ServicesList',
+
+    propTypes: {
+      services: React.PropTypes.array.isRequired,
+      serviceTypesIndex: React.PropTypes.object.isRequired,
+      educatorsIndex: React.PropTypes.object.isRequired
+    },
+
+    render: function() {
+      var elements = (this.props.services.length === 0)
+        ? dom.div({ style: styles.noItems }, 'No services')
+        : _.sortBy(this.props.services, 'date_started').reverse().map(this.renderService);
+      return dom.div({ className: 'ServicesList' }, elements);
+    },
+
+    // TODO(kr) allow editing, fixup.  'no longer active'
+    // TODO(kr) for now, going with ignoring older data we could interpret to be here,
+    // for end-user simplicity.  Start with fresh data.
+    renderService: function(service) {
+      var serviceText = this.props.serviceTypesIndex[service.service_type_id].name;
+      var momentStarted = moment.utc(service.date_started);
+      var educator = this.props.educatorsIndex[service.assigned_to_educator_id];
+      return dom.div({
+        key: service.id,
+        style: merge(styles.service, { background: serviceColor(service.service_type_id) })
+      },
+        dom.div({ style: { display: 'flex' } },
+          dom.div({ style: { flex: 1 } },
+            dom.div({ style: { fontWeight: 'bold' } }, serviceText),
+            dom.div({},
+              'With ',
+              createEl(Educator, { educator: educator })
+            ),
+            dom.div({},
+              'Since ',
+              momentStarted.format('MMMM D, YYYY'),
+              dom.span({ style: styles.daysAgo }, momentStarted.fromNow(true))
+            )
+          )
+          // TODO(kr) re-enable
+          // dom.div({},
+          //   dom.button({ className: 'btn', style: styles.discontinue }, 'Discontinue')
+          // )
+        ),
+        dom.div({ style: merge(styles.userText, { paddingTop: 15 }) }, service.comment)
+      );
+    }
+  });
+})();

--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -244,7 +244,7 @@
         onClick: this.onColumnClicked.bind(this, columnKey)
       }, this.padElements(styles.summaryWrapper, [
         this.renderPlacement(student),
-        this.renderInterventions(student),
+        this.renderServices(student),
         this.renderStaff(student)
       ]));
     },
@@ -263,25 +263,26 @@
       });
     },
 
-    renderInterventions: function(student) {
+    renderServices: function(student) {
       if (student.interventions.length === 0) {
         return createEl(SummaryList, {
           title: 'Services',
           elements: ['No services']
         });
       }
-
+      
       var limit = 3;
-      var sortedInterventions = _.sortBy(student.interventions, 'start_date').reverse();
-      var elements = sortedInterventions.slice(0, limit).map(function(intervention) {
-        var interventionText = this.props.interventionTypesIndex[intervention.intervention_type_id].name;
-        var daysText = moment.utc(intervention.start_date).from(this.props.nowMomentFn(), true);
-        return dom.span({ key: intervention.id },
-          dom.span({}, interventionText),
+      var sortedServices = _.sortBy(this.props.feed.services, 'date_started').reverse();
+      var elements = sortedServices.slice(0, limit).map(function(service) {
+        var serviceText = this.props.serviceTypesIndex[service.service_type_id].name;
+        var daysText = moment.utc(service.date_started).from(this.props.nowMomentFn(), true);
+        return dom.span({ key: service.id },
+          dom.span({}, serviceText),
           dom.span({ style: { opacity: 0.25, paddingLeft: 10 } }, daysText)
         );
       }, this);
-      if (sortedInterventions.length > limit) elements.push(dom.div({}, '+ ' + (sortedInterventions.length - limit) + ' more'));
+      if (sortedServices.length > limit) elements.push(dom.div({}, '+ ' + (sortedServices.length - limit) + ' more'));
+
       return createEl(SummaryList, {
         title: 'Services',
         elements: elements

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -151,15 +151,15 @@ class StudentsController < ApplicationController
 
   # TODO(kr) temporary, until building backend tables
   def fixture_service_types_index
-    [
-      { id: 502, name: 'Attendance Officer' },
-      { id: 503, name: 'Attendance Contract' },
-      { id: 504, name: 'Behavior Contract' },
-      { id: 505, name: 'Counseling, in-house' },
-      { id: 506, name: 'Counseling, outside' },
-      { id: 507, name: 'Reading intervention' },
-      { id: 508, name: 'Math intervention' }
-    ]
+    {
+      502 => { id: 502, name: 'Attendance Officer' },
+      503 => { id: 503, name: 'Attendance Contract' },
+      504 => { id: 504, name: 'Behavior Contract' },
+      505 => { id: 505, name: 'Counseling, in-house' },
+      506 => { id: 506, name: 'Counseling, outside' },
+      507 => { id: 507, name: 'Reading intervention' },
+      508 => { id: 508, name: 'Math intervention' }
+    }
   end
 
   # Merges 'event_notes' table with 'discontinued_event_notes' to
@@ -168,7 +168,7 @@ class StudentsController < ApplicationController
     fixture_educator_id = 1
     [{
       id: 133,
-      service_type_id: 1,
+      service_type_id: 503,
       recorded_by_educator_id: fixture_educator_id,
       assigned_to_educator_id: fixture_educator_id,
       date_started: '2016-02-09',
@@ -176,7 +176,7 @@ class StudentsController < ApplicationController
       discontinued_by_educator_id: fixture_educator_id
     }, {
       id: 134,
-      service_type_id: 1,
+      service_type_id: 506,
       recorded_by_educator_id: fixture_educator_id,
       assigned_to_educator_id: fixture_educator_id,
       date_started: '2016-02-08',

--- a/app/demo_data/fake_intervention_generator.rb
+++ b/app/demo_data/fake_intervention_generator.rb
@@ -20,23 +20,33 @@ class FakeInterventionGenerator
       number_of_hours: rand(1..8),
       goal: goal_for(intervention_type),
       custom_intervention_name: nil,
-      progress_notes: generate_progress_notes_for(intervention_type, educator)
+      progress_notes: []
     }
   end
 
+  def next_progress_note(intervention)
+    ProgressNote.new({
+      intervention: intervention,
+      created_at: intervention.end_date + rand(0..14).days,
+      content: progress_note_for(intervention),
+      educator_id: intervention.educator.id
+    })
+  end
+
+  private
   def sample_intervention_type
     InterventionType.all.sample
   end
 
   def comment_for(intervention_type)
-    ['foo', 'bar', 'whatever'].sample
+    ['Something happened.', 'The student had a tough day.', 'This intervention has worked well.'].sample
   end
 
   def goal_for(intervention_type)
-    ['reduce behavior', 'increase behavior', 'pass assessment', 'increase growth percentile'].sample
+    ['Reduce behavior.', 'Increase how often the student is engaged in positive behaviors.', 'The student will pass the assessment.', 'Increase growth percentile for this academic subject.'].sample
   end
 
-  def generate_progress_notes_for(intervention_type, educator)
-    []
+  def progress_note_for(intervention)
+    ['Making good progress.', 'Student is struggling.', 'Student is not progressing as expected.'].sample
   end
 end

--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -159,7 +159,14 @@ class FakeStudent
     15.in(100) do
       generator = FakeInterventionGenerator.new(@student)
       intervention_count = Rubystats::NormalDistribution.new(3, 6).rng.round
-      intervention_count.times { Intervention.new(generator.next).save! }
+      intervention_count.times do
+        intervention = Intervention.new(generator.next)
+        intervention.save!
+        rand(0..2).times do
+          intervention.progress_notes << generator.next_progress_note(intervention)
+        end
+        intervention.save!
+      end
     end
     nil
   end

--- a/app/helpers/serialize_data_helper.rb
+++ b/app/helpers/serialize_data_helper.rb
@@ -4,11 +4,13 @@ module SerializeDataHelper
     {
       id: intervention.id,
       name: intervention.name,
+      intervention_type_id: intervention.intervention_type_id,
       comment: intervention.comment,
       goal: intervention.goal,
       start_date: intervention.start_date.strftime('%B %e, %Y'),
       end_date: intervention.end_date.try(:strftime, '%B %e, %Y'),
       educator_email: intervention.educator.try(:email),
+      educator_id: intervention.educator.try(:id),
       progress_notes: intervention.progress_notes.order(created_at: :asc).map do |progress_note|
         serialize_progress_note(progress_note)
       end
@@ -19,6 +21,7 @@ module SerializeDataHelper
     {
       id: progress_note.id,
       educator_email: progress_note.educator.email,
+      educator_id: intervention.educator.id,
       content: progress_note.content,
       created_date: progress_note.created_at.strftime("%B %e, %Y %l:%M %p")
     }

--- a/app/helpers/serialize_data_helper.rb
+++ b/app/helpers/serialize_data_helper.rb
@@ -24,7 +24,8 @@ module SerializeDataHelper
       educator_email: progress_note.educator.email,
       educator_id: progress_note.educator.id,
       content: progress_note.content,
-      created_date: progress_note.created_at.strftime("%B %e, %Y %l:%M %p")
+      created_date: progress_note.created_at.strftime("%B %e, %Y %l:%M %p"),
+      created_at_timestamp: progress_note.created_at
     }
   end
 

--- a/app/helpers/serialize_data_helper.rb
+++ b/app/helpers/serialize_data_helper.rb
@@ -7,9 +7,10 @@ module SerializeDataHelper
       intervention_type_id: intervention.intervention_type_id,
       comment: intervention.comment,
       goal: intervention.goal,
-      start_date: intervention.start_date.strftime('%B %e, %Y'),
-      end_date: intervention.end_date.try(:strftime, '%B %e, %Y'),
-      educator_email: intervention.educator.try(:email),
+      start_date: intervention.start_date.strftime('%B %e, %Y'), # profile v1
+      start_date_timestamp: intervention.start_date,
+      end_date: intervention.end_date.try(:strftime, '%B %e, %Y'), # profile v1
+      educator_email: intervention.educator.try(:email), # profile v1
       educator_id: intervention.educator.try(:id),
       progress_notes: intervention.progress_notes.order(created_at: :asc).map do |progress_note|
         serialize_progress_note(progress_note)

--- a/app/helpers/serialize_data_helper.rb
+++ b/app/helpers/serialize_data_helper.rb
@@ -22,7 +22,7 @@ module SerializeDataHelper
     {
       id: progress_note.id,
       educator_email: progress_note.educator.email,
-      educator_id: intervention.educator.id,
+      educator_id: progress_note.educator.id,
       content: progress_note.content,
       created_date: progress_note.created_at.strftime("%B %e, %Y %l:%M %p")
     }

--- a/spec/controllers/progress_notes_controller_spec.rb
+++ b/spec/controllers/progress_notes_controller_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe ProgressNotesController, type: :controller do
         expect(JSON.parse(response.body)).to eq({
           "id" => 2,
           "educator_email" => educator.email,
+          "educator_id" => educator.id,
           "content" => "note text goes here",
           "created_date" => Time.now.utc.strftime("%B %e, %Y %l:%M %p")
         })

--- a/spec/controllers/progress_notes_controller_spec.rb
+++ b/spec/controllers/progress_notes_controller_spec.rb
@@ -23,19 +23,23 @@ RSpec.describe ProgressNotesController, type: :controller do
           content: 'note text goes here'
         }
       }
-      it 'creates a new intervention' do
+      it 'creates a new progress note' do
         expect { make_request(params) }.to change(ProgressNote, :count).by 1
       end
       it 'responds with json' do
+        Timecop.freeze
+        now_utc = Time.now.utc
         make_request(params)
+
         expect(response.headers["Content-Type"]).to eq 'application/json; charset=utf-8'
         expect(response.status).to eq 200
         expect(JSON.parse(response.body)).to eq({
-          "id" => 2,
+          "id" => intervention.progress_notes.last.id,
           "educator_email" => educator.email,
           "educator_id" => educator.id,
           "content" => "note text goes here",
-          "created_date" => Time.now.utc.strftime("%B %e, %Y %l:%M %p")
+          "created_date" => now_utc.strftime("%B %e, %Y %l:%M %p"),
+          "created_at_timestamp" => now_utc.as_json
         })
       end
     end

--- a/spec/javascripts/student_profile_v2/fixtures.js
+++ b/spec/javascripts/student_profile_v2/fixtures.js
@@ -552,271 +552,304 @@
       }
     },
     "feed": {
-      "v1_notes": [
-        {
-          "id": 19,
-          "content": "We talked with an outside therapist.",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "created_at_timestamp": "2016-02-11T14:41:52.857Z",
-          "created_at": "February 11, 2016"
-        },
-        {
-          "id": 20,
-          "content": "We talked with the family.",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "created_at_timestamp": "2016-02-11T14:41:52.861Z",
-          "created_at": "February 11, 2016"
-        },
-        {
-          "id": 21,
-          "content": "We talked with an outside therapist.",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "created_at_timestamp": "2016-02-11T14:41:52.864Z",
-          "created_at": "February 11, 2016"
-        },
-        {
-          "id": 22,
-          "content": "We talked with an outside therapist.",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "created_at_timestamp": "2016-02-11T14:41:52.868Z",
-          "created_at": "February 11, 2016"
-        },
-        {
-          "id": 23,
-          "content": "We talked with an outside therapist.",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "created_at_timestamp": "2016-02-11T14:41:52.872Z",
-          "created_at": "February 11, 2016"
-        },
-        {
-          "id": 24,
-          "content": "We talked with the family.",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "created_at_timestamp": "2016-02-11T14:41:52.875Z",
-          "created_at": "February 11, 2016"
-        },
-        {
-          "id": 25,
-          "content": "We talked with the family.",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "created_at_timestamp": "2016-02-11T14:41:52.879Z",
-          "created_at": "February 11, 2016"
-        }
-      ],
-      "v1_interventions": [
-        {
-          "id": 7,
-          "name": "Classroom Academic Intervention",
-          "comment": "whatever",
-          "goal": "increase growth percentile",
-          "start_date": "October  1, 2010",
-          "end_date": "October 15, 2010",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 8,
-          "name": "MTSS Referral",
-          "comment": "bar",
-          "goal": "increase growth percentile",
-          "start_date": "November 26, 2010",
-          "end_date": "December 10, 2010",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 9,
-          "name": "Classroom Academic Intervention",
-          "comment": "whatever",
-          "goal": "pass assessment",
-          "start_date": "January 12, 2011",
-          "end_date": "January 26, 2011",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 10,
-          "name": "Other ",
-          "comment": "foo",
-          "goal": "increase growth percentile",
-          "start_date": "February 21, 2011",
-          "end_date": "March  7, 2011",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 11,
-          "name": "Classroom Behavior Intervention",
-          "comment": "whatever",
-          "goal": "reduce behavior",
-          "start_date": "April  5, 2011",
-          "end_date": "April 19, 2011",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 12,
-          "name": "51a Filing",
-          "comment": "whatever",
-          "goal": "pass assessment",
-          "start_date": "May 11, 2011",
-          "end_date": "May 25, 2011",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 13,
-          "name": "Mobile Crisis Referral",
-          "comment": "foo",
-          "goal": "pass assessment",
-          "start_date": "June 30, 2011",
-          "end_date": "July 14, 2011",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 14,
-          "name": "MTSS Referral",
-          "comment": "bar",
-          "goal": "increase growth percentile",
-          "start_date": "July 31, 2011",
-          "end_date": "August 14, 2011",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 15,
-          "name": "Reading Tutor",
-          "comment": "foo",
-          "goal": "increase growth percentile",
-          "start_date": "September 18, 2011",
-          "end_date": "October  2, 2011",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 16,
-          "name": "Behavior Contract",
-          "comment": "foo",
-          "goal": "increase growth percentile",
-          "start_date": "October 18, 2011",
-          "end_date": "November  1, 2011",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 17,
-          "name": "After-School Tutoring (ATP)",
-          "comment": "bar",
-          "goal": "increase growth percentile",
-          "start_date": "December 12, 2011",
-          "end_date": "December 26, 2011",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 18,
-          "name": "Attendance Officer",
-          "comment": "foo",
-          "goal": "reduce behavior",
-          "start_date": "February  8, 2012",
-          "end_date": "February 22, 2012",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 19,
-          "name": "Attendance Officer",
-          "comment": "foo",
-          "goal": "increase growth percentile",
-          "start_date": "April  7, 2012",
-          "end_date": "April 21, 2012",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 20,
-          "name": "Other ",
-          "comment": "whatever",
-          "goal": "increase growth percentile",
-          "start_date": "May 24, 2012",
-          "end_date": "June  7, 2012",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 21,
-          "name": "51a Filing",
-          "comment": "bar",
-          "goal": "pass assessment",
-          "start_date": "July  2, 2012",
-          "end_date": "July 16, 2012",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 22,
-          "name": "Community Schools",
-          "comment": "whatever",
-          "goal": "pass assessment",
-          "start_date": "August 21, 2012",
-          "end_date": "September  4, 2012",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        },
-        {
-          "id": 23,
-          "name": "X Block Tutor",
-          "comment": "bar",
-          "goal": "reduce behavior",
-          "start_date": "October 13, 2012",
-          "end_date": "October 27, 2012",
-          "educator_email": "demo@example.com",
-          "educator_id":1,
-          "progress_notes": []
-        }
-      ],
-      "event_notes": [{"id":1,"student_id":6,"educator_id":1,"event_note_type_id":3,"text":"okay!","recorded_at":"2016-02-11T21:28:02.102Z","created_at":"2016-02-11T21:28:02.103Z","updated_at":"2016-02-11T21:28:02.103Z"},{"id":2,"student_id":6,"educator_id":1,"event_note_type_id":3,"text":"cool!","recorded_at":"2016-02-11T21:29:18.166Z","created_at":"2016-02-11T21:29:18.167Z","updated_at":"2016-02-11T21:29:18.167Z"},{"id":3,"student_id":6,"educator_id":1,"event_note_type_id":1,"text":"sweet","recorded_at":"2016-02-11T21:29:30.287Z","created_at":"2016-02-11T21:29:30.288Z","updated_at":"2016-02-11T21:29:30.288Z"}],
-      "services": [
-        {
-          "id": 133,
-          "service_type_id": 1,
-          "recorded_by_educator_id": 1,
-          "assigned_to_educator_id": 1,
-          "date_started": "2016-02-09"
-        },
-        {
-          "id": 134,
-          "service_type_id": 1,
-          "recorded_by_educator_id": 1,
-          "assigned_to_educator_id": 1,
-          "date_started": "2016-02-09"
-        }
-      ]
+  "event_notes": [
+    {
+      "id": 1,
+      "student_id": 6,
+      "educator_id": 1,
+      "event_note_type_id": 3,
+      "text": "okay!",
+      "recorded_at": "2016-02-11T21:28:02.102Z",
+      "created_at": "2016-02-11T21:28:02.103Z",
+      "updated_at": "2016-02-11T21:28:02.103Z"
     },
+    {
+      "id": 2,
+      "student_id": 6,
+      "educator_id": 1,
+      "event_note_type_id": 3,
+      "text": "cool!",
+      "recorded_at": "2016-02-11T21:29:18.166Z",
+      "created_at": "2016-02-11T21:29:18.167Z",
+      "updated_at": "2016-02-11T21:29:18.167Z"
+    },
+    {
+      "id": 3,
+      "student_id": 6,
+      "educator_id": 1,
+      "event_note_type_id": 1,
+      "text": "sweet",
+      "recorded_at": "2016-02-11T21:29:30.287Z",
+      "created_at": "2016-02-11T21:29:30.288Z",
+      "updated_at": "2016-02-11T21:29:30.288Z"
+    }
+  ],
+  "services": [
+    {
+      "id": 133,
+      "service_type_id": 1,
+      "recorded_by_educator_id": 1,
+      "assigned_to_educator_id": 1,
+      "date_started": "2016-02-09"
+    },
+    {
+      "id": 134,
+      "service_type_id": 1,
+      "recorded_by_educator_id": 1,
+      "assigned_to_educator_id": 1,
+      "date_started": "2016-02-09"
+    }
+  ],
+  "deprecated": {
+    "notes": [
+      {
+        "id": 19,
+        "content": "We talked with an outside therapist.",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "created_at_timestamp": "2016-02-11T14:41:52.857Z",
+        "created_at": "February 11, 2016"
+      },
+      {
+        "id": 20,
+        "content": "We talked with the family.",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "created_at_timestamp": "2016-02-11T14:41:52.861Z",
+        "created_at": "February 11, 2016"
+      },
+      {
+        "id": 21,
+        "content": "We talked with an outside therapist.",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "created_at_timestamp": "2016-02-11T14:41:52.864Z",
+        "created_at": "February 11, 2016"
+      },
+      {
+        "id": 22,
+        "content": "We talked with an outside therapist.",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "created_at_timestamp": "2016-02-11T14:41:52.868Z",
+        "created_at": "February 11, 2016"
+      },
+      {
+        "id": 23,
+        "content": "We talked with an outside therapist.",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "created_at_timestamp": "2016-02-11T14:41:52.872Z",
+        "created_at": "February 11, 2016"
+      },
+      {
+        "id": 24,
+        "content": "We talked with the family.",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "created_at_timestamp": "2016-02-11T14:41:52.875Z",
+        "created_at": "February 11, 2016"
+      },
+      {
+        "id": 25,
+        "content": "We talked with the family.",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "created_at_timestamp": "2016-02-11T14:41:52.879Z",
+        "created_at": "February 11, 2016"
+      }
+    ],
+    "interventions": [
+      {
+        "id": 7,
+        "name": "Classroom Academic Intervention",
+        "comment": "whatever",
+        "goal": "increase growth percentile",
+        "start_date": "October  1, 2010",
+        "end_date": "October 15, 2010",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 8,
+        "name": "MTSS Referral",
+        "comment": "bar",
+        "goal": "increase growth percentile",
+        "start_date": "November 26, 2010",
+        "end_date": "December 10, 2010",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 9,
+        "name": "Classroom Academic Intervention",
+        "comment": "whatever",
+        "goal": "pass assessment",
+        "start_date": "January 12, 2011",
+        "end_date": "January 26, 2011",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 10,
+        "name": "Other ",
+        "comment": "foo",
+        "goal": "increase growth percentile",
+        "start_date": "February 21, 2011",
+        "end_date": "March  7, 2011",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 11,
+        "name": "Classroom Behavior Intervention",
+        "comment": "whatever",
+        "goal": "reduce behavior",
+        "start_date": "April  5, 2011",
+        "end_date": "April 19, 2011",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 12,
+        "name": "51a Filing",
+        "comment": "whatever",
+        "goal": "pass assessment",
+        "start_date": "May 11, 2011",
+        "end_date": "May 25, 2011",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 13,
+        "name": "Mobile Crisis Referral",
+        "comment": "foo",
+        "goal": "pass assessment",
+        "start_date": "June 30, 2011",
+        "end_date": "July 14, 2011",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 14,
+        "name": "MTSS Referral",
+        "comment": "bar",
+        "goal": "increase growth percentile",
+        "start_date": "July 31, 2011",
+        "end_date": "August 14, 2011",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 15,
+        "name": "Reading Tutor",
+        "comment": "foo",
+        "goal": "increase growth percentile",
+        "start_date": "September 18, 2011",
+        "end_date": "October  2, 2011",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 16,
+        "name": "Behavior Contract",
+        "comment": "foo",
+        "goal": "increase growth percentile",
+        "start_date": "October 18, 2011",
+        "end_date": "November  1, 2011",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 17,
+        "name": "After-School Tutoring (ATP)",
+        "comment": "bar",
+        "goal": "increase growth percentile",
+        "start_date": "December 12, 2011",
+        "end_date": "December 26, 2011",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 18,
+        "name": "Attendance Officer",
+        "comment": "foo",
+        "goal": "reduce behavior",
+        "start_date": "February  8, 2012",
+        "end_date": "February 22, 2012",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 19,
+        "name": "Attendance Officer",
+        "comment": "foo",
+        "goal": "increase growth percentile",
+        "start_date": "April  7, 2012",
+        "end_date": "April 21, 2012",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 20,
+        "name": "Other ",
+        "comment": "whatever",
+        "goal": "increase growth percentile",
+        "start_date": "May 24, 2012",
+        "end_date": "June  7, 2012",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 21,
+        "name": "51a Filing",
+        "comment": "bar",
+        "goal": "pass assessment",
+        "start_date": "July  2, 2012",
+        "end_date": "July 16, 2012",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 22,
+        "name": "Community Schools",
+        "comment": "whatever",
+        "goal": "pass assessment",
+        "start_date": "August 21, 2012",
+        "end_date": "September  4, 2012",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      },
+      {
+        "id": 23,
+        "name": "X Block Tutor",
+        "comment": "bar",
+        "goal": "reduce behavior",
+        "start_date": "October 13, 2012",
+        "end_date": "October 27, 2012",
+        "educator_email": "demo@example.com",
+        "educator_id": 1,
+        "progress_notes": []
+      }
+    ]
+  }
+},
     "serviceTypesIndex": {},
     "educatorsIndex": {
       "1": {

--- a/spec/javascripts/student_profile_v2/fixtures.js
+++ b/spec/javascripts/student_profile_v2/fixtures.js
@@ -587,14 +587,14 @@
   "services": [
     {
       "id": 133,
-      "service_type_id": 1,
+      "service_type_id": 503,
       "recorded_by_educator_id": 1,
       "assigned_to_educator_id": 1,
       "date_started": "2016-02-09"
     },
     {
       "id": 134,
-      "service_type_id": 1,
+      "service_type_id": 506,
       "recorded_by_educator_id": 1,
       "assigned_to_educator_id": 1,
       "date_started": "2016-02-09"
@@ -850,7 +850,7 @@
     ]
   }
 },
-    "serviceTypesIndex": {},
+    "serviceTypesIndex": {"502":{"id":502,"name":"Attendance Officer"},"503":{"id":503,"name":"Attendance Contract"},"504":{"id":504,"name":"Behavior Contract"},"505":{"id":505,"name":"Counseling, in-house"},"506":{"id":506,"name":"Counseling, outside"},"507":{"id":507,"name":"Reading intervention"},"508":{"id":508,"name":"Math intervention"}},
     "educatorsIndex": {
       "1": {
         "id": 1,

--- a/spec/javascripts/student_profile_v2/notes_list_spec.js
+++ b/spec/javascripts/student_profile_v2/notes_list_spec.js
@@ -1,81 +1,45 @@
-// //= require ./fixtures
+//= require ./fixtures
 
-// describe('NotesList', function() {
-//   var dom = window.shared.ReactHelpers.dom;
-//   var createEl = window.shared.ReactHelpers.createEl;
-//   var merge = window.shared.ReactHelpers.merge;
+describe('NotesList', function() {
+  var dom = window.shared.ReactHelpers.dom;
+  var createEl = window.shared.ReactHelpers.createEl;
+  var merge = window.shared.ReactHelpers.merge;
 
-//   var SpecSugar = window.shared.SpecSugar;
-//   var NotesList = window.shared.NotesList;    
-//   var Fixtures = window.shared.Fixtures;
+  var SpecSugar = window.shared.SpecSugar;
+  var NotesList = window.shared.NotesList;
+  var Fixtures = window.shared.Fixtures;
+  var feed = {"event_notes":[{"id":3,"student_id":5,"educator_id":1,"event_note_type_id":2,"text":"Awesome!","recorded_at":"2016-02-26T22:20:55.398Z","created_at":"2016-02-26T22:20:55.416Z","updated_at":"2016-02-26T22:20:55.416Z"},{"id":4,"student_id":5,"educator_id":1,"event_note_type_id":2,"text":"Sweet!","recorded_at":"2016-02-27T19:23:26.835Z","created_at":"2016-02-27T19:23:26.836Z","updated_at":"2016-02-27T19:23:26.836Z"}],"services":[{"id":133,"service_type_id":503,"recorded_by_educator_id":1,"assigned_to_educator_id":1,"date_started":"2016-02-09","date_discontinued":null,"discontinued_by_educator_id":1},{"id":134,"service_type_id":506,"recorded_by_educator_id":1,"assigned_to_educator_id":1,"date_started":"2016-02-08","date_discontinued":null,"discontinued_by_educator_id":1}],"deprecated":{"notes":[{"id":5,"content":"We talked with the family.","educator_id":1,"educator_email":"demo@example.com","created_at_timestamp":"2016-02-24T01:24:32.950Z","created_at":"February 24, 2016"},{"id":6,"content":"We talked with an outside therapist.","educator_id":1,"educator_email":"demo@example.com","created_at_timestamp":"2016-02-24T01:24:32.955Z","created_at":"February 24, 2016"},{"id":7,"content":"We talked with an outside therapist.","educator_id":1,"educator_email":"demo@example.com","created_at_timestamp":"2016-02-24T01:24:32.960Z","created_at":"February 24, 2016"},{"id":8,"content":"We talked with the family.","educator_id":1,"educator_email":"demo@example.com","created_at_timestamp":"2016-02-24T01:24:32.963Z","created_at":"February 24, 2016"},{"id":9,"content":"We talked with the family.","educator_id":1,"educator_email":"demo@example.com","created_at_timestamp":"2016-02-24T01:24:32.967Z","created_at":"February 24, 2016"},{"id":10,"content":"We talked with an outside therapist.","educator_id":1,"educator_email":"demo@example.com","created_at_timestamp":"2016-02-24T01:24:32.970Z","created_at":"February 24, 2016"},{"id":11,"content":"We talked with the family.","educator_id":1,"educator_email":"demo@example.com","created_at_timestamp":"2016-02-24T01:24:32.974Z","created_at":"February 24, 2016"},{"id":12,"content":"We talked with an outside therapist.","educator_id":1,"educator_email":"demo@example.com","created_at_timestamp":"2016-02-24T01:24:32.978Z","created_at":"February 24, 2016"}],"interventions":[{"id":1,"name":"Behavior Plan","intervention_type_id":24,"comment":"bar","goal":"increase growth percentile","start_date":"October 27, 2010","start_date_timestamp":"2010-10-27","end_date":"November 10, 2010","educator_email":"demo@example.com","educator_id":1,"progress_notes":[]},{"id":2,"name":"Attendance Officer","intervention_type_id":21,"comment":"whatever","goal":"increase growth percentile","start_date":"December 11, 2010","start_date_timestamp":"2010-12-11","end_date":"December 25, 2010","educator_email":"demo@example.com","educator_id":1,"progress_notes":[]}]}};
 
-//   var helpers = {
-//     findColumns: function(el) {
-//       return $(el).find('.summary-container > div');
-//     },
-    
-//     createSpyActions: function() {
-//       return {
-//         onColumnClicked: jasmine.createSpy('onColumnClicked'),
-//         onClickSaveNotes: jasmine.createSpy('onClickSaveNotes')
-//       };
-//     },
-    
-//     renderInto: function(el, props) {
-//       var mergedProps = merge(props || {}, {
-//         nowMomentFn: function() { return Fixtures.nowMoment; },
-//         serializedData: Fixtures.studentProfile,
-//         queryParams: {}
-//       });
-//       return ReactDOM.render(createEl(NotesList, mergedProps), el);
-//     },
+  var helpers = { 
+    renderInto: function(el, props) {
+      var mergedProps = merge(props || {}, {
+        feed: feed,
+        educatorsIndex: Fixtures.studentProfile.educatorsIndex
+      });
+      return ReactDOM.render(createEl(NotesList, mergedProps), el);
+    },
 
-//     takeNotesAndSave: function(el, typeName, text) {
-//       $(el).find('.btn.take-notes').click();
-//       SpecSugar.changeTextValue($(el).find('textarea'), 'hello!');
-//       $(el).find('.btn.note-type:contains(SST meeting)').click();
-//       $(el).find('.btn.save').click();
-//     }
-//   };
+    noteTimestamps: function(el) {
+      return $(el).find('.NoteCard .date').toArray().map(function(dateEl) {
+        return moment.parseZone($(dateEl).text(), 'MMM DD, YYYY').toDate().getTime();
+      });
+    }
+  };
 
-//   SpecSugar.withTestEl('high-level integration tests', function() {
-//     it('renders everything on the happy path', function() {
-//       var el = this.testEl;
-//       helpers.renderInto(el);
+  SpecSugar.withTestEl('high-level integration tests', function() {
+    it('renders everything on the happy path', function() {
+      var el = this.testEl;
+      helpers.renderInto(el);
 
-//       expect(el).toContainText('Daisy Poppins');
-//       expect(helpers.findColumns(el).length).toEqual(5);
-//       expect($('.Sparkline').length).toEqual(9);
-//       expect($('.InterventionsDetails').length).toEqual(1);
-//     });
-
-//     it('opens dialog when clicking Take Notes button', function() {
-//       var el = this.testEl;
-//       helpers.renderInto(el);
-
-//       $(el).find('.btn.take-notes').click();
-//       expect(el).toContainText('What are these notes from?');
-//       expect(el).toContainText('Save notes');
-//     });
-
-//     it('opens dialog when clicking Record Service Delivery button', function() {
-//       var el = this.testEl;
-//       helpers.renderInto(el);
-
-//       $(el).find('.btn.record-service').click();
-//       expect(el).toContainText('Who is working with Daisy?');
-//       expect(el).toContainText('Record service');
-//     });
-
-//     it('saving notes for SST meetings works, mocking the action handlers', function() {
-//       var el = this.testEl;
-//       var component = helpers.renderInto(el, { actions: helpers.createSpyActions() });
-//       helpers.takeNotesAndSave(el, 'SST meeting', 'hello!');
-
-//       expect(component.props.actions.onClickSaveNotes).toHaveBeenCalledWith({
-//         eventNoteTypeId: 1,
-//         text: 'hello!'
-//       });
-//     });
-//   });
-// });
+      var noteTimestamps = helpers.noteTimestamps(el);
+      expect(_.first(noteTimestamps)).toBeGreaterThan(_.last(noteTimestamps));
+      expect(_.sortBy(noteTimestamps).reverse()).toEqual(noteTimestamps);
+      expect($(el).find('.NoteCard').length).toEqual(12);
+      expect(el).toContainText('Behavior Plan');
+      expect(el).toContainText('Attendance Officer');
+      expect(el).toContainText('MTSS meeting');
+      expect(el).not.toContainText('SST meeting');
+      expect(el).toContainText('Older note');
+    });
+  });
+});

--- a/spec/javascripts/student_profile_v2/notes_list_spec.js
+++ b/spec/javascripts/student_profile_v2/notes_list_spec.js
@@ -1,0 +1,81 @@
+// //= require ./fixtures
+
+// describe('NotesList', function() {
+//   var dom = window.shared.ReactHelpers.dom;
+//   var createEl = window.shared.ReactHelpers.createEl;
+//   var merge = window.shared.ReactHelpers.merge;
+
+//   var SpecSugar = window.shared.SpecSugar;
+//   var NotesList = window.shared.NotesList;    
+//   var Fixtures = window.shared.Fixtures;
+
+//   var helpers = {
+//     findColumns: function(el) {
+//       return $(el).find('.summary-container > div');
+//     },
+    
+//     createSpyActions: function() {
+//       return {
+//         onColumnClicked: jasmine.createSpy('onColumnClicked'),
+//         onClickSaveNotes: jasmine.createSpy('onClickSaveNotes')
+//       };
+//     },
+    
+//     renderInto: function(el, props) {
+//       var mergedProps = merge(props || {}, {
+//         nowMomentFn: function() { return Fixtures.nowMoment; },
+//         serializedData: Fixtures.studentProfile,
+//         queryParams: {}
+//       });
+//       return ReactDOM.render(createEl(NotesList, mergedProps), el);
+//     },
+
+//     takeNotesAndSave: function(el, typeName, text) {
+//       $(el).find('.btn.take-notes').click();
+//       SpecSugar.changeTextValue($(el).find('textarea'), 'hello!');
+//       $(el).find('.btn.note-type:contains(SST meeting)').click();
+//       $(el).find('.btn.save').click();
+//     }
+//   };
+
+//   SpecSugar.withTestEl('high-level integration tests', function() {
+//     it('renders everything on the happy path', function() {
+//       var el = this.testEl;
+//       helpers.renderInto(el);
+
+//       expect(el).toContainText('Daisy Poppins');
+//       expect(helpers.findColumns(el).length).toEqual(5);
+//       expect($('.Sparkline').length).toEqual(9);
+//       expect($('.InterventionsDetails').length).toEqual(1);
+//     });
+
+//     it('opens dialog when clicking Take Notes button', function() {
+//       var el = this.testEl;
+//       helpers.renderInto(el);
+
+//       $(el).find('.btn.take-notes').click();
+//       expect(el).toContainText('What are these notes from?');
+//       expect(el).toContainText('Save notes');
+//     });
+
+//     it('opens dialog when clicking Record Service Delivery button', function() {
+//       var el = this.testEl;
+//       helpers.renderInto(el);
+
+//       $(el).find('.btn.record-service').click();
+//       expect(el).toContainText('Who is working with Daisy?');
+//       expect(el).toContainText('Record service');
+//     });
+
+//     it('saving notes for SST meetings works, mocking the action handlers', function() {
+//       var el = this.testEl;
+//       var component = helpers.renderInto(el, { actions: helpers.createSpyActions() });
+//       helpers.takeNotesAndSave(el, 'SST meeting', 'hello!');
+
+//       expect(component.props.actions.onClickSaveNotes).toHaveBeenCalledWith({
+//         eventNoteTypeId: 1,
+//         text: 'hello!'
+//       });
+//     });
+//   });
+// });

--- a/spec/javascripts/student_profile_v2/notes_list_spec.js
+++ b/spec/javascripts/student_profile_v2/notes_list_spec.js
@@ -39,7 +39,7 @@ describe('NotesList', function() {
       expect(el).toContainText('Attendance Officer');
       expect(el).toContainText('MTSS meeting');
       expect(el).not.toContainText('SST meeting');
-      expect(el).toContainText('Older note');
+      expect(el).toContainText('Old note');
     });
   });
 });

--- a/spec/javascripts/student_profile_v2/record_service_spec.js
+++ b/spec/javascripts/student_profile_v2/record_service_spec.js
@@ -13,8 +13,8 @@ describe('RecordService', function() {
     renderInto: function(el, props) {
       var mergedProps = merge(props || {}, {
         studentFirstName: 'Tamyra',
-        serviceTypesIndex: {},
-        educatorsIndex: {},
+        serviceTypesIndex: Fixtures.studentProfile.serviceTypesIndex,
+        educatorsIndex: Fixtures.studentProfile.educatorsIndex,
         nowMoment: Fixtures.nowMoment,
         currentEducator: Fixtures.currentEducator,
         onSave: jasmine.createSpy('onSave'),


### PR DESCRIPTION
This updates the schools#profile controller code and UI code to render the new `services` table that will be written as part of the backend work in https://github.com/studentinsights/studentinsights/issues/115.  It also adds updates the fixture data in the controller to simulate this in development mode, and adds placeholder fixtures for the `service_types` constants table.

The notes UI shows data from `event_notes`, but also merges in data from the deprecated `interventions`, `notes` tables.  Doesn't yet show progress notes.
<img width="617" alt="screen shot 2016-02-26 at 5 21 03 pm" src="https://cloud.githubusercontent.com/assets/1056957/13367071/7a5ea68c-dcad-11e5-9412-a05616cb6156.png">

The "services" list now shows services data (previously it actually read from the old interventions table):
<img width="620" alt="screen shot 2016-02-26 at 5 16 56 pm" src="https://cloud.githubusercontent.com/assets/1056957/13367087/93445214-dcad-11e5-89e2-db555ccc7567.png">

"Services" in the summary panel, which used to show the deprecated intervention data, now shows the new `services` data as well:
<img width="294" alt="screen shot 2016-02-26 at 5 18 33 pm" src="https://cloud.githubusercontent.com/assets/1056957/13367076/81c98112-dcad-11e5-9a7f-3aa3a4d972df.png">