### PR TITLE
Remove color in profile v2 sparklines for now

### DIFF
--- a/app/assets/javascripts/student_profile_v2/sparkline.js
+++ b/app/assets/javascripts/student_profile_v2/sparkline.js
@@ -27,8 +27,12 @@
 
     render: function() {
       var padding = 3; // for allowing circle data points at the edge to be full shown
+      
       // TODO(kr) work more on coloring across all charts
-      var color = d3.scale.linear().domain([-1, 0, 1]).range(['red', '#666', 'blue']);
+      // for now, disable since the mapping to color isn't clear enough and
+      // doesn't match the longer-view charts
+      var color = function() { return '#666'; };
+
       var x = d3.time.scale()
         .domain(this.props.dateRange)
         .range([padding, this.props.width - padding]);


### PR DESCRIPTION
This is part of https://github.com/studentinsights/studentinsights/issues/5.

The coloring doesn't match other charts, and the prototype mapping isn't intuitive now (since it's computed on the full range of data, not the range of data that's visible to the user).  It also doesn't match the larger charts below, so removing it for now and we'll revisit separately in https://github.com/studentinsights/studentinsights/issues/133.

Before:
<img width="1258" alt="screen shot 2016-02-29 at 12 08 47 pm" src="https://cloud.githubusercontent.com/assets/1056957/13402353/d9f9a7cc-dedd-11e5-8d13-666edbea69ac.png">


After:
<img width="1248" alt="screen shot 2016-02-29 at 12 08 36 pm" src="https://cloud.githubusercontent.com/assets/1056957/13402350/d71e2cc6-dedd-11e5-8b61-05bc2891d7bb.png">
