### PR TITLE
Create sped referral form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'jquery-rails'
 gem 'jquery-ui-rails', '~> 5.0.3'
 gem 'net-sftp'
 gem 'net-ssh'
-gem 'pdfkit'
 gem 'probability'
 gem 'react-rails', '~> 1.5.0'   # Provides React, handles swapping between dev/production builds.
                                 # See config/initializers/assets.rb

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'seedbank'
 gem 'thor'
 gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
+gem 'wicked_pdf'
+gem 'wkhtmltopdf-binary'
 
 group :production do
   gem 'rails_12factor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,8 @@ GEM
       raindrops (~> 0.7)
     warden (1.2.6)
       rack (>= 1.0)
+    wicked_pdf (1.0.4)
+    wkhtmltopdf-binary (0.9.9.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -266,6 +268,8 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   unicorn
+  wicked_pdf
+  wkhtmltopdf-binary
 
 BUNDLED WITH
    1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,6 @@ GEM
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     orm_adapter (0.5.0)
-    pdfkit (0.8.2)
     pg (0.18.4)
     phantomjs (2.1.1.0)
     pivotal_git_scripts (1.4.0)
@@ -246,7 +245,6 @@ DEPENDENCIES
   launchy
   net-sftp
   net-ssh
-  pdfkit
   pg
   phantomjs
   pivotal_git_scripts
@@ -270,4 +268,4 @@ DEPENDENCIES
   unicorn
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -32,7 +32,6 @@ class StudentsController < ApplicationController
 
     @roster_url = homeroom_path(@student.homeroom)
     @csv_url = student_path(@student) + ".csv"
-    @student_url = student_path(@student)
 
     respond_to do |format|
       format.html
@@ -40,7 +39,6 @@ class StudentsController < ApplicationController
         render csv: StudentProfileCsvExporter.new(@student).profile_csv_export,
         filename: 'export'
       }
-      format.pdf { render text: PDFKit.new(@student_url).to_pdf }
     end
   end
 

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -63,6 +63,15 @@ class StudentsController < ApplicationController
     }
   end
 
+  def sped_referral
+    @student = Student.find(params[:id])
+    respond_to do |format|
+      format.pdf do
+        render pdf: "sped_referral"
+      end
+    end
+  end
+
   # post
   def event_note
     clean_params = params.require(:event_note).permit(*[

--- a/app/views/students/sped_referral.pdf.erb
+++ b/app/views/students/sped_referral.pdf.erb
@@ -1,0 +1,1 @@
+SPED Referral for <%= @student.first_name %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,9 +19,6 @@ module SomervilleTeacherTool
     config.autoload_paths += %W(#{config.root}/app/dashboard_queries)
     config.autoload_paths += %W(#{config.root}/lib)
 
-    require 'pdfkit'
-    config.middleware.use PDFKit::Middleware
-
     config.generators do |g|
       g.stylesheets false
       g.javascripts false

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,3 +2,4 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+Mime::Type.register "application/pdf", :pdf

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,0 +1,21 @@
+# WickedPDF Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `render :pdf` call.
+#
+# To learn more, check out the README:
+#
+# https://github.com/mileszs/wicked_pdf/blob/master/README.md
+
+WickedPdf.config = {
+  # Path to the wkhtmltopdf executable: This usually isn't needed if using
+  # one of the wkhtmltopdf-binary family of gems.
+  # exe_path: '/usr/local/bin/wkhtmltopdf',
+  #   or
+  # exe_path: Gem.bin_path('wkhtmltopdf-binary', 'wkhtmltopdf')
+
+  # Layout file to be used for all PDFs
+  # (but can be overridden in `render :pdf` calls)
+  # layout: 'pdf.html',
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
 
   resources :students do
     get :profile, on: :member
+    get :sped_referral, on: :member
     post :event_note, on: :member
   end
   resources :homerooms


### PR DESCRIPTION
Switched out the pdfkit gem for the wicked_pdf gem because wicked_pdf is  better documented and pdfkit was never fully implemented in this application. Created a route at students/:id/sped_referral.pdf and render a pdf with the student's name. One small step toward https://github.com/studentinsights/studentinsights/issues/8