### PR TITLE
Guard for if PDF mime type is already registered

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,4 +2,4 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
-Mime::Type.register "application/pdf", :pdf
+Mime::Type.register 'application/pdf', :pdf unless Mime::Type.lookup_by_extension(:pdf)


### PR DESCRIPTION
Removes these warnings when starting Rails:
```
/Users/krobinson/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.1.4/lib/action_dispatch/http/mime_type.rb:163: warning: already initialized constant Mime::PDF
/Users/krobinson/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.1.4/lib/action_dispatch/http/mime_type.rb:163: warning: previous definition of PDF was here
```

From http://stackoverflow.com/a/24770295/5711971, seems like this isn't needed.

@eudaimonious if I remember right this helped us last night in https://github.com/studentinsights/studentinsights/pull/137, not sure what's up exactly but this removes the warning and the feature still works. :)