### PR TITLE
Profile - remove fixtures for services and implement endpoint for saving

### DIFF
--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -201,6 +201,7 @@
       var columnKey = 'interventions';
 
       return dom.div({
+        className: 'interventions-column',
         style: merge(styles.column, this.selectedColumnStyles(columnKey)),
         onClick: this.onColumnClicked.bind(this, columnKey)
       }, this.padElements(styles.summaryWrapper, [

--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -225,7 +225,8 @@
     },
 
     renderServices: function(student) {
-      if (student.interventions.length === 0) {
+      var services = this.props.feed.services;
+      if (services.length === 0) {
         return createEl(SummaryList, {
           title: 'Services',
           elements: ['No services']
@@ -233,7 +234,7 @@
       }
       
       var limit = 3;
-      var sortedServices = _.sortBy(this.props.feed.services, 'date_started').reverse();
+      var sortedServices = _.sortBy(services, 'date_started').reverse();
       var elements = sortedServices.slice(0, limit).map(function(service) {
         var serviceText = this.props.serviceTypesIndex[service.service_type_id].name;
         var daysText = moment.utc(service.date_started).from(this.props.nowMomentFn(), true);

--- a/app/assets/javascripts/student_profile_v2/summary_list.js
+++ b/app/assets/javascripts/student_profile_v2/summary_list.js
@@ -5,8 +5,9 @@
   var merge = window.shared.ReactHelpers.merge;
 
   var SummaryList = window.shared.SummaryList = React.createClass({
+    displayName: 'SummaryList',
     render: function() {
-      return dom.div({ style: { paddingBottom: 10 } },
+      return dom.div({ className: 'SummaryList', style: { paddingBottom: 10 } },
         dom.div({ style: { fontWeight: 'bold' } }, this.props.title),
         dom.ul({}, this.props.elements.map(function(element, index) {
           return dom.li({ key: index }, element);

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -52,7 +52,7 @@ class StudentsController < ApplicationController
       feed: student_feed(student),
       chart_data: chart_data,
       intervention_types_index: intervention_types_index,
-      service_types_index: fixture_service_types_index, # TODO(kr) implement this as part of the backend work
+      service_types_index: service_types_index,
       educators_index: educators_index,
       attendance_data: {
         discipline_incidents: student.most_recent_school_year.discipline_incidents,
@@ -97,19 +97,14 @@ class StudentsController < ApplicationController
       :date_started,
       :provided_by_educator_id
     ])
-    
-    # TODO(kr) Placeholder response in development mode, for
-    # testing UI end-to-end.  Remove this when productionizing.
-    if Rails.env.development?
-      render json: clean_params.as_json.merge({
-        recorded_by_educator_id: current_educator.id,
-        date_discontinued: nil,
-        discontinued_by_educator_id: nil,
-        id: rand(2000..3000)
-      })
+    service = Service.new(clean_params.merge({
+      recorded_by_educator_id: current_educator.id,
+      recorded_at: Time.now
+    }))
+    if service.save
+      render json: service.as_json
     else
-      # TODO(kr) Production path not implemented yet, needs models
-      return render json: clean_params.as_json, status: 501
+      render json: { errors: service.errors.full_messages }, status: 422
     end
   end
 
@@ -167,52 +162,14 @@ class StudentsController < ApplicationController
     (search_token_scores.sum.to_f / search_tokens.length)
   end
 
-  # TODO(kr) this has some placeholder fixture data for now, to test design prototypes on the v2 student profile
-  # page
   def student_feed(student)
     {
       event_notes: student.event_notes,
-      services: if Rails.env.development? then fixture_services else [] end,
+      services: student.services,
       deprecated: {
         notes: student.student_notes.map { |note| serialize_student_note(note) },
         interventions: student.interventions.map { |intervention| serialize_intervention(intervention) }
       }
     }
-  end
-
-  # TODO(kr) temporary, until building backend tables
-  def fixture_service_types_index
-    {
-      502 => { id: 502, name: 'Attendance Officer' },
-      503 => { id: 503, name: 'Attendance Contract' },
-      504 => { id: 504, name: 'Behavior Contract' },
-      505 => { id: 505, name: 'Counseling, in-house' },
-      506 => { id: 506, name: 'Counseling, outside' },
-      507 => { id: 507, name: 'Reading intervention' },
-      508 => { id: 508, name: 'Math intervention' }
-    }
-  end
-
-  # Merges 'event_notes' table with 'discontinued_event_notes' to
-  # present the current view of what's active and what's been discontinued.
-  def fixture_services
-    fixture_educator_id = 1
-    [{
-      id: 133,
-      service_type_id: 503,
-      provided_by_educator_id: fixture_educator_id,
-      recorded_by_educator_id: fixture_educator_id,
-      date_started: '2016-02-09',
-      date_discontinued: nil,
-      discontinued_by_educator_id: fixture_educator_id
-    }, {
-      id: 134,
-      service_type_id: 506,
-      provided_by_educator_id: fixture_educator_id,
-      recorded_by_educator_id: fixture_educator_id,
-      date_started: '2016-02-08',
-      date_discontinued: nil,
-      discontinued_by_educator_id: fixture_educator_id
-    }]
   end
 end

--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -4,8 +4,10 @@ class FakeStudent
     @student = Student.create(data)
     add_attendance_events
     add_discipline_incidents
-    add_interventions
-    add_notes
+    add_deprecated_interventions
+    add_deprecated_notes
+    add_event_notes
+    add_services
     add_student_assessments_from_x2
     add_student_assessments_from_star
     homeroom.students << @student
@@ -155,7 +157,7 @@ class FakeStudent
     end
   end
 
-  def add_interventions
+  def add_deprecated_interventions
     15.in(100) do
       generator = FakeInterventionGenerator.new(@student)
       intervention_count = Rubystats::NormalDistribution.new(3, 6).rng.round
@@ -171,7 +173,7 @@ class FakeStudent
     nil
   end
 
-  def add_notes
+  def add_deprecated_notes
     generator = FakeNoteGenerator.new(@student)
     note_count = if @student.interventions.size > 0
       rand(2..10)
@@ -182,5 +184,13 @@ class FakeStudent
     end
     note_count.times { StudentNote.new(generator.next).save! }
     nil
+  end
+
+  def add_event_notes
+    # TODO(kr)
+  end
+
+  def add_services
+    # TODO(kr)
   end
 end

--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -6,8 +6,6 @@ class FakeStudent
     add_discipline_incidents
     add_deprecated_interventions
     add_deprecated_notes
-    add_event_notes
-    add_services
     add_student_assessments_from_x2
     add_student_assessments_from_star
     homeroom.students << @student
@@ -184,13 +182,5 @@ class FakeStudent
     end
     note_count.times { StudentNote.new(generator.next).save! }
     nil
-  end
-
-  def add_event_notes
-    # TODO(kr)
-  end
-
-  def add_services
-    # TODO(kr)
   end
 end

--- a/app/helpers/serialize_data_helper.rb
+++ b/app/helpers/serialize_data_helper.rb
@@ -57,4 +57,13 @@ module SerializeDataHelper
     end
     index
   end
+
+  # Used to send down constants to the UI
+  def service_types_index
+    index = {}
+    ServiceType.all.each do |service_type|
+      index[service_type.id] = service_type
+    end
+    index
+  end
 end

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -287,13 +287,25 @@ describe StudentsController, :type => :controller do
         end
 
         it 'creates a new service' do
-          skip 'TODO(kr) as part of backend service work'
+          expect { make_post_request(student, post_params) }.to change(Service, :count).by 1
         end
 
         it 'responds with JSON' do
           make_post_request(student, post_params)
-          expect(response.status).to eq 501
-          skip 'TODO(kr) as part of backend service work'
+          expect(response.status).to eq 200
+          make_post_request(student, post_params)
+          expect(response.headers["Content-Type"]).to eq 'application/json; charset=utf-8'
+          expect(JSON.parse(response.body).keys).to eq [
+            'id',
+            'student_id',
+            'provided_by_educator_id',
+            'recorded_by_educator_id',
+            'service_type_id',
+            'recorded_at',
+            'date_started',
+            'created_at',
+            'updated_at'
+          ]
         end
       end
 
@@ -304,16 +316,27 @@ describe StudentsController, :type => :controller do
             service_type_id: 503,
             date_started: '2016-02-22',
             provided_by_educator_id: provided_by_educator.id,
-            recorded_by_educator_id: 187
+            recorded_by_educator_id: 350
           })
-          skip 'TODO(kr) as part of backend service work'
+          response_body = JSON.parse(response.body)
+          expect(response_body['recorded_by_educator_id']).to eq educator.id
+          expect(response_body['recorded_by_educator_id']).not_to eq 350
         end
       end
 
       context 'when missing params' do
         it 'fails with error messages' do
           make_post_request(student, { text: 'foo' })
-          skip 'TODO(kr) as part of backend service work'
+          expect(response.status).to eq 422
+          response_body = JSON.parse(response.body)
+          expect(response_body).to eq({
+            "errors" => [
+              "Provided by educator can't be blank",
+              "Student can't be blank",
+              "Service type can't be blank",
+              "Date started can't be blank"
+            ]
+          })
         end
       end
     end

--- a/spec/javascripts/student_profile_v2/page_container_spec.js
+++ b/spec/javascripts/student_profile_v2/page_container_spec.js
@@ -13,6 +13,10 @@ describe('PageContainer', function() {
     findColumns: function(el) {
       return $(el).find('.summary-container > div');
     },
+
+    interventionSummaryLists: function(el) {
+      return $(el).find('.interventions-column .SummaryList').toArray();
+    },
     
     createSpyActions: function() {
       return {
@@ -54,8 +58,16 @@ describe('PageContainer', function() {
 
       expect(el).toContainText('Daisy Poppins');
       expect(helpers.findColumns(el).length).toEqual(5);
-      expect($('.Sparkline').length).toEqual(9);
-      expect($('.InterventionsDetails').length).toEqual(1);
+      expect($(el).find('.Sparkline').length).toEqual(9);
+      expect($(el).find('.InterventionsDetails').length).toEqual(1);
+
+      var interventionLists = helpers.interventionSummaryLists(el);
+      expect(interventionLists.length).toEqual(3);
+      expect(interventionLists[0]).toContainText('Reg Ed');
+      expect(interventionLists[0]).toContainText('Homeroom 102');
+      expect(interventionLists[1]).toContainText('Counseling, outside');
+      expect(interventionLists[1]).toContainText('Attendance Contract');
+      expect(interventionLists[2]).toContainText('demo@');
     });
 
     it('opens dialog when clicking Take Notes button', function() {


### PR DESCRIPTION
This is part of https://github.com/studentinsights/studentinsights/issues/5 and https://github.com/studentinsights/studentinsights/issues/115.

It updates the controller code to read services out of the DB and send them to the UI, and also to implement the write path endpoint.

It also fixes a bug in the interventions summary UI, which was still only showing `interventions` and not `services`.

<img width="308" alt="screen shot 2016-03-02 at 2 51 53 pm" src="https://cloud.githubusercontent.com/assets/1056957/13473628/26be5d90-e088-11e5-835f-6e7671996412.png">
