### PR TITLE
Fix bug with record service button backround color when enabled

### DIFF
--- a/app/assets/javascripts/student_profile_v2/record_service.js
+++ b/app/assets/javascripts/student_profile_v2/record_service.js
@@ -183,14 +183,13 @@
 
     renderButtons: function() {
       var isFormComplete = (this.state.providedByEducatorId && this.state.serviceTypeId && this.state.momentStarted);
-      var isSaveEnabled = !isFormComplete;
       return dom.div({ style: { marginTop: 15 } },
         dom.button({
           style: {
             marginTop: 20,
-            background: (isSaveEnabled) ? undefined : '#ccc'
+            background: (isFormComplete) ? undefined : '#ccc'
           },
-          disabled: isSaveEnabled,
+          disabled: !isFormComplete,
           className: 'btn save',
           onClick: this.onClickSave
         }, 'Record service'),

--- a/spec/javascripts/student_profile_v2/record_service_spec.js
+++ b/spec/javascripts/student_profile_v2/record_service_spec.js
@@ -28,6 +28,10 @@ describe('RecordService', function() {
       return $(el).find('.btn.service-type').toArray().map(function(el) {
         return $.trim(el.innerText);
       });
+    },
+
+    findSaveButton: function(el) {
+      return $(el).find('.btn.save');
     }
   };
 
@@ -51,7 +55,8 @@ describe('RecordService', function() {
       expect($(el).find('.Select').length).toEqual(1);
       expect(el).toContainText('When did they start?');
       expect($(el).find('.Datepicker .datepicker.hasDatepicker').length).toEqual(1);
-      expect($(el).find('.btn.save').length).toEqual(1);
+      expect(helpers.findSaveButton(el).length).toEqual(1);
+      expect(helpers.findSaveButton(el).attr('disabled')).toEqual('disabled');
       expect($(el).find('.btn.cancel').length).toEqual(1);
     });
   });


### PR DESCRIPTION
The enabled/disabled check was correct, but the button styling was backward so it looks enabled when it was disabled, and looked disabled when it was enabled.

The bug: when all info is present button looks disabled:
<img width="562" alt="screen shot 2016-03-09 at 6 40 59 am" src="https://cloud.githubusercontent.com/assets/1056957/13634503/f6116e80-e5c3-11e5-8980-2ba3adad11e8.png">

Fixed:
<img width="566" alt="screen shot 2016-03-09 at 6 56 24 am" src="https://cloud.githubusercontent.com/assets/1056957/13634522/0d692e42-e5c4-11e5-8aae-a4e45500edc7.png">
