### PR TITLE
Factor out SlicePanel components and styles, revise hover styling

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -42,10 +42,14 @@
 //= require session_timeout_warning
 //= require student_searchbar
 //= require_tree ./helpers
+
+// shared react compoents:
+//= require ./components/fixed_table
+//= require ./components/collapsable_table
 //= require_tree ./components
 
 // student profile page v2:
-// components:
+// pure ui components:
   //= require ./student_profile_v2/service_color
   //= require ./student/profile_charts/profile_chart_settings
   //= require ./student_profile_v2/feed_helpers

--- a/app/assets/javascripts/components/collapsable_table.js
+++ b/app/assets/javascripts/components/collapsable_table.js
@@ -1,0 +1,64 @@
+(function() {
+
+  window.shared || (window.shared = {});
+  var dom = window.shared.ReactHelpers.dom;
+  var createEl = window.shared.ReactHelpers.createEl;
+  var merge = window.shared.ReactHelpers.merge;
+
+  var FixedTable = window.shared.FixedTable;
+  var styles = window.shared.styles;
+
+  // Table for SlicePanels that shows a set of filters for a particular
+  // dimension, and supports collapsing the list when there are no items
+  // that fix particular values.
+  var CollapsableTable = window.shared.CollapsableTable = React.createClass({
+    displayName: 'CollapsableTable',
+    getDefaultProps: function() {
+      return {
+        minHeight: 132,
+        limit: 5,
+        className: ''
+      };
+    },
+
+    getInitialState: function() {
+      return {
+        isExpanded: false
+      };
+    },
+
+    onCollapseClicked: function(e) {
+      this.setState({ isExpanded: false });
+    },
+
+    onExpandClicked: function(e) {
+      this.setState({ isExpanded: true });
+    },
+
+    render: function() {
+      var truncatedItems = (this.state.isExpanded)
+        ? this.props.items
+        : this.props.items.slice(0, this.props.limit);
+      return dom.div({ className: 'CollapsableTable' },
+        createEl(FixedTable, merge(this.props, {
+          items: truncatedItems,
+          children: this.renderCollapseOrExpand()
+        }))
+      );
+    },
+
+    renderCollapseOrExpand: function() {
+      if (this.props.items.length <= this.props.limit) return;
+      return dom.a({
+        style: {
+          fontSize: styles.fontSize,
+          color: '#999',
+          paddingTop: 5,
+          display: 'block'
+        },
+        onClick: (this.state.isExpanded) ? this.onCollapseClicked : this.onExpandClicked
+      }, (this.state.isExpanded) ? '- Hide details' : '+ Show all');
+
+    }
+  });
+})();

--- a/app/assets/javascripts/components/fixed_table.js
+++ b/app/assets/javascripts/components/fixed_table.js
@@ -1,0 +1,134 @@
+(function() {
+
+  window.shared || (window.shared = {});
+  var dom = window.shared.ReactHelpers.dom;
+  var createEl = window.shared.ReactHelpers.createEl;
+  var merge = window.shared.ReactHelpers.merge;
+
+  var styles = window.shared.styles;
+
+  /*
+  A fixed-size table of items for SlicePanel, describing a set of 
+  values for a dimension that the user can filter by.
+  Items are shown in the order they are passed, and there is
+  no user interation to change the list of items.
+  */
+  var FixedTable = window.shared.FixedTable = React.createClass({
+    displayName: 'FixedTable',
+
+    onRowClicked: function(item, e) {
+      this.props.onFilterToggled(item.filter);
+    },
+
+    render: function() {
+      return this.renderTableFor(this.props.title, this.props.items, this.props);
+    },
+
+    // title height is fixed since font-weight causes loading a font which delays initial render
+    renderTableFor: function(title, items, options) {
+      options || (options = {});
+      var className = options.className || '';
+      var selectedFilterIdentifiers = _.pluck(this.props.filters, 'identifier');
+      return dom.div({
+        className: 'FixedTable panel ' + className,
+        style: {
+          display: 'inline-block',
+          paddingTop: 5,
+          paddingBottom: 5
+        }
+      },
+        dom.div({ className: 'FixedTable', style: { marginBottom: 5, paddingLeft: 5, fontWeight: 'bold', height: '1em' }}, title),
+        dom.table({},
+          dom.tbody({}, items.map(function(item) {
+            var key = item.caption;
+            var isFilterApplied = _.contains(selectedFilterIdentifiers, item.filter.identifier);
+            return dom.tr({
+              className: 'clickable-row',
+              key: item.caption,
+              style: {
+                backgroundColor: (isFilterApplied) ? colors.selection: null,
+                cursor: 'pointer'
+              },
+              onClick: this.onRowClicked.bind(this, item)
+            },
+              dom.td({
+                className: 'caption-cell',
+                style: { opacity: (item.percentage === 0) ? 0.15 : 1 }
+              },
+                dom.a({
+                  style: { fontSize: styles.fontSize, paddingLeft: 10 }
+                }, item.caption)
+              ),
+              dom.td({ style: { fontSize: styles.fontSize, width: 48, textAlign: 'right', paddingRight: 8 }},
+                (item.percentage ===  0) ? '' : Math.ceil(100 * item.percentage) + '%'),
+              dom.td({ style: { fontSize: styles.fontSize, width: 50 } }, this.renderBar(item.percentage, 50))
+            );
+          }, this))
+        ),
+        dom.div({ style: { paddingLeft: 5 } }, this.props.children)
+      );
+    },
+
+    renderBar: function(percentage, width) {
+      return dom.div({
+        className: 'bar',
+        style: {
+          width: Math.round(width*percentage) + '%',
+          height: '1em',
+        }
+      });
+    }
+  });
+
+  // table that supports collapsing
+  var CollapsableTable = React.createClass({
+    displayName: 'CollapsableTable',
+    getDefaultProps: function() {
+      return {
+        minHeight: 132,
+        limit: 5,
+        className: ''
+      };
+    },
+
+    getInitialState: function() {
+      return {
+        isExpanded: false
+      };
+    },
+
+    onCollapseClicked: function(e) {
+      this.setState({ isExpanded: false });
+    },
+
+    onExpandClicked: function(e) {
+      this.setState({ isExpanded: true });
+    },
+
+    render: function() {
+      var truncatedItems = (this.state.isExpanded)
+        ? this.props.items
+        : this.props.items.slice(0, this.props.limit);
+      return dom.div({ className: 'CollapsableTable' },
+        createEl(FixedTable, merge(this.props, {
+          items: truncatedItems,
+          children: this.renderCollapseOrExpand()
+        }))
+      );
+    },
+
+    renderCollapseOrExpand: function() {
+      if (this.props.items.length <= this.props.limit) return;
+      return dom.a({
+        style: {
+          fontSize: styles.fontSize,
+          color: '#999',
+          paddingTop: 5,
+          display: 'block'
+        },
+        onClick: (this.state.isExpanded) ? this.onCollapseClicked : this.onExpandClicked
+      }, (this.state.isExpanded) ? '- Hide details' : '+ Show all');
+
+    }
+  });
+})();

--- a/app/assets/javascripts/components/slice_panels.js
+++ b/app/assets/javascripts/components/slice_panels.js
@@ -1,136 +1,14 @@
 (function() {
 
   window.shared || (window.shared = {});
-  var Filters = window.shared.Filters;
-  var Routes = window.shared.Routes;
-  var SlicePanels = window.shared.SlicePanels;
+  var CollapsableTable = window.shared.CollapsableTable;
   var styles = window.shared.styles;
   var colors = window.shared.colors;
   var dom = window.shared.ReactHelpers.dom;
   var createEl = window.shared.ReactHelpers.createEl;
   var merge = window.shared.ReactHelpers.merge;
 
-  // fixed items, already sorted, no collapsing
-  var FixedTable = React.createClass({
-    displayName: 'FixedTable',
-
-    onRowClicked: function(item, e) {
-      this.props.onFilterToggled(item.filter);
-    },
-
-    render: function() {
-      return this.renderTableFor(this.props.title, this.props.items, this.props);
-    },
-
-    // title height is fixed since font-weight causes loading a font which delays initial render
-    renderTableFor: function(title, items, options) {
-      options || (options = {});
-      var className = options.className || '';
-      var selectedFilterIdentifiers = _.pluck(this.props.filters, 'identifier');
-      return dom.div({
-        className: 'FixedTable panel ' + className,
-        style: {
-          display: 'inline-block',
-          paddingTop: 5,
-          paddingBottom: 5
-        }
-      },
-        dom.div({ className: 'FixedTable', style: { marginBottom: 5, paddingLeft: 5, fontWeight: 'bold', height: '1em' }}, title),
-        dom.table({},
-          dom.tbody({}, items.map(function(item) {
-            var key = item.caption;
-            var isFilterApplied = _.contains(selectedFilterIdentifiers, item.filter.identifier);
-            return dom.tr({
-              className: 'clickable-row',
-              key: item.caption,
-              style: {
-                backgroundColor: (isFilterApplied) ? colors.selection: null,
-                cursor: 'pointer'
-              },
-              onClick: this.onRowClicked.bind(this, item)
-            },
-              dom.td({
-                className: 'caption-cell',
-                style: { opacity: (item.percentage === 0) ? 0.15 : 1 }
-              },
-                dom.a({
-                  style: { fontSize: styles.fontSize, paddingLeft: 10 }
-                }, item.caption)
-              ),
-              dom.td({ style: { fontSize: styles.fontSize, width: 48, textAlign: 'right', paddingRight: 8 }},
-                (item.percentage ===  0) ? '' : Math.ceil(100 * item.percentage) + '%'),
-              dom.td({ style: { fontSize: styles.fontSize, width: 50 } }, this.renderBar(item.percentage, 50))
-            );
-          }, this))
-        ),
-        dom.div({ style: { paddingLeft: 5 } }, this.props.children)
-      );
-    },
-
-    renderBar: function(percentage, width) {
-      return dom.div({
-        className: 'bar',
-        style: {
-          width: Math.round(width*percentage) + '%',
-          height: '1em',
-        }
-      });
-    }
-  });
-
-  // table that supports collapsing
-  var CollapsableTable = React.createClass({
-    displayName: 'CollapsableTable',
-    getDefaultProps: function() {
-      return {
-        minHeight: 132,
-        limit: 5,
-        className: ''
-      };
-    },
-
-    getInitialState: function() {
-      return {
-        isExpanded: false
-      };
-    },
-
-    onCollapseClicked: function(e) {
-      this.setState({ isExpanded: false });
-    },
-
-    onExpandClicked: function(e) {
-      this.setState({ isExpanded: true });
-    },
-
-    render: function() {
-      var truncatedItems = (this.state.isExpanded)
-        ? this.props.items
-        : this.props.items.slice(0, this.props.limit);
-      return dom.div({ className: 'CollapsableTable' },
-        createEl(FixedTable, merge(this.props, {
-          items: truncatedItems,
-          children: this.renderCollapseOrExpand()
-        }))
-      );
-    },
-
-    renderCollapseOrExpand: function() {
-      if (this.props.items.length <= this.props.limit) return;
-      return dom.a({
-        style: {
-          fontSize: styles.fontSize,
-          color: '#999',
-          paddingTop: 5,
-          display: 'block'
-        },
-        onClick: (this.state.isExpanded) ? this.onCollapseClicked : this.onExpandClicked
-      }, (this.state.isExpanded) ? '- Hide details' : '+ Show all');
-
-    }
-  });
-
-  window.shared.SlicePanels = React.createClass({
+  var SlicePanels = window.shared.SlicePanels = React.createClass({
     displayName: 'SlicePanels',
     propTypes: {
       filters: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,

--- a/app/assets/stylesheets/components/fixed_table.scss
+++ b/app/assets/stylesheets/components/fixed_table.scss
@@ -1,0 +1,22 @@
+.FixedTable {
+  table {
+    table-layout: fixed;
+    border-collapse: collapse;
+
+    td {
+      padding: 0;
+    }
+
+    tr.clickable-row:hover {
+      outline: 1px solid lighten($gray, 40%);
+
+      a:hover {
+        color: $gray;
+      }
+    }
+  }
+
+  .bar {
+    background-color: rgba(49, 119, 201, 0.75);
+  }
+}

--- a/app/assets/stylesheets/components/slice_panels.scss
+++ b/app/assets/stylesheets/components/slice_panels.scss
@@ -32,45 +32,4 @@
   .interventions-column table td.caption-cell {
     width: 175px;
   }
-
-  .clickable-row:hover {
-    text-decoration: underline;
-  }
-
-
-  .FixedTable {
-    table {
-      table-layout: fixed;
-      border-collapse: collapse;
-
-      td {
-        padding: 0;
-      }
-    }
-
-    .bar {
-      background-color: rgba(49, 119, 201, 0.75);
-    }
-  }
-
-
-  .StudentsTable {
-    table.students-table {
-      border-collapse: collapse;
-
-      thead th {
-        font-size: 12px;
-        border-bottom: 1px solid #ccc;
-      }
-
-      tr:hover {
-        background-color: $table-row-hover;
-      }
-
-      th, td {
-        padding: 4px 10px;
-        text-align: left;
-      }
-    }
-  }
 }

--- a/app/assets/stylesheets/components/students_table.scss
+++ b/app/assets/stylesheets/components/students_table.scss
@@ -1,0 +1,19 @@
+.StudentsTable {
+  table.students-table {
+    border-collapse: collapse;
+
+    thead th {
+      font-size: 12px;
+      border-bottom: 1px solid #ccc;
+    }
+
+    tr:hover {
+      background-color: $table-row-hover;
+    }
+
+    th, td {
+      padding: 4px 10px;
+      text-align: left;
+    }
+  }
+}

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -8,6 +8,8 @@
 @import 'nav';
 
 @import 'components/slice_panels';
+@import 'components/fixed_table';
+@import 'components/students_table';
 
 @import 'signin';
 @import 'roster';


### PR DESCRIPTION
This builds on the awesome work @lilybarrett did in https://github.com/studentinsights/studentinsights/pull/168.  It breaks up the pieces in the `SlicePanel` component into separate files and stylesheets to make them easier to discover in the future.

@lilybarrett I noticed this morning that the text on the left inside each row becomes a subtle dark blue on hover, so I fixed that up to stay the same.
<img width="208" alt="screen shot 2016-03-09 at 8 21 06 am" src="https://cloud.githubusercontent.com/assets/1056957/13636610/c57a0810-e5d0-11e5-9d3f-ea70da52d0f9.png">

I also realized in using this a bit this morning that the underline styling looks a lot like a link, which I didn't realize when we were talking about it last night.  This might be confusing to folks, since links usually take you away to a new page when you click on them, but these rows act more like buttons, where you click on them and the page changes in response.  So here's another iteration, trying to make them feel "clickable" and communicate _clicking here will change something on the page_ more than _this is a link and clicking will take you to another page_

<img width="206" alt="screen shot 2016-03-09 at 8 24 58 am" src="https://cloud.githubusercontent.com/assets/1056957/13636613/c704c666-e5d0-11e5-9487-bb399866eee2.png">

@lilybarrett Let me know what you think, and if this seems cool I can merge it later today or tomorrow AM.  And thanks again for your help!