### PR TITLE
Tighten import tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /sketch
 /data
 coverage
+spec/logs/logs.txt
 
 # This holds configuration for testing production import scripts locally, so it shouldn't be checked into
 # source control.

--- a/spec/importers/behavior_importer_spec.rb
+++ b/spec/importers/behavior_importer_spec.rb
@@ -3,68 +3,101 @@ require 'rails_helper'
 
 RSpec.describe BehaviorImporter do
 
-  let(:importer) {
-    Importer.new(current_file_importer: described_class.new)
-  }
-
-  before { FactoryGirl.create(:student, local_id: '11') }
-  before { FactoryGirl.create(:student, local_id: '12') }
-  before { FactoryGirl.create(:student, local_id: '13') }
-  before { FactoryGirl.create(:student, local_id: '14') }
-
-  let(:import) { importer.start_import(csv) }
-
   describe '#import_row' do
-    context 'realistic data ("good" case), not great data' do
-      let(:file) { File.open("#{Rails.root}/spec/fixtures/fake_behavior_export.txt", "r:CP1252") }  # Windows 1252
-      let(:transformer) { CsvTransformer.new }
-      let(:csv) { transformer.transform(file) }
-      let!(:student_we_want_to_update) { FactoryGirl.create(:student_we_want_to_update) }
+    let(:importer) { described_class.new }
+    before { importer.import_row(row) }
+    let(:incidents) { student.reload.most_recent_school_year.discipline_incidents }
+    let(:incident) { incidents.last }
 
-      before do |example|
-        import unless example.metadata[:skip_before]
-      end
+    context 'typical row' do
+      let(:student) { FactoryGirl.create(:student, local_id: '10') }
+      let(:row) {
+        {
+          local_id: student.local_id,
+          incident_code: "Hitting",
+          event_date: Date.new(2015, 10, 1),
+          incident_time: "13:00:00",
+          incident_location: "Classroom",
+          incident_description: "Hit another student.",
+          school_local_id: "SHS"
+        }
+      }
 
-      it 'does not raise errors about byte sequence, length, missing date/time values' do
-        expect { import }.not_to raise_error
+      it 'creates discipline incident for the correct student' do
+        expect(incidents.size).to eq 1
       end
-      it 'creates new discipline incidents', skip_before: true do
-        expect { import }.to change(DisciplineIncident, :count).by 4
+      it 'assigns the incident code correctly' do
+        expect(incident.incident_code).to eq 'Hitting'
       end
-
-      context 'student we want to update' do
-        it 'creates discipline incident for the correct student' do
-          expect(student_we_want_to_update.reload.most_recent_school_year.discipline_incidents.size).to eq 1
-        end
-        it 'assigns the incident code correctly' do
-          incident = student_we_want_to_update.reload.most_recent_school_year.discipline_incidents.last
-          expect(incident.incident_code).to eq 'Hitting'
-        end
+      it 'sets has exact time to true' do
+        expect(incident.has_exact_time).to eq true
       end
-      context 'has exact time' do
-        let(:incident_with_time_data) { Student.find_by_local_id("10").reload.most_recent_school_year.discipline_incidents.last }
-        it 'sets has exact time to true' do
-          expect(incident_with_time_data.has_exact_time).to eq true
-        end
-        it 'assigns the date and time correctly' do
-          expect(incident_with_time_data.occurred_at).to eq Time.utc(2015, 10, 1, 13, 00)
-        end
-      end
-      context 'time missing' do
-        let(:incident_without_time_data) { Student.find_by_local_id("13").most_recent_school_year.discipline_incidents.last }
-        it 'sets has exact time to false' do
-          expect(incident_without_time_data.has_exact_time).to eq false
-        end
-        it 'assigns the date without a time' do
-          expect(incident_without_time_data.occurred_at).to eq Time.utc(2015, 10, 3)
-        end
-      end
-      context 'description text has non UTF-8 byte sequence' do
-        let(:incident_with_non_utf8_description) { Student.find_by_local_id("12").most_recent_school_year.discipline_incidents.last }
-        it 'fights back' do
-          expect(incident_with_non_utf8_description.reload.incident_description).to eq("pencil that didn’t need to be")
-        end
+      it 'assigns the date and time correctly' do
+        expect(incident.occurred_at).to eq Time.utc(2015, 10, 1, 13, 00)
       end
     end
+
+    context 'very long incident description' do
+      let!(:student) { FactoryGirl.create(:student, local_id: '11') }
+      let(:big_block_of_text) { "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." }
+      let(:row) {
+        {
+          local_id: student.local_id,
+          incident_code: "Lorem ipsuming",
+          event_date: Date.new(2015, 10, 1),
+          incident_time: "13:00:00",
+          incident_location: "Classroom",
+          incident_description: big_block_of_text,
+          school_local_id: "SHS"
+        }
+      }
+
+      it 'assigns the description correctly' do
+        expect(incident.incident_description).to eq big_block_of_text
+      end
+
+    end
+
+    context 'time missing' do
+      let!(:student) { FactoryGirl.create(:student, local_id: '13') }
+      let(:row) {
+        {
+          local_id: student.local_id,
+          incident_code: "Bullying",
+          event_date: Date.new(2015, 10, 3),
+          incident_time: nil,
+          incident_location: "Classroom",
+          incident_description: "Bullied another student.",
+          school_local_id: "SHS"
+        }
+      }
+
+      it 'sets has exact time to false' do
+        expect(incident.has_exact_time).to eq false
+      end
+      it 'assigns the date without a time' do
+        expect(incident.occurred_at).to eq Time.utc(2015, 10, 3)
+      end
+    end
+
+    context 'description text has non UTF-8 byte sequence' do
+      let!(:student) { FactoryGirl.create(:student, local_id: '12') }
+      let(:row) {
+        {
+          local_id: student.local_id,
+          incident_code: "Unauthorized pencil sharpening",
+          event_date: Date.new(2015, 10, 2),
+          incident_time: "13:00:00",
+          incident_location: "Classroom",
+          incident_description: "pencil that didn’t need to be",
+          school_local_id: "SHS"
+        }
+      }
+
+      it 'fights back' do
+        expect(incident.reload.incident_description).to eq("pencil that didn’t need to be")
+      end
+    end
+
   end
 end

--- a/spec/importers/importer_spec.rb
+++ b/spec/importers/importer_spec.rb
@@ -2,37 +2,52 @@ require 'rails_helper'
 
 RSpec.describe Importer do
 
-  describe '#import' do
+  describe '#connect_transform_import' do
 
-    let(:file_importer_class) { StudentsImporter }
-
-    let(:file_importer) { file_importer_class.new }
+    let(:log_dir) { "#{Rails.root}/spec/logs" }
+    before { Dir.mkdir(log_dir) unless File.exists?(log_dir) }
+    let(:logs_path) { "#{Rails.root}/spec/logs/logs.txt" }
+    let(:log) { File.new(logs_path, 'w') }
 
     context 'CSV with 1 High School student, 1 Healey student (Elem), 1 Brown student (Elem)' do
 
       let(:fixture_path) { "#{Rails.root}/spec/fixtures/fake_students_export.txt" }
-      let(:file) { File.open(fixture_path) }
-      let(:transformer) { CsvTransformer.new }
-      let(:csv) { transformer.transform(file) }
+      let(:file) { File.read(fixture_path) }
+      let(:mock_client) { double(:sftp_client, read_file: file) }
 
       context 'no scope' do
-        let(:importer) { Importer.new(current_file_importer: file_importer) }
+        let(:file_importer) { StudentsImporter.new }
+        let(:importer) {
+          Importer.new(
+            file_importers: [file_importer],
+            client: mock_client,
+            log_destination: log
+          )
+        }
+
         it 'imports both students' do
-          expect { importer.start_import(csv) }.to change(Student, :count).by 3
+          expect { importer.connect_transform_import }.to change(Student, :count).by 3
         end
       end
 
       context 'scope is Healey School' do
         let(:healey) { FactoryGirl.create(:healey) }
-        let(:importer) { Importer.new(
-            school_scope: [healey.local_id], current_file_importer: file_importer
+        let(:file_importer) { StudentsImporter.new }
+        let(:importer) {
+          Importer.new(
+            school_scope: [healey.local_id],
+            file_importers: [file_importer],
+            client: mock_client,
+            log_destination: log
           )
         }
+
         it 'only imports the Healey student' do
-          expect { importer.start_import(csv) }.to change(Student, :count).by 1
+          expect { importer.connect_transform_import }.to change(Student, :count).by 1
         end
       end
-
     end
+
   end
+
 end

--- a/spec/importers/star_math_importer_spec.rb
+++ b/spec/importers/star_math_importer_spec.rb
@@ -9,43 +9,42 @@ RSpec.describe StarMathImporter do
       let(:file) { File.open("#{Rails.root}/spec/fixtures/fake_star_math.csv") }
       let(:transformer) { StarMathCsvTransformer.new }
       let(:csv) { transformer.transform(file) }
-      let(:math_importer) {
-        Importer.new(current_file_importer: described_class.new)
-      }
+      let(:math_importer) { described_class.new }
+      let(:import) { csv.each { |row| math_importer.import_row(row) } }
 
       context 'with good data' do
 
         context 'existing student' do
           let!(:student) { FactoryGirl.create(:student_we_want_to_update) }
           it 'creates a new student assessment' do
-            expect { math_importer.start_import(csv) }.to change { StudentAssessment.count }.by 1
+            expect { import }.to change { StudentAssessment.count }.by 1
           end
           it 'creates a new STAR MATH assessment' do
-            math_importer.start_import(csv)
+            import
             student_assessment = StudentAssessment.last
             assessment = student_assessment.assessment
             expect(assessment.family).to eq "STAR"
             expect(assessment.subject).to eq "Mathematics"
           end
           it 'sets math percentile rank correctly' do
-            math_importer.start_import(csv)
+            import
             expect(StudentAssessment.last.percentile_rank).to eq 70
           end
           it 'sets date taken correctly' do
-            math_importer.start_import(csv)
+            import
             expect(StudentAssessment.last.date_taken).to eq Date.new(2015, 1, 21)
           end
           it 'does not create a new student' do
-            expect { math_importer.start_import(csv) }.to change(Student, :count).by 0
+            expect { import }.to change(Student, :count).by 0
           end
         end
 
         context 'student does not exist' do
           it 'does not create a new student assessment' do
-            expect { math_importer.start_import(csv) }.to change { StudentAssessment.count }.by 0
+            expect { import }.to change { StudentAssessment.count }.by 0
           end
           it 'does not create a new student' do
-            expect { math_importer.start_import(csv) }.to change(Student, :count).by 0
+            expect { import }.to change(Student, :count).by 0
           end
         end
       end
@@ -56,7 +55,7 @@ RSpec.describe StarMathImporter do
         let(:csv) { transformer.transform(file) }
         let(:math_importer) { StarMathImporter.new }
         it 'raises an error' do
-          expect { math_importer.start_import(csv) }.to raise_error NoMethodError
+          expect { import }.to raise_error NoMethodError
         end
       end
     end

--- a/spec/importers/star_reading_importer_spec.rb
+++ b/spec/importers/star_reading_importer_spec.rb
@@ -9,52 +9,53 @@ RSpec.describe StarReadingImporter do
       let(:file) { File.open("#{Rails.root}/spec/fixtures/fake_star_reading.csv") }
       let(:transformer) { StarReadingCsvTransformer.new }
       let(:csv) { transformer.transform(file) }
-      let(:reading_importer) {
-        Importer.new(current_file_importer: described_class.new)
-      }
+      let(:reading_importer) { described_class.new }
+      let(:import) { csv.each { |row| reading_importer.import_row(row) } }
 
       context 'with good data' do
         context 'existing student' do
           let!(:student) { FactoryGirl.create(:student_we_want_to_update) }
           it 'creates a new student assessment' do
-            expect { reading_importer.start_import(csv) }.to change { StudentAssessment.count }.by 1
+            expect { import }.to change { StudentAssessment.count }.by 1
           end
           it 'creates a new STAR Reading assessment' do
-            reading_importer.start_import(csv)
+            import
             student_assessment = StudentAssessment.last
             expect(student_assessment.family).to eq "STAR"
             expect(student_assessment.subject).to eq "Reading"
           end
           it 'sets instructional reading level correctly' do
-            reading_importer.start_import(csv)
+            import
             expect(StudentAssessment.last.instructional_reading_level).to eq 5.0
           end
           it 'sets date taken correctly' do
-            reading_importer.start_import(csv)
+            import
             expect(StudentAssessment.last.date_taken).to eq Date.new(2015, 1, 21)
           end
           it 'does not create a new student' do
-            expect { reading_importer.start_import(csv) }.to change(Student, :count).by 0
+            expect { import }.to change(Student, :count).by 0
           end
         end
         context 'student does not exist' do
           it 'does not create a new student assessment' do
-            expect { reading_importer.start_import(csv) }.to change { StudentAssessment.count }.by 0
+            expect { import }.to change { StudentAssessment.count }.by 0
           end
           it 'does not create a new student' do
-            expect { reading_importer.start_import(csv) }.to change(Student, :count).by 0
+            expect { import }.to change(Student, :count).by 0
           end
         end
       end
+
       context 'with bad data' do
         let(:file) { File.open("#{Rails.root}/spec/fixtures/bad_star_reading_data.csv") }
         let(:transformer) { StarReadingCsvTransformer.new }
         let(:csv) { transformer.transform(file) }
         let(:reading_importer) { StarReadingImporter.new }
         it 'raises an error' do
-          expect { reading_importer.start_import(csv) }.to raise_error NoMethodError
+          expect { import }.to raise_error NoMethodError
         end
       end
+
     end
   end
 end

--- a/spec/importers/students_importer_spec.rb
+++ b/spec/importers/students_importer_spec.rb
@@ -2,9 +2,6 @@ require 'rails_helper'
 
 RSpec.describe StudentsImporter do
 
-  let(:importer) {
-    Importer.new(current_file_importer: described_class.new)
-  }
 
   describe '#import_row' do
 
@@ -12,16 +9,18 @@ RSpec.describe StudentsImporter do
       let(:file) { File.open("#{Rails.root}/spec/fixtures/fake_students_export.txt") }
       let(:transformer) { CsvTransformer.new }
       let(:csv) { transformer.transform(file) }
+      let(:importer) { described_class.new }
+      let(:import) { csv.each { |row| importer.import_row(row) }}
 
       let!(:high_school) { School.create(local_id: 'SHS') }
       let!(:healey) { School.create(local_id: 'HEA') }
 
       it 'imports students' do
-        expect { importer.start_import(csv) }.to change { Student.count }.by 3
+        expect { import }.to change { Student.count }.by 3
       end
 
       it 'imports student data correctly' do
-        importer.start_import(csv)
+        import
 
         first_student = Student.find_by_state_id('1000000000')
         expect(first_student.reload.school).to eq healey

--- a/spec/importers/x2_assessment_importer_spec.rb
+++ b/spec/importers/x2_assessment_importer_spec.rb
@@ -14,16 +14,9 @@ RSpec.describe X2AssessmentImporter do
       context 'for Healey school' do
 
         let!(:student) { FactoryGirl.create(:student, local_id: '100') }
-
         let(:healey) { School.where(local_id: "HEA").first_or_create! }
-
-        let(:healey_importer) {
-          Importer.new(current_file_importer: described_class.new, school_scope: 'HEA')
-        }
-
-        before(:each) do
-          healey_importer.start_import(csv)
-        end
+        let(:importer) { described_class.new }
+        before { csv.each { |row| importer.import_row(row) }}
 
         it 'imports only white-listed assessments' do
           expect(StudentAssessment.count).to eq 6


### PR DESCRIPTION
## Notes

+ One problem with the import specs was that they were too integration-y
+ They made use of classes besides the class under test, which made them difficult to change and violated separation of concerns
+ This PR tightens up the import specs so that they focus more closely on the class being tested

## Also

+ Pass log output destination to `Importer` as an instance variable so that we can redirect and test log output
+ Side effect, we can cut ugly `unless Rails.env.test?` conditionals