### PR TITLE
Overview - Add event notes to filters

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -46,6 +46,9 @@
 //= require datepicker_config
 //= require session_timeout_warning
 //= require student_searchbar
+
+//= require ./helpers/react_helpers
+//= require ./helpers/feed_helpers
 //= require_tree ./helpers
 
 // shared react compoents:
@@ -57,7 +60,6 @@
 // pure ui components:
   //= require ./student_profile_v2/service_color
   //= require ./student/profile_charts/profile_chart_settings
-  //= require ./student_profile_v2/feed_helpers
   //= require ./student_profile_v2/educator
   //= require ./student_profile_v2/datepicker
   //= require ./student_profile_v2/highcharts_wrapper

--- a/app/assets/javascripts/components/slice_panels.js
+++ b/app/assets/javascripts/components/slice_panels.js
@@ -15,6 +15,7 @@
       students: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
       allStudents: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
       serviceTypesIndex: React.PropTypes.object.isRequired,
+      eventNoteTypesIndex: React.PropTypes.object.isRequired,
       onFilterToggled: React.PropTypes.func.isRequired
     },
 
@@ -135,7 +136,12 @@
         this.renderTable({
           title: 'Services',
           items: this.serviceItems(),
-          limit: 7
+          limit: 4
+        }),
+        this.renderTable({
+          title: 'Notes',
+          items: this.mergedNoteItems(),
+          limit: 4
         }),
         this.renderSimpleTable('Program', 'program_assigned', { limit: 3 }),
         this.renderSimpleTable('Homeroom', 'homeroom_name', {
@@ -169,6 +175,24 @@
       });
 
       return [this.createItem('None', Filters.ServiceType(null))].concat(sortedItems);
+    },
+
+    // TODO(kr) add other note types
+    mergedNoteItems: function() {
+      var students = this.props.allStudents;
+      var allEventNotes = _.compact(_.flatten(_.pluck(students, 'event_notes')));
+      var allEventNoteTypesIds = _.unique(allEventNotes.map(function(eventNote) {
+        return parseInt(eventNote.event_note_type_id, 10);
+      }));
+      var eventNoteItems = allEventNoteTypesIds.map(function(eventNoteTypeId) {
+        var eventNoteTypeName = this.props.eventNoteTypesIndex[eventNoteTypeId].name;
+        return this.createItem(eventNoteTypeName, Filters.EventNoteType(eventNoteTypeId));
+      }, this);
+      var sortedItems =  _.sortBy(eventNoteItems, function(item) {
+        return -1 * students.filter(item.filter.filterFn).length;
+      });
+
+      return [this.createItem('None', Filters.EventNoteType(null))].concat(sortedItems);
     },
 
     renderGradeTable: function() {

--- a/app/assets/javascripts/helpers/feed_helpers.js
+++ b/app/assets/javascripts/helpers/feed_helpers.js
@@ -45,6 +45,18 @@
       return _.sortBy(mergedNotes, 'sort_timestamp').reverse();
     },
 
+    matchesMergedNoteType: function(mergedNote, mergedNoteType, mergedNoteTypeId) {
+      if (mergedNote.type !== mergedNoteType) return false;
+      switch (mergedNote.type) {
+        case 'event_notes': return (mergedNote.event_note_type_id === mergedNoteTypeId);
+        case 'deprecated_notes': return true;
+        case 'deprecated_interventions': return (mergedNote.intervention_type_id === mergedNoteTypeId);
+        case 'deprecated_progress_notes': return (mergedNote.intervention.intervention_type_id === mergedNoteTypeId);
+      }
+
+      return false;
+    },
+
     // Returns a list of all educatorIds that are active for the student,
     // based on the feed.
     allEducatorIds: function(feed) {

--- a/app/assets/javascripts/helpers/filters.js
+++ b/app/assets/javascripts/helpers/filters.js
@@ -1,6 +1,8 @@
 (function() {
   // Define filter operations
   window.shared || (window.shared = {});
+  var FeedHelpers = window.shared.FeedHelpers;
+
   window.shared.Filters = Filters = {
     Range: function(key, range) {
       return {
@@ -54,6 +56,37 @@
           }).length > 0;
         },
         key: 'service_type'
+      };
+    },
+    EventNoteType: function(eventNoteTypeId) {
+      return {
+        identifier: ['event_note_type', eventNoteTypeId].join(':'),
+        filterFn: function(student) {
+          if (eventNoteTypeId === null) return (student.event_notes.length === 0);
+          return student.event_notes.filter(function(eventNote) {
+            return (eventNote.event_note_type_id === eventNoteTypeId);
+          }).length > 0;
+        },
+        key: 'event_note_type'
+      };
+    },
+    MergedNoteType: function(mergedNoteType, mergedNoteTypeId) {
+      return {
+        identifier: ['merged_note_type', mergedNoteType, mergedNoteTypeId].join(':'),
+        filterFn: function(student) {
+          var mergedNotes = FeedHelpers.mergedNotes({
+            event_notes: student.event_notes,
+            deprecated: {
+              interventions: student.interventions,
+              notes: student.notes
+            }
+          });
+          if (mergedNoteType === null && mergedNoteTypeId === null) return (mergedNotes.length === 0);
+          return mergedNotes.filter(function(mergedNote) {
+            return FeedHelpers.matchesMergedNoteType(mergedNote, mergedNoteType, mergedNoteTypeId);
+          }).length > 0;
+        },
+        key: 'merged_note_type'
       };
     },
     YearsEnrolled: function(value) {

--- a/app/assets/javascripts/school_overview/main.js
+++ b/app/assets/javascripts/school_overview/main.js
@@ -15,6 +15,7 @@ $(function() {
       ReactDOM.render(createEl(SchoolOverviewPage, {
         allStudents: serializedData.students,
         serviceTypesIndex: serializedData.constantIndexes.service_types_index,
+        eventNoteTypesIndex: serializedData.constantIndexes.event_note_types_index,
         initialFilters: Filters.parseFiltersHash(window.location.hash)
       }), document.getElementById('main'));
     }

--- a/app/assets/javascripts/school_overview/school_overview_page.js
+++ b/app/assets/javascripts/school_overview/school_overview_page.js
@@ -20,6 +20,7 @@
     propTypes: {
       allStudents: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
       serviceTypesIndex: React.PropTypes.object.isRequired,
+      eventNoteTypesIndex: React.PropTypes.object.isRequired,
       initialFilters: React.PropTypes.arrayOf(React.PropTypes.object)
     },
 
@@ -194,6 +195,7 @@
            allStudents: this.props.allStudents,
            students: this.getFilteredStudents(),
            serviceTypesIndex: this.props.serviceTypesIndex,
+           eventNoteTypesIndex: this.props.eventNoteTypesIndex,
            filters: this.state.filters,
            onFilterToggled: this.onFilterToggled
          })),

--- a/app/assets/javascripts/school_star/main.js
+++ b/app/assets/javascripts/school_star/main.js
@@ -18,6 +18,7 @@ $(function() {
         students: serializedData.studentsWithStarReading,
         dateNow: new Date(),
         serviceTypesIndex: serializedData.constantIndexes.service_types_index,
+        eventNoteTypesIndex: serializedData.constantIndexes.event_note_types_index,
         initialFilters: Filters.parseFiltersHash(window.location.hash)
       }), document.getElementById('main'));
     }

--- a/app/assets/javascripts/school_star/star_reading_page.js
+++ b/app/assets/javascripts/school_star/star_reading_page.js
@@ -14,6 +14,7 @@ $(function() {
 
     propTypes: {
       serviceTypesIndex: React.PropTypes.object.isRequired,
+      eventNoteTypesIndex: React.PropTypes.object.isRequired,
       initialFilters: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
       dateNow: React.PropTypes.object.isRequired,
       recentThresholdInDays: React.PropTypes.number
@@ -139,6 +140,7 @@ $(function() {
           allStudents: this.props.students,
           students: this.filteredStudents(),
           serviceTypesIndex: this.props.serviceTypesIndex,
+          eventNoteTypesIndex: this.props.eventNoteTypesIndex,
           filters: this.state.filters,
           onFilterToggled: this.onFilterToggled
         })),

--- a/spec/javascripts/components/slice_panels_spec.js
+++ b/spec/javascripts/components/slice_panels_spec.js
@@ -17,6 +17,7 @@ describe('SlicePanels', function() {
         filters: [],
         interventionTypesIndex: FixtureConstantIndexes.interventionTypesIndex,
         serviceTypesIndex: FixtureConstantIndexes.serviceTypesIndex,
+        eventNoteTypesIndex: FixtureConstantIndexes.eventNoteTypesIndex,
         students: [],
         allStudents: [],
         onFilterToggled: jasmine.createSpy('onFilterToggled')
@@ -61,7 +62,7 @@ describe('SlicePanels', function() {
         ['STAR Reading', 'MCAS ELA', 'Growth - MCAS ELA'],
         ['STAR Math', 'MCAS Math', 'Growth - MCAS Math'],
         ['Discipline incidents', 'Absences', 'Tardies'],
-        ['Services', 'Program', 'Homeroom']
+        ['Services', 'Notes', 'Program', 'Homeroom']
       ]);
 
     });
@@ -79,7 +80,7 @@ describe('SlicePanels', function() {
          [5, 5, 5],
          [5, 5, 5],
          [5, 5, 5],
-         [4, 2, 1]
+         [4, 4, 2, 1]
       ]);
     });
   });


### PR DESCRIPTION
Before:
<img width="248" alt="screen shot 2016-03-21 at 7 43 58 pm" src="https://cloud.githubusercontent.com/assets/1056957/13937685/4569f352-ef9d-11e5-92a9-073ede58d4a0.png">

After:
<img width="245" alt="screen shot 2016-03-21 at 7 41 09 pm" src="https://cloud.githubusercontent.com/assets/1056957/13937665/27ee12b8-ef9d-11e5-88b8-4c1625c48474.png">

This doesn't search for "older notes" that are read from interventions, progress notes and v1 notes.  It'd be nice to add that as an "older note" option in a separate step.