### PR TITLE
Update config for different deployments to declare SHOULD_REPORT_ANALYTICS

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ So far, Student Insights can import CSV and JSON and can fetch data from AWS and
 
 ### LDAP
 
-The project is configured to use LDAP as its authentication strategy in production. To use database authentication (in a production demo site, for example) set a `DEMO_SITE` environment variable. Authentication strategies are defined in `educator.rb`.
+The project is configured to use LDAP as its authentication strategy in production. To use database authentication (in a production demo site, for example) set the `SHOULD_USE_LDAP` environment variable. Authentication strategies are defined in `educator.rb`.
 
 ### Heroku
 

--- a/app/assets/javascripts/env.js.erb
+++ b/app/assets/javascripts/env.js.erb
@@ -4,6 +4,7 @@
   // Describe server-side environment and configuration to the JS UI code.
   window.shared.Env = {
     railsEnvironment: '<%= Rails.env %>',
+    shouldReportAnalytics: <%= if ENV['SHOULD_REPORT_ANALYTICS'] then 'true' else 'false' end %>,
     isDemoSite: <%= if ENV['DEMO_SITE'] then 'true' else 'false' end %>,
     sessionTimeoutInSeconds: <%= Devise.timeout_in.to_i %>
   };

--- a/app/assets/javascripts/env.js.erb
+++ b/app/assets/javascripts/env.js.erb
@@ -4,8 +4,9 @@
   // Describe server-side environment and configuration to the JS UI code.
   window.shared.Env = {
     railsEnvironment: '<%= Rails.env %>',
-    shouldReportAnalytics: <%= if ENV['SHOULD_REPORT_ANALYTICS'] then 'true' else 'false' end %>,
-    isDemoSite: <%= if ENV['DEMO_SITE'] then 'true' else 'false' end %>,
+    deployment: '<%= EnvironmentVariable.value('DEPLOYMENT') %>',
+    shouldReportAnalytics: <%= if EnvironmentVariable.is_true('SHOULD_REPORT_ANALYTICS') then 'true' else 'false' end %>,
+    isDemoSite: <%= if EnvironmentVariable.is_true('DEMO_SITE') then 'true' else 'false' end %>,
     sessionTimeoutInSeconds: <%= Devise.timeout_in.to_i %>
   };
 })();

--- a/app/assets/javascripts/env.js.erb
+++ b/app/assets/javascripts/env.js.erb
@@ -4,7 +4,7 @@
   // Describe server-side environment and configuration to the JS UI code.
   window.shared.Env = {
     railsEnvironment: '<%= Rails.env %>',
-    deployment: '<%= EnvironmentVariable.value('DEPLOYMENT') %>',
+    deploymentKey: '<%= EnvironmentVariable.value('DEPLOYMENT_KEY') %>',
     shouldReportAnalytics: <%= if EnvironmentVariable.is_true('SHOULD_REPORT_ANALYTICS') then 'true' else 'false' end %>,
     isDemoSite: <%= if EnvironmentVariable.is_true('DEMO_SITE') then 'true' else 'false' end %>,
     sessionTimeoutInSeconds: <%= Devise.timeout_in.to_i %>

--- a/app/assets/javascripts/helpers/mixpanel_utils.js
+++ b/app/assets/javascripts/helpers/mixpanel_utils.js
@@ -11,6 +11,7 @@
       try {
         window.mixpanel.register({
           'isDemoSite': Env.isDemoSite,
+          'deployment': Env.deployment,
           'educator_id': currentEducator.id,
           'educator_is_admin': currentEducator.admin,
           'educator_school_id': currentEducator.school_id

--- a/app/assets/javascripts/helpers/mixpanel_utils.js
+++ b/app/assets/javascripts/helpers/mixpanel_utils.js
@@ -10,8 +10,8 @@
 
       try {
         window.mixpanel.register({
-          'isDemoSite': Env.isDemoSite,
-          'deployment': Env.deployment,
+          'isDemoSite': Env.isDemoSite, // deprecated
+          'deployment_key': Env.deploymentKey,
           'educator_id': currentEducator.id,
           'educator_is_admin': currentEducator.admin,
           'educator_school_id': currentEducator.school_id

--- a/app/assets/javascripts/helpers/mixpanel_utils.js
+++ b/app/assets/javascripts/helpers/mixpanel_utils.js
@@ -6,7 +6,8 @@
   window.shared.MixpanelUtils = {
     registerUser: function(currentEducator) {
       if (!window.mixpanel) return;
-      if (Env.railsEnvironment !== 'production') return;
+      if (!Env.shouldReportAnalytics) return;
+
       try {
         window.mixpanel.register({
           'isDemoSite': Env.isDemoSite,

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -1,10 +1,10 @@
 class Educator < ActiveRecord::Base
   devise :rememberable, :trackable, :timeoutable
 
-  if Rails.env.development? || ENV['DEMO_SITE']
-    devise :database_authenticatable
-  else
+  if EnvironmentVariable.is_true('SHOULD_USE_LDAP')
     devise :ldap_authenticatable
+  else
+    devise :database_authenticatable
   end
 
   belongs_to  :school

--- a/lib/environment_variable.rb
+++ b/lib/environment_variable.rb
@@ -1,11 +1,12 @@
 class EnvironmentVariable
-  def is_true(string_key)
+  def self.is_true(string_key)
     value = ENV[string_key]
     return false if value == nil
     return false unless value.downcase == 'true'
+    true
   end
 
-  def value(string_key)
+  def self.value(string_key)
     ENV[string_key]
   end
 end

--- a/lib/environment_variable.rb
+++ b/lib/environment_variable.rb
@@ -1,0 +1,11 @@
+class EnvironmentVariable
+  def is_true(string_key)
+    value = ENV[string_key]
+    return false if value == nil
+    return false unless value.downcase == 'true'
+  end
+
+  def value(string_key)
+    ENV[string_key]
+  end
+end

--- a/spec/lib/environment_variable_spec.rb
+++ b/spec/lib/environment_variable_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+require './lib/environment_variable'
+
+RSpec.describe EnvironmentVariable do
+  describe '#is_true' do
+    it 'interprets string values as booleans' do
+      ENV['lowercase_false'] = 'false'
+      ENV['uppercase_false'] = 'FALSE'
+      ENV['lowercase_true'] = 'true'
+      ENV['uppercase_true'] = 'TRUE'
+      ENV['misspelled_typo_treu'] = 'treu'
+
+      expect(EnvironmentVariable.is_true('nonexistent_key')).to eq false
+      expect(EnvironmentVariable.is_true('lowercase_false')).to eq false
+      expect(EnvironmentVariable.is_true('uppercase_false')).to eq false
+      expect(EnvironmentVariable.is_true('lowercase_true')).to eq true
+      expect(EnvironmentVariable.is_true('uppercase_true')).to eq true
+      expect(EnvironmentVariable.is_true('misspelled_typo_treu')).to eq false
+    end
+  end
+end

--- a/vendor/assets/javascripts/rollbar.js
+++ b/vendor/assets/javascripts/rollbar.js
@@ -6,8 +6,7 @@
   // Sets global configuration for the Rollbar error reporting library,
   // based on the environment, and then loads the Rollbar code or not.
   var Env = window.shared.Env;
-  if (Env.railsEnvironment !== 'production') return;
-  if (Env.isDemoSite) return;
+  if (!Env.shouldReportAnalytics) return;
   
   var _rollbarConfig = {
     accessToken: "a79df03b6e734ef78f9149de2329d886",


### PR DESCRIPTION
MixPanel data includes the staging site, when it should only include the production deployment.  There's no way to distinguish right now, so I updated the Heroku config for each deployment, and then updated Rollbar and Mixpanel reporting to use this instead of the environment check.

<img width="602" alt="screen shot 2016-03-22 at 7 24 47 am" src="https://cloud.githubusercontent.com/assets/1056957/13950099/6b67830a-efff-11e5-826f-af07e8c65620.png">
