### PR TITLE
Add header navigations links to STAR pages, add classroom roster links to STAR pages

### DIFF
--- a/app/assets/javascripts/components/star_charts_page.js
+++ b/app/assets/javascripts/components/star_charts_page.js
@@ -203,9 +203,7 @@ $(function() {
               dom.td({ style: { textAlign: 'right', color: color(delta) } }, (delta > 0) ? '+' + delta : delta),
               dom.td({ style: { color: '#ccc' } }, ' → '),
               dom.td({}, + _.last(student.star_results).percentile_rank),
-              dom.td({}, dom.a({ style: { fontSize: styles.fontSize }, href: Routes.student(student.id) }, student.first_name + ' ' + student.last_name)),
-              dom.td({}, student.grade),
-              dom.td({}, dom.a({ href: Routes.homeroom(student.homeroom_id) }, student.homeroom_id))
+              dom.td({}, dom.a({ style: { fontSize: styles.fontSize }, href: Routes.student(student.id) }, student.first_name + ' ' + student.last_name))
             );
           }, this))
         )

--- a/app/assets/stylesheets/controls.scss
+++ b/app/assets/stylesheets/controls.scss
@@ -12,6 +12,7 @@
   color: $light-gray;
   margin-right: 5px;
   margin-top: 3px;
+  margin-left: 15px;
 }
 
 #roster-nav-options {

--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -29,6 +29,9 @@
 
     a {
       padding-right: 10px;
+      &:hover {
+        text-decoration: underline;
+      }
 
       @media screen and (max-width: $phase2) {
         padding-right: 20px;

--- a/app/assets/stylesheets/student.scss
+++ b/app/assets/stylesheets/student.scss
@@ -330,12 +330,17 @@
   margin-bottom: 15px;
   background-color: $light-background;
   border-bottom: 1px solid $light-line;
-  padding: 30px;
+  padding: 20px;
 
   h1 {
     font-weight: 400;
     display: inline;
   }
+
+  .homeroom-links a:not(:first-child) {
+    padding-left: 10px;
+  }
+
   p {
     float: right;
     @media screen and (max-width: $phase2) {

--- a/app/controllers/homerooms_controller.rb
+++ b/app/controllers/homerooms_controller.rb
@@ -18,6 +18,10 @@ class HomeroomsController < ApplicationController
 
     # Bulk intervention assignment in far-right column
     @bulk_intervention_assignment = BulkInterventionAssignment.new
+
+    # For links to STAR pages
+    @school_id = @homeroom.students.map(&:school_id).uniq.first # should be only one
+    @star_homeroom_anchor = "equal:homeroom_name:#{@homeroom.name}"
   end
 
   private

--- a/app/views/homerooms/show.html.erb
+++ b/app/views/homerooms/show.html.erb
@@ -20,6 +20,12 @@
         <p>Help</p>
         <span id="roster-help-icon">?</span>
       </div>
+      <% if current_educator.admin? %>
+        <div class="homeroom-links">
+          <%= link_to 'STAR Reading', star_reading_school_path(@school_id, anchor: @star_homeroom_anchor) %>
+          <%= link_to 'STAR Math', star_math_school_path(@school_id, anchor: @star_homeroom_anchor) %>
+        </div>
+      <% end %>
     </div>
 
     <div id="roster-chart"></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,13 +22,13 @@
         <nav>
           <% if educator_signed_in? %>
             <div class="nav-options">
+              <% if current_educator.admin? %>
+                <%= link_to 'School Overview Dashboard', school_path(School.first) %>
+                <%= link_to 'STAR Reading', star_reading_school_path(School.first) %>
+                <%= link_to 'STAR Math', star_math_school_path(School.first) %>
+              <% end %>
               <p class="search-label">Search for student:</p>
               <input id="student-searchbar" />
-              <% if current_educator.admin? %>
-                <% unless controller_name == 'schools' && action_name == 'show' %>
-                  <%= link_to 'School Overview Dashboard', school_path(School.first) %>
-                <% end %>
-              <% end %>
             </div>
             <%= link_to "Sign Out", destroy_educator_session_path, method: :delete %>
           <% else %>


### PR DESCRIPTION
This is part of https://github.com/studentinsights/studentinsights/pull/2 and builds on https://github.com/studentinsights/studentinsights/pull/223.  These links are still visible only to admin.

New links to STAR pages in the navigation bar for admin:
<img width="1313" alt="screen shot 2016-03-22 at 8 59 16 am" src="https://cloud.githubusercontent.com/assets/1056957/13952395/892ff40a-f00c-11e5-8e71-6ab7f488cd00.png">

New links to STAR pages for a particular classroom on the classroom roster page:
<img width="1097" alt="screen shot 2016-03-22 at 8 59 27 am" src="https://cloud.githubusercontent.com/assets/1056957/13952400/8ca5aeae-f00c-11e5-9908-f7e48950fb19.png">

Showing homeroom selection after clicking from classroom roster page:
<img width="1326" alt="screen shot 2016-03-22 at 8 59 36 am" src="https://cloud.githubusercontent.com/assets/1056957/13952404/8e390ab8-f00c-11e5-8905-1ec095f17cf6.png">

Small update to STAR charts to remove "grade number" and "homeroom_id" columns that were not explained and aren't useful for this first use case:
<img width="821" alt="screen shot 2016-03-22 at 9 03 51 am" src="https://cloud.githubusercontent.com/assets/1056957/13952496/11b0f770-f00d-11e5-9178-89836d10b7b8.png">
