### PR TITLE
Fix IE11 width bug for SlicePanels, shorten School Overview link

### DIFF
--- a/app/assets/javascripts/components/slice_panels.js
+++ b/app/assets/javascripts/components/slice_panels.js
@@ -24,6 +24,7 @@
         className: 'SlicePanels columns-container',
         style: {
           display: 'flex',
+          width: '100%',
           flexDirection: 'row',
           fontSize: styles.fontSize
         }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
           <% if educator_signed_in? %>
             <div class="nav-options">
               <% if current_educator.admin? %>
-                <%= link_to 'School Overview Dashboard', school_path(School.first) %>
+                <%= link_to 'School Overview', school_path(School.first) %>
                 <%= link_to 'STAR Reading', star_reading_school_path(School.first) %>
                 <%= link_to 'STAR Math', star_math_school_path(School.first) %>
               <% end %>


### PR DESCRIPTION
Addresses https://github.com/studentinsights/studentinsights/issues/12.

Before, on Windows 7, IE11 1024 pixel width:
![image](https://cloud.githubusercontent.com/assets/1056957/13952874/5fd5c564-f00f-11e5-9c22-e5e5f4eb7db8.png)

After, on Windows 7, IE11 1024 pixel width:
<img width="986" alt="screen shot 2016-03-22 at 9 18 07 am" src="https://cloud.githubusercontent.com/assets/1056957/13952884/6b3095e2-f00f-11e5-8581-f1f18c753cbf.png">

After, Mac laptop Chrome:
<img width="1329" alt="screen shot 2016-03-22 at 9 19 16 am" src="https://cloud.githubusercontent.com/assets/1056957/13952883/6ad0d120-f00f-11e5-827b-f7a798dab702.png">
