### PR TITLE
Remove old School.first from navigation links, use educator.school

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,9 +23,10 @@
           <% if educator_signed_in? %>
             <div class="nav-options">
               <% if current_educator.admin? %>
-                <%= link_to 'School Overview', school_path(School.first) %>
-                <%= link_to 'STAR Reading', star_reading_school_path(School.first) %>
-                <%= link_to 'STAR Math', star_math_school_path(School.first) %>
+                <% school = current_educator.school %>
+                <%= link_to 'School Overview', school_path(school) %>
+                <%= link_to 'STAR Reading', star_reading_school_path(school) %>
+                <%= link_to 'STAR Math', star_math_school_path(school) %>
               <% end %>
               <p class="search-label">Search for student:</p>
               <input id="student-searchbar" />

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,11 +22,10 @@
         <nav>
           <% if educator_signed_in? %>
             <div class="nav-options">
-              <% if current_educator.admin? %>
-                <% school = current_educator.school %>
-                <%= link_to 'School Overview', school_path(school) %>
-                <%= link_to 'STAR Reading', star_reading_school_path(school) %>
-                <%= link_to 'STAR Math', star_math_school_path(school) %>
+              <% if current_educator.admin? && current_educator.school != nil %>
+                <%= link_to 'School Overview', school_path(current_educator.school) %>
+                <%= link_to 'STAR Reading', star_reading_school_path(current_educator.school) %>
+                <%= link_to 'STAR Math', star_math_school_path(current_educator.school) %>
               <% end %>
               <p class="search-label">Search for student:</p>
               <input id="student-searchbar" />


### PR DESCRIPTION
This was using `School.first` initially, but this isn't correct and the staging environment revealed it.  Updated to look at `current_educator.school` for now.