### PR TITLE
Color the chart lines green or red based on the visible line.

### DIFF
--- a/app/assets/javascripts/student_profile_v2/sparkline.js
+++ b/app/assets/javascripts/student_profile_v2/sparkline.js
@@ -59,24 +59,24 @@
       }
 
       var color = function(val) {
-          //val represents a number of how much the line on the chart increased
-          //or decreased.
+          //val represents a number of how much the line on the 
+          //chart increased or decreased.
 
-          //If the line in the viewable area of the chart increases, color it green
-          //otherwise color it red.
+          //If the line in the viewable area of the chart 
+          //increases, color it green, otherwise color it red.
 
-          //if (d >= 0){ return 'green'; }
-          //else       { return 'red'; }
-          val = val * 2
-          //val = val + 50;   //Casting a range of roughly -100 to 100 to be from 0 to 100
-          //console.log("val: " + val);
+          //This amplifies the amount of the move so that 
+          //the colorizing significantly colorizes small moves
+          //
+          //Perhaps an argument could be made to colorize against
+          //the maximum change from the maximum student
+          if (val < 5){
+             val = val * 8
+          }
 
           if (val > 100)    {  val = 100;  }
           else if (val < -100) {  val = -100;    }
 
-          //var r = Math.floor((255 * (100 - val)) / 100),
-          //    g = Math.floor((255 * val) / 100),
-          //    b = 0;
           var red = new Object();
           red.r = 255;
           red.g = 0;
@@ -97,13 +97,8 @@
           else{
               var stuff = makeGradientColor(grey, red, -val)
           }
-          //console.log(stuff.r + " " + stuff.g + " " + stuff.b);
-
           var rgb = "rgb(" + stuff.r + "," + stuff.g + "," + stuff.b + ")"
-          //console.log("rgb: " + rgb);
           return rgb;
-           
-
       };
 
       var x = d3.time.scale()

--- a/app/assets/javascripts/student_profile_v2/sparkline.js
+++ b/app/assets/javascripts/student_profile_v2/sparkline.js
@@ -31,7 +31,32 @@
       // TODO(kr) work more on coloring across all charts
       // for now, disable since the mapping to color isn't clear enough and
       // doesn't match the longer-view charts
-      var color = function() { return '#666'; };
+      var color = function(val) {
+          //val represents a number of how much the line on the chart increased
+          //or decreased.
+
+          //If the line in the viewable area of the chart increases, color it green
+          //otherwise color it red.
+
+          //if (d >= 0){ return 'green'; }
+          //else       { return 'red'; }
+
+          val = val + 50;   //Casting a range of roughly -100 to 100 to be from 0 to 100
+          //console.log("val: " + val);
+
+          if (val > 100)    {  val = 100;  }
+          else if (val < 0) {  val = 0;    }
+
+          var r = Math.floor((255 * (100 - val)) / 100),
+              g = Math.floor((255 * val) / 100),
+              b = 0;
+
+          var rgb = "rgb(" + r + "," + g + "," + b + ")"
+          //console.log("rgb: " + rgb);
+          return rgb;
+           
+
+      };
 
       var x = d3.time.scale()
         .domain(this.props.dateRange)
@@ -44,7 +69,7 @@
         .y(function(d) { return y(d[3]); })
         .interpolate('linear');
 
-      var lineColor = color(this.delta(this.props.quads));
+      var lineColor = color(this.delta(this.props));
       return dom.div({ className: 'Sparkline', style: { overflow: 'hidden' }},
         dom.svg({
           height: this.props.height,
@@ -93,19 +118,67 @@
         });
       });
     },
+    delta: function(local_props) {
+      //This method returns a number representing the amount of gain or loss 
+      //in the viewable box of the chart.  If the window cuts off the
+      //line between two points, the midpoint between the two points is 
+      //estimated.  This is a hack because the chart is hidden from view by 
+      //the css overflow:hidden property and we have to be clever
+      //to find that point again so we can decide is the visible slope is
+      //positive or negative, to color the line correctly.
 
-    delta: function(quads) {
-      var filteredQuadValues = _.compact(quads.map(function(quad) {
-        var date = this.quadDate(quad);
-        if (date > this.props.dateRange[0] && date < this.props.dateRange[1]) return null;
-        return quad[3];
-      }, this));
-      if (filteredQuadValues.length < 2) return 0;
-      return _.last(filteredQuadValues) - _.first(filteredQuadValues);
+      //If there are no quads for data points, this method returns zero.
+      //console.log(local_props);
+
+      var leftWindowDate = local_props.dateRange[0];
+      //flipPoint tells us the first index where the line got cut off by the overflow:hidden
+      var flipPoint = -1;
+      for(index = 0; index < local_props.quads.length; index++){
+          var pointdate = new Date(local_props.quads[index][0] + "-" + 
+                  local_props.quads[index][1] + "-" + 
+                  local_props.quads[index][2]);
+          if (pointdate < leftWindowDate){
+              flipPoint = index; 
+          }
+      }
+      //console.log("flipPoint: " + flipPoint);
+      if (flipPoint == -1){
+          return 0;
+      }
+      if (flipPoint == local_props.quads.length-1){
+          return local_props.quads[local_props.quads.length-1] - local_props.quads[local_props.quads.length-2];
+      }
+
+      var rightDate = this.quadDate(local_props.quads[flipPoint+1]);
+      var leftDate =  this.quadDate(local_props.quads[flipPoint]);
+      //what percentage is the leftMost Boundary date of the window between
+      //the two data points found left and right of that leftmost point.
+      var percentageBetweenDates = Math.round(100 - ((rightDate.valueOf() - 
+          leftDate.valueOf()) * 100 ) / local_props.dateRange[0].valueOf());
+
+      //console.log("percentageBetweenDates: " + percentageBetweenDates);
+
+      var left_value1 = local_props.quads[flipPoint][3];
+      var left_value2 = local_props.quads[flipPoint+1][3];
+      var right_value = local_props.quads[local_props.quads.length-1][3];
+
+      var difference = left_value2 - left_value1;   
+      //We need the difference value with positive/negative sign, so we can calculate slope
+
+      //console.log("left_value1: " + left_value1);
+      //The leftmost value is the percentage we are at between the dates plus the left.
+      var leftWindowValue = (left_value1 + ((percentageBetweenDates /100) * difference));
+
+      //console.log("leftWindowValue: " + leftWindowValue);
+      var gain = right_value - leftWindowValue;    //This is the gain or loss in the viewable window
+      //console.log("gain is: " + gain);
+      return gain;
+
+
     },
-
-    quadDate: function(quad) { 
+    quadDate: function(quad) {
       return new Date(quad[0], quad[1] - 1, quad[2]);
     }
+
   });
 })();

--- a/app/assets/javascripts/student_profile_v2/sparkline.js
+++ b/app/assets/javascripts/student_profile_v2/sparkline.js
@@ -31,6 +31,33 @@
       // TODO(kr) work more on coloring across all charts
       // for now, disable since the mapping to color isn't clear enough and
       // doesn't match the longer-view charts
+      function makeGradientColor(color1, color2, percent) {
+          var newColor = {};
+
+          function makeChannel(a, b) {
+              return(a + Math.round((b-a)*(percent/100)));
+          }
+
+          function makeColorPiece(num) {
+              num = Math.min(num, 255);   // not more than 255
+              num = Math.max(num, 0);     // not less than 0
+              var str = num.toString(16);
+              if (str.length < 2) {
+                  str = "0" + str;
+              }
+              return(str);
+          }
+
+          newColor.r = makeChannel(color1.r, color2.r);
+          newColor.g = makeChannel(color1.g, color2.g);
+          newColor.b = makeChannel(color1.b, color2.b);
+          newColor.cssColor = "#" + 
+                              makeColorPiece(newColor.r) + 
+                              makeColorPiece(newColor.g) + 
+                              makeColorPiece(newColor.b);
+          return(newColor);
+      }
+
       var color = function(val) {
           //val represents a number of how much the line on the chart increased
           //or decreased.
@@ -40,18 +67,39 @@
 
           //if (d >= 0){ return 'green'; }
           //else       { return 'red'; }
-
-          val = val + 50;   //Casting a range of roughly -100 to 100 to be from 0 to 100
+          val = val * 2
+          //val = val + 50;   //Casting a range of roughly -100 to 100 to be from 0 to 100
           //console.log("val: " + val);
 
           if (val > 100)    {  val = 100;  }
-          else if (val < 0) {  val = 0;    }
+          else if (val < -100) {  val = -100;    }
 
-          var r = Math.floor((255 * (100 - val)) / 100),
-              g = Math.floor((255 * val) / 100),
-              b = 0;
+          //var r = Math.floor((255 * (100 - val)) / 100),
+          //    g = Math.floor((255 * val) / 100),
+          //    b = 0;
+          var red = new Object();
+          red.r = 255;
+          red.g = 0;
+          red.b = 0;
 
-          var rgb = "rgb(" + r + "," + g + "," + b + ")"
+          var blue = new Object();
+          blue.r = 0;
+          blue.g = 0;
+          blue.b = 255;
+
+          var grey = new Object();
+          grey.r = 120;
+          grey.g = 120;
+          grey.b = 120;
+          if (val > 0){
+              var stuff = makeGradientColor(grey, blue, val)
+          }
+          else{
+              var stuff = makeGradientColor(grey, red, -val)
+          }
+          //console.log(stuff.r + " " + stuff.g + " " + stuff.b);
+
+          var rgb = "rgb(" + stuff.r + "," + stuff.g + "," + stuff.b + ")"
           //console.log("rgb: " + rgb);
           return rgb;
            
@@ -68,8 +116,13 @@
         .x(function(d) { return x(this.quadDate(d)); }.bind(this))
         .y(function(d) { return y(d[3]); })
         .interpolate('linear');
-
-      var lineColor = color(this.delta(this.props));
+      //console.log(this.props);
+      if (this.props.colorize == true){
+        var lineColor = color(this.delta(this.props));
+      }
+      else{
+        var lineColor = color(0);  //0 means default grey color
+      }
       return dom.div({ className: 'Sparkline', style: { overflow: 'hidden' }},
         dom.svg({
           height: this.props.height,

--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -284,7 +284,7 @@
         this.wrapSummary({
           caption: 'STAR Reading',
           value: student.most_recent_star_reading_percentile,
-          sparkline: this.renderSparkline(chartData.star_series_reading_percentile || [])
+          sparkline: this.renderSparkline(chartData.star_series_reading_percentile || [], null, true)
         }),
         this.wrapSummary({
           caption: 'MCAS ELA',
@@ -292,12 +292,12 @@
           sparkline: this.renderSparkline(chartData.mcas_series_ela_scaled || [], {
             valueRange: Scales.mcas.valueRange,
             thresholdValue: Scales.mcas.threshold
-          })
+          }, true)
         }),
         this.wrapSummary({
           caption: 'MCAS ELA Growth',
           value: student.most_recent_mcas_ela_growth,
-          sparkline: this.renderSparkline(chartData.mcas_series_ela_growth || [])
+          sparkline: this.renderSparkline(chartData.mcas_series_ela_growth || [], null, true)
         })
       );
     },
@@ -315,7 +315,7 @@
         this.wrapSummary({
           caption: 'STAR Math',
           value: student.most_recent_star_math_percentile,
-          sparkline: this.renderSparkline(chartData.star_series_math_percentile || [])
+          sparkline: this.renderSparkline(chartData.star_series_math_percentile || [], null, true)
         }),
         this.wrapSummary({
           caption: 'MCAS Math',
@@ -323,12 +323,12 @@
           sparkline: this.renderSparkline(chartData.mcas_series_math_scaled || [], {
             valueRange: Scales.mcas.valueRange,
             thresholdValue: Scales.mcas.threshold
-          })
+          }, true)
         }),
         this.wrapSummary({
           caption: 'MCAS Math Growth',
           value: student.most_recent_mcas_math_growth,
-          sparkline: this.renderSparkline(chartData.mcas_series_math_growth || [])
+          sparkline: this.renderSparkline(chartData.mcas_series_math_growth || [], null, true)
         })
       );
     },
@@ -380,9 +380,10 @@
     },
 
     // quads format is: [[year, month (Ruby), day, value]]
-    renderSparkline: function(quads, props) {
+    renderSparkline: function(quads, props, do_color) {
       return createEl(Sparkline, merge({
         height: styles.sparklineHeight,
+        colorize: do_color,
         width: styles.sparklineWidth,
         quads: quads,
         dateRange: this.dateRange(),


### PR DESCRIPTION
Before all the charts had grey lines like this:
![student_insight_colors_original](https://cloud.githubusercontent.com/assets/330247/13973372/8aa35ea0-f078-11e5-9266-dc59216cd73e.png)

So I changed it so that when the viewable window has lines that go up, it is colored blue:
![student_insight_colors_updated2](https://cloud.githubusercontent.com/assets/330247/13973369/82b33648-f078-11e5-82a4-72ecbeefb216.png)


And like this:

![student_insight_colors_updated3](https://cloud.githubusercontent.com/assets/330247/13973396/d0f25988-f078-11e5-954b-7d59393171ae.png)


What I do is get the date of the this.props leftmost position on the viewable window on the SVG. I was able to get the indexes of the points to its left and right, and I was able to get the y values at those points. I got the percentage the date is between the two dates, and then apply that same ratio to the y values to get the final leftmost y value. Then I compare that to the rightmost value and apply a color between green and red for how much it went up or down.  