### PR TITLE
Add initial cut at User personas

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,16 @@ Check out the [demo site](https://somerville-teacher-tool-demo.herokuapp.com/):
   - username: `demo@example.com`
   - password: `demo-password`
 
-## Product overview
+## User personas: Who we're serving
+There are three main user personas we're serving. Principals, Interventionists and Classroom Teachers. Right now we're focused primarily on serving principals, and the rough progression will likely be to Interventionists next. Early adopter Classroom Teachers are great, but focused on scaling adoption across all classroom teachers isn't a priority yet.
+
+Principals are responsible for a school, from ensuring all students are progressing academically to making hiring and staffing decisions for teachers.
+
+Interventionists are typically folks who provide some kind of specialized service to students, like counseling, behavioral services or specialized reading instruction. They caseloads of 20-70 students and are often involved in interdisciplinary teams focused on supporting students who are most at-risk.
+
+Classroom Teachers are responsible for teaching all subjects in an elementary level, and at the middle school level typically teach two subjects, with a few periods of each subject.
+
+## Product overview: How we're helping
 #### School overview
 Principals and intervention specialists can get an overview of all students at school, updated automatically as new data comes in.  This includes demographic information (left), academic progress indicators (center), and educational interventions (right).
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are three main user personas we're serving. Principals, Interventionists a
 
 Principals are responsible for a school, from ensuring all students are progressing academically to making hiring and staffing decisions for teachers.
 
-Interventionists are typically folks who provide some kind of specialized service to students, like counseling, behavioral services or specialized reading instruction. They caseloads of 20-70 students and are often involved in interdisciplinary teams focused on supporting students who are most at-risk.
+Interventionists are typically folks who provide some kind of specialized service to students, like counseling, behavioral services or specialized reading instruction. They have caseloads of 20-70 students and are often involved in interdisciplinary teams focused on supporting students who are most at-risk.
 
 Classroom Teachers are responsible for teaching all subjects in an elementary level, and at the middle school level typically teach two subjects, with a few periods of each subject.
 


### PR DESCRIPTION
This came up during Code for Boston in https://github.com/studentinsights/studentinsights/issues/208, and this is partially addressing https://github.com/studentinsights/studentinsights/issues/156.

The background here is that in working on improvements or features that involve some aspect of product or design, it's often helpful to talk about our users as a way to understand what problems they have and how we can help.  This is mostly done in-person, and we're not really capturing any of this in the project in a way that makes it easier for us as a diverse and often distributed team to build a shared understanding here.

Doing this in person is great! and we should keep doing it.  But this is a first step at capturing some of this as a way to help onboard new team members more easily, and as a way to make concrete some of the important background knowledge and assumptions that folks have who've been working on the project longer.