### PR TITLE
Remove unnecessary nil guard

### DIFF
--- a/app/importers/importer.rb
+++ b/app/importers/importer.rb
@@ -29,7 +29,6 @@ class Importer
       CleanupReport.new(@log, file_name, pre_cleanup_csv.size, data.size).print
 
       data.each.each_with_index do |row, index|
-        row.delete_if { |key, value| key.blank? }
         file_importer.import_row(row) if filter.include?(row)
         ProgressBar.new(@log, file_name, data.size, index + 1).print
       end


### PR DESCRIPTION
## Notes

+ We don't need this `nil` guard for two reasons:

  1. We know all about the structure of the exported flat files (because they come from the scripts in our x2_export directory), and they don't contain any null headers
  2. On the import side, we explicitly state which headers to import, and we don't import any values with null headers