### PR TITLE
More robust tests for import task

### DIFF
--- a/app/importers/sources/somerville_star_importers.rb
+++ b/app/importers/sources/somerville_star_importers.rb
@@ -5,6 +5,7 @@ class SomervilleStarImporters
 
   def initialize(options = {})
     @school_scope = options["school"]
+    @log = options["test_mode"] ? LogHelper::Redirect.instance.file : STDOUT
   end
 
   def options
@@ -17,7 +18,8 @@ class SomervilleStarImporters
         StarReadingImporter::HistoricalImporter,
         StarMathImporter,
         StarMathImporter::HistoricalImporter
-      ].map(&:new)
+      ].map(&:new),
+      log_destination: @log
     }
   end
 

--- a/app/importers/sources/somerville_x2_importers.rb
+++ b/app/importers/sources/somerville_x2_importers.rb
@@ -7,13 +7,15 @@ class SomervilleX2Importers
     @school_scope = options["school"]
     @first_time = options["first_time"]
     @x2_file_importers = options["x2_file_importers"]
+    @log = options["test_mode"] ? LogHelper::Redirect.instance.file : STDOUT
   end
 
   def base_options
     {
       school_scope: @school_scope,
       client: SftpClient.for_x2,
-      file_importers: file_importers.map(&:new)
+      file_importers: file_importers.map(&:new),
+      log_destination: @log
     }
   end
 

--- a/app/reports/assessments_report.rb
+++ b/app/reports/assessments_report.rb
@@ -1,7 +1,7 @@
-class AssessmentsReport
+class AssessmentsReport < Struct.new :log
 
   def print_report
-    puts report
+    log.puts(report)
   end
 
   def headers

--- a/app/reports/import_task_report.rb
+++ b/app/reports/import_task_report.rb
@@ -13,7 +13,7 @@ class ImportTaskReport
   end
 
   def puts(text)
-    @log.write(text)
+    @log.puts(text)
   end
 
   ## INITIAL REPORT ##

--- a/app/reports/import_task_report.rb
+++ b/app/reports/import_task_report.rb
@@ -2,17 +2,27 @@ class ImportTaskReport
 
   attr_accessor :models_for_report
 
-  def initialize(models_for_report)
+  def initialize(models_for_report, log)
+    @log = log
     @models_for_report = models_for_report
     @initial_counts_hash = compute_initial_counts
+  end
+
+  def newline
+    @log.write("\n")
+  end
+
+  def puts(text)
+    @log.write(text)
   end
 
   ## INITIAL REPORT ##
 
   def print_initial_report
-    puts; puts "=== STARTING IMPORT TASK... ==="
-    puts; puts "=== INITIAL DATABASE COUNTS ==="
-    puts; puts initial_counts_report
+    newline; puts "=== STARTING IMPORT TASK... ==="
+    newline; puts "=== INITIAL DATABASE COUNTS ==="
+    newline; puts initial_counts_report
+    return
   end
 
   def initial_counts_report
@@ -30,11 +40,11 @@ class ImportTaskReport
   ## END OF TASK REPORTS ##
 
   def print_final_report
-    puts; puts; puts "=== FINAL DATABASE COUNTS ==="
-    puts; puts end_of_task_report
-    puts; puts; puts "=== BY SCHOOL ==="
+    newline; newline; puts "=== FINAL DATABASE COUNTS ==="
+    newline; puts end_of_task_report
+    newline; newline; puts "=== BY SCHOOL ==="
     puts by_school_report
-    puts; AssessmentsReport.new.print_report
+    newline; AssessmentsReport.new(@log).print_report
   end
 
   def end_of_task_report

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -36,11 +36,16 @@ class Import
       type: :array,
       default: SomervilleX2Importers.file_importer_names,
       desc: "Import data from the specified files: #{SomervilleX2Importers.file_importer_names}"
+    class_option :test_mode,
+      type: :boolean,
+      default: false,
+      desc: "Redirect log output away from STDOUT; do not load Rails during import"
 
     no_commands do
       def report
         models = [ Student, StudentAssessment, DisciplineIncident, Absence, Tardy, Educator, School ]
-        @report ||= ImportTaskReport.new(models)
+        log = options["test_mode"] ? LogHelper::Redirect.instance.file : STDOUT
+        @report ||= ImportTaskReport.new(models, log)
       end
 
       def importers(sources = options["source"])
@@ -53,7 +58,7 @@ class Import
     end
 
     def load_rails
-      require File.expand_path("../../../config/environment.rb", __FILE__)
+      require File.expand_path("../../../config/environment.rb", __FILE__) unless options["test_mode"]
     end
 
     def print_initial_report

--- a/spec/importers/importer_spec.rb
+++ b/spec/importers/importer_spec.rb
@@ -4,10 +4,7 @@ RSpec.describe Importer do
 
   describe '#connect_transform_import' do
 
-    let(:log_dir) { "#{Rails.root}/spec/logs" }
-    before { Dir.mkdir(log_dir) unless File.exists?(log_dir) }
-    let(:logs_path) { "#{Rails.root}/spec/logs/logs.txt" }
-    let(:log) { File.new(logs_path, 'w') }
+    let(:log) { LogHelper::Redirect.instance.file }
 
     context 'CSV with 1 High School student, 1 Healey student (Elem), 1 Brown student (Elem)' do
 

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 load File.expand_path('../../../../lib/tasks/import.thor', __FILE__)
 
 RSpec.describe Import do
@@ -10,10 +10,9 @@ RSpec.describe Import do
       allow(SftpClient).to receive_messages(for_x2: sftp_client_double, for_star: sftp_client_double)
     end
 
-    let(:commands) { Import::Start.start }
+    let(:commands) { Import::Start.start(%w[--test-mode]) }
 
     it 'invokes all the commands and returns the correct kind of values' do
-      expect(commands[0]).to eq false
       expect(commands[1]).to eq nil
       expect(commands[2]).to eq ['HEA']
       expect(commands[3]).to be_a Array

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe Import do
 
   describe '.start' do
     before do
-      sftp_client_double = double(read_file: 'meow')
       allow(SftpClient).to receive_messages(for_x2: sftp_client_double, for_star: sftp_client_double)
     end
 
+    let(:sftp_client_double) { double(read_file: 'meow') }
     let(:commands) { Import::Start.start(%w[--test-mode]) }
 
     it 'invokes all the commands and returns the correct kind of values' do
@@ -21,11 +21,33 @@ RSpec.describe Import do
     end
 
     let(:importers) { commands[3] }
+    let(:first_importer) { importers[0] }
+    let(:second_importer) { importers[1] }
 
     it 'returns the correct importers' do
       expect(importers.size).to eq 2
-      expect(importers[0]).to be_a Importer
-      expect(importers[1]).to be_a Importer
+
+      expect(first_importer).to be_a Importer
+      expect(second_importer).to be_a Importer
+
+      expect(first_importer.client).to eq sftp_client_double
+      expect(first_importer.school_scope).to eq ["HEA"]
+      expect(first_importer.file_importers.map { |i| i.class }).to eq [
+        StudentsImporter,
+        X2AssessmentImporter,
+        BehaviorImporter,
+        EducatorsImporter,
+        AttendanceImporter
+      ]
+
+      expect(second_importer.client).to eq sftp_client_double
+      expect(second_importer.school_scope).to eq ["HEA"]
+      expect(second_importer.file_importers.map { |i| i.class }).to eq [
+        StarReadingImporter,
+        StarReadingImporter::HistoricalImporter,
+        StarMathImporter,
+        StarMathImporter::HistoricalImporter
+      ]
     end
 
   end

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -4,6 +4,33 @@ load File.expand_path('../../../../lib/tasks/import.thor', __FILE__)
 RSpec.describe Import do
   let(:task) { Import::Start.new }
 
+  describe '.start' do
+    before do
+      sftp_client_double = double(read_file: 'meow')
+      allow(SftpClient).to receive_messages(for_x2: sftp_client_double, for_star: sftp_client_double)
+    end
+
+    let(:commands) { Import::Start.start }
+
+    it 'invokes all the commands and returns the correct kind of values' do
+      expect(commands[0]).to eq false
+      expect(commands[1]).to eq nil
+      expect(commands[2]).to eq ['HEA']
+      expect(commands[3]).to be_a Array
+      expect(commands[4]).to eq []
+      expect(commands[5]).to eq nil
+    end
+
+    let(:importers) { commands[3] }
+
+    it 'returns the correct importers' do
+      expect(importers.size).to eq 2
+      expect(importers[0]).to be_a Importer
+      expect(importers[1]).to be_a Importer
+    end
+
+  end
+
   describe '#importers' do
     context 'when provided with the default sources' do
       it 'returns X2 and STAR importers' do

--- a/spec/support/log_redirect_helper.rb
+++ b/spec/support/log_redirect_helper.rb
@@ -1,0 +1,24 @@
+module LogHelper
+  class Redirect
+    include Singleton
+
+    attr_reader :file
+
+    def log_directory
+      "#{Rails.root}/spec/logs"
+    end
+
+    def log_path
+      "#{log_directory}/logs.txt"
+    end
+
+    def initialize
+      Dir.mkdir(log_directory) unless File.exists?(log_directory)
+      @file = File.new(log_path, 'w')
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include LogHelper
+end


### PR DESCRIPTION
## Notes

+ Add an integration test for our import task — one that exercises the import task code as if it were importing data from a real SFTP site

+ This catches errors that can be missed by the existing tests, which are more like unit tests

+ Two problems that came up while writing import integration tests:

  1. Import task logs being spit out while the tests were running, and 
  2. Issues with Rails being loaded zero / multiple times by RSpec / Thor

+ To handle this, created a "test mode" for the import task which skips loading Rails and redirects logging output

+ Not ideal, but worth it because it lets us easily run integration tests on the rest of the import task