### PR TITLE
Simplify routes.rb and remove unused routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,10 @@
 Rails.application.routes.draw do
 
   devise_for :educators
-
   authenticated :educator do
     root to: 'educators#homepage', as: 'educator_homepage'
   end
+  get '/educators/reset'=> 'educators#reset_session_clock'
 
   root 'pages#about'
   get 'about' => 'pages#about'
@@ -13,21 +13,23 @@ Rails.application.routes.draw do
   get 'not_authorized' => 'pages#not_authorized'
 
   get '/students/names' => 'students#names'
-  get '/educators/reset'=> 'educators#reset_session_clock'
-
-  resources :students do
-    get :profile, on: :member
-    get :deprecated_v1_profile, on: :member
-    get :sped_referral, on: :member
-    post :event_note, on: :member
-    post :service, on: :member
+  resources :students, only: [:show] do
+    member do
+      get :profile
+      get :deprecated_v1_profile
+      get :sped_referral
+      post :event_note
+      post :service
+    end
   end
-  resources :homerooms
-  resources :interventions
-  resources :progress_notes
-  resources :student_notes
-  resources :bulk_intervention_assignments
-  resources :schools do
+
+  resources :homerooms, only: [:show]
+  resources :interventions, only: [:create, :destroy]
+  resources :progress_notes, only: [:create]
+  resources :student_notes, only: [:create]
+  resources :bulk_intervention_assignments, only: [:new, :create]
+
+  resources :schools, only: [:show] do
     get :star_reading, on: :member
     get :star_math, on: :member
   end


### PR DESCRIPTION
This came up in adding a new route for discontinuing a service.  The `resources` function was generating many routes that we don't actually have controller actions for.

Before:
```
$ bundle exec rake routes | wc -l
      82
```

After:
```
$ bundle exec rake routes | wc -l
      35
```