### PR TITLE
Fix bug choosing educator, introduced in updating react-select

### DIFF
--- a/app/assets/javascripts/student_profile_v2/record_service.js
+++ b/app/assets/javascripts/student_profile_v2/record_service.js
@@ -74,8 +74,8 @@
       this.setState({ momentStarted: updatedMoment });
     },
 
-    onAssignedEducatorChanged: function(educatorId) {
-      this.setState({ providedByEducatorId: educatorId });
+    onAssignedEducatorChanged: function(selectParams) {
+      this.setState({ providedByEducatorId: selectParams.value });
     },
 
     onServiceClicked: function(serviceTypeId, event) {


### PR DESCRIPTION
Initial manual verification wasn't good enough, this broke in https://github.com/studentinsights/studentinsights/pull/255.  The react-select API changed to pass a map to the change callback, not just the value.

Also fixed in the pending https://github.com/studentinsights/studentinsights/pull/257.