### PR TITLE
Support serializing Service and EventNote filters in hash

### DIFF
--- a/app/assets/javascripts/helpers/filters.js
+++ b/app/assets/javascripts/helpers/filters.js
@@ -118,6 +118,9 @@
       if (parts[0] === 'intervention_type') return Filters.InterventionType(parts[1]);
       if (parts[0] === 'risk_level') return Filters.InterventionType(parseFloat(parts[1]));
       if (parts[0] === 'years_enrolled') return Filters.YearsEnrolled(parseFloat(parts[1]));
+      if (parts[0] === 'service_type') return Filters.ServiceType(parseFloat(parts[1]));
+      if (parts[0] === 'event_note_type') return Filters.EventNoteType(parseFloat(parts[1]));
+      
       return null;
     },
 


### PR DESCRIPTION
I added these filters and UI elements, but didn't update the hash parsing to read them when reloading the page.

You can see this locally in thie example URL: http://localhost:3000/schools/1#service_type%3A503&event_note_type%3A304, loaded in a new window.

Before:
<img width="264" alt="screen shot 2016-04-03 at 1 23 36 pm" src="https://cloud.githubusercontent.com/assets/1056957/14233750/6e87d540-f99f-11e5-85e5-ab99b4ee6969.png">

After:
<img width="267" alt="screen shot 2016-04-03 at 1 23 38 pm" src="https://cloud.githubusercontent.com/assets/1056957/14233752/7a1a2f7a-f99f-11e5-84c0-92fd3a68890a.png">
