### PR TITLE
Add logging around timing on schools#show

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,4 +44,19 @@ class ApplicationController < ActionController::Base
   def redirect_unauthorized!
     redirect_to not_authorized_path
   end
+
+  # Used to wrap a block with timing measurements and logging, returning the value of the
+  # block.
+  #
+  # Example: students = log_timing('load students') { Student.all }
+  # Outputs: log_timing:end [load students] 2998ms
+  def log_timing(message)
+    return_value = nil
+
+    logger.info "log_timing:start [#{message}]"
+    timing_ms = Benchmark.ms { return_value = yield }
+    logger.info "log_timing:end [#{message}] #{timing_ms.round}ms"
+
+    return_value
+  end
 end

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -7,14 +7,16 @@ class SchoolsController < ApplicationController
 
   def show
     authorized_students = current_educator.students_for_school_overview
-    
+
     # TODO(kr) Read from cache, since this only updates daily
-    student_hashes = authorized_students.map do |student|
-      student_hash_for_slicing(student)
+    student_hashes = log_timing('schools#show student_hashes') do
+      authorized_students.map {|student| student_hash_for_slicing(student) }
     end
 
     # Read data stored StudentInsights each time, with no caching
-    merged_student_hashes = merge_mutable_fields_for_slicing(student_hashes)
+    merged_student_hashes = log_timing('schools#show merge_mutable_fields_for_slicing') do
+      merge_mutable_fields_for_slicing(student_hashes)
+    end
 
     @serialized_data = {
       students: merged_student_hashes,


### PR DESCRIPTION
Adding this to see what's happening as we work towards https://github.com/studentinsights/studentinsights/issues/3.

From staging, this is taking 20 seconds to load the `student_hashes`, even though the aggregate ActiveRecord timing reports only 10 seconds.  So I'm assuming it's taking a significant amount of time to actually generate the hash/array structures or the actual JSON serialization of this data.

```
2016-04-03T17:28:27.915956+00:00 app[web.1]: Started GET "/schools/hea" for 50.153.135.35 at 2016-04-03 17:28:27 +0000
2016-04-03T17:28:27.918452+00:00 app[web.1]: Processing by SchoolsController#show as HTML
2016-04-03T17:28:27.918576+00:00 app[web.1]:   Parameters: {"id"=>"hea"}
2016-04-03T17:28:27.925428+00:00 app[web.1]: log_timing:start [schools#show student_hashes]
2016-04-03T17:28:48.104998+00:00 app[web.1]: log_timing:end [schools#show student_hashes] 20179ms
2016-04-03T17:28:48.105039+00:00 app[web.1]: log_timing:start [schools#show merge_mutable_fields_for_slicing]
2016-04-03T17:28:48.387789+00:00 app[web.1]: log_timing:end [schools#show merge_mutable_fields_for_slicing] 283ms
2016-04-03T17:28:49.736531+00:00 heroku[router]: at=info method=GET path="/schools/hea" host=student-insights-staging.herokuapp.com request_id=b710650b-9693-4a14-91ca-854e2292f3e7 fwd="50.153.135.35" dyno=web.1 connect=1ms service=21822ms status=304 bytes=878
2016-04-03T17:28:49.726557+00:00 app[web.1]:   Rendered shared/serialized_data.html.erb within layouts/application (1302.0ms)
2016-04-03T17:28:49.727756+00:00 app[web.1]:   Rendered shared/_mixpanel.html.erb (0.1ms)
2016-04-03T17:28:49.730276+00:00 app[web.1]: Completed 200 OK in 21812ms (Views: 1306.3ms | ActiveRecord: 10324.7ms)
```

@alexsoble How was your experience with https://www.skylight.io/?  I saw you added but then removed it, but it might be a better way to get this kind of information in a more actionable and navigable way.