### PR TITLE
Handle inactive students

### DIFF
--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -37,7 +37,7 @@ class FakeStudent
   def base_data
     {
       school_id: School.first.id,
-      enrollment_status: "Active",
+      enrollment_status: enrollment_status,
       grade: "5",
       hispanic_latino: [true, false].sample,
       race: ["A", "B", "H", "W"].sample,
@@ -57,6 +57,10 @@ class FakeStudent
       local_id = random_local_id
     end
     local_id
+  end
+
+  def enrollment_status
+    7.in(8) ? 'Active' : 'Transferred'
   end
 
   def random_local_id

--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -37,6 +37,7 @@ class FakeStudent
   def base_data
     {
       school_id: School.first.id,
+      enrollment_status: "Active",
       grade: "5",
       hispanic_latino: [true, false].sample,
       race: ["A", "B", "H", "W"].sample,
@@ -101,7 +102,7 @@ class FakeStudent
   end
 
   def create_star_assessment_generators(student, options)
-    
+
   end
 
   def add_student_assessments_from_x2
@@ -121,7 +122,7 @@ class FakeStudent
     options = {
       start_date: start_date,
       star_period_days: star_period_days
-    }    
+    }
 
     generators = [
       FakeStarMathResultGenerator.new(@student, options),

--- a/app/importers/rows/student_row.rb
+++ b/app/importers/rows/student_row.rb
@@ -31,6 +31,7 @@ class StudentRow < Struct.new(:row, :school_ids_dictionary)
   def demographic_attributes
     {
       state_id: row[:state_id],
+      enrollment_status: row[:enrollment_status],
       home_language: row[:home_language],
       program_assigned: row[:program_assigned],
       limited_english_proficiency: row[:limited_english_proficiency],

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -42,9 +42,11 @@ class Educator < ActiveRecord::Base
 
     if schoolwide_access?
       school.students
+            .active
             .includes(eager_loads)
     elsif has_access_to_grade_levels?
       school.students
+            .active
             .where(grade: grade_level_access)
             .includes(eager_loads)
     end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -26,6 +26,10 @@ class Student < ActiveRecord::Base
     where.not(school: nil)
   end
 
+  def self.active
+    where(enrollment_status: 'Active')
+  end
+
   ## STUDENT ASSESSMENT RESULTS ##
 
   def latest_result_by_family_and_subject(family_name, subject_name)

--- a/db/migrate/20160325103532_add_enrollment_status_to_students.rb
+++ b/db/migrate/20160325103532_add_enrollment_status_to_students.rb
@@ -1,0 +1,5 @@
+class AddEnrollmentStatusToStudents < ActiveRecord::Migration
+  def change
+    add_column :students, :enrollment_status, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -282,6 +282,7 @@ ActiveRecord::Schema.define(version: 20160402225642) do
     t.integer  "most_recent_mcas_ela_scaled"
     t.integer  "most_recent_star_reading_percentile"
     t.integer  "most_recent_star_math_percentile"
+    t.string   "enrollment_status",                   null: false
   end
 
   add_index "students", ["homeroom_id"], name: "index_students_on_homeroom_id", using: :btree

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     local_id { generate(:student_local_id) }
     grade { generate(:valid_grade_level) }
     association :homeroom
+    enrollment_status "Active"
 
     trait :with_risk_level do
       after(:create) do |student|

--- a/spec/fixtures/fake_students_export.txt
+++ b/spec/fixtures/fake_students_export.txt
@@ -1,4 +1,4 @@
-"state_id","local_id","full_name","home_language","program_assigned","limited_english_proficiency","sped_placement","disability","sped_level_of_need","plan_504","student_address","grade","registration_date","free_reduced_lunch","homeroom","school_local_id"
-"1000000000","100","Fake Student, First","English","Sp Ed","Fluent","Full Inclusion","Specific LDs","Moderate","Not 504","155 9th St, San Francisco, CA","07","2008-02-20","Not Eligible","Homeroom 200","HEA"
-"1000000001","101","Fake Student, Second","Vietnamese","Reg Ed","FLEP-Transitioning",\N,\N,\N,"Not 504","155 9th St, San Francisco, CA","07","2005-08-05","Free Lunch","Homeroom 200","SHS"
-"1000000002","103","Fake Student, Second","Vietnamese","Reg Ed","FLEP-Transitioning",\N,\N,\N,"Not 504","155 9th St, San Francisco, CA","07","2005-08-05","Free Lunch","Homeroom 200","BRN"
+"state_id","local_id","full_name","home_language","program_assigned","limited_english_proficiency","sped_placement","disability","sped_level_of_need","plan_504","student_address","grade","registration_date","free_reduced_lunch","homeroom","school_local_id","enrollment_status"
+"1000000000","100","Fake Student, First","English","Sp Ed","Fluent","Full Inclusion","Specific LDs","Moderate","Not 504","155 9th St, San Francisco, CA","07","2008-02-20","Not Eligible","Homeroom 200","HEA","Active"
+"1000000001","101","Fake Student, Second","Vietnamese","Reg Ed","FLEP-Transitioning",\N,\N,\N,"Not 504","155 9th St, San Francisco, CA","07","2005-08-05","Free Lunch","Homeroom 200","SHS","Active"
+"1000000002","103","Fake Student, Second","Vietnamese","Reg Ed","FLEP-Transitioning",\N,\N,\N,"Not 504","155 9th St, San Francisco, CA","07","2005-08-05","Free Lunch","Homeroom 200","BRN","Active"

--- a/x2_export/students_export.sql
+++ b/x2_export/students_export.sql
@@ -2,6 +2,7 @@ use x2data
 SELECT
   'state_id',
   'local_id', -- LASID
+  'enrollment_status',
   'full_name',
   'home_language',
   'program_assigned',
@@ -20,6 +21,7 @@ UNION ALL
 SELECT
   STD_ID_STATE,
   STD_ID_LOCAL,
+  STD_ENROLLMENT_STATUS,
   std_name_view,
   STD_HOME_LANGUAGE_CODE,
   STD_FIELDB_068, -- Program assigned
@@ -37,7 +39,6 @@ SELECT
 FROM student
 INNER JOIN school
   ON student.STD_SKL_OID=school.SKL_OID
-WHERE STD_ENROLLMENT_STATUS = 'Active'
 AND STD_ID_STATE IS NOT NULL
 AND STD_OID IS NOT NULL
   INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/students_export.txt"


### PR DESCRIPTION
## What this changes / fixes

+ Students who are not actively enrolled in Somerville Public Schools are now imported into Student Insights, including the enrollment status for each student
+ Students not actively enrolled are not surfaced on the school overview page or on the STAR changes-over-time pages
+ Tested on the staging site

## What this doesn't fix 

+ Inactive students still have profiles, we should indicate their `enrollment_status` as part of the profile (breaking that into a separate issue)
+ Does not affect the homeroom view, which shouldn't be an issue because non-actively enrolled students do not belong to homerooms