### PR TITLE
Fix bug in behavior import

### DIFF
--- a/app/importers/rows/behavior_row.rb
+++ b/app/importers/rows/behavior_row.rb
@@ -4,11 +4,18 @@ class BehaviorRow < Struct.new(:row)
   end
 
   def build
-    student_school_year.discipline_incidents.first_or_initialize(occurred_at: occurred_at, incident_code: row[:incident_code]) do |incident|
-      incident.has_exact_time = has_exact_time?
-      incident.incident_location = row[:incident_location]
-      incident.incident_description = row[:incident_description]
-    end
+    discipline_incident = student_school_year.discipline_incidents.find_or_initialize_by(
+      occurred_at: occurred_at,
+      incident_code: row[:incident_code]
+    )
+
+    discipline_incident.assign_attributes(
+      has_exact_time: has_exact_time?,
+      incident_location: row[:incident_location],
+      incident_description: row[:incident_description],
+    )
+
+    discipline_incident
   end
 
   private

--- a/spec/importers/file_importers/behavior_importer_spec.rb
+++ b/spec/importers/file_importers/behavior_importer_spec.rb
@@ -37,6 +37,43 @@ RSpec.describe BehaviorImporter do
       end
     end
 
+    context 'multiple rows' do
+      let(:student) { FactoryGirl.create(:student, local_id: '10') }
+      before { importer.import_row(row_two) }
+
+      let(:row) {
+        {
+          local_id: student.local_id,
+          incident_code: "Hitting",
+          event_date: Date.new(2015, 10, 1),
+          incident_time: "13:00:00",
+          incident_location: "Classroom",
+          incident_description: "Hit another student.",
+          school_local_id: "SHS"
+        }
+      }
+      let(:row_two) {
+        {
+          local_id: student.local_id,
+          incident_code: "Hitting",
+          event_date: Date.new(2015, 10, 2),
+          incident_location: "Classroom",
+          incident_description: "Hit another student again.",
+          school_local_id: "SHS"
+        }
+      }
+
+      it 'creates two discipline incidents' do
+        expect(incidents.size).to eq 2
+      end
+
+      it 'sets the descriptions correctly' do
+        expect(incidents[1].incident_description).to eq "Hit another student."
+        expect(incidents[0].incident_description).to eq "Hit another student again."
+      end
+
+    end
+
     context 'very long incident description' do
       let!(:student) { FactoryGirl.create(:student, local_id: '11') }
       let(:big_block_of_text) { "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." }


### PR DESCRIPTION
## Notes

+ The code was failing to import all but the first discipline incident for each school year

+ This was because of a misunderstanding of how `first_or_initialize` works

    + Instead of finding the first incident with the supplied attributes, it was simply finding the first incident of the student's school year

+ The supplied attributes to `first_or_initialize` are only used by the method if calling `first` yields `nil`: http://apidock.com/rails/ActiveRecord/Relation/first_or_initialize

+ Should resolve #258 after running the import task again on both sites
