### PR TITLE
Remove null: false constraint on enrollment status

### DIFF
--- a/db/migrate/20160404192409_add_enrollment_status_to_students.rb
+++ b/db/migrate/20160404192409_add_enrollment_status_to_students.rb
@@ -1,5 +1,5 @@
 class AddEnrollmentStatusToStudents < ActiveRecord::Migration
   def change
-    add_column :students, :enrollment_status, :string, null: false
+    add_column :students, :enrollment_status, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -282,7 +282,7 @@ ActiveRecord::Schema.define(version: 20160404162153) do
     t.integer  "most_recent_mcas_ela_scaled"
     t.integer  "most_recent_star_reading_percentile"
     t.integer  "most_recent_star_math_percentile"
-    t.string   "enrollment_status",                   null: false
+    t.string   "enrollment_status"
   end
 
   add_index "students", ["homeroom_id"], name: "index_students_on_homeroom_id", using: :btree


### PR DESCRIPTION
## Notes

+ The old won't run in production because existing students would have `enrollment_status: null`
+ Deleting an existing migration isn't great, but it's the only way to make this work in production 
+ Will need to rollback and rerun