### PR TITLE
Show enrolllment status in profile

### DIFF
--- a/app/assets/javascripts/student_profile_v2/student_profile_header.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_header.js
@@ -39,31 +39,39 @@
           href: Routes.student(student.id),
           style: styles.nameTitle
         }, student.first_name + ' ' + student.last_name),
-        dom.span({
-          style: styles.titleItem
-        }, '•'),
+        this.bulletSpacer(),
         dom.a({
           href: Routes.school(student.school_id),
           style: styles.titleItem
         }, student.school_name),
-        dom.span({
-          style: styles.titleItem
-        }, '•'),
+        this.bulletSpacer(),
         dom.span({
           style: styles.titleItem
         }, 'Grade ' + student.grade),
-        dom.span({
-          style: styles.titleItem
-        }, '•'),
-        dom.a({
-          className: 'homeroom-link',
-          href: Routes.homeroom(student.homeroom_id),
-          style: styles.titleItem
-        }, 'Homeroom ' + student.homeroom_name),
+        this.bulletSpacer(),
+        this.homeroomOrEnrollmentStatus(),
         createEl(RiskBubble, {
           riskLevel: student.student_risk_level.level
         })
       );
+    },
+
+    bulletSpacer: function() {
+      return dom.span({ style: styles.titleItem }, '•');
+    },
+
+    homeroomOrEnrollmentStatus: function() {
+      var student =  this.props.student;
+      if (student.enrollment_status === 'Active') {
+        return dom.a({
+          className: 'homeroom-link',
+          href: Routes.homeroom(student.homeroom_id),
+          style: styles.titleItem
+        }, 'Homeroom ' + student.homeroom_name);
+      } else {
+        return dom.span({ style: styles.titleItem }, student.enrollment_status);
+      }
     }
+
   });
 })();

--- a/spec/javascripts/student_profile_v2/fixtures.js
+++ b/spec/javascripts/student_profile_v2/fixtures.js
@@ -186,6 +186,7 @@
       "first_name": "Daisy",
       "last_name": "Poppins",
       "state_id": null,
+      "enrollment_status": "Active",
       "home_language": "English",
       "school_id": 1,
       "student_address": null,

--- a/spec/javascripts/student_profile_v2/student_profile_header_spec.js
+++ b/spec/javascripts/student_profile_v2/student_profile_header_spec.js
@@ -10,22 +10,41 @@ describe('StudentProfileHeader', function() {
   var Fixtures = window.shared.Fixtures;
 
   var helpers = {
-    renderInto: function(el, props) {
-      var mergedProps = merge(props || {}, {
-        student: Fixtures.studentProfile.student
-      });
+    renderActiveStudent: function(el, props) {
+      var mergedProps = merge(props || {}, { student: Fixtures.studentProfile.student });
+      return ReactDOM.render(createEl(StudentProfileHeader, mergedProps), el);
+    },
+
+    renderTransferredStudent: function(el, props) {
+      var this_student = Fixtures.studentProfile.student;
+      this_student['enrollment_status'] = 'Transferred';
+
+      var mergedProps = merge(props || {}, { student: this_student });
       return ReactDOM.render(createEl(StudentProfileHeader, mergedProps), el);
     }
+
   };
 
-  SpecSugar.withTestEl('high-level integration tests', function() {
-    it('renders note-taking area', function() {
+  SpecSugar.withTestEl('active enrolled student', function() {
+    it('renders note-taking area with homeroom', function() {
       var el = this.testEl;
-      helpers.renderInto(el);
+      helpers.renderActiveStudent(el);
 
       expect(el).toContainText('Daisy Poppins');
       expect(el).toContainText('Arthur D Healey');
       expect($(el).find('a.homeroom-link')).toContainText('102');
     });
   });
+
+  SpecSugar.withTestEl('non-active Transferred student', function() {
+    it('renders note-taking area with Transferred status', function() {
+      var el = this.testEl;
+      helpers.renderTransferredStudent(el);
+
+      expect(el).toContainText('Daisy Poppins');
+      expect(el).toContainText('Arthur D Healey');
+      expect(el).toContainText('Transferred');
+    });
+  });
+
 });


### PR DESCRIPTION
## Notes 

+ Only show status for non-Active students ("Transferred", "Withdraw", etc.) in the student Profile
+ Show enrollment status in the Student Profile Header instead of Homeroom, since non-Active students no longer belong to a homeroom
+ This is good to do because a student's enrollment status changes over time, so if an educator shares a student profile URL with another eudcator and later the student leaves Somerville Public Schools, we need to highlight that change