### PR TITLE
Fix discipline incidents ordering

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -29,7 +29,7 @@ class StudentsController < ApplicationController
       event_note_types_index: event_note_types_index,
       educators_index: educators_index,
       attendance_data: {
-        discipline_incidents: student.most_recent_school_year.discipline_incidents,
+        discipline_incidents: student.most_recent_school_year.discipline_incidents.order(occurred_at: :desc),
         tardies: student.most_recent_school_year.tardies,
         absences: student.most_recent_school_year.absences
       }

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -126,6 +126,35 @@ describe StudentsController, :type => :controller do
           ]
         end
 
+        context 'student has multiple discipline incidents' do
+          let!(:student) { FactoryGirl.create(:student) }
+          let(:most_recent_school_year) { student.most_recent_school_year }
+          let(:serialized_data) { assigns(:serialized_data) }
+          let(:attendance_data) { serialized_data[:attendance_data] }
+          let(:discipline_incidents) { attendance_data[:discipline_incidents] }
+
+          let!(:more_recent_incident) {
+            FactoryGirl.create(
+              :discipline_incident,
+              student_school_year: most_recent_school_year,
+              occurred_at: Time.now - 1.day
+            )
+          }
+
+          let!(:less_recent_incident) {
+            FactoryGirl.create(
+              :discipline_incident,
+              student_school_year: most_recent_school_year,
+              occurred_at: Time.now - 2.days
+            )
+          }
+
+          it 'sets the correct order' do
+            make_request({ student_id: student.id, format: :html })
+            expect(discipline_incidents).to eq [more_recent_incident, less_recent_incident]
+          end
+        end
+
         context 'educator has grade level access' do
           let(:educator) { FactoryGirl.create(:educator, grade_level_access: [student.grade] )}
 
@@ -529,4 +558,5 @@ describe StudentsController, :type => :controller do
       end
     end
   end
+
 end


### PR DESCRIPTION
## Notes

+ Make sure discipline incidents are ordered by `occurred_at` in Student Profile V2
+ #288 