### PR TITLE
Remove invalid ACCESS assessment subjects

### DIFF
--- a/db/migrate/20160406202337_remove_invalid_access_assessments.rb
+++ b/db/migrate/20160406202337_remove_invalid_access_assessments.rb
@@ -1,0 +1,8 @@
+class RemoveInvalidAccessAssessments < ActiveRecord::Migration
+  def change
+    access_ell_assessment = Assessment.find_by_family_and_subject('ACCESS', 'ELL')
+    access_ell_assessment.destroy unless access_ell_assessment.nil?
+    access_overall_assessment = Assessment.find_by_family_and_subject('ACCESS', 'Overall')
+    access_overall_assessment.destroy unless access_overall_assessment.nil?
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160404162153) do
+ActiveRecord::Schema.define(version: 20160406202337) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
## Notes

+ Subject 'ELL' came from an earlier data dump before we had linked with X2
+ Subject 'Overall' is duplicative of 'Composite'
+ This should fix our failing `IntegrityCheck` in production
+ #16