### PR TITLE
Workaround bug in missing performance_level for DIBELS profile

### DIFF
--- a/app/assets/javascripts/student_profile_v2/profile_details.js
+++ b/app/assets/javascripts/student_profile_v2/profile_details.js
@@ -116,6 +116,9 @@
         });
       });
       _.each(this.props.feed.dibels, function(obj) {
+        // TODO(kr) need to investigate further, whether this is local demo data or production
+        // data quality issue
+        if (obj.performance_level === null) return;
         events.push({
           type: 'DIBELS',
           message: name + ' scored ' + obj.performance_level.toUpperCase() + ' in DIBELS.',


### PR DESCRIPTION
Ran into this locally, didn't get to look yet and it may be only a local development data bug, but adding a quick workaround since it prevents rendering of that details pane.

<img width="786" alt="screen shot 2016-04-06 at 10 12 55 pm" src="https://cloud.githubusercontent.com/assets/1056957/14338888/8224efc4-fc48-11e5-9805-6e78af160da9.png">