### PR TITLE
Fix student header layout and edge case bugs for risk bubble

### DIFF
--- a/app/assets/javascripts/student_profile_v2/risk_bubble.js
+++ b/app/assets/javascripts/student_profile_v2/risk_bubble.js
@@ -7,23 +7,22 @@
   var styles = {
     riskBubble: {
       fontSize: 20,
-      width: '35',
-      height: '35',
+      width: 35,
+      height: 35,
       color: 'white',
-      borderRadius: '30',
-      paddingTop: '3',
+      borderRadius: 30,
+      paddingTop: 3,
       textAlign: 'center',
-      marginTop: '10',
-      marginRight: '25',
-      display: 'inline-block',
-      float: 'right'
+      marginTop: 10,
+      marginLeft: 5, 
+      marginRight: 5,
+      display: 'inline-block'
     },
 
     riskItem: {
       fontSize: 25,
       padding: 5,
-      float: 'right',
-      marginTop: '3'
+      marginTop: 3
     }
 };
 
@@ -35,21 +34,23 @@
     },
 
     render: function() {
-      return dom.span({},
-        dom.span({
-          style: merge(styles.riskBubble, { backgroundColor: this.bubbleColor() })
-        }, this.props.riskLevel),
+      return dom.span({}, 
         dom.span({
           style: styles.riskItem
-        }, "Risk Level")
+        }, 'Risk Level'),
+        dom.span({
+          style: merge(styles.riskBubble, { backgroundColor: this.bubbleColor() })
+        }, (this.props.riskLevel === null) ? 'NA' : this.props.riskLevel)
       );
 
     },
 
     bubbleColor: function() {
-      if (this.props.riskLevel === 1) return 'green';
-      if (this.props.riskLevel === 2) return '#ffc41d';
-      if (this.props.riskLevel === 3) return 'red';
+      if (this.props.riskLevel === null) return '#555555';
+      if (this.props.riskLevel === 0) return '#bbd86b';
+      if (this.props.riskLevel === 1) return '#62c186';
+      if (this.props.riskLevel === 2) return '#ffcb08';
+      if (this.props.riskLevel === 3) return '#f15a3d';
     }
   })
 

--- a/app/assets/javascripts/student_profile_v2/student_profile_header.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_header.js
@@ -9,14 +9,15 @@
   var styles = {
     titleContainer: {
       fontSize: 16,
-      padding: 20
+      padding: 20,
+      display: 'flex'
     },
     nameTitle: {
-      fontSize: 30,
+      fontSize: 28,
       fontWeight: 'bold'
     },
     titleItem: {
-      fontSize: 25,
+      fontSize: 24,
       padding: 5
     }
   };
@@ -35,24 +36,36 @@
     render: function() {
       var student =  this.props.student;
       return dom.div({ style: styles.titleContainer },
-        dom.a({
-          href: Routes.student(student.id),
-          style: styles.nameTitle
-        }, student.first_name + ' ' + student.last_name),
-        this.bulletSpacer(),
-        dom.a({
-          href: Routes.school(student.school_id),
-          style: styles.titleItem
-        }, student.school_name),
-        this.bulletSpacer(),
-        dom.span({
-          style: styles.titleItem
-        }, 'Grade ' + student.grade),
-        this.bulletSpacer(),
-        this.homeroomOrEnrollmentStatus(),
-        createEl(RiskBubble, {
-          riskLevel: student.student_risk_level.level
-        })
+        dom.div({ style: { display: 'inline-block', flex: 'auto' } },
+          dom.a({
+            href: Routes.student(student.id),
+            style: styles.nameTitle
+          }, student.first_name + ' ' + student.last_name),
+          dom.div({ style: { display: 'inline-block' } },
+            this.bulletSpacer(),
+            this.homeroomOrEnrollmentStatus(),
+            this.bulletSpacer(),
+            dom.span({
+              style: styles.titleItem
+            }, 'Grade ' + student.grade),
+            this.bulletSpacer(),
+            dom.a({
+              href: Routes.school(student.school_id),
+              style: styles.titleItem
+            }, student.school_name)
+          )
+        ),
+        dom.div({
+          style: {
+            width: '15em',
+            display: 'flex',
+            justifyContent: 'flex-end'
+          },
+        },
+          createEl(RiskBubble, {
+            riskLevel: student.student_risk_level.level
+          })
+        )
       );
     },
 


### PR DESCRIPTION
Full layout, risk level bubble color fixed for level 0:
<img width="1407" alt="screen shot 2016-04-06 at 11 20 03 pm" src="https://cloud.githubusercontent.com/assets/1056957/14339646/3d73eb22-fc4e-11e5-82c8-3740becd4ba9.png">

Layout fixed, and classroom/grade/school wrap together:
<img width="1060" alt="screen shot 2016-04-06 at 11 19 05 pm" src="https://cloud.githubusercontent.com/assets/1056957/14339648/3f54137c-fc4e-11e5-9dff-af172f038dbc.png">

Risk level bubble color and text fixed for n/a:
<img width="1248" alt="screen shot 2016-04-06 at 11 12 34 pm" src="https://cloud.githubusercontent.com/assets/1056957/14339655/577c6f4e-fc4e-11e5-8b1c-202a65f2678c.png">
