### PR TITLE
Move more import functions to FileImporters

### DIFF
--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -1,10 +1,6 @@
 class AttendanceImporter < Struct.new :school_scope, :client
 
   def remote_file_name
-    # Expects a CSV with the following headers, transformed to symbols by CsvTransformer during import:
-    #
-    # [ "state_id", "local_id", "absence", "tardy", "event_date", "school_local_id" ]
-
     'attendance_export.txt'
   end
 

--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -1,4 +1,4 @@
-class AttendanceImporter
+class AttendanceImporter < Struct.new :school_scope
 
   def remote_file_name
     # Expects a CSV with the following headers, transformed to symbols by CsvTransformer during import:
@@ -10,6 +10,10 @@ class AttendanceImporter
 
   def data_transformer
     CsvTransformer.new
+  end
+
+  def filter
+    SchoolFilter.new(school_scope)
   end
 
   def import_row(row)

--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -1,4 +1,4 @@
-class AttendanceImporter < Struct.new :school_scope
+class AttendanceImporter < Struct.new :school_scope, :client
 
   def remote_file_name
     # Expects a CSV with the following headers, transformed to symbols by CsvTransformer during import:

--- a/app/importers/file_importers/behavior_importer.rb
+++ b/app/importers/file_importers/behavior_importer.rb
@@ -1,4 +1,4 @@
-class BehaviorImporter
+class BehaviorImporter < Struct.new :school_scope
 
   def remote_file_name
     # Expects a CSV with the following headers, transformed to symbols by CsvTransformer during import:
@@ -11,6 +11,10 @@ class BehaviorImporter
 
   def data_transformer
     CsvTransformer.new
+  end
+
+  def filter
+    SchoolFilter.new(school_scope)
   end
 
   def import_row(row)

--- a/app/importers/file_importers/behavior_importer.rb
+++ b/app/importers/file_importers/behavior_importer.rb
@@ -1,11 +1,6 @@
 class BehaviorImporter < Struct.new :school_scope, :client
 
   def remote_file_name
-    # Expects a CSV with the following headers, transformed to symbols by CsvTransformer during import:
-    #
-    # [ "state_id", "local_id", "incident_code", "event_date", "incident_time",
-    #   "incident_location", "incident_description", "school_local_id" ]
-
     'behavior_export.txt'
   end
 

--- a/app/importers/file_importers/behavior_importer.rb
+++ b/app/importers/file_importers/behavior_importer.rb
@@ -1,4 +1,4 @@
-class BehaviorImporter < Struct.new :school_scope
+class BehaviorImporter < Struct.new :school_scope, :client
 
   def remote_file_name
     # Expects a CSV with the following headers, transformed to symbols by CsvTransformer during import:

--- a/app/importers/file_importers/bulk_attendance_importer.rb
+++ b/app/importers/file_importers/bulk_attendance_importer.rb
@@ -1,4 +1,4 @@
-class BulkAttendanceImporter
+class BulkAttendanceImporter < Struct.new :school_scope
 
   def initialize(options = {})
     # Required
@@ -19,6 +19,10 @@ class BulkAttendanceImporter
 
   def data_transformer
     CsvTransformer.new
+  end
+
+  def filter
+    SchoolFilter.new(school_scope)
   end
 
   def connect_transform_import

--- a/app/importers/file_importers/bulk_attendance_importer.rb
+++ b/app/importers/file_importers/bulk_attendance_importer.rb
@@ -1,4 +1,4 @@
-class BulkAttendanceImporter < Struct.new :school_scope
+class BulkAttendanceImporter < Struct.new :school_scope, :client
 
   def initialize(options = {})
     # Required

--- a/app/importers/file_importers/bulk_attendance_importer.rb
+++ b/app/importers/file_importers/bulk_attendance_importer.rb
@@ -10,10 +10,6 @@ class BulkAttendanceImporter < Struct.new :school_scope, :client
   end
 
   def remote_file_name
-    # Expects a CSV with the following headers, transformed to symbols by CsvTransformer during import:
-    #
-    # [ "state_id", "local_id", "absence", "tardy", "event_date", "school_local_id" ]
-
     'attendance_export.txt'
   end
 

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -1,10 +1,6 @@
 class EducatorsImporter < Struct.new :school_scope, :client
 
   def remote_file_name
-    # Expects a CSV with the following headers, transformed to symbols by CsvTransformer during import:
-    #
-    # [ "state_id", "local_id", "full_name", "staff_type", "homeroom", "school_local_id"]
-
     'educators_export.txt'
   end
 

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -1,8 +1,4 @@
-class EducatorsImporter
-
-  def initialize
-    @school_ids_dictionary = School.all.map { |school| [school.local_id, school.id] }.to_h
-  end
+class EducatorsImporter < Struct.new :school_scope
 
   def remote_file_name
     # Expects a CSV with the following headers, transformed to symbols by CsvTransformer during import:
@@ -16,8 +12,16 @@ class EducatorsImporter
     CsvTransformer.new
   end
 
+  def filter
+    SchoolFilter.new(school_scope)
+  end
+
+  def school_ids_dictionary
+    @dictionary ||= School.all.map { |school| [school.local_id, school.id] }.to_h
+  end
+
   def import_row(row)
-    educator = EducatorRow.new(row, @school_ids_dictionary).build
+    educator = EducatorRow.new(row, school_ids_dictionary).build
     educator.save!
 
     homeroom = Homeroom.find_by_name!(row[:homeroom]) if row[:homeroom].present?

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -1,4 +1,4 @@
-class EducatorsImporter < Struct.new :school_scope
+class EducatorsImporter < Struct.new :school_scope, :client
 
   def remote_file_name
     # Expects a CSV with the following headers, transformed to symbols by CsvTransformer during import:

--- a/app/importers/file_importers/star_math_importer.rb
+++ b/app/importers/file_importers/star_math_importer.rb
@@ -1,4 +1,4 @@
-class StarMathImporter < Struct.new :school_scope
+class StarMathImporter < Struct.new :school_scope, :client
 
   def remote_file_name
     'SM.csv'

--- a/app/importers/file_importers/star_math_importer.rb
+++ b/app/importers/file_importers/star_math_importer.rb
@@ -1,4 +1,4 @@
-class StarMathImporter
+class StarMathImporter < Struct.new :school_scope
 
   def remote_file_name
     'SM.csv'
@@ -6,6 +6,10 @@ class StarMathImporter
 
   def data_transformer
     StarMathCsvTransformer.new
+  end
+
+  def filter
+    SchoolFilter.new(school_scope)
   end
 
   def star_mathematics_assessment

--- a/app/importers/file_importers/star_reading_importer.rb
+++ b/app/importers/file_importers/star_reading_importer.rb
@@ -1,4 +1,4 @@
-class StarReadingImporter
+class StarReadingImporter < Struct.new :school_scope
 
   def remote_file_name
     'SR.csv'

--- a/app/importers/file_importers/star_reading_importer.rb
+++ b/app/importers/file_importers/star_reading_importer.rb
@@ -8,6 +8,10 @@ class StarReadingImporter < Struct.new :school_scope, :client
     StarReadingCsvTransformer.new
   end
 
+  def filter
+    SchoolFilter.new(school_scope)
+  end
+
   def star_reading_assessment
     @assessment ||= Assessment.where(family: "STAR", subject: "Reading").first_or_create!
   end

--- a/app/importers/file_importers/star_reading_importer.rb
+++ b/app/importers/file_importers/star_reading_importer.rb
@@ -1,4 +1,4 @@
-class StarReadingImporter < Struct.new :school_scope
+class StarReadingImporter < Struct.new :school_scope, :client
 
   def remote_file_name
     'SR.csv'

--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -1,13 +1,6 @@
 class StudentsImporter < Struct.new :school_scope, :client
 
   def remote_file_name
-    # Expects a CSV with the following headers, transformed to symbols by CsvTransformer during import:
-    #
-    # [ "state_id", "local_id", "full_name", "home_language", "program_assigned",
-    #   "limited_english_proficiency", "sped_placement", "disability", "sped_level_of_need",
-    #   "plan_504", "student_address", "grade", "registration_date", "free_reduced_lunch",
-    #   "homeroom", "school_local_id" ]
-
     'students_export.txt'
   end
 

--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -1,4 +1,4 @@
-class StudentsImporter < Struct.new :school_scope
+class StudentsImporter < Struct.new :school_scope, :client
 
   def remote_file_name
     # Expects a CSV with the following headers, transformed to symbols by CsvTransformer during import:

--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -1,8 +1,4 @@
-class StudentsImporter
-
-  def initialize
-    @school_ids_dictionary = School.all.map { |school| [school.local_id, school.id] }.to_h
-  end
+class StudentsImporter < Struct.new :school_scope
 
   def remote_file_name
     # Expects a CSV with the following headers, transformed to symbols by CsvTransformer during import:
@@ -19,8 +15,16 @@ class StudentsImporter
     CsvTransformer.new
   end
 
+  def filter
+    SchoolFilter.new(school_scope)
+  end
+
+  def school_ids_dictionary
+    @dictionary ||= School.all.map { |school| [school.local_id, school.id] }.to_h
+  end
+
   def import_row(row)
-    student = StudentRow.new(row, @school_ids_dictionary).build
+    student = StudentRow.new(row, school_ids_dictionary).build
     if student.save!
       assign_student_to_homeroom(student, row[:homeroom])
       student.create_student_risk_level!

--- a/app/importers/file_importers/x2_assessment_importer.rb
+++ b/app/importers/file_importers/x2_assessment_importer.rb
@@ -4,12 +4,6 @@ class X2AssessmentImporter < Struct.new :school_scope, :client
   WHITELIST = Regexp.union(/ACCESS/, /WIDA-ACCESS/, /DIBELS/, /MCAS/).freeze
 
   def remote_file_name
-    # Expects a CSV with the following headers, transformed to symbols by CsvTransformer during import:
-    #
-    # [ "state_id", "local_id", "school_local_id", "assessment_date",
-    #   "assessment_scale_score", "assessment_performance_level", "assessment_growth",
-    #   "assessment_name", "assessment_subject", "assessment_test" ]
-
     'assessment_export.txt'
   end
 
@@ -22,6 +16,12 @@ class X2AssessmentImporter < Struct.new :school_scope, :client
   end
 
   def import_row(row)
+    # Expects the following headers:
+    #
+    #   :state_id, :local_id, :school_local_id, :assessment_date,
+    #   :assessment_scale_score, :assessment_performance_level, :assessment_growth,
+    #   :assessment_name, :assessment_subject, :assessment_test
+
     return unless row[:assessment_test].match(WHITELIST)
 
     row[:assessment_growth] = nil if !/\D/.match(row[:assessment_growth]).nil?

--- a/app/importers/file_importers/x2_assessment_importer.rb
+++ b/app/importers/file_importers/x2_assessment_importer.rb
@@ -1,4 +1,4 @@
-class X2AssessmentImporter
+class X2AssessmentImporter < Struct.new :school_scope
   # Aspen X2 is the name of Somerville's Student Information System.
 
   WHITELIST = Regexp.union(/ACCESS/, /WIDA-ACCESS/, /DIBELS/, /MCAS/).freeze
@@ -15,6 +15,10 @@ class X2AssessmentImporter
 
   def data_transformer
     CsvTransformer.new
+  end
+
+  def filter
+    SchoolFilter.new(school_scope)
   end
 
   def import_row(row)

--- a/app/importers/file_importers/x2_assessment_importer.rb
+++ b/app/importers/file_importers/x2_assessment_importer.rb
@@ -1,4 +1,4 @@
-class X2AssessmentImporter < Struct.new :school_scope
+class X2AssessmentImporter < Struct.new :school_scope, :client
   # Aspen X2 is the name of Somerville's Student Information System.
 
   WHITELIST = Regexp.union(/ACCESS/, /WIDA-ACCESS/, /DIBELS/, /MCAS/).freeze

--- a/app/importers/importer.rb
+++ b/app/importers/importer.rb
@@ -2,13 +2,11 @@ require 'csv'
 
 class Importer
 
-  attr_reader     :file_importers,  # File imports are classes that implement two methods:
+  attr_reader     :file_importers   # File imports are classes that implement two methods:
                                     # remote_file_name => name of the remote file to import
                                     # import_row => method for importing each row
-                  :client
 
   def initialize(options = {})
-    @client = options[:client]                    # Required - client for connecting to remote site
     @file_importers = options[:file_importers]    # Required - array of per-file importers
     @log = options[:log_destination] || STDOUT
   end
@@ -16,7 +14,7 @@ class Importer
   def connect_transform_import
     file_importers.each do |file_importer|
       file_name = file_importer.remote_file_name
-      file = @client.read_file(file_name)
+      file = file_importer.client.read_file(file_name)
 
       pre_cleanup_csv = CSV.parse(file, headers: true)
       data = file_importer.data_transformer.transform(file)

--- a/app/importers/importer.rb
+++ b/app/importers/importer.rb
@@ -5,18 +5,12 @@ class Importer
   attr_reader     :file_importers,  # File imports are classes that implement two methods:
                                     # remote_file_name => name of the remote file to import
                                     # import_row => method for importing each row
-                  :client,
-                  :school_scope
+                  :client
 
   def initialize(options = {})
     @client = options[:client]                    # Required - client for connecting to remote site
     @file_importers = options[:file_importers]    # Required - array of per-file importers
-    @school_scope = options[:school_scope]        # Optional array of school local IDs
     @log = options[:log_destination] || STDOUT
-  end
-
-  def filter
-    @filter ||= SchoolFilter.new(@school_scope)
   end
 
   def connect_transform_import
@@ -29,7 +23,7 @@ class Importer
       CleanupReport.new(@log, file_name, pre_cleanup_csv.size, data.size).print
 
       data.each.each_with_index do |row, index|
-        file_importer.import_row(row) if filter.include?(row)
+        file_importer.import_row(row) if file_importer.filter.include?(row)
         ProgressBar.new(@log, file_name, data.size, index + 1).print
       end
     end

--- a/app/importers/rows/attendance_row.rb
+++ b/app/importers/rows/attendance_row.rb
@@ -1,4 +1,9 @@
 class AttendanceRow < Struct.new(:row)
+
+  # Expects the following headers:
+  #
+  # :state_id, :local_id, :absence, :tardy, :event_date, :school_local_id
+
   class NullRelation
     class NullEvent
       def save!; end

--- a/app/importers/rows/behavior_row.rb
+++ b/app/importers/rows/behavior_row.rb
@@ -1,4 +1,9 @@
 class BehaviorRow < Struct.new(:row)
+  # Expects the following headers:
+  #
+  #  :state_id, :local_id, :incident_code, :event_date, :incident_time,
+  #  :incident_location, :incident_description, :school_local_id
+
   def self.build(row)
     new(row).build
   end

--- a/app/importers/rows/educator_row.rb
+++ b/app/importers/rows/educator_row.rb
@@ -1,4 +1,7 @@
 class EducatorRow < Struct.new(:row, :school_ids_dictionary)
+  # Expects a CSV with the following headers:
+  #
+  # :state_id, :local_id, :full_name, :staff_type, :homeroom, :school_local_id
 
   def self.build(row)
     new(row).build
@@ -24,7 +27,7 @@ class EducatorRow < Struct.new(:row, :school_ids_dictionary)
   private
 
   def is_admin?
-    row[:staff_type].present? && row[:staff_type] == "Administrator"
+    row[:staff_type].present? && row[:staff_type] == 'Administrator'
   end
 
   def school_local_id

--- a/app/importers/rows/student_row.rb
+++ b/app/importers/rows/student_row.rb
@@ -1,4 +1,10 @@
 class StudentRow < Struct.new(:row, :school_ids_dictionary)
+  # Expects the following headers:
+  #
+  #   :state_id, :local_id, :full_name, :home_language, :program_assigned,
+  #   :limited_english_proficiency, :sped_placement, :disability,
+  #   sped_level_of_need: :plan_504, :student_address, :grade,
+  #   :registration_date, :free_reduced_lunch, :homeroom, :school_local_id
 
   def self.build(row)
     new(row).build

--- a/app/importers/sources/somerville_star_importers.rb
+++ b/app/importers/sources/somerville_star_importers.rb
@@ -10,7 +10,6 @@ class SomervilleStarImporters
 
   def options
     {
-      school_scope: @school_scope,
       client: SftpClient.for_star,
       data_transformer: CsvTransformer.new,
       file_importers: [
@@ -18,7 +17,7 @@ class SomervilleStarImporters
         StarReadingImporter::HistoricalImporter,
         StarMathImporter,
         StarMathImporter::HistoricalImporter
-      ].map(&:new),
+      ].map { |i| i.new(@school_scope) },
       log_destination: @log
     }
   end

--- a/app/importers/sources/somerville_star_importers.rb
+++ b/app/importers/sources/somerville_star_importers.rb
@@ -17,13 +17,17 @@ class SomervilleStarImporters
     }
   end
 
+  def sftp_client
+    @client ||= SftpClient.for_star
+  end
+
   def file_importers
     [
       StarReadingImporter,
       StarReadingImporter::HistoricalImporter,
       StarMathImporter,
       StarMathImporter::HistoricalImporter
-    ].map { |i| i.new(@school_scope, SftpClient.for_star) }
+    ].map { |i| i.new(@school_scope, sftp_client) }
   end
 
   def importer

--- a/app/importers/sources/somerville_star_importers.rb
+++ b/app/importers/sources/somerville_star_importers.rb
@@ -12,14 +12,18 @@ class SomervilleStarImporters
     {
       client: SftpClient.for_star,
       data_transformer: CsvTransformer.new,
-      file_importers: [
-        StarReadingImporter,
-        StarReadingImporter::HistoricalImporter,
-        StarMathImporter,
-        StarMathImporter::HistoricalImporter
-      ].map { |i| i.new(@school_scope) },
+      file_importers: file_importers,
       log_destination: @log
     }
+  end
+
+  def file_importers
+    [
+      StarReadingImporter,
+      StarReadingImporter::HistoricalImporter,
+      StarMathImporter,
+      StarMathImporter::HistoricalImporter
+    ].map { |i| i.new(@school_scope, SftpClient.for_star) }
   end
 
   def importer

--- a/app/importers/sources/somerville_x2_importers.rb
+++ b/app/importers/sources/somerville_x2_importers.rb
@@ -12,8 +12,7 @@ class SomervilleX2Importers
 
   def base_options
     {
-      client: SftpClient.for_x2,
-      file_importers: file_importers.map { |i| i.new(@school_scope) },
+      file_importers: file_importers.map { |i| i.new(@school_scope, SftpClient.for_x2) },
       log_destination: @log
     }
   end

--- a/app/importers/sources/somerville_x2_importers.rb
+++ b/app/importers/sources/somerville_x2_importers.rb
@@ -12,9 +12,8 @@ class SomervilleX2Importers
 
   def base_options
     {
-      school_scope: @school_scope,
       client: SftpClient.for_x2,
-      file_importers: file_importers.map(&:new),
+      file_importers: file_importers.map { |i| i.new(@school_scope) },
       log_destination: @log
     }
   end

--- a/app/importers/sources/somerville_x2_importers.rb
+++ b/app/importers/sources/somerville_x2_importers.rb
@@ -10,9 +10,13 @@ class SomervilleX2Importers
     @log = options["test_mode"] ? LogHelper::Redirect.instance.file : STDOUT
   end
 
+  def sftp_client
+    @client ||= SftpClient.for_x2
+  end
+
   def base_options
     {
-      file_importers: file_importers.map { |i| i.new(@school_scope, SftpClient.for_x2) },
+      file_importers: file_importers.map { |i| i.new(@school_scope, sftp_client) },
       log_destination: @log
     }
   end

--- a/spec/importers/importer_spec.rb
+++ b/spec/importers/importer_spec.rb
@@ -29,11 +29,10 @@ RSpec.describe Importer do
 
       context 'scope is Healey School' do
         let(:healey) { FactoryGirl.create(:healey) }
-        let(:file_importer) { StudentsImporter.new }
+        let(:school_scope) { [healey.local_id] }
         let(:importer) {
           Importer.new(
-            school_scope: [healey.local_id],
-            file_importers: [file_importer],
+            file_importers: [StudentsImporter.new(school_scope)],
             client: mock_client,
             log_destination: log
           )

--- a/spec/importers/importer_spec.rb
+++ b/spec/importers/importer_spec.rb
@@ -13,11 +13,10 @@ RSpec.describe Importer do
       let(:mock_client) { double(:sftp_client, read_file: file) }
 
       context 'no scope' do
-        let(:file_importer) { StudentsImporter.new }
+        let(:file_importer) { StudentsImporter.new(nil, mock_client) }
         let(:importer) {
           Importer.new(
             file_importers: [file_importer],
-            client: mock_client,
             log_destination: log
           )
         }
@@ -32,8 +31,7 @@ RSpec.describe Importer do
         let(:school_scope) { [healey.local_id] }
         let(:importer) {
           Importer.new(
-            file_importers: [StudentsImporter.new(school_scope)],
-            client: mock_client,
+            file_importers: [StudentsImporter.new(school_scope, mock_client)],
             log_destination: log
           )
         }

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe Import do
       expect(second_importer).to be_a Importer
 
       expect(first_importer.client).to eq sftp_client_double
-      expect(first_importer.school_scope).to eq ["HEA"]
       expect(first_importer.file_importers.map { |i| i.class }).to eq [
         StudentsImporter,
         X2AssessmentImporter,
@@ -41,7 +40,6 @@ RSpec.describe Import do
       ]
 
       expect(second_importer.client).to eq sftp_client_double
-      expect(second_importer.school_scope).to eq ["HEA"]
       expect(second_importer.file_importers.map { |i| i.class }).to eq [
         StarReadingImporter,
         StarReadingImporter::HistoricalImporter,

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Import do
       expect(first_importer).to be_a Importer
       expect(second_importer).to be_a Importer
 
-      expect(first_importer.client).to eq sftp_client_double
+      expect(first_importer.file_importers.first.client).to eq sftp_client_double
       expect(first_importer.file_importers.map { |i| i.class }).to eq [
         StudentsImporter,
         X2AssessmentImporter,
@@ -39,7 +39,7 @@ RSpec.describe Import do
         AttendanceImporter
       ]
 
-      expect(second_importer.client).to eq sftp_client_double
+      expect(second_importer.file_importers.first.client).to eq sftp_client_double
       expect(second_importer.file_importers.map { |i| i.class }).to eq [
         StarReadingImporter,
         StarReadingImporter::HistoricalImporter,


### PR DESCRIPTION
## What's new?

+ Move responsibility for school scope and SFTP client down the `FileImporter` level
+ This lets us move one more responsibility out of the `Importer` class, which is serving mostly as a pass-through for variables
+ Goal is to slim down the `Importer` class until we can easily delete it from the codebase, leaving fewer steps in the logical chain of the import task
