### PR TITLE
Save memory by cutting out duplicate CSV parsing

### DIFF
--- a/app/importers/data_transformers/csv_transformer.rb
+++ b/app/importers/data_transformers/csv_transformer.rb
@@ -2,10 +2,14 @@ require 'csv'
 
 class CsvTransformer
 
+  attr_accessor :pre_cleanup_csv_size
+
   def transform(file)
     csv = CSV.parse(file, headers: true,
                           header_converters: :symbol,
                           converters: lambda { |h| nil_converter(h) })
+
+    @pre_cleanup_csv_size = csv.size
 
     csv.delete_if { |row| CsvRowCleaner.new(row).dirty_data? }
 

--- a/app/importers/data_transformers/star_csv_transformer.rb
+++ b/app/importers/data_transformers/star_csv_transformer.rb
@@ -1,8 +1,12 @@
 module StarCsvTransformer
   require 'csv'
 
+  attr_accessor :pre_cleanup_csv_size
+
   def transform(file)
-    CSV.parse(file, headers: true, header_converters: lambda { |h| convert_headers(h) })
+    csv = CSV.parse(file, headers: true, header_converters: lambda { |h| convert_headers(h) })
+    @pre_cleanup_csv_size = csv.size
+    csv
   end
 
   def convert_headers(header)

--- a/app/importers/importer.rb
+++ b/app/importers/importer.rb
@@ -16,9 +16,11 @@ class Importer
       file_name = file_importer.remote_file_name
       file = file_importer.client.read_file(file_name)
 
-      pre_cleanup_csv = CSV.parse(file, headers: true)
-      data = file_importer.data_transformer.transform(file)
-      CleanupReport.new(@log, file_name, pre_cleanup_csv.size, data.size).print
+      transformer = file_importer.data_transformer
+      data = transformer.transform(file)
+      pre_cleanup_csv_size = transformer.pre_cleanup_csv_size
+
+      CleanupReport.new(@log, file_name, pre_cleanup_csv_size, data.size).print
 
       data.each.each_with_index do |row, index|
         file_importer.import_row(row) if file_importer.filter.include?(row)


### PR DESCRIPTION
## Notes 

+ We are parsing each CSV twice, once to get its initial size, then to clean it up and import it
+ Cut that out, big waste of memory
+ #11