### PR TITLE
Turn off ProgressBar in production

### DIFF
--- a/app/importers/importer.rb
+++ b/app/importers/importer.rb
@@ -8,6 +8,7 @@ class Importer
 
   def initialize(options = {})
     @file_importers = options[:file_importers]    # Required - array of per-file importers
+    @progress_bar = options[:progress_bar]
     @log = options[:log_destination] || STDOUT
   end
 
@@ -24,7 +25,7 @@ class Importer
 
       data.each.each_with_index do |row, index|
         file_importer.import_row(row) if file_importer.filter.include?(row)
-        ProgressBar.new(@log, file_name, data.size, index + 1).print
+        ProgressBar.new(@log, file_name, data.size, index + 1).print if @progress_bar
       end
     end
   end

--- a/app/importers/importer.rb
+++ b/app/importers/importer.rb
@@ -15,8 +15,9 @@ class Importer
   def connect_transform_import
     file_importers.each do |file_importer|
       file_name = file_importer.remote_file_name
-      file = file_importer.client.read_file(file_name)
+      @log.write("\nImporting #{file_name}...")
 
+      file = file_importer.client.read_file(file_name)
       transformer = file_importer.data_transformer
       data = transformer.transform(file)
       pre_cleanup_csv_size = transformer.pre_cleanup_csv_size

--- a/app/importers/importer.rb
+++ b/app/importers/importer.rb
@@ -25,7 +25,10 @@ class Importer
 
       data.each.each_with_index do |row, index|
         file_importer.import_row(row) if file_importer.filter.include?(row)
-        ProgressBar.new(@log, file_name, data.size, index + 1).print if @progress_bar
+
+        if @progress_bar == :true  # Thor passes Boolean options as Symbols :/
+          ProgressBar.new(@log, file_name, data.size, index + 1).print
+        end
       end
     end
   end

--- a/app/importers/sources/somerville_star_importers.rb
+++ b/app/importers/sources/somerville_star_importers.rb
@@ -5,6 +5,7 @@ class SomervilleStarImporters
 
   def initialize(options = {})
     @school_scope = options["school"]
+    @progress_bar = options["progress_bar"]
     @log = options["test_mode"] ? LogHelper::Redirect.instance.file : STDOUT
   end
 
@@ -13,7 +14,8 @@ class SomervilleStarImporters
       client: SftpClient.for_star,
       data_transformer: CsvTransformer.new,
       file_importers: file_importers,
-      log_destination: @log
+      log_destination: @log,
+      progress_bar: @progress_bar
     }
   end
 

--- a/app/importers/sources/somerville_x2_importers.rb
+++ b/app/importers/sources/somerville_x2_importers.rb
@@ -7,6 +7,7 @@ class SomervilleX2Importers
     @school_scope = options["school"]
     @first_time = options["first_time"]
     @x2_file_importers = options["x2_file_importers"]
+    @progress_bar = options["progress_bar"]
     @log = options["test_mode"] ? LogHelper::Redirect.instance.file : STDOUT
   end
 
@@ -17,7 +18,8 @@ class SomervilleX2Importers
   def base_options
     {
       file_importers: file_importers.map { |i| i.new(@school_scope, sftp_client) },
-      log_destination: @log
+      log_destination: @log,
+      progress_bar: @progress_bar
     }
   end
 

--- a/app/reports/cleanup_report.rb
+++ b/app/reports/cleanup_report.rb
@@ -1,11 +1,11 @@
 class CleanupReport < Struct.new :log, :file_name, :pre_cleanup_size, :post_cleanup_size
 
   def print
-    log.write([spacing, before_text, after_text, spacing].join("\n"))
+    log.write([extra_spacing, before_text, after_text, extra_spacing].join("\n"))
   end
 
-  def spacing
-    "\n\n"
+  def extra_spacing
+    "\n"
   end
 
   def before_text

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -40,6 +40,10 @@ class Import
       type: :boolean,
       default: false,
       desc: "Redirect log output away from STDOUT; do not load Rails during import"
+    class_option :progress_bar,
+      type: :boolean,
+      default: :false,
+      desc: "Show a progress bar for CSV reading (useful in development)"
 
     no_commands do
       def report


### PR DESCRIPTION
## Notes

+ Even after refactoring to fix blatant memory waste, `ProgressBar` is 4th on the list of files that allocate the most memory during import: https://github.com/studentinsights/studentinsights/issues/11#issuecomment-207137096
+ It's also not very useful in production, because the progress bar output is garbled when served over Heroku's remote logging
+ So let's make `ProgressBar` an optional developer tool and turn off by default
+ #11

