### PR TITLE
Remove precomputed_student_hashes_doc and add new table with unique c…

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -42,15 +42,15 @@ class SchoolsController < ApplicationController
   # raw query.
   # Results an array of student_hashes.
   def load_precomputed_student_hashes(time_now, authorized_student_ids)
-    begin
-      key = precomputed_student_hashes_key(time_now, authorized_student_ids)
-      doc = PrecomputedStudentHashesDoc.find(key)
-      JSON.parse(doc.json)['student_hashes']
-    rescue ActiveRecord::RecordNotFound => err
-      logger.error "load_precomputed_student_hashes failed, err: #{err.inspect}"
-      authorized_students = Student.find(authorized_student_ids)
-      authorized_students.map {|student| student_hash_for_slicing(student) }
-    end
+    key = precomputed_student_hashes_key(time_now, authorized_student_ids)
+    doc = PrecomputedQueryDoc.find_by_key(key)
+    return JSON.parse(doc.json)['student_hashes'] unless doc.nil?
+    
+    # Fallback to performing the full query if something went wrong reading the 
+    # precomputed value
+    logger.error "load_precomputed_student_hashes failed for key: #{key}"
+    authorized_students = Student.find(authorized_student_ids)
+    authorized_students.map {|student| student_hash_for_slicing(student) }
   end
 
   def serialized_data_for_star

--- a/app/helpers/students_query_helper.rb
+++ b/app/helpers/students_query_helper.rb
@@ -38,6 +38,6 @@ module StudentsQueryHelper
   def precomputed_student_hashes_key(time_now, authorized_student_ids)
     timestamp = Time.now.beginning_of_day.to_i
     authorized_students_key = authorized_student_ids.sort.join(',')
-    [timestamp, authorized_students_key].join('_')
+    ['precomputed_student_hashes', timestamp, authorized_students_key].join('_')
   end
 end

--- a/app/jobs/precompute_student_hashes_job.rb
+++ b/app/jobs/precompute_student_hashes_job.rb
@@ -34,7 +34,7 @@ class PrecomputeStudentHashesJob
     key = precomputed_student_hashes_key(precomputed_time, authorized_student_ids)
 
     # This is a non-atomic upsert
-    PrecomputedStudentHashesDoc.find(key).destroy! if PrecomputedStudentHashesDoc.exists?(key)
-    PrecomputedStudentHashesDoc.create!(key: key, json: { student_hashes: student_hashes }.to_json )
+    PrecomputedQueryDoc.find(key).destroy! if PrecomputedQueryDoc.exists?(key)
+    PrecomputedQueryDoc.create!(key: key, json: { student_hashes: student_hashes }.to_json )
   end
 end

--- a/app/models/precomputed_query_doc.rb
+++ b/app/models/precomputed_query_doc.rb
@@ -1,0 +1,6 @@
+class PrecomputedQueryDoc < ActiveRecord::Base
+  # A key-value store for holding a precomputed JSON doc, like Redis but durable since it's precomputed
+  # and not a read-through cache.
+  # The primary key means nothing, and reads and writes should be done on the `key` column, which
+  # has an index and uniqueness constraint.
+end

--- a/app/models/precomputed_student_hashes_doc.rb
+++ b/app/models/precomputed_student_hashes_doc.rb
@@ -1,5 +1,0 @@
-class PrecomputedStudentHashesDoc < ActiveRecord::Base
-  self.primary_key = 'key'
-  # A key-value store for holding a precomputed JSON doc, like Redis but durable since it's precomputed
-  # and not a read-through cache.
-end

--- a/db/migrate/20160410171252_migrate_precomputed_student_hashes_to_unique_key.rb
+++ b/db/migrate/20160410171252_migrate_precomputed_student_hashes_to_unique_key.rb
@@ -1,0 +1,15 @@
+class MigratePrecomputedStudentHashesToUniqueKey < ActiveRecord::Migration
+  # This removes the `precomputed_student_hashes_docs` table, where we've run into
+  # issues with Rails not encoding the string type for the primary key into schema.rb,
+  # and replaces it with a new table that keeps the regular Rails primary and adds
+  # treats the string key as a plain field with an index and uniqueness constraint.
+  def change
+    drop_table :precomputed_student_hashes_docs
+    create_table :precomputed_query_docs do |t|
+      t.string :key
+      t.text :json
+      t.timestamps
+    end
+    add_index :precomputed_query_docs, :key, :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160407194935) do
+ActiveRecord::Schema.define(version: 20160410171252) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -160,11 +160,14 @@ ActiveRecord::Schema.define(version: 20160407194935) do
     t.string   "custom_intervention_name"
   end
 
-  create_table "precomputed_student_hashes_docs", primary_key: "key", force: true do |t|
+  create_table "precomputed_query_docs", force: true do |t|
+    t.string   "key"
     t.text     "json"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  add_index "precomputed_query_docs", ["key"], name: "index_precomputed_query_docs_on_key", unique: true, using: :btree
 
   create_table "progress_notes", force: true do |t|
     t.integer  "intervention_id"


### PR DESCRIPTION
…olumn

This is addressing problems mentioned in https://github.com/studentinsights/studentinsights/issues/319 and earlier PRs (originally introduced in https://github.com/studentinsights/studentinsights/pull/270).  It appears Rails doesn't always respect column types for primary keys that are non-numeric (eg., string primary keys) when updating `schema.rb`.  Many thanks to @ jochakovsky and @kbweaver for the help debugging this!

This PR drops the old table, and makes a new one that has an additional column with a uniqueness constraint that effectively serves as a primary key, and let's Rails create the integer primary key it wants to and then ignores it.  Deploying this will effectively empty the precomputed query table, and so I'll re-run the rake task to generate those values after deploying.

I verified that this works locally using both `bundle exec rake db:setup db:seed:demo` and `bundle exec rake db:create db:migrate db:seed:demo` and then running the specs (since we shouldn't have any functional differences between them).  Also verified locally that this degrades gracefully when no value is found, that the job works and that the controller uses values found in the precomputed query table.