### PR TITLE
Add migration to allow longer key and document values for precomputed…

### DIFF
--- a/db/migrate/20160410174144_increase_precomputed_query_doc_size.rb
+++ b/db/migrate/20160410174144_increase_precomputed_query_doc_size.rb
@@ -1,0 +1,6 @@
+class IncreasePrecomputedQueryDocSize < ActiveRecord::Migration
+  def change
+    change_column :precomputed_query_docs, :key, :text, :limit => nil
+    change_column :precomputed_query_docs, :json, :text, :limit => nil
+  end
+end


### PR DESCRIPTION
… queries

Follow-up to https://github.com/studentinsights/studentinsights/pull/320 after deploying and verifying manually in staging, to address this:
```
2016-04-10T17:40:54.786356+00:00 app[run.9912]: PG::StringDataRightTruncation: ERROR:  value too long for type character varying(255)
2016-04-10T17:40:54.786366+00:00 app[run.9912]: : INSERT INTO "precomputed_query_docs" ("created_at", "json", "key", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"
2016-04-10T17:40:54.788748+00:00 app[run.9912]: rake aborted!
2016-04-10T17:40:54.788826+00:00 app[run.9912]: ActiveRecord::StatementInvalid: PG::StringDataRightTruncation: ERROR:  value too long for type character varying(255)
```
