### PR TITLE
Add more tolerance to controller code reading precomputed values, dur…

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160410171252) do
+ActiveRecord::Schema.define(version: 20160410174144) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -161,7 +161,7 @@ ActiveRecord::Schema.define(version: 20160410171252) do
   end
 
   create_table "precomputed_query_docs", force: true do |t|
-    t.string   "key"
+    t.text     "key"
     t.text     "json"
     t.datetime "created_at"
     t.datetime "updated_at"


### PR DESCRIPTION
…ing migration

Follow on to https://github.com/studentinsights/studentinsights/pull/322, to add more graceful degradation before running the migration, or any other active record issues with reading the precomputed table.

For example:
```
2016-04-10T17:48:50.278604+00:00 app[web.1]: PG::UndefinedTable: ERROR:  relation "precomputed_query_docs" does not exist
2016-04-10T17:48:50.278627+00:00 app[web.1]: LINE 5:                WHERE a.attrelid = '"precomputed_query_docs"'...
2016-04-10T17:48:50.278628+00:00 app[web.1]:                                           ^
2016-04-10T17:48:50.278629+00:00 app[web.1]: :               SELECT a.attname, format_type(a.atttypid, a.atttypmod),
2016-04-10T17:48:50.278630+00:00 app[web.1]:                      pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
2016-04-10T17:48:50.278630+00:00 app[web.1]:                 FROM pg_attribute a LEFT JOIN pg_attrdef d
2016-04-10T17:48:50.278631+00:00 app[web.1]:                   ON a.attrelid = d.adrelid AND a.attnum = d.adnum
2016-04-10T17:48:50.278631+00:00 app[web.1]:                WHERE a.attrelid = '"precomputed_query_docs"'::regclass
2016-04-10T17:48:50.278632+00:00 app[web.1]:                  AND a.attnum > 0 AND NOT a.attisdropped
2016-04-10T17:48:50.278632+00:00 app[web.1]:                ORDER BY a.attnum
2016-04-10T17:48:50.278633+00:00 app[web.1]:
2016-04-10T17:48:50.278971+00:00 app[web.1]: Completed 500 Internal Server Error in 209ms (ActiveRecord: 59.5ms)
2016-04-10T17:48:50.280934+00:00 app[web.1]:
2016-04-10T17:48:50.280952+00:00 app[web.1]: LINE 5:                WHERE a.attrelid = '"precomputed_query_docs"'...
2016-04-10T17:48:50.280951+00:00 app[web.1]: ActiveRecord::StatementInvalid (PG::UndefinedTable: ERROR:  relation "precomputed_query_docs" does not exist
```