### PR TITLE
Include attendance data for all previous years in profile page, flex scales for outliers

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -65,8 +65,8 @@
   //= require ./student_profile_v2/datepicker
   //= require ./student_profile_v2/highcharts_wrapper
   //= require ./student_profile_v2/sparkline
-  //= require ./student_profile_v2/scales
   //= require ./student_profile_v2/quad_converter
+  //= require ./student_profile_v2/scales
   //= require ./student_profile_v2/academic_summary
   //= require ./student_profile_v2/take_notes
   //= require ./student_profile_v2/notes_list

--- a/app/assets/javascripts/student_profile_v2/attendance_details.js
+++ b/app/assets/javascripts/student_profile_v2/attendance_details.js
@@ -58,7 +58,8 @@
     render: function() {
       return dom.div({ className: 'AttendanceDetails' },
         this.renderDisciplineIncidents(),
-        this.renderAbsencesAndTardies(),
+        this.renderAbsences(),
+        this.renderTardies(),
         this.renderIncidentHistory()
       );
     },
@@ -79,26 +80,34 @@
       });
     },
 
-    renderAbsencesAndTardies: function() {
+    renderAbsences: function() {
+      var range = Scales.absences.flexibleRange(this.props.cumulativeAbsences);
       return createEl(ProfileChart, {
-        titleText: 'Absences and Tardies, last 4 years',
-        legend: { enabled: true },
+        titleText: 'Absences, last 4 years',
         yAxis: {
-          min: _.min([Scales.absences.valueRange[0], Scales.tardies.valueRange[0]]),
-          max: _.max([
-            Scales.absences.valueRange[1],
-            Scales.tardies.valueRange[1],
-            d3.max(this.props.cumulativeTardies, QuadConverter.toValue),
-            d3.max(this.props.cumulativeAbsences, QuadConverter.toValue)
-          ]),
+          min: range[0],
+          max: range[1],
+          title: { text: 'Count per year' }
+        },
+        quadSeries: [{
+          name: 'Absences per school year',
+          data: this.props.cumulativeAbsences
+        }]
+      });
+    },
+
+    renderTardies: function() {
+      var range = Scales.tardies.flexibleRange(this.props.cumulativeTardies);
+      return createEl(ProfileChart, {
+        titleText: 'Tardies, last 4 years',
+        yAxis: {
+          min: range[0],
+          max: range[1],
           title: { text: 'Count per year' }
         },
         quadSeries: [{
           name: 'Tardies per school year',
           data: this.props.cumulativeTardies
-        }, {
-          name: 'Absences per school year',
-          data: this.props.cumulativeAbsences
         }]
       });
     },

--- a/app/assets/javascripts/student_profile_v2/attendance_details.js
+++ b/app/assets/javascripts/student_profile_v2/attendance_details.js
@@ -5,6 +5,7 @@
   var merge = window.shared.ReactHelpers.merge;
 
   var ProfileChart = window.shared.ProfileChart;
+  var QuadConverter = window.shared.QuadConverter;
   var Scales = window.shared.Scales;
 
   var styles = {
@@ -63,12 +64,12 @@
     },
 
     renderDisciplineIncidents: function() {
-      var range = Scales.disciplineIncidents.valueRange;
+      var flexibleRange = Scales.disciplineIncidents.flexibleRange(this.props.cumulativeDisciplineIncidents);
       return createEl(ProfileChart, {
         titleText: 'Discipline incidents, last 4 years',
         yAxis: {
-          min: range[0],
-          max: range[1],
+          min: flexibleRange[0],
+          max: flexibleRange[1],
           title: { text: 'Count per year' }
         },
         quadSeries: [{
@@ -84,7 +85,12 @@
         legend: { enabled: true },
         yAxis: {
           min: _.min([Scales.absences.valueRange[0], Scales.tardies.valueRange[0]]),
-          max: _.max([Scales.absences.valueRange[1], Scales.tardies.valueRange[1]]),
+          max: _.max([
+            Scales.absences.valueRange[1],
+            Scales.tardies.valueRange[1],
+            d3.max(this.props.cumulativeTardies, QuadConverter.toValue),
+            d3.max(this.props.cumulativeAbsences, QuadConverter.toValue)
+          ]),
           title: { text: 'Count per year' }
         },
         quadSeries: [{
@@ -101,7 +107,10 @@
       return dom.div({ style: styles.container },
         dom.h4({ style: styles.title }, 'Incident History'),
         (this.props.disciplineIncidents.length === 0) ? dom.div({}, 'None') : this.props.disciplineIncidents.map(function(incident) {
-        return dom.div({ style: styles.box, key: incident.occurred_at },
+        return dom.div({
+          style: styles.box,
+          key: [incident.occurred_at, incident.incident_description].join()
+        },
           dom.div({ style: styles.header },
             dom.div({ style: styles.item }, dom.span({ style: styles.itemHead }, 'Date: '), dom.span({}, moment.utc(incident.occurred_at).format('MMM D, YYYY'))),
             dom.div({ style: styles.item }, dom.span({ style: styles.itemHead }, 'Code: '), dom.span({}, incident.incident_code)),

--- a/app/assets/javascripts/student_profile_v2/quad_converter.js
+++ b/app/assets/javascripts/student_profile_v2/quad_converter.js
@@ -10,6 +10,10 @@
       return QuadConverter.toMoment(quad).toDate();
     },
 
+    toValue: function(quad) {
+      return quad[3];
+    },
+
     // Fills in data points for start of the school year (8/15) and for current day.
     // Also collapses multiple events on the same day.
     convertAttendanceEvents: function(attendanceEvents, nowDate, dateRange) {

--- a/app/assets/javascripts/student_profile_v2/scales.js
+++ b/app/assets/javascripts/student_profile_v2/scales.js
@@ -1,22 +1,45 @@
 (function() {
   window.shared || (window.shared = {});
 
+  var QuadConverter = window.shared.QuadConverter;
+
   var Scales = window.shared.Scales = {
     mcas: {
       valueRange: [200, 300],
       threshold: 240
     },
+
     disciplineIncidents: {
-      valueRange: [0, 20],
-      threshold: 10
+      valueRange: [0, 10],
+      threshold: 5,
+      flexibleRange: function(cumulativeQuads) {
+        return Scales.flexibleQuadRange(cumulativeQuads, Scales.disciplineIncidents.valueRange);
+      }
     },
+
     absences: {
-      valueRange: [0, 40],
-      threshold: 20
+      valueRange: [0, 20],
+      threshold: 10,
+      flexibleRange: function(cumulativeQuads) {
+        return Scales.flexibleQuadRange(cumulativeQuads, Scales.absences.valueRange);
+      }
     },
     tardies: {
-      valueRange: [0, 60],
-      threshold: 30
+      valueRange: [0, 40],
+      threshold: 20,
+      flexibleRange: function(cumulativeQuads) {
+        return Scales.flexibleQuadRange(cumulativeQuads, Scales.tardies.valueRange);
+      }
+    },
+
+    // Take a valueRange and list of cumulativeQuads, and adjust the max so that the range
+    // will always show the largest value.
+    flexibleQuadRange: function(cumulativeQuads, valueRange) {
+      var max = _.max([
+        valueRange[1],
+        d3.max(cumulativeQuads, QuadConverter.toValue)
+      ]);
+      return [valueRange[0], max];
     }
   };
 })();

--- a/app/assets/javascripts/student_profile_v2/scales.js
+++ b/app/assets/javascripts/student_profile_v2/scales.js
@@ -7,16 +7,16 @@
       threshold: 240
     },
     disciplineIncidents: {
-      valueRange: [0, 6],
-      threshold: 3
-    },
-    absences: {
       valueRange: [0, 20],
       threshold: 10
     },
-    tardies: {
+    absences: {
       valueRange: [0, 40],
       threshold: 20
+    },
+    tardies: {
+      valueRange: [0, 60],
+      threshold: 30
     }
   };
 })();

--- a/app/assets/javascripts/student_profile_v2/scales.js
+++ b/app/assets/javascripts/student_profile_v2/scales.js
@@ -10,8 +10,8 @@
     },
 
     disciplineIncidents: {
-      valueRange: [0, 10],
-      threshold: 5,
+      valueRange: [0, 6],
+      threshold: 3,
       flexibleRange: function(cumulativeQuads) {
         return Scales.flexibleQuadRange(cumulativeQuads, Scales.disciplineIncidents.valueRange);
       }

--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -374,35 +374,33 @@
         style: merge(styles.column, styles.academicColumn, this.selectedColumnStyles(columnKey)),
         onClick: this.onColumnClicked.bind(this, columnKey)
       },
-        this.renderAttendanceEventsSummary(attendanceData.discipline_incidents, {
+        this.renderAttendanceEventsSummary(attendanceData.discipline_incidents, Scales.disciplineIncidents.flexibleRange, {
           caption: 'Discipline incidents',
-          valueRange: Scales.disciplineIncidents.valueRange,
           thresholdValue: Scales.disciplineIncidents.threshold,
           shouldDrawCircles: false
         }),
-        this.renderAttendanceEventsSummary(attendanceData.absences, {
+        this.renderAttendanceEventsSummary(attendanceData.absences, Scales.absences.flexibleRange, {
           caption: 'Absences',
-          valueRange: Scales.absences.valueRange,
           thresholdValue: Scales.absences.threshold,
           shouldDrawCircles: false
         }),
-        this.renderAttendanceEventsSummary(attendanceData.tardies, {
+        this.renderAttendanceEventsSummary(attendanceData.tardies, Scales.tardies.flexibleRange, {
           caption: 'Tardies',
-          valueRange: Scales.tardies.valueRange,
           thresholdValue: Scales.tardies.threshold,
           shouldDrawCircles: false
         })
       );
     },
 
-    renderAttendanceEventsSummary: function(attendanceEvents, props) {
+    renderAttendanceEventsSummary: function(attendanceEvents, flexibleRangeFn, props) {
       var cumulativeQuads = this.cumulativeCountQuads(attendanceEvents);
       var value = (cumulativeQuads.length > 0) ? _.last(cumulativeQuads)[3] : 0;
+      var valueRange = flexibleRangeFn(cumulativeQuads);
 
       return this.wrapSummary(merge({
         title: props.title,
         value: value,
-        sparkline: this.renderSparkline(cumulativeQuads, props)
+        sparkline: this.renderSparkline(cumulativeQuads, merge({ valueRange: valueRange }, props))
       }, props));
     },
 


### PR DESCRIPTION
Addresses https://github.com/studentinsights/studentinsights/issues/290.

This updates the student profile page to include attendance events from previous years in:
 1. the summary section up top
 2. the attendance, tardy and absence detail charts
 3. in the full case history details

It also:
  1. updates the scale functions for projecting values onto the y-axis, so that the full range of data is always shown and the y-scale is compressed if necessary
  2. splits the absences and tardy charts on the details page so they can use independent y-scales

No major changes in query performance, response is still in the 100s of ms:
<img width="756" alt="screen shot 2016-04-10 at 3 31 20 pm" src="https://cloud.githubusercontent.com/assets/1056957/14412471/64348358-ff31-11e5-8ebb-922818f01c84.png">


#### Showing more data from previous years
Before, with no data for previous years:
<img width="216" alt="screen shot 2016-04-10 at 3 38 27 pm" src="https://cloud.githubusercontent.com/assets/1056957/14412509/5eabfad2-ff32-11e5-9dc4-7e699fca7728.png">
<img width="1263" alt="screen shot 2016-04-10 at 3 38 52 pm" src="https://cloud.githubusercontent.com/assets/1056957/14412507/5b6392e0-ff32-11e5-9036-b55e653ed645.png">

After, with context about previous years and with absences and tardies split:
<img width="207" alt="screen shot 2016-04-10 at 3 38 45 pm" src="https://cloud.githubusercontent.com/assets/1056957/14412512/68d22464-ff32-11e5-8ed8-0028d74c5308.png">
<img width="1266" alt="screen shot 2016-04-10 at 3 38 40 pm" src="https://cloud.githubusercontent.com/assets/1056957/14412511/675b03f8-ff32-11e5-89eb-f0915c4bc539.png">
(same result on full case history, not shown here for simplicity since it contains student data that needs to be scrubbed)

#### Showing effects of flexible y-axis scales:
Before, the count of absences overflowed the y scale:
<img width="210" alt="screen shot 2016-04-10 at 3 33 15 pm" src="https://cloud.githubusercontent.com/assets/1056957/14412475/93abc934-ff31-11e5-9127-56c9556035dc.png">


After, the scale flexes and pushes the threshold down to show the full range:
<img width="215" alt="screen shot 2016-04-10 at 3 33 09 pm" src="https://cloud.githubusercontent.com/assets/1056957/14412477/95d53ce0-ff31-11e5-9d76-a794d85b7320.png">

#### More about y-scale functions
For students that are outliers and have more events than a typical student, the full range of values will be shown and the y-scale will be compressed.  In practice, this means any student who takes up the full visual range of the chart should stick out to users, although students who are extreme outliers will appear visually similar to students who have large values and are at risk.  Concretely, the sparkline for "discipline incidents" will look similar visually for a student with 10 incidents and a student with 50 incidents.  The dotted line for the warning threshold, and the actual number still cue the users as to the actual magnitude.