### PR TITLE
Update spec to cloneDeep and not mutate Fixtures values, move DIBELS out of feed

### DIFF
--- a/app/assets/javascripts/student_profile_v2/page_container.js
+++ b/app/assets/javascripts/student_profile_v2/page_container.js
@@ -50,6 +50,7 @@
         chartData: serializedData.chartData,
         attendanceData: serializedData.attendanceData,
         access: serializedData.access,
+        dibels: serializedData.dibels,
 
         // ui
         selectedColumnKey: queryParams.column || 'interventions',
@@ -172,6 +173,7 @@
           'feed',
           'access',
           'chartData',
+          'dibels',
           'attendanceData',
           'selectedColumnKey',
           'requests'

--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -73,6 +73,7 @@
       // data
       student: React.PropTypes.object.isRequired,
       feed: React.PropTypes.object.isRequired,
+      dibels: React.PropTypes.array.isRequired,
       chartData: React.PropTypes.shape({
         // ela
         most_recent_star_reading_percentile: React.PropTypes.number,
@@ -314,15 +315,15 @@
       var student = this.props.student;
       var chartData = this.props.chartData;
       var grade = student.grade;
-      var dibels = this.props.feed.dibels;
+      var dibels = _.sortBy(this.props.dibels, 'date_taken');
 
       var belowGradeFour = _.includes(['KF', 'PK', '1', '2', '3'], grade);
       var hasDibels = (dibels.length > 0);
 
       if (belowGradeFour && hasDibels) {
-        var latest_dibels = dibels[0].performance_level.toUpperCase();
+        var latestDibels = _.last(dibels).performance_level.toUpperCase();
         return dom.div({ style: styles.summaryWrapper },
-          createEl(SummaryWithoutSparkline, { caption: 'DIBELS', value: latest_dibels })
+          createEl(SummaryWithoutSparkline, { caption: 'DIBELS', value: latestDibels })
         );
       } else {
         return this.wrapSummary({

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -20,6 +20,7 @@ class StudentsController < ApplicationController
       notes: student.student_notes.map { |note| serialize_student_note(note) },
       feed: student_feed(student),
       chart_data: chart_data,
+      dibels: student.student_assessments.by_family('DIBELS'),
       intervention_types_index: intervention_types_index,
       service_types_index: service_types_index,
       event_note_types_index: event_note_types_index,
@@ -132,6 +133,7 @@ class StudentsController < ApplicationController
     (search_token_scores.sum.to_f / search_tokens.length)
   end
 
+  # The feed of mutable data that changes most frequently and is owned by Student Insights
   def student_feed(student)
     {
       event_notes: student.event_notes.map {|event_note| serialize_event_note(event_note) },
@@ -142,8 +144,7 @@ class StudentsController < ApplicationController
       deprecated: {
         notes: student.student_notes.map { |note| serialize_student_note(note) },
         interventions: student.interventions.map { |intervention| serialize_intervention(intervention) }
-      },
-      dibels: student.student_assessments.by_family('DIBELS').order_by_date_taken_desc
+      }
     }
   end
 end

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -46,12 +46,11 @@ describe StudentsController, :type => :controller do
           expect(serialized_data[:current_educator]).to eq educator
           expect(serialized_data[:student]["id"]).to eq student.id
           expect(serialized_data[:notes]).to eq []
-
+          expect(serialized_data[:dibels]).to eq []
           expect(serialized_data[:feed]).to eq ({
             event_notes: [],
             services: {active: [], discontinued: []},
-            deprecated: {notes: [], interventions: []},
-            dibels: []
+            deprecated: {notes: [], interventions: []}
           })
 
           expect(serialized_data[:chart_data]).to include(:attendance_events_school_years)
@@ -523,7 +522,7 @@ describe StudentsController, :type => :controller do
 
     it 'returns services' do
       feed = controller.send(:student_feed, student)
-      expect(feed.keys).to eq([:event_notes, :services, :deprecated, :dibels])
+      expect(feed.keys).to eq([:event_notes, :services, :deprecated])
       expect(feed[:services].keys).to eq [:active, :discontinued]
       expect(feed[:services][:active].first[:id]).to eq service.id
     end

--- a/spec/javascripts/student_profile_v2/fixtures.js
+++ b/spec/javascripts/student_profile_v2/fixtures.js
@@ -174,6 +174,7 @@
     "serviceTypesIndex": FixtureConstantIndexes.serviceTypesIndex,
     "eventNoteTypesIndex": FixtureConstantIndexes.eventNoteTypesIndex,
     "interventionTypesIndex": FixtureConstantIndexes.interventionTypesIndex,
+    "dibels": [],
     "student": {
       "id": 23,
       "grade": "5",
@@ -845,8 +846,7 @@
             "progress_notes": []
           }
         ]
-      },
-      "dibels": []
+      }
     },
     "educatorsIndex": {
       "1": {

--- a/spec/javascripts/student_profile_v2/student_profile_v2_page_spec.js
+++ b/spec/javascripts/student_profile_v2/student_profile_v2_page_spec.js
@@ -12,7 +12,7 @@ describe('StudentProfileV2Page', function() {
 
   var helpers = {
     renderStudentProfilePage: function(el, grade, dibels) {
-      var serializedData = Fixtures.studentProfile;
+      var serializedData = _.cloneDeep(Fixtures.studentProfile);
       if (grade) { serializedData["student"]["grade"] = grade; };
       if (dibels) { serializedData["feed"]["dibels"] = dibels; };
 

--- a/spec/javascripts/student_profile_v2/student_profile_v2_page_spec.js
+++ b/spec/javascripts/student_profile_v2/student_profile_v2_page_spec.js
@@ -14,7 +14,7 @@ describe('StudentProfileV2Page', function() {
     renderStudentProfilePage: function(el, grade, dibels) {
       var serializedData = _.cloneDeep(Fixtures.studentProfile);
       if (grade) { serializedData["student"]["grade"] = grade; };
-      if (dibels) { serializedData["feed"]["dibels"] = dibels; };
+      if (dibels) { serializedData["dibels"] = dibels; };
 
       var mergedProps = {
         serializedData: serializedData,


### PR DESCRIPTION
@alexsoble This test code mutates the `Fixtures.studentProfile` object that is shared across different tests, so this updates it to clone the fixture before mutating it so there's no chance of pollution across tests.

It also updates the student serialization, to move DIBELs data out of the `feed` structure, which was intended to hold the mutable data that Student Insights owns.  I also updated that with a comment to express that intent, since it wasn't in code anywhere. :)