### PR TITLE
Don't send nil DIBELS assessments to UI, fix validation on StudentAssessment to guard, update specs

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -20,7 +20,7 @@ class StudentsController < ApplicationController
       student: serialize_student_for_profile(student),
       feed: student_feed(student),
       chart_data: chart_data,
-      dibels: student.student_assessments.by_family('DIBELS'),
+      dibels: student.student_assessments.by_family('DIBELS').select {|dibels| !dibels.performance_level.nil? },
       intervention_types_index: intervention_types_index,
       service_types_index: service_types_index,
       event_note_types_index: event_note_types_index,

--- a/app/importers/file_importers/star_math_importer.rb
+++ b/app/importers/file_importers/star_math_importer.rb
@@ -22,13 +22,24 @@ class StarMathImporter < Struct.new :school_scope, :client
 
     return if student.nil?
 
-    star_assessment = StudentAssessment.where({
+    existing_star_assessment = StudentAssessment.where({
       student_id: student.id,
       date_taken: date_taken,
       assessment: star_mathematics_assessment
-    }).first_or_create!
+    }).first
 
-    star_assessment.update_attributes({percentile_rank: row[:percentile_rank]})
+    if existing_star_assessment.nil?
+      StudentAssessment.create!({
+        student_id: student.id,
+        date_taken: date_taken,
+        assessment: star_mathematics_assessment,
+        percentile_rank: row[:percentile_rank]
+      })
+    else
+      existing_star_assessment.update_attributes({
+        percentile_rank: row[:percentile_rank]
+      })
+    end
   end
 
   class HistoricalImporter < StarMathImporter

--- a/app/importers/file_importers/star_math_importer.rb
+++ b/app/importers/file_importers/star_math_importer.rb
@@ -22,24 +22,15 @@ class StarMathImporter < Struct.new :school_scope, :client
 
     return if student.nil?
 
-    existing_star_assessment = StudentAssessment.where({
+    student_assessment = StudentAssessment.find_or_initialize_by({
       student_id: student.id,
       date_taken: date_taken,
       assessment: star_mathematics_assessment
-    }).first
-
-    if existing_star_assessment.nil?
-      StudentAssessment.create!({
-        student_id: student.id,
-        date_taken: date_taken,
-        assessment: star_mathematics_assessment,
-        percentile_rank: row[:percentile_rank]
-      })
-    else
-      existing_star_assessment.update_attributes({
-        percentile_rank: row[:percentile_rank]
-      })
-    end
+    })
+    student_assessment.update!({
+      percentile_rank: row[:percentile_rank]
+    })
+    student_assessment
   end
 
   class HistoricalImporter < StarMathImporter

--- a/app/importers/file_importers/star_reading_importer.rb
+++ b/app/importers/file_importers/star_reading_importer.rb
@@ -22,16 +22,26 @@ class StarReadingImporter < Struct.new :school_scope, :client
 
     return if student.nil?
 
-    star_assessment = StudentAssessment.where({
+    existing_star_assessment = StudentAssessment.where({
       student_id: student.id,
       date_taken: date_taken,
       assessment: star_reading_assessment
-    }).first_or_create!
+    }).first
 
-    star_assessment.update_attributes({
-      percentile_rank: row[:percentile_rank],
-      instructional_reading_level: row[:instructional_reading_level]
-    })
+    if existing_star_assessment.nil?
+      StudentAssessment.create!({
+        student_id: student.id,
+        date_taken: date_taken,
+        assessment: star_reading_assessment,
+        percentile_rank: row[:percentile_rank],
+        instructional_reading_level: row[:instructional_reading_level]
+      })
+    else
+      star_assessment.update_attributes({
+        percentile_rank: row[:percentile_rank],
+        instructional_reading_level: row[:instructional_reading_level]
+      })
+    end
   end
 
   class HistoricalImporter < StarReadingImporter

--- a/app/importers/file_importers/star_reading_importer.rb
+++ b/app/importers/file_importers/star_reading_importer.rb
@@ -22,26 +22,16 @@ class StarReadingImporter < Struct.new :school_scope, :client
 
     return if student.nil?
 
-    existing_star_assessment = StudentAssessment.where({
+    student_assessment = StudentAssessment.find_or_initialize_by({
       student_id: student.id,
       date_taken: date_taken,
       assessment: star_reading_assessment
-    }).first
-
-    if existing_star_assessment.nil?
-      StudentAssessment.create!({
-        student_id: student.id,
-        date_taken: date_taken,
-        assessment: star_reading_assessment,
-        percentile_rank: row[:percentile_rank],
-        instructional_reading_level: row[:instructional_reading_level]
-      })
-    else
-      star_assessment.update_attributes({
-        percentile_rank: row[:percentile_rank],
-        instructional_reading_level: row[:instructional_reading_level]
-      })
-    end
+    })
+    student_assessment.update!({
+      percentile_rank: row[:percentile_rank],
+      instructional_reading_level: row[:instructional_reading_level]
+    })
+    student_assessment
   end
 
   class HistoricalImporter < StarReadingImporter

--- a/app/importers/importer.rb
+++ b/app/importers/importer.rb
@@ -25,7 +25,11 @@ class Importer
       CleanupReport.new(@log, file_name, pre_cleanup_csv_size, data.size).print
 
       data.each.each_with_index do |row, index|
-        file_importer.import_row(row) if file_importer.filter.include?(row)
+        begin
+          file_importer.import_row(row) if file_importer.filter.include?(row)
+        rescue ActiveRecord::RecordInvalid => import_row_error
+          @log.write("Caught exception importing a row: #{import_row_error}")
+        end
 
         if @progress_bar == :true  # Thor passes Boolean options as Symbols :/
           ProgressBar.new(@log, file_name, data.size, index + 1).print

--- a/app/importers/rows/dibels_row.rb
+++ b/app/importers/rows/dibels_row.rb
@@ -13,9 +13,7 @@ class DibelsRow < Struct.new :row
     )
 
     student_assessment.assign_attributes(
-      scale_score: row[:assessment_scale_score],
-      performance_level: row[:assessment_performance_level],
-      growth_percentile: row[:assessment_growth]
+      performance_level: row[:assessment_performance_level]
     )
 
     student_assessment

--- a/app/importers/rows/mcas_row.rb
+++ b/app/importers/rows/mcas_row.rb
@@ -20,7 +20,8 @@ class McasRow < Struct.new :row
       date_taken: row[:assessment_date]
     )
 
-    student_assessment.assign_attributes(
+    # TODO(kr) not sure what we want here if validation fails, right now this will raise
+    student_assessment.update!(
       scale_score: row[:assessment_scale_score],
       performance_level: row[:assessment_performance_level],
       growth_percentile: row[:assessment_growth]

--- a/app/importers/rows/mcas_row.rb
+++ b/app/importers/rows/mcas_row.rb
@@ -19,14 +19,11 @@ class McasRow < Struct.new :row
       assessment: assessment,
       date_taken: row[:assessment_date]
     )
-
-    # TODO(kr) not sure what we want here if validation fails, right now this will raise
     student_assessment.update!(
       scale_score: row[:assessment_scale_score],
       performance_level: row[:assessment_performance_level],
       growth_percentile: row[:assessment_growth]
     )
-
     student_assessment
   end
 

--- a/app/models/student_assessment.rb
+++ b/app/models/student_assessment.rb
@@ -12,29 +12,26 @@ class StudentAssessment < ActiveRecord::Base
   validate :validate_assessment_attributes
 
   def validate_assessment_attributes
-    if !valid_assessment_attributes
-      errors.add(:base, "Invalid assessment attributes: #{self.attributes.inspect}")
+    case assessment.family
+      when 'MCAS' then validate_mcas_attributes
+      when 'STAR' then validate_star_attributes
+      when 'DIBELS' then validate_dibels_attributes
     end
   end
 
-  def valid_assessment_attributes
-    case assessment.family
-    when 'MCAS'
-      scale_score.present? &&
-      growth_percentile.present? &&
-      performance_level.present? &&
-      percentile_rank.nil?
-    when 'STAR'
-      percentile_rank.present? &&
-      scale_score.nil? &&
-      growth_percentile.nil? &&
-      performance_level.nil?
-    when 'DIBELS'
-      performance_level.present? &&
-      percentile_rank.nil? &&
-      scale_score.nil? &&
-      growth_percentile.nil?
-    end
+  def validate_mcas_attributes
+    return if scale_score.present? && growth_percentile.present? && performance_level.present? && percentile_rank.nil?
+    errors.add(:scale_score, "Invalid MCAS attributes: #{self.attributes.inspect}")
+  end
+
+  def validate_star_attributes
+    return if percentile_rank.present? && scale_score.nil? && growth_percentile.nil? && performance_level.nil?
+    errors.add(:percentile_rank, "Invalid STAR attributes: #{self.attributes.inspect}")
+  end
+
+  def validate_dibels_attributes
+    return if performance_level.present? && percentile_rank.nil? && scale_score.nil? && growth_percentile.nil?
+    errors.add(:performance_level, "Invalid DIBELS attributes: #{self.attributes.inspect}")
   end
 
   def assign_to_school_year

--- a/app/models/student_assessment.rb
+++ b/app/models/student_assessment.rb
@@ -9,7 +9,13 @@ class StudentAssessment < ActiveRecord::Base
   delegate :grade, to: :student
   validates_presence_of :date_taken, :student, :assessment
   validates :student, uniqueness: { scope: [:assessment_id, :date_taken] }
-  validate :valid_assessment_attributes
+  validate :validate_assessment_attributes
+
+  def validate_assessment_attributes
+    if !valid_assessment_attributes
+      errors.add(:base, "Invalid assessment attributes: #{self.attributes.inspect}")
+    end
+  end
 
   def valid_assessment_attributes
     case assessment.family

--- a/app/reports/integrity_check.rb
+++ b/app/reports/integrity_check.rb
@@ -14,7 +14,6 @@ class IntegrityCheck
     raise "no homerooms" unless Homeroom.count > 0
     raise "no student assessments" unless StudentAssessment.count > 0
     raise "no educators" unless Educator.count > 0
-    # StudentAssessment.by_family('DIBELS').where(:performance_level => nil).to_a
   end
 
   def models_to_check

--- a/app/reports/integrity_check.rb
+++ b/app/reports/integrity_check.rb
@@ -14,6 +14,7 @@ class IntegrityCheck
     raise "no homerooms" unless Homeroom.count > 0
     raise "no student assessments" unless StudentAssessment.count > 0
     raise "no educators" unless Educator.count > 0
+    # StudentAssessment.by_family('DIBELS').where(:performance_level => nil).to_a
   end
 
   def models_to_check

--- a/spec/decorators/student_assessment_decorator_spec.rb
+++ b/spec/decorators/student_assessment_decorator_spec.rb
@@ -4,7 +4,7 @@ describe StudentAssessmentDecorator do
 
   describe '#performance_level' do
     context 'assessment has no performance level' do
-      let(:decorated_student_assessment) { FactoryGirl.create(:mcas_math_assessment).decorate }
+      let(:decorated_student_assessment) { FactoryGirl.create(:star_math_warning_assessment).decorate }
       it 'presents "—"' do
         expect(decorated_student_assessment.performance_level).to eq "—"
       end

--- a/spec/factories/student_assessments.rb
+++ b/spec/factories/student_assessments.rb
@@ -61,7 +61,7 @@ FactoryGirl.define do
       end
     end
     factory :access do
-      association :assessment, family: "ACCESS"
+      association :assessment, family: "ACCESS", subject: 'Composite'
     end
   end
 end

--- a/spec/factories/student_assessments.rb
+++ b/spec/factories/student_assessments.rb
@@ -13,6 +13,8 @@ FactoryGirl.define do
         end
         factory :mcas_math_advanced_assessment do
           performance_level "A"
+          scale_score { rand(260..280) }
+          growth_percentile { rand(25..75) }
         end
         factory :mcas_math_student_assessment_score_240 do
           scale_score 240

--- a/spec/factories/student_assessments.rb
+++ b/spec/factories/student_assessments.rb
@@ -10,6 +10,8 @@ FactoryGirl.define do
         association :assessment, subject: "Mathematics", family: "MCAS"
         factory :mcas_math_warning_assessment do
           performance_level "W"
+          scale_score { rand(220..240) }
+          growth_percentile { rand(25..75) }
         end
         factory :mcas_math_advanced_assessment do
           performance_level "A"

--- a/spec/factories/student_assessments.rb
+++ b/spec/factories/student_assessments.rb
@@ -36,6 +36,7 @@ FactoryGirl.define do
       end
       factory :star_assessment do
         factory :star_math_assessment do
+          percentile_rank { rand(25..75) }
           association :assessment, subject: "Mathematics", family: "STAR"
           factory :star_math_warning_assessment do
             percentile_rank 8

--- a/spec/fixtures/bad_x2_assessments.csv
+++ b/spec/fixtures/bad_x2_assessments.csv
@@ -1,3 +1,2 @@
 'local_id','school_local_id','assessment_id','assessment_date','assessment_scale_score','assessment_perf_level','assessment_name','assessment_subject','assessment_test'
 "100","HEA",\N,"nodate","222.00","NI","MCAS 2014 English Language Arts","ELA","MCAS"
-"100","HEA","2014-05-01","214.00","W","baf","MCAS 2014 Mathematics","Mathematics","MCAS"

--- a/spec/fixtures/bad_x2_assessments.csv
+++ b/spec/fixtures/bad_x2_assessments.csv
@@ -1,2 +1,3 @@
 'local_id','school_local_id','assessment_id','assessment_date','assessment_scale_score','assessment_perf_level','assessment_name','assessment_subject','assessment_test'
 "100","HEA",\N,"nodate","222.00","NI","MCAS 2014 English Language Arts","ELA","MCAS"
+"100","HEA","2014-05-01","214.00","W","baf","MCAS 2014 Mathematics","Mathematics","MCAS"

--- a/spec/fixtures/fake_x2_assessments.csv
+++ b/spec/fixtures/fake_x2_assessments.csv
@@ -1,7 +1,7 @@
 'local_id','school_local_id','assessment_date','assessment_scale_score','assessment_performance_level','assessment_growth','assessment_name','assessment_subject','assessment_test'
 "100","HEA","2014-05-01","222.00","NI","70","MCAS 2014 English Language Arts","ELA","MCAS"
 "100","HEA","2014-05-02","222.00","NI","70",\N,\N,"MAP: Reading 2-5 Common Core 2010 V2"
-"100","HEA","2014-05-01","214.00","W","baf","MCAS 2014 Mathematics","Mathematics","MCAS"
+"100","HEA","2014-05-01","214.00","W","35","MCAS 2014 Mathematics","Mathematics","MCAS"
 "100","HEA","2014-05-01",\N,\N,\N,\N,"GRADE","GRADE"
 "100","HEA","2008-09-22",\N,"Benchmark","NWF: 90,ORF: 70","DIBELS SY09 Admin #1","DIBELS","DIBELS"
 "100","HEA","2014-01-01","368.00","4.2",\N,"WIDA-ACCESS 2014 Winter Writing","Composite","WIDA-ACCESS"

--- a/spec/fixtures/invalid_mcas_x2_assessments.csv
+++ b/spec/fixtures/invalid_mcas_x2_assessments.csv
@@ -1,0 +1,2 @@
+'local_id','school_local_id','assessment_date','assessment_scale_score','assessment_performance_level','assessment_growth','assessment_name','assessment_subject','assessment_test'
+"100","HEA","2014-05-01","214.00","W","baf","MCAS 2014 Mathematics","Mathematics","MCAS"

--- a/spec/importers/file_importers/x2_assessment_importer_spec.rb
+++ b/spec/importers/file_importers/x2_assessment_importer_spec.rb
@@ -3,6 +3,13 @@ require 'rails_helper'
 RSpec.describe X2AssessmentImporter do
 
   describe '#import' do
+    # context 'with bad data' do
+    #   let(:file) { File.open("#{Rails.root}/spec/fixtures/bad_x2_assessments.csv") }
+    #   let(:transformer) { CsvTransformer.new }
+    #   let(:csv) { transformer.transform(file) }
+    #   # expect({ csv.each { |row| importer.import_row(row) } }).to raise
+    # end
+
     context 'with good data and no Assessment records in the database' do
       before { Assessment.destroy_all }
       after { Assessment.seed_somerville_assessments }
@@ -35,7 +42,7 @@ RSpec.describe X2AssessmentImporter do
               mcas_student_assessment = mcas_assessment.student_assessments.last
               expect(mcas_student_assessment.scale_score).to eq(214)
               expect(mcas_student_assessment.performance_level).to eq('W')
-              expect(mcas_student_assessment.growth_percentile).to eq(nil)
+              expect(mcas_student_assessment.growth_percentile).to eq(35)
             end
           end
           context 'ELA' do

--- a/spec/importers/rows/dibels_row_spec.rb
+++ b/spec/importers/rows/dibels_row_spec.rb
@@ -4,7 +4,12 @@ RSpec.describe DibelsRow do
 
   let(:student) { FactoryGirl.create(:student) }
   let(:row) {
-    { assessment_test: 'DIBELS', local_id: student.local_id, assessment_date: Date.today }
+    {
+      assessment_test: 'DIBELS',
+      local_id: student.local_id,
+      assessment_date: Date.today,
+      assessment_performance_level: 'Strategic'
+    }
   }
 
   let(:assessment) { Assessment.last }
@@ -18,5 +23,4 @@ RSpec.describe DibelsRow do
   it 'creates a student assessment result' do
     expect(StudentAssessment.count).to eq 1
   end
-
 end

--- a/spec/importers/rows/mcas_row_spec.rb
+++ b/spec/importers/rows/mcas_row_spec.rb
@@ -1,6 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe McasRow do
+  def mcas_row_attributes(attrs)
+    {
+      assessment_test: 'MCAS',
+      assessment_date: Date.today,
+      assessment_scale_score: rand(220..280),
+      assessment_performance_level: ['W', 'P', 'NI'].sample,
+      assessment_growth: rand(25..75)
+    }.merge(attrs)
+  end
 
   context 'with no Assessment records in the database' do
     before { Assessment.destroy_all }
@@ -9,13 +18,11 @@ RSpec.describe McasRow do
 
     context 'invalid subject (i.e. not used in Student Insights)' do
       let(:row) {
-        {
-          assessment_test: 'MCAS',
+        mcas_row_attributes({
           assessment_subject: 'Technology',
           assessment_name: 'MCAS 2016 Technology',
-          local_id: student.local_id,
-          assessment_date: Date.today
-        }
+          local_id: student.local_id
+        })
       }
       before { McasRow.build(row).save! }
 
@@ -26,13 +33,11 @@ RSpec.describe McasRow do
 
     context 'MCAS Mathematics' do
       let(:row) {
-        {
-          assessment_test: 'MCAS',
+        mcas_row_attributes({
           assessment_subject: 'Mathematics',
           assessment_name: 'MCAS 2016 Mathematics',
-          local_id: student.local_id,
-          assessment_date: Date.today
-        }
+          local_id: student.local_id
+        })
       }
 
       context 'when the Assessment family already exists' do
@@ -65,13 +70,11 @@ RSpec.describe McasRow do
 
     context 'MCAS English Language Arts, when the ELA Assessment does not yet exist' do
       let(:row) {
-        {
-          assessment_test: 'MCAS',
+        mcas_row_attributes({
           assessment_subject: 'Arts',
           assessment_name: 'MCAS 2016 English Language Arts',
           local_id: student.local_id,
-          assessment_date: Date.today
-        }
+        })
       }
       before { McasRow.build(row).save! }
 
@@ -82,7 +85,6 @@ RSpec.describe McasRow do
       it 'creates a new Assessment as a side-effect' do
         expect(Assessment.count).to eq 1
         expect(Assessment.last.subject).to eq 'ELA'
-
       end
     end
   end

--- a/spec/models/student_assessment_spec.rb
+++ b/spec/models/student_assessment_spec.rb
@@ -77,41 +77,31 @@ RSpec.describe StudentAssessment, type: :model do
   end
 
   describe '.by_family_and_subject' do
-    let!(:mcas_math) { FactoryGirl.create(:assessment, family: 'MCAS', subject: 'Mathematics' ) }
-    let!(:student_assessment) do
-      FactoryGirl.create(:student_assessment, {
-        assessment: mcas_math,
-        scale_score: 280
-      })
-    end
+    let!(:student_assessment) { FactoryGirl.create(:mcas_math_advanced_assessment) }
     context 'MCAS & math' do
-      let(:result) { StudentAssessment.by_family_and_subject("MCAS", "Mathematics") }
       context 'there are only MCAS math student assessments' do
-        let(:assessment) { FactoryGirl.create(:assessment, :mcas, :math) }
         it 'returns the MCAS and math student assessments' do
-          expect(result).to eq([student_assessment])
+          expect(StudentAssessment.by_family_and_subject("MCAS", "Mathematics")).to eq([student_assessment])
         end
       end
-      context 'there are MCAS reading student assessments' do
-        let(:assessment) { FactoryGirl.create(:assessment, :mcas, :ela) }
+      context 'there are no MCAS math student assessments' do
         it 'returns an empty association' do
-          expect(result).to be_empty
+          expect(StudentAssessment.by_family_and_subject("MCAS", "Reading")).to be_empty
         end
       end
     end
   end
 
   describe '.by_family' do
-    let!(:student_assessment) { FactoryGirl.create(:student_assessment, assessment: assessment) }
     context 'ACCESS' do
       context 'there are only ACCESS student assessments' do
-        let(:assessment) { FactoryGirl.create(:assessment, :access) }
+        let!(:access_student_assessment) { FactoryGirl.create(:access) }
         it 'returns the ACCESS student assessments' do
-          expect(StudentAssessment.by_family("ACCESS")).to eq([student_assessment])
+          expect(StudentAssessment.by_family("ACCESS")).to eq([access_student_assessment])
         end
       end
       context 'there are no ACCESS student assessments' do
-        let(:assessment) { FactoryGirl.create(:assessment, :star, :math) }
+        let!(:dibels_student_assessment) { FactoryGirl.create(:dibels_with_performance_level) }
         it 'returns an empty association' do
           expect(StudentAssessment.by_family("ACCESS")).to be_empty
         end

--- a/spec/models/student_assessment_spec.rb
+++ b/spec/models/student_assessment_spec.rb
@@ -9,34 +9,46 @@ RSpec.describe StudentAssessment, type: :model do
     let(:day_before_yesterday) { Time.now - 2.days }
 
     context 'unique across the combination of student/assessment/date_taken' do
-      before {
-        FactoryGirl.create(
-          :student_assessment, assessment: dibels, date_taken: day_before_yesterday, student: student
-        )
-      }
+      before do
+        FactoryGirl.create(:student_assessment, {
+          assessment: dibels,
+          performance_level: 'Strategic',
+          date_taken: day_before_yesterday,
+          student: student
+        })
+      end
 
-      subject(:student_assessment) {
-        FactoryGirl.build(
-          :student_assessment, assessment: dibels, date_taken: yesterday, student: student
-        )
-      }
+      subject(:student_assessment) do
+        FactoryGirl.build(:student_assessment, {
+          assessment: dibels,
+          performance_level: 'Strategic',
+          date_taken: yesterday,
+          student: student
+        })
+      end
 
       it 'is valid' do
         expect(subject).to be_valid
       end
     end
     context 'not unique across the combination of student/assessment/date_taken' do
-      before {
-        FactoryGirl.create(
-          :student_assessment, assessment: dibels, date_taken: yesterday, student: student
-        )
-      }
+      before do
+        FactoryGirl.create(:student_assessment, {
+          assessment: dibels,
+          performance_level: 'Strategic',
+          date_taken: yesterday,
+          student: student
+        })
+      end
 
-      subject(:student_assessment) {
-        FactoryGirl.build(
-          :student_assessment, assessment: dibels, date_taken: yesterday, student: student
-        )
-      }
+      subject(:student_assessment) do
+        FactoryGirl.build(:student_assessment, {
+          assessment: dibels,
+          performance_level: 'Strategic',
+          date_taken: yesterday,
+          student: student
+        })
+      end
 
       it 'is not valid' do
         expect(subject).not_to be_valid
@@ -44,8 +56,34 @@ RSpec.describe StudentAssessment, type: :model do
     end
   end
 
+  describe 'validates that DIBELS records have performance_level' do
+    let!(:student) { FactoryGirl.create(:student) }
+    let!(:yesterday) { Time.now - 1.day }
+    let!(:dibels) { FactoryGirl.create(:assessment, family: 'DIBELS') }
+
+    it 'cannot make DIBELS assessment with no performance_level' do
+      student_assessment = StudentAssessment.create({
+        :student_id =>  student.id,
+        :assessment_id => dibels.id,
+        :date_taken =>  yesterday,
+        :scale_score => nil,
+        :growth_percentile => nil,
+        :performance_level => nil,
+        :percentile_rank => nil,
+        :instructional_reading_level => nil
+      })
+      expect(student_assessment).not_to be_valid
+    end
+  end
+
   describe '.by_family_and_subject' do
-    let!(:student_assessment) { FactoryGirl.create(:student_assessment, assessment: assessment) }
+    let!(:mcas_math) { FactoryGirl.create(:assessment, family: 'MCAS', subject: 'Mathematics' ) }
+    let!(:student_assessment) do
+      FactoryGirl.create(:student_assessment, {
+        assessment: mcas_math,
+        scale_score: 280
+      })
+    end
     context 'MCAS & math' do
       let(:result) { StudentAssessment.by_family_and_subject("MCAS", "Mathematics") }
       context 'there are only MCAS math student assessments' do

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Student do
+  def create_student_assessment(attrs)
+    StudentAssessment.create!(attrs.merge({
+      scale_score: 240,
+      growth_percentile: 35,
+      performance_level: 'A'
+    }))
+  end
 
   describe '#latest_result_by_family_and_subject' do
     let(:student) { FactoryGirl.create(:student) }
@@ -21,11 +28,11 @@ RSpec.describe Student do
       end
       context 'when the student has results' do
         let!(:mcas_math_result) {
-          StudentAssessment.create!(
+          create_student_assessment({
             student: student,
             assessment: assessment,
-            date_taken: Date.today - 1.year,
-          )
+            date_taken: Date.today - 1.year
+          })
         }
         context 'when the student has a Math result but not MCAS' do
           let(:assessment_family) { "Doc's Special Exam" }
@@ -41,7 +48,7 @@ RSpec.describe Student do
           end
           context 'when the student has multiple MCAS math results' do
             let!(:more_recent_mcas_math_result) {
-              StudentAssessment.create!(
+              create_student_assessment(
                 student: student,
                 assessment: assessment,
                 date_taken: Date.today,
@@ -58,7 +65,7 @@ RSpec.describe Student do
 
   describe '#ordered_results_by_family_and_subject' do
     let(:student) { FactoryGirl.create(:student) }
-    let!(:mcas_math) { Assessment.create!(family: "MCAS", subject: "Mathematics") }
+    let!(:mcas_math) { FactoryGirl.create(:assessment, :mcas, :math) }
     let(:result) { student.ordered_results_by_family_and_subject("MCAS", "Mathematics") }
 
     context 'when the student has no MCAS Math result' do
@@ -68,11 +75,11 @@ RSpec.describe Student do
     end
     context 'when one MCAS Math result exists' do
       let!(:mcas_math_result) {
-        StudentAssessment.create!(
+        create_student_assessment({
           student: student,
           assessment: mcas_math,
           date_taken: Date.today,
-        )
+        })
       }
       it "returns the student's most recent MCAS math results" do
         expect(result).to eq([mcas_math_result])
@@ -80,25 +87,25 @@ RSpec.describe Student do
     end
     context 'when several MCAS Math results exist' do
       let!(:newest_mcas_math_result) {
-        StudentAssessment.create!(
+        create_student_assessment({
           student: student,
           assessment: mcas_math,
           date_taken: 1.year.ago,
-        )
+        })
       }
       let!(:oldest_mcas_math_result) {
-        StudentAssessment.create!(
+        create_student_assessment({
           student: student,
           assessment: mcas_math,
           date_taken: 5.years.ago,
-        )
+        })
       }
       let!(:middle_mcas_math_result) {
-        StudentAssessment.create!(
+        create_student_assessment({
           student: student,
           assessment: mcas_math,
           date_taken: 3.years.ago,
-        )
+        })
       }
       it "returns the student's most MCAS math results in ascending order" do
         expect(result).to eq([


### PR DESCRIPTION
This starts updating the controller and UI code to filter out DIBELS assessments that have `nil` performance_level values, and updates the demo data generator to not create records like this.

There is a validation on the `StudentAssessment` model that looks like it's trying to enforce this, but a bug prevents this from actually being enforced.  This PR fixes the bug, but I got stuck on updating the associated RSpecs and need to take a break.  This just pushes the current progress.

Related to https://github.com/studentinsights/studentinsights/issues/291.