### PR TITLE
Fix West Somerville educator import issue

### DIFF
--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -20,7 +20,7 @@ class EducatorsImporter < Struct.new :school_scope, :client
     educator = EducatorRow.new(row, school_ids_dictionary).build
     educator.save!
 
-    homeroom = Homeroom.find_by_name!(row[:homeroom]) if row[:homeroom].present?
+    homeroom = Homeroom.find_by_name(row[:homeroom]) if row[:homeroom].present?
     homeroom.update(educator: educator) if homeroom.present?
   end
 

--- a/spec/importers/file_importers/educators_importer_spec.rb
+++ b/spec/importers/file_importers/educators_importer_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe EducatorsImporter do
 
       context 'name of homeroom that does not exist' do
         it 'raises an error' do
-          expect { described_class.new.import_row(row) }.to raise_error ActiveRecord::RecordNotFound
+          expect { described_class.new.import_row(row) }.to_not raise_error
         end
       end
     end


### PR DESCRIPTION
## What's new?

+ Educators with homerooms that have no students assigned to them (i.e. the gym teacher at West Somerville Neighborhood School) don't blow up the import process anymore
+ These staff members could log into Student Insights via LDAP if they wanted to, just wouldn't have permissions to view any student data
+ #333