### PR TITLE
Handle student-level authorization across multiple schools

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -27,8 +27,9 @@ class Educator < ActiveRecord::Base
   def is_authorized_for_student(student)
     return false if self.restricted_to_sped_students && !(student.program_assigned.in? ['Sp Ed', 'SEIP'])
     return false if self.restricted_to_english_language_learners && student.limited_english_proficiency == 'Fluent'
+    return false if self.school.present? && self.school != student.school
 
-    return true if self.schoolwide_access? # Schoolwide admin
+    return true if self.schoolwide_access? || self.admin? # Schoolwide admin
     return true if self.has_access_to_grade_levels? && student.grade.in?(self.grade_level_access) # Grade level access
     return true if student.in?(self.students) # Homeroom level access
     false

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -23,6 +23,56 @@ RSpec.describe Educator do
     end
   end
 
+  describe '#is_authorized_for_student' do
+    let(:authorized?) { educator.is_authorized_for_student(student) }
+
+    context 'educator belongs to school' do
+      let(:healey) { FactoryGirl.create(:healey) }
+
+      context 'student belongs to same school' do
+        let(:student) { FactoryGirl.create(:student, school: healey) }
+        context 'educator does not have schoolwide access' do
+          let(:educator) { FactoryGirl.create(:educator, school: healey) }
+          it 'is not authorized' do
+            expect(authorized?).to be false
+          end
+        end
+        context 'educator has schoolwide access' do
+          let(:educator) { FactoryGirl.create(:educator, school: healey, schoolwide_access: true) }
+          it 'is authorized' do
+            expect(authorized?).to be true
+          end
+        end
+      end
+
+      context 'student belongs to different school' do
+        let(:brown) { FactoryGirl.create(:brown) }
+        let(:educator) { FactoryGirl.create(:educator, school: healey, schoolwide_access: true) }
+        let(:student) { FactoryGirl.create(:student, school: brown) }
+        it 'is not authorized' do
+          expect(authorized?).to be false
+        end
+      end
+
+    end
+
+    context 'educator does not belong to school' do
+      let(:student) { FactoryGirl.create(:student) }
+      context 'educator is admin' do
+        let(:educator) { FactoryGirl.create(:educator, :admin) }
+        it 'is authorized' do
+          expect(authorized?).to be true
+        end
+      end
+      context 'educator is not admin' do
+        let(:educator) { FactoryGirl.create(:educator) }
+        it 'is not authorized' do
+          expect(authorized?).to be false
+        end
+      end
+    end
+  end
+
   describe '#local_id' do
     context 'no local id' do
       it 'is invalid' do


### PR DESCRIPTION
## Notes

+ Non-admin educators should only have access to data from students at their own school

+ Admin educators w/o school assigned (i.e. district-wide administrators) should have access to any student's data, regardless of school

+ This also produces the expected behavior for student search bar, since the student search bar calls the same `#is_authorized_for(student)` method in the controller

+ #332

+ TODO: Formally document the authorization model somewhere, this is important to do