### PR TITLE
Don't redirect district-wide admins to schools without students

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -63,7 +63,7 @@ class Educator < ActiveRecord::Base
   end
 
   def default_school
-    school || School.first
+    school || School.with_students.first
   end
 
   def has_access_to_grade_levels?

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -4,6 +4,10 @@ class School < ActiveRecord::Base
   has_many :students
   has_many :educators
 
+  def self.with_students
+    School.all.select { |s| s.students.count > 0 }
+  end
+
   def self.seed_somerville_schools
     School.create([
       { state_id: 15, local_id: "BRN", name: "Benjamin G Brown", school_type: "ES" },

--- a/spec/controllers/educators_controller_spec.rb
+++ b/spec/controllers/educators_controller_spec.rb
@@ -47,6 +47,7 @@ describe EducatorsController, :type => :controller do
         context 'educator not assigned to school' do
           let(:educator) { FactoryGirl.create(:educator, :admin) }
           let!(:school) { FactoryGirl.create(:school) }
+          before { FactoryGirl.create(:student, school: school) }
           let!(:another_school) { FactoryGirl.create(:school) }
           it 'redirects to first school page' do
             make_request

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -126,6 +126,7 @@ describe HomeroomsController, :type => :controller do
 
           context 'educator does not have correct grade level access, but has access to a different grade' do
             let(:school) { FactoryGirl.create(:school) }
+            before { FactoryGirl.create(:student, school: school) }
             let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['3'], school: school )}
             let(:homeroom) { FactoryGirl.create(:grade_5_homeroom) }
 
@@ -163,6 +164,7 @@ describe HomeroomsController, :type => :controller do
         end
 
         context 'garbage homeroom params' do
+          before { FactoryGirl.create(:student, school: school) }
           it 'redirects to overview page' do
             make_request('garbage homeroom ids rule')
             expect(response).to redirect_to(school_url(school))

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe School do
+
+  describe '.with_students' do
+    subject { School.with_students }
+
+    context 'no schools have students' do
+      before { FactoryGirl.create(:school) }
+      it 'returns empty array' do
+        expect(subject).to eq []
+      end
+    end
+
+    context 'all schools have students' do
+      let!(:healey) { FactoryGirl.create(:healey) }
+      let!(:brown) { FactoryGirl.create(:brown) }
+      before { FactoryGirl.create(:student, school: healey) }
+      before { FactoryGirl.create(:student, school: brown) }
+      it 'returns all schools' do
+        expect(subject).to eq [healey, brown]
+      end
+    end
+
+    context 'some schools have students' do
+      let!(:healey) { FactoryGirl.create(:healey) }
+      let!(:brown) { FactoryGirl.create(:brown) }
+      before { FactoryGirl.create(:student, school: healey) }
+      it 'returns the correct schools' do
+        expect(subject).to eq [healey]
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
## Notes

+ `School.first` isn't a good place to send admins without a specific school, because some schools have zero students loaded in from Aspen/X2 at this point
+ #332