### PR TITLE
Improve educator dropdown in service assignment

### DIFF
--- a/app/assets/javascripts/student_profile_v2/record_service.js
+++ b/app/assets/javascripts/student_profile_v2/record_service.js
@@ -104,7 +104,7 @@
     },
 
     renderWhichService: function() {
-      return dom.div({}, 
+      return dom.div({},
         dom.div({ style: { marginBottom: 5 } }, 'Which service?'),
         dom.div({ style: { display: 'flex', justifyContent: 'flex-start' } },
           dom.div({ style: styles.buttonWidth },
@@ -150,12 +150,16 @@
         return { value: educator.id, label: name };
       });
 
+      var sortedOptions = _.sortBy(options, function(o)
+        { return o.label; }
+      );
+
       return createEl(ReactSelect, {
         name: 'assigned-educator-select',
         clearable: false,
         placeholder: 'Type name..',
         value: this.state.providedByEducatorId,
-        options: options,
+        options: sortedOptions,
         onChange: this.onAssignedEducatorChanged
       });
     },

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -25,7 +25,7 @@ class StudentsController < ApplicationController
       intervention_types_index: intervention_types_index,
       service_types_index: service_types_index,
       event_note_types_index: event_note_types_index,
-      educators_index: educators_index,
+      educators_index: student.try(:school).try(:educators_index),
       access: student.latest_access_results,
       attendance_data: student_profile_attendance_data(student)
     }

--- a/app/helpers/serialize_data_helper.rb
+++ b/app/helpers/serialize_data_helper.rb
@@ -69,15 +69,6 @@ module SerializeDataHelper
     }
   end
 
-  # Used to send down all types, for lookups from otherrecords
-  def educators_index
-    index = {}
-    Educator.all.each do |educator|
-      index[educator.id] = educator.as_json.symbolize_keys.slice(:id, :email, :full_name)
-    end
-    index
-  end
-
   def service_types_index
     index = {}
     ServiceType.all.each do |service_type|

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -91,6 +91,10 @@ class Educator < ActiveRecord::Base
     allowed_homerooms.order(:name)
   end
 
+  def for_index
+    as_json.symbolize_keys.slice(:id, :email, :full_name)
+  end
+
   def permissions_hash
     {
       admin: admin,

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -9,7 +9,7 @@ class School < ActiveRecord::Base
   end
 
   def educators_index
-    educators.map { |e| [e.id, e.for_index] }.to_h
+    educators.order(:full_name).map { |e| [e.id, e.for_index] }.to_h
   end
 
   def self.seed_somerville_schools

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -8,8 +8,16 @@ class School < ActiveRecord::Base
     School.all.select { |s| s.students.count > 0 }
   end
 
+  def educators_no_test_accounts
+    educators.where.not(local_id: 'LDAP')
+  end
+
+  def educators_by_name
+    educators_no_test_accounts.order(:full_name)
+  end
+
   def educators_index
-    educators.order(:full_name).map { |e| [e.id, e.for_index] }.to_h
+    educators_by_name.map { |e| [e.id, e.for_index] }.to_h
   end
 
   def self.seed_somerville_schools

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -12,12 +12,8 @@ class School < ActiveRecord::Base
     educators.where.not(local_id: 'LDAP')
   end
 
-  def educators_by_name
-    educators_no_test_accounts.order(:full_name)
-  end
-
   def educators_index
-    educators_by_name.map { |e| [e.id, e.for_index] }.to_h
+    educators_no_test_accounts.map { |e| [e.id, e.for_index] }.to_h
   end
 
   def self.seed_somerville_schools

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -8,6 +8,10 @@ class School < ActiveRecord::Base
     School.all.select { |s| s.students.count > 0 }
   end
 
+  def educators_index
+    educators.map { |e| [e.id, e.for_index] }.to_h
+  end
+
   def self.seed_somerville_schools
     School.create([
       { state_id: 15, local_id: "BRN", name: "Benjamin G Brown", school_type: "ES" },

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -10,8 +10,9 @@ end
 
 describe StudentsController, :type => :controller do
   describe '#show' do
+    let!(:school) { FactoryGirl.create(:school) }
     let(:educator) { FactoryGirl.create(:educator_with_homeroom) }
-    let(:student) { FactoryGirl.create(:student, :with_risk_level) }
+    let(:student) { FactoryGirl.create(:student, :with_risk_level, school: school) }
     let(:homeroom) { student.homeroom }
     let!(:student_school_year) { FactoryGirl.create(:student_school_year, student: student) }
 
@@ -32,8 +33,7 @@ describe StudentsController, :type => :controller do
       before { sign_in(educator) }
 
       context 'educator has schoolwide access' do
-        let!(:school) { FactoryGirl.create(:school) }
-        let(:educator) { FactoryGirl.create(:educator, :admin )}
+        let(:educator) { FactoryGirl.create(:educator, :admin, school: school) }
         let(:serialized_data) { assigns(:serialized_data) }
 
         it 'is successful' do
@@ -111,7 +111,7 @@ describe StudentsController, :type => :controller do
         end
 
         context 'student has multiple discipline incidents' do
-          let!(:student) { FactoryGirl.create(:student) }
+          let!(:student) { FactoryGirl.create(:student, school: school) }
           let(:most_recent_school_year) { student.most_recent_school_year }
           let(:serialized_data) { assigns(:serialized_data) }
           let(:attendance_data) { serialized_data[:attendance_data] }


### PR DESCRIPTION
## What's new?

+ When assigning an educator to a service, the educator drop-down list now:
  1. is scoped by school
  2. is alphabetized
  3. excludes the LDAP test user account