### PR TITLE
Profile page: remove time subtext from services summary

### DIFF
--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -296,10 +296,8 @@
       var sortedServices = _.sortBy(activeServices, 'date_started').reverse();
       var elements = sortedServices.slice(0, limit).map(function(service) {
         var serviceText = this.props.serviceTypesIndex[service.service_type_id].name;
-        var daysText = moment.utc(service.date_started).from(this.props.nowMomentFn(), true);
         return dom.span({ key: service.id },
-          dom.span({}, serviceText),
-          dom.span({ style: { opacity: 0.25, paddingLeft: 10 } }, daysText)
+          dom.span({}, serviceText)
         );
       }, this);
       if (sortedServices.length > limit) elements.push(dom.div({}, '+ ' + (sortedServices.length - limit) + ' more'));


### PR DESCRIPTION
This simplifies the services summary panel in the profile page, which also helps it stay clear when resized to smaller screen widths:

Before:
<img width="1309" alt="screen shot 2016-04-12 at 8 05 46 pm" src="https://cloud.githubusercontent.com/assets/1056957/14479245/8a27d4c4-00ea-11e6-895c-2479f428c775.png">

After:
<img width="1322" alt="screen shot 2016-04-12 at 8 08 36 pm" src="https://cloud.githubusercontent.com/assets/1056957/14479248/8e06c816-00ea-11e6-954d-56e7ad6be57a.png">
