### PR TITLE
Fixed tabs on IE 11. Updated styling on reading and math sections 

### DIFF
--- a/app/assets/javascripts/student_profile_v2/ela_details.js
+++ b/app/assets/javascripts/student_profile_v2/ela_details.js
@@ -7,10 +7,43 @@
   var ProfileChart = window.shared.ProfileChart;
   var ProfileChartSettings = window.ProfileChartSettings;
 
+  var styles = {
+    title: {
+      color: 'black',
+      paddingBottom: 20,
+      fontSize: 24
+    },
+    container: {
+      width: '100%',
+      marginTop: 50,
+      marginLeft: 'auto',
+      marginRight: 'auto',
+      border: '1px solid #ccc',
+      padding: '30px 30px 30px 30px',
+      position: 'relative'
+    },
+    secHead: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      borderBottom: '1px solid #333',
+      position: 'absolute',
+      top: 30,
+      left: 30,
+      right: 30
+    },
+    navBar: {
+      fontSize: 18
+    },
+    navTop: {
+      textAlign: 'right',
+      verticalAlign: 'text-top'
+    }
+  };
+
   /*
   This renders details about ELA performance and growth in the student profile page.
   It's mostly historical charts.
-  
+
   On charts, we could filter out older values, since they're drawn outside of the visible projection
   area, and Highcharts hovers look a little strange because of that.  It shows a bit more
   historical context though, so we'll keep all data points, even those outside of the visible
@@ -29,50 +62,72 @@
 
     render: function() {
       return dom.div({ className: 'ELADetails'},
+        this.renderNavBar(),
         this.renderStarReading(),
         this.renderMCASELAScores(),
         this.renderMCASELAGrowth()
       );
     },
 
+    renderNavBar: function() {
+      return dom.div({ style: styles.navBar },
+          dom.a({ style: styles.navBar, href: '#Star'}, 'STAR Reading Chart'), ' | ',
+          dom.a({ style: styles.navBar, href: '#Scores'}, 'MCAS ELA Scores Chart'), ' | ',
+          dom.a({ style: styles.navBar, href: '#SGPs'}, 'MCAS ELA SGPs Chart')
+        );
+    },
+
+    renderHeader: function(title) {
+      return dom.div({ style: styles.secHead },
+        dom.h4({ style: styles.title }, title),
+        dom.span({ style: styles.navTop }, dom.a({ href: '#' }, 'Back to top'))
+      );
+    },
+
     renderStarReading: function() {
-      return createEl(ProfileChart, {
+      return dom.div({ id: 'Star', style: styles.container},
+        this.renderHeader('STAR Reading, last 4 years'),
+        createEl(ProfileChart, {
         quadSeries: [{
           name: 'Percentile rank',
           data: this.props.chartData.star_series_reading_percentile
         }],
-        titleText: 'STAR Reading, last 4 years',
+        titleText: '',
         yAxis: merge(this.percentileYAxis(), {
           title: { text: 'Percentile rank' }
         })
-      });
+      }));
     },
 
     renderMCASELAScores: function() {
-      return createEl(ProfileChart, {
+      return dom.div({ id: 'Scores', style: styles.container},
+        this.renderHeader('MCAS ELA Scores, last 4 years'),
+        createEl(ProfileChart, {
         quadSeries: [{
           name: 'Scaled score',
           data: this.props.chartData.mcas_series_ela_scaled
         }],
-        titleText: 'MCAS ELA Scores, last 4 years',
+        titleText: '',
         yAxis: merge(ProfileChartSettings.default_mcas_score_yaxis,{
           plotLines: ProfileChartSettings.mcas_level_bands,
           title: { text: 'Scaled score' }
         })
-      });
+      }));
     },
 
     renderMCASELAGrowth: function() {
-      return createEl(ProfileChart, {
+      return dom.div({ id: 'SGPs', style: styles.container},
+        this.renderHeader('Student growth percentile (SGP), last 4 years'),
+        createEl(ProfileChart, {
         quadSeries: [{
-          name: 'Student growth percentile (SGP)',
+          name: '',
           data: this.props.chartData.mcas_series_ela_growth
         }],
         titleText: 'MCAS ELA SGPs, last 4 years',
         yAxis: merge(this.percentileYAxis(), {
           title: { text: 'Student growth percentile (SGP)' }
         })
-      });
+      }));
     },
 
     // TODO(er) factor out

--- a/app/assets/javascripts/student_profile_v2/math_details.js
+++ b/app/assets/javascripts/student_profile_v2/math_details.js
@@ -7,10 +7,43 @@
   var ProfileChart = window.shared.ProfileChart;
   var ProfileChartSettings = window.ProfileChartSettings;
 
+  var styles = {
+    title: {
+      color: 'black',
+      paddingBottom: 20,
+      fontSize: 24
+    },
+    container: {
+      width: '100%',
+      marginTop: 50,
+      marginLeft: 'auto',
+      marginRight: 'auto',
+      border: '1px solid #ccc',
+      padding: '30px 30px 30px 30px',
+      position: 'relative'
+    },
+    secHead: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      borderBottom: '1px solid #333',
+      position: 'absolute',
+      top: 30,
+      left: 30,
+      right: 30
+    },
+    navBar: {
+      fontSize: 18
+    },
+    navTop: {
+      textAlign: 'right',
+      verticalAlign: 'text-top'
+    }
+  };
+
   /*
   This renders details about math performance and growth in the student profile page.
   It's mostly historical charts.
-  
+
   On charts, we could filter out older values, since they're drawn outside of the visible projection
   area, and Highcharts hovers look a little strange because of that.  It shows a bit more
   historical context though, so we'll keep all data points, even those outside of the visible
@@ -29,14 +62,33 @@
 
     render: function() {
       return dom.div({ className: 'MathDetails' },
+        this.renderNavBar(),
         this.renderStarMath(),
         this.renderMCASMathScore(),
         this.renderMCASMathGrowth()
       );
     },
 
+    renderNavBar: function() {
+      return dom.div({ style: styles.navBar },
+          dom.a({ style: styles.navBar, href: '#starMath'}, 'STAR Math Chart'), ' | ',
+          dom.a({ style: styles.navBar, href: '#MCASMath'}, 'MCAS Math Chart'), ' | ',
+          dom.a({ style: styles.navBar, href: '#MCASMathGrowth'}, 'MCAS Math SGPs')
+        );
+    },
+
+    renderHeader: function(title) {
+      return dom.div({ style: styles.secHead },
+        dom.h4({ style: styles.title }, title),
+        dom.span({ style: styles.navTop }, dom.a({ href: '#' }, 'Back to top'))
+      );
+    },
+
+
     renderStarMath: function() {
-      return createEl(ProfileChart, {
+      return dom.div({ id: 'starMath', style: styles.container},
+        this.renderHeader('STAR Math, last 4 years'),
+        createEl(ProfileChart, {
         quadSeries: [{
           name: 'Percentile rank',
           data: this.props.chartData.star_series_math_percentile
@@ -45,11 +97,13 @@
         yAxis: merge(this.percentileYAxis(), {
           title: { text: 'Percentile rank' }
         })
-      });
+      }));
     },
 
     renderMCASMathScore: function() {
-      return createEl(ProfileChart, {
+      return dom.div({ id: 'MCASMath', style: styles.container},
+        this.renderHeader('MCAS Math Scores, last 4 years'),
+        createEl(ProfileChart, {
         quadSeries: [{
           name: 'Scaled score',
           data: this.props.chartData.mcas_series_math_scaled
@@ -59,11 +113,13 @@
           plotLines: ProfileChartSettings.mcas_level_bands,
           title: { text: 'Scaled score' }
         })
-      });
+      }));
     },
 
     renderMCASMathGrowth: function() {
-      return createEl(ProfileChart, {
+      return dom.div({ id: 'MCASMathGrowth', style: styles.container},
+        this.renderHeader('MCAS Math SGPs, last 4 years'),
+        createEl(ProfileChart, {
         quadSeries: [{
           name: 'Student growth percentile (SGP)',
           data: this.props.chartData.mcas_series_math_growth
@@ -72,7 +128,7 @@
         yAxis: merge(this.percentileYAxis(), {
           title: { text: 'Student growth percentile (SGP)' }
         })
-      });
+      }));
     },
 
     // TODO(er) factor out

--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -47,12 +47,12 @@
       background: '#ededed'
     },
     column: {
-      flex: 1,
+      flexGrow: '1',
+      flexShrink: '0',
       padding: '22px 26px 16px 26px',
       cursor: 'pointer',
       borderColor: 'white',
       borderTop: 0,
-      height: '80%',
       margin: 0,
       borderRadius: '0 0 5px 5px',
       width: '100%'
@@ -63,7 +63,7 @@
       margin: '0 5px 0 0',
       borderRadius: '5px 5px 5px 5px',
       border: '1px solid #ccc',
-      width: '20%'
+      width: '20%',
      },
     selectedColumn: {
       borderStyle: 'solid',
@@ -88,7 +88,8 @@
       padding: '10px 5px 5px 5px',
       margin: 0,
       borderRadius: '5px 5px 0 0',
-      background: 'white'
+      background: 'white',
+      cursor: 'pointer'
     },
     sparklineWidth: 150,
     sparklineHeight: 50


### PR DESCRIPTION
I think I fixed the issue of the tabs not displaying properly on IE 
<img width="1179" alt="screen shot 2016-04-12 at 10 03 00 pm" src="https://cloud.githubusercontent.com/assets/11449339/14480806/5fb266c2-00fa-11e6-8f4f-a432b553e13a.png">


I added the nav bars and styling to charts on the math and reading sections:
<img width="1200" alt="screen shot 2016-04-12 at 9 56 24 pm" src="https://cloud.githubusercontent.com/assets/11449339/14480756/022f60fe-00fa-11e6-8fb6-9c126b77599d.png">
<img width="1190" alt="screen shot 2016-04-12 at 9 56 55 pm" src="https://cloud.githubusercontent.com/assets/11449339/14480761/07532908-00fa-11e6-81df-47e9b22d7ea8.png">

