### PR TITLE
Restore bw120 UI changes to Profile V2 + apply IE fix

### DIFF
--- a/app/assets/javascripts/student_profile_v2/attendance_details.js
+++ b/app/assets/javascripts/student_profile_v2/attendance_details.js
@@ -10,14 +10,16 @@
 
   var styles = {
     box: {
-      border: '1px solid #eee',
+      border: '1px solid #ccc',
       padding:15,
       marginTop: 10,
       marginBottom: 10,
-      width: '100%'
+      width: '100%',
+      backgroundColor: '#f2f2f2'
     },
     item: {
-      paddingBottom: 10
+      paddingBottom: 10,
+      width: 160
     },
     itemHead: {
       fontWeight: 'bold',
@@ -34,14 +36,38 @@
     },
     title: {
       color: 'black',
-      borderBottom: '1px solid #333',
-      paddingBottom: 10,
-      marginBottom: 20,
-      marginTop: 20,
+      paddingBottom: 20,
       fontSize: 24
     },
     container: {
-      width: '50%'
+      width: '100%',
+      marginTop: 50,
+      marginLeft: 'auto',
+      marginRight: 'auto',
+      border: '1px solid #ccc',
+      padding: '30px 30px 30px 30px',
+      position: 'relative'
+    },
+    centerItem: {
+      paddingBottom: 10,
+      textAlign: 'center',
+      width: 75
+    },
+    secHead: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      borderBottom: '1px solid #333',
+      position: 'absolute',
+      top: 30,
+      left: 30,
+      right: 30
+    },
+    navBar: {
+      fontSize: 18
+    },
+    navTop: {
+      textAlign: 'right',
+      verticalAlign: 'text-top'
     }
   };
 
@@ -57,6 +83,7 @@
     // TODO(kr) clicking on data point jumps to timeline with full details
     render: function() {
       return dom.div({ className: 'AttendanceDetails' },
+        this.renderNavBar(),
         this.renderDisciplineIncidents(),
         this.renderAbsences(),
         this.renderTardies(),
@@ -64,26 +91,46 @@
       );
     },
 
+    renderNavBar: function() {
+      return dom.div({ style: styles.navBar },
+          dom.a({ style: styles.navBar, href: '#disciplineChart'}, 'Discipline Chart'), ' | ',
+          dom.a({ style: styles.navBar, href: '#absences'}, 'Absences Chart'), ' | ',
+          dom.a({ style: styles.navBar, href: '#tardies'}, 'Tardies Chart'), ' | ',
+          dom.a({ style: styles.navBar, href: '#history'}, 'Incident History')
+        );
+    },
+
+    renderHeader: function(title) {
+      return dom.div({ style: styles.secHead },
+        dom.h4({ style: styles.title }, title),
+        dom.span({ style: styles.navTop }, dom.a({ href: '#' }, 'Back to top'))
+      );
+    },
+
     renderDisciplineIncidents: function() {
       var flexibleRange = Scales.disciplineIncidents.flexibleRange(this.props.cumulativeDisciplineIncidents);
-      return createEl(ProfileChart, {
-        titleText: 'Discipline incidents, last 4 years',
-        yAxis: {
-          min: flexibleRange[0],
-          max: flexibleRange[1],
-          title: { text: 'Count per year' }
-        },
-        quadSeries: [{
-          name: 'Events per school year',
-          data: this.props.cumulativeDisciplineIncidents
-        }]
-      });
+      return dom.div({ id: 'disciplineChart', style: styles.container},
+        this.renderHeader('Discipline incidents, last 4 years'),
+        createEl(ProfileChart, {
+          titleText: '',
+          yAxis: {
+            min: flexibleRange[0],
+            max: flexibleRange[1],
+            title: { text: 'Count per year' }
+          },
+          quadSeries: [{
+            name: 'Events per school year',
+            data: this.props.cumulativeDisciplineIncidents
+          }]
+        }));
     },
 
     renderAbsences: function() {
       var range = Scales.absences.flexibleRange(this.props.cumulativeAbsences);
-      return createEl(ProfileChart, {
-        titleText: 'Absences, last 4 years',
+      return dom.div({ id: 'absences', style: styles.container},
+        this.renderHeader('Absences, last 4 years'),
+        createEl(ProfileChart, {
+        titleText: '',
         yAxis: {
           min: range[0],
           max: range[1],
@@ -93,13 +140,15 @@
           name: 'Absences per school year',
           data: this.props.cumulativeAbsences
         }]
-      });
+      }));
     },
 
     renderTardies: function() {
       var range = Scales.tardies.flexibleRange(this.props.cumulativeTardies);
-      return createEl(ProfileChart, {
-        titleText: 'Tardies, last 4 years',
+      return dom.div({ id: 'tardies', style: styles.container},
+        this.renderHeader('Tardies, last 4 years'),
+        createEl(ProfileChart, {
+        titleText: '',
         yAxis: {
           min: range[0],
           max: range[1],
@@ -109,25 +158,28 @@
           name: 'Tardies per school year',
           data: this.props.cumulativeTardies
         }]
-      });
+      }));
+    },
+
+    renderIncidents: function() {
+      return  dom.div({ style: { paddingTop: 60 }}, this.props.disciplineIncidents.map(function(incident) {
+        return dom.div({ style: styles.box, key: incident.occurred_at },
+          dom.div({ style: styles.header },
+            dom.div({ style: styles.item }, dom.span({ style: styles.itemHead }, 'Date: '), dom.span({}, moment.utc(incident.occurred_at).format('MMM D, YYYY'))),
+            dom.div({ style: styles.centerItem }, dom.span({ style: styles.itemHead }, 'Code: '), dom.span({}, incident.incident_code)),
+            dom.div({ style: styles.item }, dom.span({ style: styles.itemHead }, 'Location: '), dom.span({}, incident.incident_location))
+          ),
+          dom.div({}, dom.span({ style: styles.desc }, 'Description: ')),
+          dom.div({}, incident.incident_description))
+
+      }));
     },
 
     renderIncidentHistory: function() {
-      return dom.div({ style: styles.container },
-        dom.h4({ style: styles.title }, 'Incident History'),
-        (this.props.disciplineIncidents.length === 0) ? dom.div({}, 'None') : this.props.disciplineIncidents.map(function(incident) {
-        return dom.div({
-          style: styles.box,
-          key: [incident.occurred_at, incident.incident_description].join()
-        },
-          dom.div({ style: styles.header },
-            dom.div({ style: styles.item }, dom.span({ style: styles.itemHead }, 'Date: '), dom.span({}, moment.utc(incident.occurred_at).format('MMM D, YYYY'))),
-            dom.div({ style: styles.item }, dom.span({ style: styles.itemHead }, 'Code: '), dom.span({}, incident.incident_code)),
-            dom.div({ style: styles.item }, dom.span({ style: styles.itemHead }, 'Location: '), dom.span({}, incident.incident_location))
-          ),
-          dom.div({}, dom.span({ style: styles.desc }, 'Description: '), dom.div({}, incident.incident_description))
-        )
-      }));
+      return dom.div({ id: "history", style: styles.container },
+        this.renderHeader('Incident History'),
+        (this.props.disciplineIncidents.length > 0) ? this.renderIncidents() : dom.div({ style: {paddingTop: 60}}, 'No Incidents')
+      );
     },
   });
 })();

--- a/app/assets/javascripts/student_profile_v2/ela_details.js
+++ b/app/assets/javascripts/student_profile_v2/ela_details.js
@@ -7,10 +7,43 @@
   var ProfileChart = window.shared.ProfileChart;
   var ProfileChartSettings = window.ProfileChartSettings;
 
+  var styles = {
+    title: {
+      color: 'black',
+      paddingBottom: 20,
+      fontSize: 24
+    },
+    container: {
+      width: '100%',
+      marginTop: 50,
+      marginLeft: 'auto',
+      marginRight: 'auto',
+      border: '1px solid #ccc',
+      padding: '30px 30px 30px 30px',
+      position: 'relative'
+    },
+    secHead: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      borderBottom: '1px solid #333',
+      position: 'absolute',
+      top: 30,
+      left: 30,
+      right: 30
+    },
+    navBar: {
+      fontSize: 18
+    },
+    navTop: {
+      textAlign: 'right',
+      verticalAlign: 'text-top'
+    }
+  };
+
   /*
   This renders details about ELA performance and growth in the student profile page.
   It's mostly historical charts.
-  
+
   On charts, we could filter out older values, since they're drawn outside of the visible projection
   area, and Highcharts hovers look a little strange because of that.  It shows a bit more
   historical context though, so we'll keep all data points, even those outside of the visible
@@ -29,50 +62,72 @@
 
     render: function() {
       return dom.div({ className: 'ELADetails'},
+        this.renderNavBar(),
         this.renderStarReading(),
         this.renderMCASELAScores(),
         this.renderMCASELAGrowth()
       );
     },
 
+    renderNavBar: function() {
+      return dom.div({ style: styles.navBar },
+          dom.a({ style: styles.navBar, href: '#Star'}, 'STAR Reading Chart'), ' | ',
+          dom.a({ style: styles.navBar, href: '#Scores'}, 'MCAS ELA Scores Chart'), ' | ',
+          dom.a({ style: styles.navBar, href: '#SGPs'}, 'MCAS ELA SGPs Chart')
+        );
+    },
+
+    renderHeader: function(title) {
+      return dom.div({ style: styles.secHead },
+        dom.h4({ style: styles.title }, title),
+        dom.span({ style: styles.navTop }, dom.a({ href: '#' }, 'Back to top'))
+      );
+    },
+
     renderStarReading: function() {
-      return createEl(ProfileChart, {
+      return dom.div({ id: 'Star', style: styles.container},
+        this.renderHeader('STAR Reading, last 4 years'),
+        createEl(ProfileChart, {
         quadSeries: [{
           name: 'Percentile rank',
           data: this.props.chartData.star_series_reading_percentile
         }],
-        titleText: 'STAR Reading, last 4 years',
+        titleText: '',
         yAxis: merge(this.percentileYAxis(), {
           title: { text: 'Percentile rank' }
         })
-      });
+      }));
     },
 
     renderMCASELAScores: function() {
-      return createEl(ProfileChart, {
+      return dom.div({ id: 'Scores', style: styles.container},
+        this.renderHeader('MCAS ELA Scores, last 4 years'),
+        createEl(ProfileChart, {
         quadSeries: [{
           name: 'Scaled score',
           data: this.props.chartData.mcas_series_ela_scaled
         }],
-        titleText: 'MCAS ELA Scores, last 4 years',
+        titleText: '',
         yAxis: merge(ProfileChartSettings.default_mcas_score_yaxis,{
           plotLines: ProfileChartSettings.mcas_level_bands,
           title: { text: 'Scaled score' }
         })
-      });
+      }));
     },
 
     renderMCASELAGrowth: function() {
-      return createEl(ProfileChart, {
+      return dom.div({ id: 'SGPs', style: styles.container},
+        this.renderHeader('Student growth percentile (SGP), last 4 years'),
+        createEl(ProfileChart, {
         quadSeries: [{
-          name: 'Student growth percentile (SGP)',
+          name: '',
           data: this.props.chartData.mcas_series_ela_growth
         }],
         titleText: 'MCAS ELA SGPs, last 4 years',
         yAxis: merge(this.percentileYAxis(), {
           title: { text: 'Student growth percentile (SGP)' }
         })
-      });
+      }));
     },
 
     // TODO(er) factor out

--- a/app/assets/javascripts/student_profile_v2/math_details.js
+++ b/app/assets/javascripts/student_profile_v2/math_details.js
@@ -7,10 +7,43 @@
   var ProfileChart = window.shared.ProfileChart;
   var ProfileChartSettings = window.ProfileChartSettings;
 
+  var styles = {
+    title: {
+      color: 'black',
+      paddingBottom: 20,
+      fontSize: 24
+    },
+    container: {
+      width: '100%',
+      marginTop: 50,
+      marginLeft: 'auto',
+      marginRight: 'auto',
+      border: '1px solid #ccc',
+      padding: '30px 30px 30px 30px',
+      position: 'relative'
+    },
+    secHead: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      borderBottom: '1px solid #333',
+      position: 'absolute',
+      top: 30,
+      left: 30,
+      right: 30
+    },
+    navBar: {
+      fontSize: 18
+    },
+    navTop: {
+      textAlign: 'right',
+      verticalAlign: 'text-top'
+    }
+  };
+
   /*
   This renders details about math performance and growth in the student profile page.
   It's mostly historical charts.
-  
+
   On charts, we could filter out older values, since they're drawn outside of the visible projection
   area, and Highcharts hovers look a little strange because of that.  It shows a bit more
   historical context though, so we'll keep all data points, even those outside of the visible
@@ -29,14 +62,33 @@
 
     render: function() {
       return dom.div({ className: 'MathDetails' },
+        this.renderNavBar(),
         this.renderStarMath(),
         this.renderMCASMathScore(),
         this.renderMCASMathGrowth()
       );
     },
 
+    renderNavBar: function() {
+      return dom.div({ style: styles.navBar },
+          dom.a({ style: styles.navBar, href: '#starMath'}, 'STAR Math Chart'), ' | ',
+          dom.a({ style: styles.navBar, href: '#MCASMath'}, 'MCAS Math Chart'), ' | ',
+          dom.a({ style: styles.navBar, href: '#MCASMathGrowth'}, 'MCAS Math SGPs')
+        );
+    },
+
+    renderHeader: function(title) {
+      return dom.div({ style: styles.secHead },
+        dom.h4({ style: styles.title }, title),
+        dom.span({ style: styles.navTop }, dom.a({ href: '#' }, 'Back to top'))
+      );
+    },
+
+
     renderStarMath: function() {
-      return createEl(ProfileChart, {
+      return dom.div({ id: 'starMath', style: styles.container},
+        this.renderHeader('STAR Math, last 4 years'),
+        createEl(ProfileChart, {
         quadSeries: [{
           name: 'Percentile rank',
           data: this.props.chartData.star_series_math_percentile
@@ -45,11 +97,13 @@
         yAxis: merge(this.percentileYAxis(), {
           title: { text: 'Percentile rank' }
         })
-      });
+      }));
     },
 
     renderMCASMathScore: function() {
-      return createEl(ProfileChart, {
+      return dom.div({ id: 'MCASMath', style: styles.container},
+        this.renderHeader('MCAS Math Scores, last 4 years'),
+        createEl(ProfileChart, {
         quadSeries: [{
           name: 'Scaled score',
           data: this.props.chartData.mcas_series_math_scaled
@@ -59,11 +113,13 @@
           plotLines: ProfileChartSettings.mcas_level_bands,
           title: { text: 'Scaled score' }
         })
-      });
+      }));
     },
 
     renderMCASMathGrowth: function() {
-      return createEl(ProfileChart, {
+      return dom.div({ id: 'MCASMathGrowth', style: styles.container},
+        this.renderHeader('MCAS Math SGPs, last 4 years'),
+        createEl(ProfileChart, {
         quadSeries: [{
           name: 'Student growth percentile (SGP)',
           data: this.props.chartData.mcas_series_math_growth
@@ -72,7 +128,7 @@
         yAxis: merge(this.percentileYAxis(), {
           title: { text: 'Student growth percentile (SGP)' }
         })
-      });
+      }));
     },
 
     // TODO(er) factor out

--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -47,12 +47,12 @@
       background: '#ededed'
     },
     column: {
-      flex: 1,
+      flexGrow: '1',
+      flexShrink: '0',
       padding: '22px 26px 16px 26px',
       cursor: 'pointer',
       borderColor: 'white',
       borderTop: 0,
-      height: '80%',
       margin: 0,
       borderRadius: '0 0 5px 5px',
       width: '100%'
@@ -63,7 +63,7 @@
       margin: '0 5px 0 0',
       borderRadius: '5px 5px 5px 5px',
       border: '1px solid #ccc',
-      width: '20%'
+      width: '20%',
      },
     selectedColumn: {
       borderStyle: 'solid',
@@ -88,7 +88,8 @@
       padding: '10px 5px 5px 5px',
       margin: 0,
       borderRadius: '5px 5px 0 0',
-      background: 'white'
+      background: 'white',
+      cursor: 'pointer'
     },
     sparklineWidth: 150,
     sparklineHeight: 50

--- a/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
+++ b/app/assets/javascripts/student_profile_v2/student_profile_v2_page.js
@@ -28,33 +28,72 @@
     summaryContainer: {
       display: 'flex',
       flexDirection: 'row',
-      background: '#eee',
-      marginLeft: 20,
-      marginRight: 20
+      alignItems: 'stretch',
+      marginLeft: 'auto',
+      marginRight: 'auto',
+      width: '95%',
+
     },
     detailsContainer: {
       margin: 30
     },
     academicColumn: {
-      textAlign: 'center',
-      flex: 1,
-      maxWidth: 220
+      textAlign: 'left',
+    },
+    profileColumn: {
+      background: '#ededed'
+    },
+    interventionsColumn: {
+      background: '#ededed'
     },
     column: {
       flex: 1,
-      padding: 15,
-      cursor: 'pointer'
+      padding: '22px 26px 16px 26px',
+      cursor: 'pointer',
+      borderColor: 'white',
+      borderTop: 0,
+      height: '80%',
+      margin: 0,
+      borderRadius: '0 0 5px 5px',
+      width: '100%'
     },
+    columnContainer: {
+      display: 'flex',
+      flexDirection: 'column',
+      margin: '0 5px 0 0',
+      borderRadius: '5px 5px 5px 5px',
+      border: '1px solid #ccc',
+      width: '20%'
+     },
     selectedColumn: {
-      border: '5px solid rgba(49, 119, 201, 0.64)',
-      padding: 10
+      borderStyle: 'solid',
+      borderColor: '#3177c9',
+      borderWidth: '0 5px 5px 5px',
+      padding: '22px 21px 11px 21px',
+    },
+    selectedTab: {
+      background: '#3177c9',
+      color: 'white',
+      borderBottom: 0,
     },
     summaryWrapper: {
       paddingBottom: 10
     },
+    tab: {
+      fontWeight: 'bold',
+      width: '100%',
+      height: 40,
+      borderBottom: 0,
+      textAlign: 'center',
+      padding: '10px 5px 5px 5px',
+      margin: 0,
+      borderRadius: '5px 5px 0 0',
+      background: 'white'
+    },
     sparklineWidth: 150,
     sparklineHeight: 50
   };
+
 
   var StudentProfileV2Page = window.shared.StudentProfileV2Page = React.createClass({
     displayName: 'StudentProfileV2Page',
@@ -115,6 +154,9 @@
     selectedColumnStyles: function(columnKey) {
       return (columnKey === this.props.selectedColumnKey) ? styles.selectedColumn : {};
     },
+    selectedTabStyles: function(columnKey) {
+      return (columnKey === this.props.selectedColumnKey) ? styles.selectedTab : {};
+    },
 
     render: function() {
       return dom.div({ className: 'StudentProfileV2Page' },
@@ -126,6 +168,7 @@
           this.renderMathColumn(),
           this.renderAttendanceColumn(),
           this.renderInterventionsColumn()
+
         ),
         dom.div({ style: styles.detailsContainer }, this.renderSectionDetails())
       );
@@ -198,30 +241,32 @@
         demographicsElements.push('ACCESS Composite score: ' + this.props.access.composite);
       };
 
-      return dom.div({
-        style: merge(styles.column, this.selectedColumnStyles(columnKey)),
+      return dom.div({ style: styles.columnContainer, onClick: this.onColumnClicked.bind(this, columnKey) }, dom.div({ style: merge(styles.tab, this.selectedTabStyles(columnKey)) }, "Overview"),
+      dom.div({
+        style: merge(styles.column, styles.academicColumn, this.selectedColumnStyles(columnKey), styles.profileColumn),
         onClick: this.onColumnClicked.bind(this, columnKey)
       },
         createEl(SummaryList, {
           title: 'Demographics',
           elements: demographicsElements,
         })
-      );
+      ));
     },
 
     renderInterventionsColumn: function() {
       var student = this.props.student;
       var columnKey = 'interventions';
 
-      return dom.div({
+      return dom.div({ style: styles.columnContainer, onClick: this.onColumnClicked.bind(this, columnKey) }, dom.div({ style: merge(styles.tab, this.selectedTabStyles(columnKey)) }, "Interventions"),
+      dom.div({
         className: 'interventions-column',
-        style: merge(styles.column, this.selectedColumnStyles(columnKey)),
+        style: merge(styles.column, styles.academicColumn, styles.interventionsColumn, this.selectedColumnStyles(columnKey)),
         onClick: this.onColumnClicked.bind(this, columnKey)
       }, this.padElements(styles.summaryWrapper, [
         this.renderPlacement(student),
         this.renderServices(student),
         this.renderStaff(student)
-      ]));
+      ])));
     },
 
     renderPlacement: function(student) {
@@ -287,7 +332,8 @@
       var chartData = this.props.chartData;
       var columnKey = 'ela';
 
-      return dom.div({
+      return dom.div({ style: styles.columnContainer, onClick: this.onColumnClicked.bind(this, columnKey) }, dom.div({ style: merge(styles.tab, this.selectedTabStyles(columnKey)) }, "Reading"),
+      dom.div({
         className: 'ela-background',
         style: merge(styles.column, styles.academicColumn, this.selectedColumnStyles(columnKey)),
         onClick: this.onColumnClicked.bind(this, columnKey)
@@ -306,7 +352,7 @@
           })
         }),
         this.renderMcasElaSgpOrDibels()
-      );
+      ));
     },
 
     renderMcasElaSgpOrDibels: function () {
@@ -337,7 +383,8 @@
       var chartData = this.props.chartData;
       var columnKey = 'math';
 
-      return dom.div({
+      return dom.div({ style: styles.columnContainer, onClick: this.onColumnClicked.bind(this, columnKey)}, dom.div({ style: merge(styles.tab, this.selectedTabStyles(columnKey)) }, "Math"),
+      dom.div({
         className: 'math-background',
         style: merge(styles.column, styles.academicColumn, this.selectedColumnStyles(columnKey)),
         onClick: this.onColumnClicked.bind(this, columnKey)
@@ -360,7 +407,7 @@
           value: student.most_recent_mcas_math_growth,
           sparkline: this.renderSparkline(chartData.mcas_series_math_growth || [])
         })
-      );
+      ));
     },
 
     renderAttendanceColumn: function() {
@@ -368,7 +415,8 @@
       var attendanceData = this.props.attendanceData;
       var columnKey = 'attendance';
 
-      return dom.div({
+      return dom.div({ style: styles.columnContainer, onClick: this.onColumnClicked.bind(this, columnKey) }, dom.div({ style: merge(styles.tab, this.selectedTabStyles(columnKey)) }, "Attendance and Behavior"),
+        dom.div({
         className: 'attendance-background',
         style: merge(styles.column, styles.academicColumn, this.selectedColumnStyles(columnKey)),
         onClick: this.onColumnClicked.bind(this, columnKey)
@@ -388,7 +436,7 @@
           thresholdValue: Scales.tardies.threshold,
           shouldDrawCircles: false
         })
-      );
+      ));
     },
 
     renderAttendanceEventsSummary: function(attendanceEvents, flexibleRangeFn, props) {


### PR DESCRIPTION
## The story

+ @bw120 submitted a pull request last night at Code for Boston with UI improvements to the profile page: #199

+ I merged in the pull request, but forgot to check it against Internet Explorer (our targeted browser!)

+ Browser compatibility issues strike — the changes messed with the layout in IE

+ @bw120 submitted an excellent patch which fixed the issues in IE: #350

+ I gave the patch a quick look but checked against the wrong version of IE (late, was tired), looked to me like @bw120's patch didn't actually fix the issue

  + Protip, don't review PRs when tired

+ Decided with @kevinrobinson to revert the changes so we could go home for the night and look at it in the morning: #351 

+ Rechecked @bw120's fix against IE 11 / Win7 this morning, looks good!

+ This PR reverts-the-reverts (i.e. restores @bw120's UI changes) and applies his IE fix on top