### PR TITLE
Fix bug with precomputed doc upsert

### DIFF
--- a/app/jobs/precompute_student_hashes_job.rb
+++ b/app/jobs/precompute_student_hashes_job.rb
@@ -34,7 +34,8 @@ class PrecomputeStudentHashesJob
     key = precomputed_student_hashes_key(precomputed_time, authorized_student_ids)
 
     # This is a non-atomic upsert
-    PrecomputedQueryDoc.find(key).destroy! if PrecomputedQueryDoc.exists?(key)
+    pre_existing_doc = PrecomputedQueryDoc.find_by_key(key)
+    pre_existing_doc.destroy! if pre_existing_doc.present?
     PrecomputedQueryDoc.create!(key: key, json: { student_hashes: student_hashes }.to_json )
   end
 end


### PR DESCRIPTION
## Notes

+ Finder method wasn't looking up docs correctly because it was searching for a primary key
+ The column named "key" on PrecomputedQueryDoc is not the primary key according to Rails
+ https://github.com/studentinsights/studentinsights/issues/359#issuecomment-209662975