### PR TITLE
Don't precompute student overview for educators without students

### DIFF
--- a/app/jobs/precompute_student_hashes_job.rb
+++ b/app/jobs/precompute_student_hashes_job.rb
@@ -17,14 +17,18 @@ class PrecomputeStudentHashesJob
   end
 
   private
+
   def school_overview_precompute_jobs(date_timestamp)
-    all_jobs = Educator.all.map do |educator|
-      {
-        date_timestamp: date_timestamp,
-        authorized_student_ids: educator.students_for_school_overview.map(&:id)
-      }
-    end
-    all_jobs.uniq
+    Educator.all.map { |educator| educator_to_job(educator, date_timestamp) }.uniq.compact
+  end
+
+  def educator_to_job(educator, date_timestamp)
+    return unless educator.students_for_school_overview.size > 0
+
+    return {
+      date_timestamp: date_timestamp,
+      authorized_student_ids: educator.students_for_school_overview.map(&:id)
+    }
   end
 
   def precompute_and_write_student_hashes!(date_timestamp, authorized_student_ids)

--- a/app/jobs/precompute_student_hashes_job.rb
+++ b/app/jobs/precompute_student_hashes_job.rb
@@ -1,19 +1,19 @@
-class PrecomputeStudentHashesJob
+class PrecomputeStudentHashesJob < Struct.new :log
   include StudentsQueryHelper
 
   # Runs the job for a particular day, querying for all educators' authorizations,
   # precomputing the `student_hashes` for them and writing them to the database.
   def precompute_all!(date_timestamp)
-    puts 'Querying for jobs...'
+    log.puts 'Querying for jobs...'
     jobs = school_overview_precompute_jobs(date_timestamp)
-    puts "Found #{jobs.size} jobs."
+    log.puts "Found #{jobs.size} jobs."
 
-    puts 'Starting precomputing...'
+    log.puts 'Starting precomputing...'
     jobs.each_with_index do |job, index|
       precompute_and_write_student_hashes!(job[:date_timestamp], job[:authorized_student_ids])
-      puts "Wrote document #{index+1}..."
+      log.puts "Wrote document #{index+1}..."
     end
-    puts 'Done.'
+    log.puts 'Done.'
   end
 
   private

--- a/lib/tasks/precompute.rake
+++ b/lib/tasks/precompute.rake
@@ -1,6 +1,6 @@
 namespace :precompute do
   desc 'Precompute views of daily import data for school overview page'
   task school_overview: :environment do
-    PrecomputeStudentHashesJob.new.precompute_all!(Time.now)
+    PrecomputeStudentHashesJob.new(STDOUT).precompute_all!(Time.now)
   end
 end

--- a/spec/jobs/precompte_student_hashes_job_spec.rb
+++ b/spec/jobs/precompte_student_hashes_job_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe PrecomputeStudentHashesJob do
 
   let(:outcome) { PrecomputedQueryDoc.all }
   let(:first_json_blob) { JSON.parse!(outcome.first.json) }
+  let(:log) { LogHelper::Redirect.instance.file }
 
   describe '#school_overview_precompute_jobs' do
 
@@ -12,7 +13,7 @@ RSpec.describe PrecomputeStudentHashesJob do
       let!(:educator) { FactoryGirl.create(:educator, school: school, schoolwide_access: true) }
       let!(:student) { FactoryGirl.create(:student, school: school) }
 
-      before { PrecomputeStudentHashesJob.new.precompute_all!(Time.now) }
+      before { PrecomputeStudentHashesJob.new(log).precompute_all!(Time.now) }
 
       let(:first_json_blob_key) { first_json_blob.keys.first }
       let(:first_json_blob_value) { first_json_blob[first_json_blob_key] }
@@ -28,7 +29,7 @@ RSpec.describe PrecomputeStudentHashesJob do
       let!(:school) { FactoryGirl.create(:healey) }
       let!(:educator) { FactoryGirl.create(:educator, school: school, schoolwide_access: true) }
 
-      before { PrecomputeStudentHashesJob.new.precompute_all!(Time.now) }
+      before { PrecomputeStudentHashesJob.new(log).precompute_all!(Time.now) }
 
       it 'returns an empty array' do
         expect(outcome).to eq []

--- a/spec/jobs/precompte_student_hashes_job_spec.rb
+++ b/spec/jobs/precompte_student_hashes_job_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe PrecomputeStudentHashesJob do
+
+  let(:outcome) { PrecomputedQueryDoc.all }
+  let(:first_json_blob) { JSON.parse!(outcome.first.json) }
+
+  describe '#school_overview_precompute_jobs' do
+
+    context 'educator with students' do
+      let!(:school) { FactoryGirl.create(:healey) }
+      let!(:educator) { FactoryGirl.create(:educator, school: school, schoolwide_access: true) }
+      let!(:student) { FactoryGirl.create(:student, school: school) }
+
+      before { PrecomputeStudentHashesJob.new.precompute_all!(Time.now) }
+
+      let(:first_json_blob_key) { first_json_blob.keys.first }
+      let(:first_json_blob_value) { first_json_blob[first_json_blob_key] }
+
+      it 'returns the correct hash for the job' do
+        expect(outcome.size).to eq 1
+        expect(first_json_blob_key).to eq "student_hashes"
+        expect(first_json_blob_value.first["id"]).to eq student.id
+      end
+    end
+
+    context 'educator without students' do
+      let!(:school) { FactoryGirl.create(:healey) }
+      let!(:educator) { FactoryGirl.create(:educator, school: school, schoolwide_access: true) }
+
+      before { PrecomputeStudentHashesJob.new.precompute_all!(Time.now) }
+
+      it 'returns an empty array' do
+        expect(outcome).to eq []
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
## Notes

+ Stop creating PrecomputedOverviewDocs with empty json
+ Add a spec for precomputing job
+ Make precomputing job output redirectable so we can test it