### PR TITLE
Update query for precomputed school_overview value to respect delay i…

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -46,7 +46,7 @@ class SchoolsController < ApplicationController
       # the precompute job runs at 8am UTC, and takes a few minutes to run,
       # so keep a buffer that makes sure the import task and precompute job
       # can finish before cutting over to the next day.
-      query_time = time_now - 8.hours
+      query_time = time_now - 9.hours
       key = precomputed_student_hashes_key(query_time, authorized_student_ids)
       doc = PrecomputedQueryDoc.find_by_key(key)
       return JSON.parse(doc.json)['student_hashes'] unless doc.nil?

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -43,7 +43,11 @@ class SchoolsController < ApplicationController
   # Results an array of student_hashes.
   def load_precomputed_student_hashes(time_now, authorized_student_ids)
     begin
-      key = precomputed_student_hashes_key(time_now, authorized_student_ids)
+      # the precompute job runs at 8am UTC, and takes a few minutes to run,
+      # so keep a buffer that makes sure the import task and precompute job
+      # can finish before cutting over to the next day.
+      query_time = time_now - 8.hours
+      key = precomputed_student_hashes_key(query_time, authorized_student_ids)
       doc = PrecomputedQueryDoc.find_by_key(key)
       return JSON.parse(doc.json)['student_hashes'] unless doc.nil?
     rescue ActiveRecord::StatementInvalid => err


### PR DESCRIPTION
…n import and precompute tasks

The import task starts at 4am UTC, and the precompute task starts at 8am UTC.  Currently at the 12am UTC cutover, the read path will query immediately for that day's data, but it won't have been imported or precomputed yet.  This adds the delay, which effectively makes precomputed data available at 9am each day.  This also introduces the possibility of inconsistency between other queries that directly query the database while the import task is running.

Relatedly, improvements like @alexsoble awesomely suggested in https://github.com/studentinsights/studentinsights/issues/362 or other variants could make this more resilient (eg., look for most recent precomputed value for the authorization key, regardless of whether it's today or the previous day).

This addresses an immediate problem with timeouts around this time of day (0:45am UTC), since it can't read the precomputed values yet.