### PR TITLE
Add prototype message on STAR pages

### DIFF
--- a/app/assets/javascripts/components/star_charts_page.js
+++ b/app/assets/javascripts/components/star_charts_page.js
@@ -144,6 +144,17 @@ $(function() {
           filters: this.state.filters,
           onFilterToggled: this.onFilterToggled
         })),
+        dom.div({
+          style: {
+            background: 'red',
+            color: 'white',
+            fontWeight: 'bold',
+            padding: 20
+          },
+        },
+          dom.span({}, 'This is an experimental prototype page!'),
+          dom.span({ style: { marginLeft: 10 } }, 'Please try it out and share your feedback.')
+        ),
         dom.div({ style: { position: 'relative' } },
           dom.div({ style: { flex: 1 } },
             dom.div({ style: { display: 'flex', padding: 20 } },


### PR DESCRIPTION
We've talked with school partners about this, that this is a prototype that early adopters can experiment with and share feedback.  As we expand to more users, this puts the message front and center so that additional users can see that without in-person conversations.

<img width="1302" alt="screen shot 2016-04-14 at 9 30 35 pm" src="https://cloud.githubusercontent.com/assets/1056957/14548773/2c22ef04-0288-11e6-870c-5096d2288445.png">
