### PR TITLE
Make provided_by_educator an optional field for services

### DIFF
--- a/app/assets/javascripts/helpers/feed_helpers.js
+++ b/app/assets/javascripts/helpers/feed_helpers.js
@@ -63,7 +63,10 @@
       var mergedNotes = FeedHelpers.mergedNotes(feed);
       var idsFromNotes = _.pluck(mergedNotes, 'educator_id');
       var idsFromServices = _.pluck(feed.services.active, 'provided_by_educator_id');
-      return _.unique(idsFromNotes.concat(idsFromServices));
+      var uniqueIds = _.unique(idsFromNotes.concat(idsFromServices));
+      return _.filter(uniqueIds, function(id) {
+        return id !== null;
+      });
     }
   };
 })();

--- a/app/assets/javascripts/helpers/feed_helpers.js
+++ b/app/assets/javascripts/helpers/feed_helpers.js
@@ -64,9 +64,9 @@
       var idsFromNotes = _.pluck(mergedNotes, 'educator_id');
       var idsFromServices = _.pluck(feed.services.active, 'provided_by_educator_id');
       var uniqueIds = _.unique(idsFromNotes.concat(idsFromServices));
-      return _.filter(uniqueIds, function(id) {
-        return id !== null;
-      });
+
+      // Filter out null ids: for services with no recorded provided_by_educator
+      return _.filter(uniqueIds, function(id) { return id !== null; });
     }
   };
 })();

--- a/app/assets/javascripts/student_profile/record_service.js
+++ b/app/assets/javascripts/student_profile/record_service.js
@@ -186,7 +186,7 @@
     },
 
     renderButtons: function() {
-      var isFormComplete = (this.state.providedByEducatorId && this.state.serviceTypeId && this.state.momentStarted);
+      var isFormComplete = (this.state.serviceTypeId && this.state.momentStarted);
       return dom.div({ style: { marginTop: 15 } },
         dom.button({
           style: {

--- a/app/assets/javascripts/student_profile/services_list.js
+++ b/app/assets/javascripts/student_profile/services_list.js
@@ -3,7 +3,7 @@
   var dom = window.shared.ReactHelpers.dom;
   var createEl = window.shared.ReactHelpers.createEl;
   var merge = window.shared.ReactHelpers.merge;
-  
+
   var Educator = window.shared.Educator;
   var serviceColor = window.shared.serviceColor;
   var moment = window.moment;
@@ -107,7 +107,7 @@
     wasDiscontinued: function(service) {
       return (service.discontinued_by_educator_id !== null);
     },
-    
+
     // Active services before inactive, then sorted by time
     sortedMergedServices: function(servicesFeed) {
       return _.flatten([
@@ -127,7 +127,13 @@
       var wasDiscontinued = this.wasDiscontinued(service);
       var serviceText = this.props.serviceTypesIndex[service.service_type_id].name;
       var momentStarted = moment.utc(service.date_started);
-      var educator = this.props.educatorsIndex[service.provided_by_educator_id];
+      var providedByEducatorId = service.provided_by_educator_id;
+
+      if (providedByEducatorId) {
+        var educator = this.props.educatorsIndex[service.provided_by_educator_id];
+      } else {
+        var educator = null;
+      };
 
       return dom.div({
         key: service.id,
@@ -139,10 +145,7 @@
         dom.div({ style: { display: 'flex' } },
           dom.div({ style: { flex: 1 } },
             dom.div({ style: { fontWeight: 'bold' } }, serviceText),
-            dom.div({},
-              'With ',
-              createEl(Educator, { educator: educator })
-            ),
+            this.renderEducator(educator),
             dom.div({},
               'Since ',
               momentStarted.format('MMMM D, YYYY')
@@ -155,6 +158,14 @@
         ),
         dom.div({ style: merge(styles.userText, { paddingTop: 15 }) }, service.comment)
       );
+    },
+
+    renderEducator: function (educator) {
+      if (educator === null) {
+        return dom.div({}, 'No staff recorded');
+      } else {
+        return dom.div({}, 'With ', createEl(Educator, { educator: educator }))
+      };
     },
 
     renderDiscontinuedInformation: function(service) {

--- a/app/demo_data/fake_service_generator.rb
+++ b/app/demo_data/fake_service_generator.rb
@@ -16,7 +16,7 @@ class FakeServiceGenerator
     return {
       student_id: @student.id,
       service_type_id: service_type_id,
-      provided_by_educator_id: educator.id,
+      provided_by_educator_id: [educator.id, nil].sample,
       date_started: @date - rand(0..7),
       recorded_at: @date,
       recorded_by_educator_id: Educator.all.sample.id

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -5,7 +5,7 @@ class Service < ActiveRecord::Base
   belongs_to :service_type
   has_many :discontinued_services
 
-  validates_presence_of :recorded_by_educator_id, :provided_by_educator_id, :student_id, :service_type_id, :recorded_at, :date_started
+  validates_presence_of :recorded_by_educator_id, :student_id, :service_type_id, :recorded_at, :date_started
 
   def discontinued?
     discontinued_services.size > 0

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -400,7 +400,6 @@ describe StudentsController, :type => :controller do
           response_body = JSON.parse(response.body)
           expect(response_body).to eq({
             "errors" => [
-              "Provided by educator can't be blank",
               "Student can't be blank",
               "Service type can't be blank",
               "Date started can't be blank"


### PR DESCRIPTION
## What's new?


Now it's okay to record a service and not associate a staff member:


![service-without-staff](https://cloud.githubusercontent.com/assets/3209501/14581059/e383418a-03af-11e6-81de-2da271058b59.gif)

+ Related to #307.

+ Resolves #378.