### PR TITLE
Distinguish between educator index and educators for services list

### DIFF
--- a/app/assets/javascripts/student_profile/interventions_details.js
+++ b/app/assets/javascripts/student_profile/interventions_details.js
@@ -46,6 +46,7 @@
       serviceTypesIndex: React.PropTypes.object.isRequired,
       eventNoteTypesIndex: React.PropTypes.object.isRequired,
       educatorsIndex: React.PropTypes.object.isRequired,
+      educatorsForServicesDropdown: React.PropTypes.object.isRequired,
       eventNoteTypesIndex: React.PropTypes.object.isRequired,
       currentEducator: React.PropTypes.object.isRequired,
       actions: PropTypes.actions.isRequired,
@@ -147,7 +148,8 @@
           nowMoment: moment.utc(), // TODO(kr) thread through
           currentEducator: this.props.currentEducator,
           serviceTypesIndex: this.props.serviceTypesIndex,
-          educatorsIndex: this.props.educatorsIndex
+          educatorsIndex: this.props.educatorsIndex,
+          educatorsForServicesDropdown: this.props.educatorsForServicesDropdown,
         });
       }
 

--- a/app/assets/javascripts/student_profile/page_container.js
+++ b/app/assets/javascripts/student_profile/page_container.js
@@ -41,6 +41,7 @@
         // constants
         interventionTypesIndex: serializedData.interventionTypesIndex,
         educatorsIndex: serializedData.educatorsIndex,
+        educatorsForServicesDropdown: serializedData.educatorsForServicesDropdown,
         serviceTypesIndex: serializedData.serviceTypesIndex,
         eventNoteTypesIndex: serializedData.eventNoteTypesIndex,
 
@@ -167,6 +168,7 @@
           'currentEducator',
           'interventionTypesIndex',
           'educatorsIndex',
+          'educatorsForServicesDropdown',
           'serviceTypesIndex',
           'eventNoteTypesIndex',
           'student',

--- a/app/assets/javascripts/student_profile/record_service.js
+++ b/app/assets/javascripts/student_profile/record_service.js
@@ -57,6 +57,7 @@
       nowMoment: React.PropTypes.object.isRequired,
       serviceTypesIndex: React.PropTypes.object.isRequired,
       educatorsIndex: React.PropTypes.object.isRequired,
+      educatorsForServicesDropdown: React.PropTypes.object.isRequired,
       currentEducator: React.PropTypes.object.isRequired
     },
 
@@ -143,7 +144,7 @@
     },
 
     renderEducatorSelect: function() {
-      var options = _.values(this.props.educatorsIndex).map(function(educator) {
+      var options = _.values(this.props.educatorsForServicesDropdown).map(function(educator) {
         var name = (educator.full_name !== null)
           ? educator.full_name
           : educator.email.split('@')[0];

--- a/app/assets/javascripts/student_profile/student_profile_page.js
+++ b/app/assets/javascripts/student_profile/student_profile_page.js
@@ -106,6 +106,7 @@
       // constants
       interventionTypesIndex: React.PropTypes.object.isRequired,
       educatorsIndex: React.PropTypes.object.isRequired,
+      educatorsForServicesDropdown: React.PropTypes.object.isRequired,
       serviceTypesIndex: React.PropTypes.object.isRequired,
       eventNoteTypesIndex: React.PropTypes.object.isRequired,
 
@@ -222,6 +223,7 @@
             'serviceTypesIndex',
             'eventNoteTypesIndex',
             'educatorsIndex',
+            'educatorsForServicesDropdown',
             'actions',
             'requests'
           )));

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -24,7 +24,8 @@ class StudentsController < ApplicationController
       intervention_types_index: intervention_types_index,
       service_types_index: service_types_index,
       event_note_types_index: event_note_types_index,
-      educators_index: student.try(:school).try(:educators_index),
+      educators_index: Educator.to_index,
+      educators_for_services_dropdown: student.try(:school).try(:educators_index),
       access: student.latest_access_results,
       attendance_data: student_profile_attendance_data(student)
     }

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -89,6 +89,10 @@ class Educator < ActiveRecord::Base
     allowed_homerooms.order(:name)
   end
 
+  def self.to_index
+    all.map { |e| [e.id, e.for_index] }.to_h
+  end
+
   def for_index
     as_json.symbolize_keys.slice(:id, :email, :full_name)
   end

--- a/spec/javascripts/student_profile/fixtures.js
+++ b/spec/javascripts/student_profile/fixtures.js
@@ -799,6 +799,42 @@
         "restricted_to_english_language_learners": false
       }
     },
+    "educatorsForServicesDropdown": {
+      "1": {
+        "id": 1,
+        "email": "demo@example.com",
+        "created_at": "2016-02-11T14:41:36.284Z",
+        "updated_at": "2016-02-11T15:38:22.288Z",
+        "admin": true,
+        "phone": null,
+        "full_name": null,
+        "state_id": null,
+        "local_id": "350",
+        "staff_type": null,
+        "school_id": 1,
+        "schoolwide_access": true,
+        "grade_level_access": [],
+        "restricted_to_sped_students": false,
+        "restricted_to_english_language_learners": false
+      },
+      "2": {
+        "id": 2,
+        "email": "fake-fifth-grade@example.com",
+        "created_at": "2016-02-11T14:41:36.354Z",
+        "updated_at": "2016-02-11T14:41:36.354Z",
+        "admin": false,
+        "phone": null,
+        "full_name": null,
+        "state_id": null,
+        "local_id": "450",
+        "staff_type": null,
+        "school_id": 1,
+        "schoolwide_access": false,
+        "grade_level_access": [],
+        "restricted_to_sped_students": false,
+        "restricted_to_english_language_learners": false
+      }
+    },
     "currentEducator": Fixtures.currentEducator,
     "chartData": {
       "star_series_math_percentile": [

--- a/spec/javascripts/student_profile/record_service_spec.js
+++ b/spec/javascripts/student_profile/record_service_spec.js
@@ -15,6 +15,7 @@ describe('RecordService', function() {
         studentFirstName: 'Tamyra',
         serviceTypesIndex: Fixtures.studentProfile.serviceTypesIndex,
         educatorsIndex: Fixtures.studentProfile.educatorsIndex,
+        educatorsForServicesDropdown: Fixtures.studentProfile.educatorsForServicesDropdown,
         nowMoment: Fixtures.nowMoment,
         currentEducator: Fixtures.currentEducator,
         onSave: jasmine.createSpy('onSave'),
@@ -48,7 +49,7 @@ describe('RecordService', function() {
         'Math intervention',
         'Attendance Officer',
         'Attendance Contract',
-        'Behavior Contract' 
+        'Behavior Contract'
       ]);
 
       expect(el).toContainText('Who is working with Tamyra?');


### PR DESCRIPTION
## Why?

+ `educatorsIndex` should include all educators in the database, regardless or school or status

+ For example, an educator might write a note for a student and then change schools or leave the district
    
+ On the other hand, the services dropdown for selecting a service provider should not pre-populate with inactive educators or educators outside the student's school
   
+ This paves the way for decoupling the data source for the service provider dropdown from the `educatorsIndex` as part of #307
