### PR TITLE
Add associations to migration for progress notes

### DIFF
--- a/db/migrate/20160417124734_migrate_progress_notes_to_event_notes.rb
+++ b/db/migrate/20160417124734_migrate_progress_notes_to_event_notes.rb
@@ -2,6 +2,8 @@ class MigrateProgressNotesToEventNotes < ActiveRecord::Migration
 
   class DeprecatedProgressNotesClass < ActiveRecord::Base
     self.table_name = :progress_notes
+    belongs_to :intervention
+    belongs_to :educator
   end
 
   def change


### PR DESCRIPTION
This looks like a minor bug in https://github.com/studentinsights/studentinsights/pull/387, I get this running the migrations locally:

```
== 20160417124734 MigrateProgressNotesToEventNotes: migrating =================
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

undefined method `intervention' for #<MigrateProgressNotesToEventNotes::DeprecatedProgressNotesClass:0x007ff923347078>
Did you mean?  intervention_id
/Users/krobinson/Documents/github/studentinsights/db/migrate/20160417124734_migrate_progress_notes_to_event_notes.rb:12:in `block in change'
/Users/krobinson/Documents/github/studentinsights/db/migrate/20160417124734_migrate_progress_notes_to_event_notes.rb:11:in `change'
NoMethodError: undefined method `intervention' for #<MigrateProgressNotesToEventNotes::DeprecatedProgressNotesClass:0x007ff923347078>
Did you mean?  intervention_id
/Users/krobinson/Documents/github/studentinsights/db/migrate/20160417124734_migrate_progress_notes_to_event_notes.rb:12:in `block in change'
/Users/krobinson/Documents/github/studentinsights/db/migrate/20160417124734_migrate_progress_notes_to_event_notes.rb:11:in `change'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```