### PR TITLE
Simplify STAR pages, to emphasize recent change and cut aggregates an…

### DIFF
--- a/app/assets/javascripts/components/star_charts_page.js
+++ b/app/assets/javascripts/components/star_charts_page.js
@@ -157,16 +157,12 @@ $(function() {
         ),
         dom.div({ style: { position: 'relative' } },
           dom.div({ style: { flex: 1 } },
-            dom.div({ style: { display: 'flex', padding: 20 } },
-              this.renderScatterplot(merge(sizing, { width: 1200, height: 300 }))
-            ),
             dom.div({ style: { display: 'flex', justifyContent: 'space-around', padding: 20 } },
-              dom.div({ style: { flex: 4 } }, this.renderAllTimeStarTrends(merge(sizing, { width: 600 }))),
-              dom.div({ style: { flex: 2 } }, this.renderRecentStarChanges(merge(sizing, { width: 180 })))
+              this.renderRecentStarChanges(merge(sizing, { width: 500 })),
+              this.renderDeltaHistogram(merge(sizing, { width: 400 }))
             ),
             dom.div({ style: { display: 'flex', justifyContent: 'space-around', padding: 20, paddingTop: 0 } },
-              dom.div({ style: { flex: 4 } }, this.renderAllTimeQuartiles(merge(sizing, { width: 600 }))),
-              dom.div({ style: { flex: 2 } }, this.renderDeltaHistogram(merge(sizing, { width: 450 })))
+              this.renderScatterplot(merge(sizing, { width: 1200, height: 300 }))
             )
           )
         )
@@ -199,9 +195,20 @@ $(function() {
       return _.last(results).percentile_rank - _.first(results).percentile_rank;
     },
 
+    renderPercentile: function(percentileRank) {
+      var lastDigit = percentileRank % 10;
+      if (percentileRank === 11) return '11th';
+      if (percentileRank === 12) return '12th';
+      if (percentileRank === 13) return '13th';
+      if (lastDigit === 1) return percentileRank + 'st';
+      if (lastDigit === 2) return percentileRank + 'nd';
+      if (lastDigit === 3) return percentileRank + 'rd';
+      return percentileRank + 'th';
+    },
+
     greatestChanges: function(students, color) {
       return dom.div({ style: { paddingLeft: 5, fontSize: styles.fontSize } },
-        // dom.div({ style: { paddingBottom: 10 } }, 'Greatest changes:'),
+        dom.div({ style: { textDecoration: 'underline', paddingBottom: 5 } }, 'Greatest changes:'),
         dom.table({ style: { borderCollapse: 'collapse' } },
           dom.tbody({}, _.sortBy(students, _.compose(Math.abs, this.resultsDelta)).reverse().slice(0, this.props.studentLimit).map(function(student) {
             var delta = this.resultsDelta(student);
@@ -213,8 +220,8 @@ $(function() {
             },
               dom.td({ style: { textAlign: 'right', color: color(delta) } }, (delta > 0) ? '+' + delta : delta),
               dom.td({ style: { color: '#ccc' } }, ' → '),
-              dom.td({}, + _.last(student.star_results).percentile_rank),
-              dom.td({}, dom.a({ style: { fontSize: styles.fontSize }, href: Routes.studentProfile(student.id) }, student.first_name + ' ' + student.last_name))
+              dom.td({}, this.renderPercentile(_.last(student.star_results).percentile_rank)),
+              dom.td({ style: { paddingLeft: 10 } }, dom.a({ style: { fontSize: styles.fontSize }, href: Routes.studentProfile(student.id) }, student.first_name + ' ' + student.last_name))
             );
           }, this))
         )
@@ -236,7 +243,7 @@ $(function() {
       var dateRange = d3.extent(assessments, function(d) { return new Date(d.date_taken); });
       var x = d3.time.scale().domain(dateRange).range([0, width]);
       var y = d3.scale.linear().domain([0, 100]).range([height, 0]);
-      var color = d3.scale.linear().domain([-50, 0, 50]).range(['red','#eee','blue']);
+      var color = d3.scale.linear().domain([-25, 0, 25]).range(['red','#eee','blue']);
       var thickness = d3.scale.linear().domain([-50, 0, 50]).range([3, 0, 3]);
 
       var lineGenerator = d3.svg.line()
@@ -253,7 +260,7 @@ $(function() {
           assessments: assessments
         }),
         dom.div({ style: { display: 'flex' } },
-          dom.div({},
+          dom.div({ style: { marginTop: 25 } },
             dom.svg( {width: width, height: height },
               dom.rect({
                 x: 0,


### PR DESCRIPTION
…d longer-term charts

This is part of https://github.com/studentinsights/studentinsights/issues/2.

This is addressing awesome feedback in https://github.com/studentinsights/studentinsights/issues/373 and https://github.com/studentinsights/studentinsights/issues/374, removing the exploratory prototypes and taking the views that are most directly useful.  This page is still in prototype phase.

Changes:
 - focus on recent changes, remove charts showing longer-term trends
 - remove aggregate charts, too complicated and not directly useful
 - add suffix to percentile numbers

Screenshot:
<img width="1290" alt="screen shot 2016-04-18 at 10 08 07 am 1" src="https://cloud.githubusercontent.com/assets/1056957/14606958/8e4a95de-054d-11e6-8095-00e4226efa13.png">