### PR TITLE
Fix minor style padding regression in roster header

### DIFF
--- a/app/assets/stylesheets/roster.scss
+++ b/app/assets/stylesheets/roster.scss
@@ -7,6 +7,10 @@
   margin-top: -60px;
 }
 
+.topline-info {
+  padding: 20px 40px;
+}
+
 #roster-table {
   overflow: auto;
   width: 100%;


### PR DESCRIPTION
See https://somerville-teacher-tool-demo.herokuapp.com/homerooms/2 for an example:

Before:
<img width="1081" alt="screen shot 2016-04-18 at 10 22 49 am" src="https://cloud.githubusercontent.com/assets/1056957/14607459/90431af8-054f-11e6-8d42-ea74927f8c19.png">

After:
<img width="1086" alt="screen shot 2016-04-18 at 10 27 54 am" src="https://cloud.githubusercontent.com/assets/1056957/14607652/66da6300-0550-11e6-92d1-b1d54f9be56f.png">
