### PR TITLE
Tweak stylish newsfeed -- aligning event-type badges for easier scanning

### DIFF
--- a/app/assets/javascripts/student_profile/profile_details.js
+++ b/app/assets/javascripts/student_profile/profile_details.js
@@ -262,6 +262,7 @@
         var text = event.message;
       }
 
+      var dateStyle = {display: 'inline-block', width: 180};
       var type_to_color = {
         "Absence": '#e8fce8',
         "Tardy": '#e8fce8',
@@ -282,7 +283,7 @@
       return dom.div({key: key, style: containingDivStyle},
         dom.div({style: paddingStyle},
           dom.div({style: headerDivStyle},
-            moment(event.date).format("MMMM Do, YYYY:"),
+            dom.span({style: dateStyle}, moment(event.date).format("MMMM Do, YYYY:")),
             dom.span({style: badgeStyle}, event.type)
           ),
         text


### PR DESCRIPTION
<img width="494" alt="screen shot 2016-04-18 at 1 21 12 pm" src="https://cloud.githubusercontent.com/assets/1514487/14613045/750706be-0568-11e6-9ec3-83810b9d38b2.png">

Fixes #219. I hope `display: 'inline-block'` is well-behaved on all browsers, I've heard it might not be

So we should test this on IE. (I don't know how to use BrowserStack right now, but it would be cool to learn!)