### PR TITLE
Update DIBELS demo data generator to remove nil, duplicate CORE and B…

### DIFF
--- a/app/demo_data/fake_dibels_result_generator.rb
+++ b/app/demo_data/fake_dibels_result_generator.rb
@@ -13,7 +13,7 @@ class FakeDibelsResultGenerator
     {
       assessment_id: dibels_assessment_id,
       date_taken: DateTime.new(@dates.pop, 5, 15),
-      performance_level: ["Intensive", "Strategic", "Core", "Benchmark", "CORE", nil].sample,
+      performance_level: ["Intensive", "Strategic", "Core"].sample,
       student_id: @student.id
     }
   end


### PR DESCRIPTION
…enchmark, which isn't used

This came up from a UI bug in the demo site.  And @jsgeiser noticed that there were two CORE items and Benchmark isn't used anymore.