### PR TITLE
Load educator permissions in bulk

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -135,7 +135,38 @@ class Educator < ActiveRecord::Base
     end
   end
 
+  def self.print_permissions
+    # Useful for double-checking permissions levels with Somerville admins
+
+    Educator.all.sort_by { |educator| educator.school }.each do |educator|
+      puts "#{educator.full_name} (#{educator.school.local_id}):"
+      puts educator.permissions_in_words
+      puts
+    end
+
+    return
+  end
+
+  def permissions_in_words
+    return "No access" if has_access_to_no_students?
+
+    permissions = []
+    permissions << "Has access to homeroom #{homeroom.name}" if homeroom.present?
+    permissions << "Has schoolwide access" if schoolwide_access?
+    permissions << "Has grade level access to #{grade_level_access}" if has_grade_level_access?
+
+    return permissions
+  end
+
   private
+
+  def has_access_to_no_students?
+    schoolwide_access == false && grade_level_access == [] && homeroom.blank?
+  end
+
+  def has_grade_level_access?
+    grade_level_access != [] && !grade_level_access.nil?
+  end
 
   def has_access_to_all_students?
     restricted_to_sped_students == false &&

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -117,6 +117,24 @@ class Educator < ActiveRecord::Base
     save!
   end
 
+  def self.load_permissions(permissions_array)
+    # Expects an array of hashes:
+    # [{
+    #   full_name: EDUCATOR_FULL_NAME_1,
+    #   PERMISSIONS_ATTRIBUTES
+    # },
+    # {
+    #   full_name: EDUCATOR_FULL_NAME_2,
+    #   PERMISSIONS_ATTRIBUTES
+    # }]
+
+    permissions_array.each do |permissions_info|
+      educator = Educator.find_by_full_name!(permissions_info[:full_name])
+      educator.assign_attributes(permissions_info)
+      educator.save!
+    end
+  end
+
   private
 
   def has_access_to_all_students?


### PR DESCRIPTION
## Notes    

  + Pull in educator permissions data I've handwritten based on feedback from Uri and principals
  + Punting on building admin dashboard where principals can enter/update permissions for their staff
  + Can also be used to keep production and staging in sync with educator permissions

+ #332
