### PR TITLE
Remove outline from service buttons for consistency

### DIFF
--- a/app/assets/javascripts/student_profile/record_service.js
+++ b/app/assets/javascripts/student_profile/record_service.js
@@ -143,6 +143,7 @@
         style: merge(styles.serviceButton, styles.buttonWidth, {
           background: color,
           opacity: (this.state.serviceTypeId === null || this.state.serviceTypeId === serviceTypeId) ? 1 : 0.25,
+          outline: 0,
           border: (this.state.serviceTypeId === serviceTypeId)
             ? '4px solid rgba(49, 119, 201, 0.75)'
             : '4px solid white'


### PR DESCRIPTION
This removes the blue rectangular outline that appears around the service selection buttons when you click on them on the student profile page:

<img width="621" alt="screenshot 2016-04-26 20 13 29" src="https://cloud.githubusercontent.com/assets/12554493/14838047/7c6f49dc-0beb-11e6-87b1-86b1b2a618c5.png">

The very similar note type buttons when adding a note do not have this, because they already set outline to 0. This update just makes them consistent.

Normally, setting outline: 0 makes it very difficult to navigate the page by keyboard. However, since these buttons already have tabindex: -1, they are already inaccessible by keyboard navigation.

I found this when working on #244, and went through a lot of ideas on refactoring the button UI, including making a custom react component for buttons. However, since each place we use these buttons requires slightly different behavior, I think the best bet is to unify the styling where possible. I would appreciate some guidance on whether to use JS styles or CSS. Right now, the buttons use a combination of both, which may not be ideal? In the meantime, I think it makes sense to fix this user-facing bug.