### PR TITLE
Update project description on login page

### DIFF
--- a/app/assets/stylesheets/about.scss.erb
+++ b/app/assets/stylesheets/about.scss.erb
@@ -2,71 +2,29 @@
 
 .about-page {
 	text-align: center;
-	margin-left: auto;
-	margin-right: auto;
-	h4 {
-		margin-bottom: 10px;
+
+	.about-big, h4 {
+	  font-size: 24px;
+	  font-weight: 300;
+	  color: $blue;
 	}
 
-	h5 {
-		margin-bottom: 20px;
-	}
-}
-
-.what, .how, .logos {
-	margin-top: 70px;
-}
-
-.who {
-	margin-top: 40px;
-}
-
-.teacher-photo {
-	margin-top: 40px;
-}
-
-.logos {
-	margin-bottom: 40px;
-}
-
-.somerville-logo {
-	margin-right: 30px;
-}
-
-.what {
-
-	h4 {
-		margin-top: 15px;
-		margin-bottom: 10px;
+	.about-head, h5 {
+	  font-size: 14px;
+	  font-weight: 700;
+	  color: $gray;
+	  text-transform: uppercase;
+	  margin-bottom: 10px;
 	}
 
-	.headline {
-		margin-bottom: 20px;
-	}
-
-	#pillars {
-		margin-left: auto;
-		margin-right: auto;
-	}
-
-	.pillar {
-		width: 30%;
-	  display: inline-block;
-	  padding: 10px;
-	  @media screen and (max-width: $phase1) {
-	  	display: inline;
-	  	width: 80%;
-	  }
-	  p {
-	  	margin-bottom: 25px;
-	  }
+	.detailed-content-area {
+	  padding: 60px 0 0 0;
 	}
 }
 
 #roster {
 	background: url('<%= asset_path("roster_pillar.png") %>') no-repeat;
 }
-
 
 #profile {
 	background: url('<%= asset_path("profile_pillar.png") %>') no-repeat;
@@ -76,17 +34,7 @@
 	background: url('<%= asset_path("interventions_pillar.png") %>') no-repeat;
 }
 
-.circular {
-	display: inline-block;
-	width: 150px;
-	height: 150px;
-	border-radius: 75px;
-	-webkit-border-radius: 150px;
-	-moz-border-radius: 150px;
-	border: 3px solid $light-line;
-}
-
-#teachers {
+#data-binder {
 	display: inline-block;
 	width: 80%;
 	height: 160px;
@@ -99,10 +47,45 @@
 	}
 }
 
-.logo-list {
+.circular {
+	display: inline-block;
+	width: 150px;
+	height: 150px;
+	border-radius: 75px;
+	-webkit-border-radius: 150px;
+	-moz-border-radius: 150px;
+	border: 3px solid $light-line;
+}
 
+.logo-list {
 	li {
 		display: inline;
 		list-style-type: none;
 	}
+}
+
+.teacher-photo, .logos {
+	margin-top: 40px;
+}
+
+.somerville-logo {
+	margin-right: 30px;
+}
+
+#pillars {
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.pillar {
+	width: 30%;
+  display: inline-block;
+  padding: 10px;
+  @media screen and (max-width: $phase1) {
+  	display: inline;
+  	width: 80%;
+  }
+  p {
+  	margin-bottom: 25px;
+  }
 }

--- a/app/assets/stylesheets/overall.scss
+++ b/app/assets/stylesheets/overall.scss
@@ -31,14 +31,6 @@ body {
   clear: both;
 }
 
-.detailed-content-area {
-  padding: 30px 60px;
-}
-
-.sessions .detailed-content-area {
-  padding: 30px 0px;
-}
-
 .schools .info-area {
   margin-top: 55px;
 }

--- a/app/assets/stylesheets/type.scss
+++ b/app/assets/stylesheets/type.scss
@@ -30,19 +30,6 @@ h3 {
   color: $gray;
 }
 
-.about-big, h4 {
-  font-size: 24px;
-  font-weight: 300;
-  color: $blue;
-}
-
-.about-head, h5 {
-  font-size: 14px;
-  font-weight: 700;
-  color: $gray;
-  text-transform: uppercase;
-}
-
 h6 {
   font-size: 14px;
   font-weight: 700;

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,20 +1,26 @@
 <div class="info-area">
-  <div class="about-page detailed-content-area">
-    <div class="who">
-      <h1 class="about-head">Who is it for</h1>
-      <h2 class="about-big">This is a tool for teachers</h2>
-        <p>It's being built by Code for America's <a href="http://www.codeforamerica.org/governments/somerville/" target="_blank">Team Somerville</a>, working closely with our partners in Somerville: the 5th grade teacher team at Healey School, Principal Jill Geiser, Uri Harel (Elementary Curriculum Coordinator) and Vince McKay (Assistant Superintendent), and Stephanie Hirsch.</p>
+
+  <div class="about-page">
+
+    <div class="detailed-content-area">
+      <h1 class="about-head">What is this?</h1>
+      <h2 class="about-big">Student Insights</h2>
+      <p>a tool for Somerville educators</p>
+    </div>
+
+    <div class="detailed-content-area">
+      <h1 class="about-head">What's it supposed to fix?</h1>
+      <p>Databases that don't talk to each other.</p>
+      <p>Big gaps in student records that make you hunt down information.</p>
+      <p>Having to print out student data and store it in big binders.</p>
+
       <div class="teacher-photo">
-        <div id="teachers"></div>
+        <div id="data-binder"></div>
       </div>
     </div>
 
-
-
-    <div class ="what">
-      <h1 class="about-head">What is it</h1>
-      <p class="headline">We plan for the beta version of tool to have the following three modules</p>
-
+    <div class="detailed-content-area">
+      <h1 class="about-head">What does it do?</h1>
       <div id="pillars">
         <div class="pillar">
           <div class="circular" id="roster"></div>
@@ -32,22 +38,23 @@
             <p>Showing teachers which students are most in need of interventions and giving the ability to log interventions.</p>
         </div>
       </div>
-
     </div>
 
-    <div class="how">
-      <h1 class="about-head">How is it going</h1>
+    <div class="detailed-content-area">
+      <h1 class="about-head">How is it going?</h1>
       <h2 class="about-big">We are in development</h2>
-        <p>This is currently an <strong>alpha product</strong>. We are still working out bugs and building out new features.</p>
-        <p>See the code for this teacher tool and leave a comment on <a href="https://github.com/codeforamerica/somerville-teacher-tool" target="_blank">GitHub.</a></p>
+      <p>This is currently an <strong>alpha product</strong>.</p>
+      <p>We are still working out bugs and building out new features.</p>
+      <p>See the code for this teacher tool and leave a comment on <a href="https://github.com/codeforamerica/somerville-teacher-tool" target="_blank">GitHub.</a></p>
+
+      <div class="logos">
+        <ul class="logo-list">
+          <li><a href="http://www.somervillema.gov/" target="_blank" class="somerville-logo"><%= image_tag "somerville_logo.png" %></a></li>
+          <li><a href="https://www.codeforamerica.org/" target="_blank" class="cfa-logo"><%= image_tag "cfa_logo.png" %></a></li>
+          <ul>
+      </div>
     </div>
 
-    <div class="logos">
-      <ul class="logo-list">
-        <li><a href="http://www.somervillema.gov/" target="_blank" class="somerville-logo"><%= image_tag "somerville_logo.png" %></a></li>
-        <li><a href="https://www.codeforamerica.org/" target="_blank" class="cfa-logo"><%= image_tag "cfa_logo.png" %></a></li>
-        <ul>
-    </div>
+  </div>
 
-    </div>
 </div>


### PR DESCRIPTION
It occurred to me as our schools partner Uri was talking the other day about rolling the app out to all elementary schools in Somerville . . . 

It might be a good idea to make the project description on the login page less inaccurate! 

## New look

__Upper part:__
![screen shot 2016-04-28 at 3 01 51 pm](https://cloud.githubusercontent.com/assets/3209501/14899704/ef4cbf76-0d52-11e6-8ec3-474f138b56cc.png)

__Lower part:__
![screen shot 2016-04-28 at 3 07 42 pm](https://cloud.githubusercontent.com/assets/3209501/14899732/0e58bf32-0d53-11e6-97b7-68cfe297a22b.png)

## Copy

+ The list of people working on the app (both on the code side and the schools side) has changed over time. And will continue to change over time as the project evolves. So it doesn't make sense to have this as the first thing someone reads when s/he goes to log on. We should move this to a separate project history or contributors page.
+ Added some (hopefully) pithy sentences about what problems the project aims to fix. Those are more important from the point of view of the folks using the app than who exactly is building it.
+ The "What does it do" section is still inaccurate, because it doesn't mention the school overview page.

## CSS

+ Move CSS classes that were only being used by the about page into `about.scss.erb`.
+ Trimmed CSS, fewer IDs, more classes

This look good @kevinrobinson? Thoughts?