### PR TITLE
Require educators be assigned to school

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -14,6 +14,8 @@ class Educator < ActiveRecord::Base
 
   validates :email, presence: true, uniqueness: true
   validates :local_id, presence: true, uniqueness: true
+  validates :school_id, presence: true
+
   validate :admin_gets_access_to_all_students
 
   def admin_gets_access_to_all_students

--- a/spec/controllers/educators_controller_spec.rb
+++ b/spec/controllers/educators_controller_spec.rb
@@ -29,35 +29,25 @@ describe EducatorsController, :type => :controller do
       end
     end
 
-    context 'admin' do
+    context 'schoolwide access' do
 
-      context 'schools exist in db' do
-
-        context 'educator assigned to school' do
-          let!(:school) { FactoryGirl.create(:school) }
-          let(:educator) { FactoryGirl.create(:educator, :admin, school: school) }
-          it 'redirects to the correct school' do
-            make_request
-            expect(response).to redirect_to(school_url(school))
-          end
-        end
-
-        context 'educator not assigned to school' do
-          let(:educator) { FactoryGirl.create(:educator, :admin) }
-          let!(:school) { FactoryGirl.create(:school) }
-          before { FactoryGirl.create(:student, school: school) }
-          let!(:another_school) { FactoryGirl.create(:school) }
-          it 'redirects to first school page' do
-            make_request
-            expect(response).to redirect_to(school_url(School.first))
-          end
+      context 'educator assigned to school' do
+        let!(:school) { FactoryGirl.create(:school) }
+        let(:educator) { FactoryGirl.create(:educator, :admin, school: school) }
+        it 'redirects to the correct school' do
+          make_request
+          expect(response).to redirect_to(school_url(school))
         end
       end
 
-      context 'no schools exist' do
+      context 'educator not assigned to school' do
         let(:educator) { FactoryGirl.create(:educator, :admin) }
-        it 'throws an error' do
-          expect { make_request }.to raise_error ActionController::UrlGenerationError
+        let!(:school) { FactoryGirl.create(:school) }
+        before { FactoryGirl.create(:student, school: school) }
+        let!(:another_school) { FactoryGirl.create(:school) }
+        it 'redirects to first school page' do
+          make_request
+          expect(response).to redirect_to(school_url(School.first))
         end
       end
 

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 describe HomeroomsController, :type => :controller do
   let!(:school) { FactoryGirl.create(:school) }
-  let!(:educator) { FactoryGirl.create(:educator_with_grade_5_homeroom) }
+  let!(:educator) { FactoryGirl.create(:educator_with_grade_5_homeroom, school: school) }
   let!(:educator_without_homeroom) { FactoryGirl.create(:educator) }
-  let!(:admin_educator) { FactoryGirl.create(:educator, :admin) }
+  let!(:admin_educator) { FactoryGirl.create(:educator, :admin, school: school) }
   let(:first_homeroom_path) { homeroom_path(Homeroom.first) }
 
   describe '#show' do

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -42,9 +42,10 @@ describe ServicesController, :type => :controller do
   end
 
   describe '#destroy when authorized' do
-    let(:student) { FactoryGirl.create(:student) }
+    let(:school) { FactoryGirl.create(:school) }
+    let(:student) { FactoryGirl.create(:student, school: school) }
     let(:homeroom) { student.homeroom }
-    let(:educator) { FactoryGirl.create(:educator, :admin )}
+    let(:educator) { FactoryGirl.create(:educator, :admin, school: school) }
     let(:service) { create_service(student, educator) }
     before { sign_in(educator) }
 

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -9,6 +9,7 @@ def create_service(student, educator)
 end
 
 describe StudentsController, :type => :controller do
+
   describe '#show' do
     let!(:school) { FactoryGirl.create(:school) }
     let(:educator) { FactoryGirl.create(:educator_with_homeroom) }
@@ -29,7 +30,6 @@ describe StudentsController, :type => :controller do
     end
 
     context 'when educator is logged in' do
-
       before { sign_in(educator) }
 
       context 'educator has schoolwide access' do
@@ -139,7 +139,7 @@ describe StudentsController, :type => :controller do
         end
 
         context 'educator has grade level access' do
-          let(:educator) { FactoryGirl.create(:educator, grade_level_access: [student.grade] )}
+          let(:educator) { FactoryGirl.create(:educator, grade_level_access: [student.grade], school: school )}
 
           it 'is successful' do
             make_request({ student_id: student.id, format: :html })
@@ -148,7 +148,7 @@ describe StudentsController, :type => :controller do
         end
 
         context 'educator has homeroom access' do
-          let(:educator) { FactoryGirl.create(:educator) }
+          let(:educator) { FactoryGirl.create(:educator, school: school) }
           before { homeroom.update(educator: educator) }
 
           it 'is successful' do
@@ -158,7 +158,7 @@ describe StudentsController, :type => :controller do
         end
 
         context 'educator does not have schoolwide, grade level, or homeroom access' do
-          let(:educator) { FactoryGirl.create(:educator) }
+          let(:educator) { FactoryGirl.create(:educator, school: school) }
 
           it 'fails' do
             make_request({ student_id: student.id, format: :html })
@@ -170,7 +170,8 @@ describe StudentsController, :type => :controller do
           let(:educator) { FactoryGirl.create(:educator, {
             grade_level_access: nil,
             schoolwide_access: true,
-            restricted_to_sped_students: false
+            restricted_to_sped_students: false,
+            school: school
           }) }
 
           it 'succeeds without an exception' do
@@ -180,8 +181,8 @@ describe StudentsController, :type => :controller do
         end
 
         context 'educator has some grade level access but for the wrong grade' do
-          let(:student) { FactoryGirl.create(:student, :with_risk_level, grade: '1') }
-          let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['KF']) }
+          let(:student) { FactoryGirl.create(:student, :with_risk_level, grade: '1', school: school) }
+          let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['KF'], school: school) }
 
           it 'fails' do
             make_request({ student_id: student.id, format: :html })
@@ -192,13 +193,15 @@ describe StudentsController, :type => :controller do
         context 'educator access restricted to SPED students' do
           let(:educator) { FactoryGirl.create(:educator,
                                               grade_level_access: ['1'],
-                                              restricted_to_sped_students: true ) }
+                                              restricted_to_sped_students: true,
+                                              school: school ) }
 
           context 'student in SPED' do
             let(:student) { FactoryGirl.create(:student,
                                                :with_risk_level,
                                                grade: '1',
-                                               program_assigned: 'Sp Ed') }
+                                               program_assigned: 'Sp Ed',
+                                               school: school) }
 
             it 'is successful' do
               make_request({ student_id: student.id, format: :html })
@@ -223,13 +226,15 @@ describe StudentsController, :type => :controller do
         context 'educator access restricted to ELL students' do
           let(:educator) { FactoryGirl.create(:educator,
                                               grade_level_access: ['1'],
-                                              restricted_to_english_language_learners: true ) }
+                                              restricted_to_english_language_learners: true,
+                                              school: school ) }
 
           context 'limited English proficiency' do
             let(:student) { FactoryGirl.create(:student,
                                                :with_risk_level,
                                                grade: '1',
-                                               limited_english_proficiency: 'FLEP') }
+                                               limited_english_proficiency: 'FLEP',
+                                               school: school) }
 
             it 'is successful' do
               make_request({ student_id: student.id, format: :html })
@@ -258,14 +263,16 @@ describe StudentsController, :type => :controller do
   end
 
   describe '#event_note' do
+    let(:school) { FactoryGirl.create(:school) }
+
     def make_post_request(student, event_note_params = {})
       request.env['HTTPS'] = 'on'
       post :event_note, format: :json, id: student.id, event_note: event_note_params
     end
 
-    context 'admin educator logged in' do
-      let(:educator) { FactoryGirl.create(:educator, :admin) }
-      let!(:student) { FactoryGirl.create(:student) }
+    context 'educator logged in' do
+      let(:educator) { FactoryGirl.create(:educator, :admin, school: school) }
+      let!(:student) { FactoryGirl.create(:student, school: school) }
       let!(:event_note_type) { EventNoteType.first }
 
       before do
@@ -330,15 +337,17 @@ describe StudentsController, :type => :controller do
   end
 
   describe '#service' do
+    let!(:school) { FactoryGirl.create(:school) }
+
     def make_post_request(student, service_params = {})
       request.env['HTTPS'] = 'on'
       post :service, format: :json, id: student.id, service: service_params
     end
 
     context 'admin educator logged in' do
-      let!(:educator) { FactoryGirl.create(:educator, :admin) }
-      let!(:provided_by_educator) { FactoryGirl.create(:educator) }
-      let!(:student) { FactoryGirl.create(:student) }
+      let!(:educator) { FactoryGirl.create(:educator, :admin, school: school) }
+      let!(:provided_by_educator) { FactoryGirl.create(:educator, school: school) }
+      let!(:student) { FactoryGirl.create(:student, school: school) }
 
       before do
         sign_in(educator)
@@ -410,17 +419,18 @@ describe StudentsController, :type => :controller do
   end
 
   describe '#names' do
+    let(:school) { FactoryGirl.create(:healey) }
+
     def make_request(query)
       request.env['HTTPS'] = 'on'
       get :names, q: query, format: :json
     end
 
     context 'admin educator logged in' do
-      let!(:educator) { FactoryGirl.create(:educator, :admin) }
+      let!(:educator) { FactoryGirl.create(:educator, :admin, school: school) }
       before { sign_in(educator) }
       context 'query matches student name' do
-        let(:healey) { FactoryGirl.create(:healey) }
-        let!(:juan) { FactoryGirl.create(:student, first_name: 'Juan', school: healey, grade: '5') }
+        let!(:juan) { FactoryGirl.create(:student, first_name: 'Juan', school: school, grade: '5') }
         let!(:jacob) { FactoryGirl.create(:student, first_name: 'Jacob', grade: '5') }
 
         it 'is successful' do

--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
     password "PairShareCompare"
     email { FactoryGirl.generate(:email) }
     local_id { FactoryGirl.generate(:staff_local_id) }
+    association :school
 
     trait :admin do
       admin true

--- a/spec/importers/file_importers/educators_importer_spec.rb
+++ b/spec/importers/file_importers/educators_importer_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe EducatorsImporter do
 
   describe '#import_row' do
+    let!(:school) { FactoryGirl.create(:healey) }
 
     context 'good row' do
 
@@ -12,7 +13,8 @@ RSpec.describe EducatorsImporter do
 
           context 'without homeroom' do
             let(:row) {
-              { state_id: "500", local_id: "200", full_name: "Young, Jenny", login_name: "jyoung" }
+              { state_id: "500", local_id: "200", full_name: "Young, Jenny",
+                login_name: "jyoung", school_local_id: "HEA" }
             }
 
             before do
@@ -41,7 +43,8 @@ RSpec.describe EducatorsImporter do
                   local_id: "200",
                   full_name: "Young, Jenny",
                   login_name: "jyoung",
-                  homeroom: homeroom_name
+                  homeroom: homeroom_name,
+                  school_local_id: "HEA"
                 }
               }
               it 'creates an educator' do
@@ -67,7 +70,8 @@ RSpec.describe EducatorsImporter do
                     local_id: "201",
                     full_name: "Gardner, Dylan",
                     login_name: "dgardner",
-                    homeroom: another_homeroom_name
+                    homeroom: another_homeroom_name,
+                    school_local_id: "HEA"
                   }
                 }
                 it 'creates multiple educators' do
@@ -80,7 +84,6 @@ RSpec.describe EducatorsImporter do
             end
 
             context 'with school local ID' do
-              let!(:healey) { FactoryGirl.create(:healey) }
               let(:row) {
                 {
                   state_id: "500",
@@ -88,14 +91,14 @@ RSpec.describe EducatorsImporter do
                   full_name: "Young, Jenny",
                   login_name: "jyoung",
                   homeroom: homeroom_name,
-                  school_local_id: 'HEA'
+                  school_local_id: "HEA"
                 }
               }
 
               it 'assigns the educator to the correct school' do
                 described_class.new.import_row(row)
                 educator = Educator.last
-                expect(educator.school).to eq(healey)
+                expect(educator.school).to eq(school)
               end
             end
           end
@@ -108,7 +111,8 @@ RSpec.describe EducatorsImporter do
               full_name: "Hill,
               Marian", staff_type:
               "Administrator",
-              login_name: "mhill"
+              login_name: "mhill",
+              school_local_id: "HEA"
             }
           }
 
@@ -126,11 +130,8 @@ RSpec.describe EducatorsImporter do
         let!(:educator) { FactoryGirl.create(:educator, :local_id_200) }
         let(:row) {
           {
-            state_id: "500",
-            local_id: "200",
-            full_name: "Young, Jenny",
-            login_name: "jyoung",
-            homeroom: homeroom_name
+            state_id: "500", local_id: "200", full_name: "Young, Jenny",
+            login_name: "jyoung", homeroom: homeroom_name, school_local_id: "HEA"
           }
         }
 
@@ -149,10 +150,8 @@ RSpec.describe EducatorsImporter do
         let!(:educator) { FactoryGirl.create(:educator, schoolwide_access: true, local_id: '1' )}
         let(:row) {
           {
-            state_id: "1",
-            local_id: "1",
-            full_name: "Grrr, Bettina",
-            login_name: "bttgrr"
+            state_id: "1", local_id: "1", full_name: "Grrr, Bettina",
+            login_name: "bttgrr", school_local_id: "HEA"
           }
         }
 
@@ -168,18 +167,21 @@ RSpec.describe EducatorsImporter do
       end
 
     end
+
   end
 
   describe '#update_homeroom' do
+    let!(:school) { FactoryGirl.create(:healey) }
 
     context 'row with homeroom name' do
       let(:row) {
-        { state_id: "500", local_id: "200", full_name: "Young, Jenny", homeroom: "HEA 100", login_name: "jyoung" }
+        { state_id: "500", local_id: "200", full_name: "Young, Jenny",
+          homeroom: "HEA 100", login_name: "jyoung", school_local_id: "HEA" }
       }
 
       context 'name of homeroom that exists' do
         let!(:homeroom) { FactoryGirl.create(:homeroom, :named_hea_100) }
-        it 'assigns the homeroom tho the educator' do
+        it 'assigns the homeroom to the educator' do
           described_class.new.import_row(row)
           expect(Educator.last.homeroom).to eq homeroom
         end

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -56,21 +56,6 @@ RSpec.describe Educator do
 
     end
 
-    context 'educator does not belong to school' do
-      let(:student) { FactoryGirl.create(:student) }
-      context 'educator is admin' do
-        let(:educator) { FactoryGirl.create(:educator, :admin) }
-        it 'is authorized' do
-          expect(authorized?).to be true
-        end
-      end
-      context 'educator is not admin' do
-        let(:educator) { FactoryGirl.create(:educator) }
-        it 'is not authorized' do
-          expect(authorized?).to be false
-        end
-      end
-    end
   end
 
   describe '#local_id' do


### PR DESCRIPTION
This [yak-shaving](http://catb.org/jargon/html/Y/yak-shaving.html) for #435. When scoping educator UI access by school, specs blew up because our test educators weren't all assigned to schools.

Since we punted on building views for district wide educators (#338, explicitly de-prioritized in conversation with Uri), all educators should be assigned a school. 

If you're assigned to zero schools, we can't show you any data. We're not building out the use case for a district-wide admin assigned to all schools. And we haven't run across a use case of an educator who works with multiple schools.

Even if it's not really super essential for #435, this clarifies our data model, adds good validation, and makes our specs simpler.