### PR TITLE
Attendance events can now occur in the current school year.

### DIFF
--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -147,28 +147,30 @@ class FakeStudent
   end
 
   def add_attendance_events
-    # Probabilities: https://github.com/codeforamerica/somerville-teacher-tool/issues/94
-    attendance_event_generator = Rubystats::NormalDistribution.new(8.8, 10)
+    d = {
+      0 => 0.04,
+      (1..6) => 0.41,
+      (15..28) => 0.52,
+      (29..100) => 0.03,
+    }
 
-    94.in(100) do
-      attendance_event_generator.rng.round(0).times do
+    events_for_year = DemoDataUtil.sample_from_distribution(d)
+    events_for_year.times do
+      # Randomly determine the school year it occurred.
+      year = [0, 1, 2, 3, 4, 5].sample
+      date_begin = Time.local(2010 + year, 8, 1)
+      date_end = Time.local(2011 + year, 7, 31)
 
-        # Randomly determine the school year it occurred.
-        year = [0, 1, 2, 3, 4, 5].sample
-        date_begin = Time.local(2010 + year, 8, 1)
-        date_end = Time.local(2011 + year, 7, 31)
+      attendance_event = [Absence.new, Tardy.new].sample
+      attendance_event.student_school_year = @student.student_school_years.first
 
-        attendance_event = [Absence.new, Tardy.new].sample
-        attendance_event.student_school_year = @student.student_school_years.first
-
-        # Make sure event isn't listed as having happened in the future.
-        occurred_at = Time.at(date_begin + rand * (date_end.to_f - date_begin.to_f))
-        if occurred_at < Time.new then
-          attendance_event.occurred_at = occurred_at
-        end
-
-        attendance_event.save
+      # Make sure event isn't listed as having happened in the future.
+      occurred_at = Time.at(date_begin + rand * (date_end.to_f - date_begin.to_f))
+      if occurred_at < Time.new then
+        attendance_event.occurred_at = occurred_at
       end
+
+      attendance_event.save
     end
   end
 

--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -148,23 +148,26 @@ class FakeStudent
 
   def add_attendance_events
     # Probabilities: https://github.com/codeforamerica/somerville-teacher-tool/issues/94
-
     attendance_event_generator = Rubystats::NormalDistribution.new(8.8, 10)
 
     94.in(100) do
-      5.times do |n|
-        attendance_event_generator.rng.round(0).times do
+      attendance_event_generator.rng.round(0).times do
 
-          # Randomly determine the school year it occurred.
-          year = [0, 1, 2, 3, 4].sample
-          date_begin = Time.local(2010 + year, 8, 1)
-          date_end = Time.local(2011 + year, 7, 31)
+        # Randomly determine the school year it occurred.
+        year = [0, 1, 2, 3, 4, 5].sample
+        date_begin = Time.local(2010 + year, 8, 1)
+        date_end = Time.local(2011 + year, 7, 31)
 
-          attendance_event = [Absence.new, Tardy.new].sample
-          attendance_event.student_school_year = @student.student_school_years.first
-          attendance_event.occurred_at = Time.at(date_begin + rand * (date_end.to_f - date_begin.to_f))
-          attendance_event.save
+        attendance_event = [Absence.new, Tardy.new].sample
+        attendance_event.student_school_year = @student.student_school_years.first
+
+        # Make sure event isn't listed as having happened in the future.
+        occurred_at = Time.at(date_begin + rand * (date_end.to_f - date_begin.to_f))
+        if occurred_at < Time.new then
+          attendance_event.occurred_at = occurred_at
         end
+
+        attendance_event.save
       end
     end
   end
@@ -181,13 +184,19 @@ class FakeStudent
     events_for_year = DemoDataUtil.sample_from_distribution(d)
     events_for_year.times do
       # Randomly determine the school year it occurred.
-      n = [0, 1, 2, 3, 4].sample
+      n = [0, 1, 2, 3, 4, 5].sample
       date_begin = Time.local(2010 + n, 8, 1)
       date_end = Time.local(2011 + n, 7, 31)
 
       discipline_incident = DisciplineIncident.new(FakeDisciplineIncident.data)
       discipline_incident.student_school_year = @student.student_school_years.first
-      discipline_incident.occurred_at = Time.at(date_begin + rand * (date_end.to_f - date_begin.to_f))
+
+      # Make sure event isn't listed as having happened in the future.
+      occurred_at = Time.at(date_begin + rand * (date_end.to_f - date_begin.to_f))
+      if occurred_at < Time.new then
+        discipline_incident.occurred_at = occurred_at
+      end
+
       discipline_incident.save
     end
   end


### PR DESCRIPTION
Fixes #227.

I changed the way we do this to a more discipline-incident-y way (generate overall, not per year). I suspect the resulting distribution isn't accurate.

<img width="207" alt="screen shot 2016-04-30 at 11 42 49 am" src="https://cloud.githubusercontent.com/assets/1514487/14937031/e3b9d29e-0ec8-11e6-81f2-c328eb53854d.png">

Does this match the real distribution?
