### PR TITLE
Add aggressive method for stealing another educator's homeroom

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -119,6 +119,20 @@ class Educator < ActiveRecord::Base
     save!
   end
 
+  def clone_permissions_and_homeroom_in_staging_from(educator_full_name)
+    # :alert: do not use in production :alert:
+    # This will change whom the homeroom belongs to!
+
+    target_educator = Educator.find_by_full_name(educator_full_name)
+    permissions = target_educator.permissions_hash
+    assign_attributes(permissions)
+    save!
+
+    target_homeroom = target_educator.homeroom
+    target_homeroom.educator = self
+    target_homeroom.save!
+  end
+
   def self.load_permissions(permissions_array)
     # Expects an array of hashes:
     # [{


### PR DESCRIPTION
## Notes

+ Useful **only in staging** for assuming another educator's homeroom with the test account and clicking around to double-check key views and facts

+ Added an 🚨  warning in the code comments, if used in production this could mess up a classroom teacher's experience :anguished: