### PR TITLE
Fix authorization for homeroom roster

### DIFF
--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -25,7 +25,7 @@ class StudentsImporter < Struct.new :school_scope, :client
   end
 
   def assign_student_to_homeroom(student, homeroom_name)
-    homeroom = Homeroom.where(name: homeroom_name).first_or_create!
+    homeroom = Homeroom.where(name: homeroom_name, school: student.school).first_or_create!
     homeroom.students << student
   end
 

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -72,7 +72,7 @@ class Educator < ActiveRecord::Base
 
   def allowed_homerooms
     # Educator can visit roster view for these homerooms
-    # For non-admins, all homerooms at their homeroom's grade level
+    return [] if school.nil?
 
     if schoolwide_access?
       school.homerooms.all

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -75,13 +75,11 @@ class Educator < ActiveRecord::Base
     # For non-admins, all homerooms at their homeroom's grade level
 
     if schoolwide_access?
-      Homeroom.all
+      school.homerooms.all
     elsif homeroom
-      # Once the app includes data for multiple schools, will
-      # need to scope by school as well as by grade level
-      Homeroom.where(grade: homeroom.grade)
+      school.homerooms.where(grade: homeroom.grade)
     elsif grade_level_access.present?
-      Homeroom.where(grade: grade_level_access)
+      school.homerooms.where(grade: grade_level_access)
     else
       []
     end

--- a/app/models/homeroom.rb
+++ b/app/models/homeroom.rb
@@ -6,6 +6,7 @@ class Homeroom < ActiveRecord::Base
   has_many :students, after_add: :update_grade
   has_many :student_risk_levels, through: :students
   belongs_to :educator
+  belongs_to :school
 
   def update_grade(student)
     # Set homeroom grade level to be first student's grade level, since

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -3,6 +3,7 @@ class School < ActiveRecord::Base
   friendly_id :local_id, use: :slugged
   has_many :students
   has_many :educators
+  has_many :homerooms
 
   def self.with_students
     School.all.select { |s| s.students.count > 0 }

--- a/db/migrate/20160428030255_add_school_id_to_homerooms.rb
+++ b/db/migrate/20160428030255_add_school_id_to_homerooms.rb
@@ -1,0 +1,5 @@
+class AddSchoolIdToHomerooms < ActiveRecord::Migration
+  def change
+    add_column :homerooms, :school_id, :integer
+  end
+end

--- a/db/migrate/20160502001001_assign_homerooms_to_schools.rb
+++ b/db/migrate/20160502001001_assign_homerooms_to_schools.rb
@@ -1,0 +1,11 @@
+class AssignHomeroomsToSchools < ActiveRecord::Migration
+  def change
+    Homeroom.find_each do |homeroom|
+      if homeroom.school.nil?
+        school = homeroom.students.try(:first).try(:school)
+        homeroom.school = school
+        homeroom.save!
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160428030255) do
+ActiveRecord::Schema.define(version: 20160502001001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160417194109) do
+ActiveRecord::Schema.define(version: 20160428030255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -132,6 +132,7 @@ ActiveRecord::Schema.define(version: 20160417194109) do
     t.integer  "educator_id"
     t.string   "slug"
     t.string   "grade"
+    t.integer  "school_id"
   end
 
   add_index "homerooms", ["educator_id"], name: "index_homerooms_on_educator_id", using: :btree

--- a/db/seeds/demo/demo.seeds.rb
+++ b/db/seeds/demo/demo.seeds.rb
@@ -36,9 +36,9 @@ Educator.create!([{
 
 puts 'Creating homerooms..'
 homerooms = [
-  Homeroom.create(name: "103", grade: "3"),
-  Homeroom.create(name: "104", grade: "4"),
-  Homeroom.create(name: "105", grade: "5")
+  Homeroom.create(name: "103", grade: "3", school: School.first),
+  Homeroom.create(name: "104", grade: "4", school: School.first),
+  Homeroom.create(name: "105", grade: "5", school: School.first),
 ]
 
 fifth_grade_educator = Educator.find_by_email('fake-fifth-grade@example.com')

--- a/db/seeds/demo/demo.seeds.rb
+++ b/db/seeds/demo/demo.seeds.rb
@@ -7,6 +7,7 @@ raise "empty yer db" if School.count > 0 ||
                         Assessment.count > 0
 
 healey = School.create(name: "Arthur D Healey")
+wsns = School.create(name: "West Somerville Neighborhood")
 
 # The local demo data setup uses the Somerville database constants
 # (eg., the set of `ServiceType`s) for generating local demo data and
@@ -22,27 +23,41 @@ Educator.create!([{
   full_name: 'Principal, Laura',
   password: "demo-password",
   local_id: '350',
-  schoolwide_access: true,
   school: School.first,
-  admin: true
+  admin: true,
+  schoolwide_access: true,
 }, {
   email: "fake-fifth-grade@example.com",
   full_name: 'Teacher, Sarah',
   password: "demo-password",
   local_id: '450',
   school: School.first,
-  admin: false
+  admin: false,
+  schoolwide_access: false,
+}, {
+  email: "wsns@example.com",
+  full_name: 'Teacher, Mari',
+  password: 'demo-password',
+  local_id: '550',
+  school: School.second,
+  admin: false,
+  schoolwide_access: false,
 }])
 
 puts 'Creating homerooms..'
 homerooms = [
-  Homeroom.create(name: "103", grade: "3", school: School.first),
-  Homeroom.create(name: "104", grade: "4", school: School.first),
-  Homeroom.create(name: "105", grade: "5", school: School.first),
+  Homeroom.create(name: "HEA 300", grade: "3", school: School.first),
+  Homeroom.create(name: "HEA 400", grade: "4", school: School.first),
+  Homeroom.create(name: "HEA 500", grade: "5", school: School.first),
+  Homeroom.create(name: "HEA 501", grade: "5", school: School.first),
+  Homeroom.create(name: "WSNS 500", grade: "5", school: School.second),
 ]
 
 fifth_grade_educator = Educator.find_by_email('fake-fifth-grade@example.com')
-Homeroom.last.update_attribute(:educator_id, fifth_grade_educator.id)
+wsns_fifth_grade_educator = Educator.find_by_email('wsns@example.com')
+
+Homeroom.find_by_name("HEA 500").update_attribute(:educator, fifth_grade_educator)
+Homeroom.find_by_name("WSNS 500").update_attribute(:educator, wsns_fifth_grade_educator)
 
 homerooms.each do |homeroom|
   puts "Creating students for homeroom #{homeroom.name}..."

--- a/spec/controllers/educators_controller_spec.rb
+++ b/spec/controllers/educators_controller_spec.rb
@@ -12,7 +12,7 @@ describe EducatorsController, :type => :controller do
     context 'non admin' do
 
       context 'with homeroom' do
-        let!(:educator) { FactoryGirl.create(:educator_with_grade_5_homeroom) }
+        let!(:educator) { FactoryGirl.create(:educator_with_homeroom) }
         it 'redirects to default homeroom' do
           make_request
           expect(response).to redirect_to(homeroom_url(educator.homeroom))

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -2,33 +2,17 @@ require 'rails_helper'
 
 describe HomeroomsController, :type => :controller do
   let!(:school) { FactoryGirl.create(:school) }
-  let!(:educator) { FactoryGirl.create(:educator_with_grade_5_homeroom, school: school) }
-  let!(:educator_without_homeroom) { FactoryGirl.create(:educator) }
-  let!(:admin_educator) { FactoryGirl.create(:educator, :admin, school: school) }
-  let(:first_homeroom_path) { homeroom_path(Homeroom.first) }
 
   describe '#show' do
-
     def make_request(slug = nil)
       request.env['HTTPS'] = 'on'
       get :show, id: slug
     end
 
-    context 'educator not logged in' do
-      it 'redirects to sign in page' do
-        make_request(educator.homeroom.slug)
-        expect(response).to redirect_to(new_educator_session_path)
-      end
-    end
-
-    context 'non-admin educator with homeroom logged in' do
+    context 'educator with homeroom logged in' do
+      let!(:educator) { FactoryGirl.create(:educator, school: school) }
+      let!(:homeroom) { FactoryGirl.create(:homeroom, educator: educator, grade: "5", school: school) }
       before { sign_in(educator) }
-
-      context 'no homeroom params' do
-        it 'raises an error' do
-          expect { make_request }.to raise_error ActionController::UrlGenerationError
-        end
-      end
 
       context 'homeroom params' do
 
@@ -42,11 +26,10 @@ describe HomeroomsController, :type => :controller do
           end
         end
 
-        context 'homeroom belongs to educator' do
-
+        context 'params for homeroom belonging to educator' do
           it 'is successful' do
             make_request(educator.homeroom.slug)
-            expect(response).to be_success
+            expect(response.status).to eq 200
           end
           it 'assigns correct homerooms to drop-down' do
             make_request(educator.homeroom.slug)
@@ -99,28 +82,28 @@ describe HomeroomsController, :type => :controller do
         context 'homeroom does not belong to educator' do
 
           context 'homeroom is grade level as educator\'s' do
-            let(:homeroom) { FactoryGirl.create(:grade_5_homeroom) }
+            let(:another_homeroom) { FactoryGirl.create(:homeroom, grade: '5', school: school) }
             it 'is successful' do
-              make_request(homeroom.slug)
-              expect(response).to be_success
+              make_request(another_homeroom.slug)
+              expect(response.status).to eq 200
             end
           end
 
           context 'homeroom is different grade level from educator\'s' do
-            let(:homeroom) { FactoryGirl.create(:homeroom) }
+            let(:yet_another_homeroom) { FactoryGirl.create(:homeroom, school: school) }
             it 'redirects to educator\'s homeroom' do
-              make_request(homeroom.slug)
+              make_request(yet_another_homeroom.slug)
               expect(response).to redirect_to(homeroom_path(educator.homeroom))
             end
           end
 
           context 'educator has appropriate grade level access' do
-            let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['5'] )}
-            let(:homeroom) { FactoryGirl.create(:grade_5_homeroom) }
+            let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['5'], school: school) }
+            let(:homeroom) { FactoryGirl.create(:homeroom, grade: '5', school: school) }
 
             it 'is successful' do
               make_request(homeroom.slug)
-              expect(response).to be_success
+              expect(response.status).to eq 200
             end
           end
 
@@ -128,7 +111,7 @@ describe HomeroomsController, :type => :controller do
             let(:school) { FactoryGirl.create(:school) }
             before { FactoryGirl.create(:student, school: school) }
             let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['3'], school: school )}
-            let(:homeroom) { FactoryGirl.create(:grade_5_homeroom) }
+            let(:homeroom) { FactoryGirl.create(:homeroom, grade: '5', school: school) }
 
             it 'redirects' do
               make_request(homeroom.slug)
@@ -139,9 +122,17 @@ describe HomeroomsController, :type => :controller do
         end
 
       end
+
+      context 'no homeroom params' do
+        it 'raises an error' do
+          expect { make_request }.to raise_error ActionController::UrlGenerationError
+        end
+      end
+
     end
 
     context 'admin educator logged in' do
+      let(:admin_educator) { FactoryGirl.create(:educator, :admin, school: school) }
       before { sign_in(admin_educator) }
 
       context 'no homeroom params' do
@@ -152,10 +143,10 @@ describe HomeroomsController, :type => :controller do
 
       context 'homeroom params' do
         context 'good homeroom params' do
-          let(:homeroom) { FactoryGirl.create(:grade_5_homeroom) }
+          let(:homeroom) { FactoryGirl.create(:homeroom, grade: '5', school: school) }
           it 'is successful' do
             make_request(homeroom.slug)
-            expect(response).to be_success
+            expect(response.status).to eq 200
           end
           it 'assigns correct homerooms to drop-down' do
             make_request(homeroom.slug)
@@ -174,8 +165,8 @@ describe HomeroomsController, :type => :controller do
       end
     end
 
-    context 'non-admin without homeroom logged in' do
-      before { sign_in(educator_without_homeroom) }
+    context 'educator without schoolwide access logged in' do
+      before { sign_in(FactoryGirl.create(:educator)) }
 
       context 'no homeroom params' do
         it 'raises an error' do
@@ -189,6 +180,16 @@ describe HomeroomsController, :type => :controller do
           make_request(homeroom.slug)
           expect(response).to redirect_to(no_homeroom_url)
         end
+      end
+    end
+
+    context 'educator not logged in' do
+      let!(:educator) { FactoryGirl.create(:educator, school: school) }
+      let!(:homeroom) { FactoryGirl.create(:homeroom, educator: educator, grade: "5", school: school) }
+
+      it 'redirects to sign in page' do
+        make_request(educator.homeroom.slug)
+        expect(response).to redirect_to(new_educator_session_path)
       end
     end
 

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -81,11 +81,19 @@ describe HomeroomsController, :type => :controller do
 
         context 'homeroom does not belong to educator' do
 
-          context 'homeroom is grade level as educator\'s' do
+          context 'homeroom is grade level as educator\'s and same school' do
             let(:another_homeroom) { FactoryGirl.create(:homeroom, grade: '5', school: school) }
             it 'is successful' do
               make_request(another_homeroom.slug)
               expect(response.status).to eq 200
+            end
+          end
+
+          context 'homeroom is grade level as educator\'s -- but different school!' do
+            let(:another_homeroom) { FactoryGirl.create(:homeroom, grade: '5', school: FactoryGirl.create(:school)) }
+            it 'redirects' do
+              make_request(another_homeroom.slug)
+              expect(response.status).to eq 302
             end
           end
 

--- a/spec/demo_data/fake_student_spec.rb
+++ b/spec/demo_data/fake_student_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe FakeStudent do
 
   let!(:school) { FactoryGirl.create(:school) }
-  let!(:homeroom) { FactoryGirl.create(:grade_5_homeroom) }
+  let!(:homeroom) { FactoryGirl.create(:homeroom, grade: '5') }
   before { FactoryGirl.create(:educator, :admin) }
   let(:student) { described_class.new(homeroom).student }
 

--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -40,12 +40,5 @@ FactoryGirl.define do
       end
     end
 
-    factory :educator_with_homeroom_with_student do
-      after(:create) do |educator|
-        homeroom = create(:homeroom, educator: educator)
-        create(:student, :with_risk_level, :registered_last_year, homeroom: homeroom)
-      end
-    end
-
   end
 end

--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -60,20 +60,5 @@ FactoryGirl.define do
         educator.homeroom = FactoryGirl.create(:homeroom_with_student_with_multiple_star_math_student_assessments)
       end
     end
-    factory :educator_with_homeroom_with_one_atp_intervention do
-      after(:create) do |educator|
-        educator.homeroom = FactoryGirl.create(:homeroom_with_one_atp_intervention)
-      end
-    end
-    factory :educator_with_homeroom_with_one_non_atp_intervention do
-      after(:create) do |educator|
-        educator.homeroom = FactoryGirl.create(:homeroom_with_one_non_atp_intervention)
-      end
-    end
-    factory :educator_with_homeroom_with_multiple_atp_interventions do
-      after(:create) do |educator|
-        educator.homeroom = FactoryGirl.create(:homeroom_with_multiple_atp_interventions)
-      end
-    end
   end
 end

--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -33,32 +33,19 @@ FactoryGirl.define do
         create(:homeroom, educator: educator)
       end
     end
+
     factory :educator_with_grade_5_homeroom do
       after(:create) do |educator|
         create(:homeroom, educator: educator, grade: "5")
       end
     end
+
     factory :educator_with_homeroom_with_student do
       after(:create) do |educator|
         homeroom = create(:homeroom, educator: educator)
         create(:student, :with_risk_level, :registered_last_year, homeroom: homeroom)
       end
     end
-    factory :educator_with_homeroom_with_three_students do
-      after(:create) do |educator|
-        homeroom = create(:homeroom, educator: educator)
-        3.times { create(:student, :with_risk_level, :registered_last_year, homeroom: homeroom) }
-      end
-    end
-    factory :educator_with_homeroom_with_student_with_mcas_math_warning do
-      after(:create) do |educator|
-        educator.homeroom = FactoryGirl.create(:homeroom_with_student_with_mcas_math_warning)
-      end
-    end
-    factory :educator_with_homeroom_with_multiple_star_math_student_assessments do
-      after(:create) do |educator|
-        educator.homeroom = FactoryGirl.create(:homeroom_with_student_with_multiple_star_math_student_assessments)
-      end
-    end
+
   end
 end

--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -34,11 +34,5 @@ FactoryGirl.define do
       end
     end
 
-    factory :educator_with_grade_5_homeroom do
-      after(:create) do |educator|
-        create(:homeroom, educator: educator, grade: "5")
-      end
-    end
-
   end
 end

--- a/spec/factories/homerooms.rb
+++ b/spec/factories/homerooms.rb
@@ -31,29 +31,5 @@ FactoryGirl.define do
       end
     end
 
-    factory :homeroom_with_one_atp_intervention do
-      after(:create) do |homeroom|
-        homeroom.students << FactoryGirl.create(:student_with_one_atp_intervention,
-                                                :with_risk_level,
-                                                :registered_last_year)
-      end
-    end
-
-    factory :homeroom_with_one_non_atp_intervention do
-      after(:create) do |homeroom|
-        homeroom.students << FactoryGirl.create(:student_with_one_non_atp_intervention,
-                                                :with_risk_level,
-                                                :registered_last_year)
-      end
-    end
-
-    factory :homeroom_with_multiple_atp_interventions do
-      after(:create) do |homeroom|
-        homeroom.students << FactoryGirl.create(:student_with_multiple_atp_interventions,
-                                                :with_risk_level,
-                                                :registered_last_year)
-      end
-    end
-
   end
 end

--- a/spec/factories/homerooms.rb
+++ b/spec/factories/homerooms.rb
@@ -31,22 +31,6 @@ FactoryGirl.define do
       end
     end
 
-    factory :homeroom_with_student_with_mcas_math_warning do
-      after(:create) do |homeroom|
-        homeroom.students << FactoryGirl.create(:student_with_mcas_math_warning_assessment,
-                                                :with_risk_level,
-                                                :registered_last_year)
-      end
-    end
-
-    factory :homeroom_with_student_with_multiple_star_math_student_assessments do
-      after(:create) do |homeroom|
-        homeroom.students << FactoryGirl.create(:student_with_star_math_student_assessments_different_days,
-                                                :with_risk_level,
-                                                :registered_last_year)
-      end
-    end
-
     factory :homeroom_with_one_atp_intervention do
       after(:create) do |homeroom|
         homeroom.students << FactoryGirl.create(:student_with_one_atp_intervention,

--- a/spec/factories/homerooms.rb
+++ b/spec/factories/homerooms.rb
@@ -9,10 +9,6 @@ FactoryGirl.define do
   factory :homeroom do
     name { FactoryGirl.generate(:name) }
 
-    factory :grade_5_homeroom do
-      grade "5"
-    end
-
     factory :homeroom_with_student do
       after(:create) do |homeroom|
         homeroom.students << FactoryGirl.create(:student, :with_risk_level, :registered_last_year)

--- a/spec/features/roster_feature_spec.rb
+++ b/spec/features/roster_feature_spec.rb
@@ -3,35 +3,57 @@ require 'capybara/rspec'
 
 describe 'roster', :type => :feature do
   context 'educator with account views roster' do
-    let(:student_rows) { all('.student-row') }
 
-    before do
+    def update_students_and_run_scenario
+      Student.all.each do |student|
+        homeroom.students << student
+        student.update_recent_student_assessments
+        student.update_risk_level
+      end
+
       mock_ldap_authorization
-      educator.students.first.update_recent_student_assessments if educator.students.present?
-      educator.students.first.update_risk_level if educator.students.present?
       educator_sign_in(educator)
     end
 
+    let(:student_rows) { all('.student-row') }
+
     context 'no students in homeroom' do
-      let!(:educator) { FactoryGirl.create(:educator_with_homeroom) }
+      let(:school) { FactoryGirl.create(:school) }
+      let(:homeroom) { FactoryGirl.create(:homeroom, school: school) }
+      let(:educator) { FactoryGirl.create(:educator, homeroom: homeroom, school: school) }
+
+      before do
+        mock_ldap_authorization
+        educator_sign_in(educator)
+      end
+
       it 'shows empty roster' do
         expect(student_rows.size).to eq 0
       end
     end
 
     context 'one student in homeroom' do
+      let(:school) { FactoryGirl.create(:school) }
+      let!(:homeroom) { FactoryGirl.create(:homeroom, school: school) }
+      let(:educator) { FactoryGirl.create(:educator, homeroom: homeroom, school: school) }
+
       context 'no student assessments' do
-        let!(:educator) { FactoryGirl.create(:educator_with_homeroom_with_student) }
+        let!(:student) { FactoryGirl.create(:student) }
+
         it 'shows roster with one student row' do
+          update_students_and_run_scenario
           expect(student_rows.size).to eq 1
         end
       end
 
       context 'one student assessment' do
         context 'MCAS' do
-          let!(:educator) { FactoryGirl.create(:educator_with_homeroom_with_student_with_mcas_math_warning) }
+          let!(:student) { FactoryGirl.create(:student_with_mcas_math_warning_assessment,
+                                                :with_risk_level,
+                                                :registered_last_year) }
 
           it 'shows the student assessment' do
+            update_students_and_run_scenario
             mcas_math_performance = page.find('td.mcas_math.performance_level')
             expect(mcas_math_performance).to have_content 'W'
           end
@@ -40,9 +62,12 @@ describe 'roster', :type => :feature do
 
       context 'multiple student assessments' do
         context 'STAR' do
-          let!(:educator) { FactoryGirl.create(:educator_with_homeroom_with_multiple_star_math_student_assessments) }
+          let!(:student) { FactoryGirl.create(:student_with_star_math_student_assessments_different_days,
+                                                :with_risk_level,
+                                                :registered_last_year) }
 
           it 'shows only the most recent STAR result in the roster' do
+            update_students_and_run_scenario
             star_math_percentile_rank = page.find('td.star_math.percentile_rank')
             expect(star_math_percentile_rank).to have_content '10'
           end
@@ -52,8 +77,13 @@ describe 'roster', :type => :feature do
     end
 
     context 'three students in homeroom' do
-      let!(:educator) { FactoryGirl.create(:educator_with_homeroom_with_three_students) }
+      let(:school) { FactoryGirl.create(:school) }
+      let(:homeroom) { FactoryGirl.create(:homeroom, school: school) }
+      let(:educator) { FactoryGirl.create(:educator, homeroom: homeroom, school: school) }
+      before { 3.times { FactoryGirl.create(:student) } }
+
       it 'shows roster with three student rows' do
+        update_students_and_run_scenario
         expect(student_rows.size).to eq 3
       end
     end

--- a/spec/features/sign_in_feature_spec.rb
+++ b/spec/features/sign_in_feature_spec.rb
@@ -6,7 +6,10 @@ describe 'educator sign in', type: :feature do
   context 'educator with LDAP authorization signs in' do
 
     context 'with homeroom' do
-      let(:educator) { FactoryGirl.create(:educator_with_homeroom) }
+      let(:school) { FactoryGirl.create(:school) }
+      let(:homeroom) { FactoryGirl.create(:homeroom, school: school) }
+      let(:educator) { FactoryGirl.create(:educator, homeroom: homeroom, school: school) }
+
       it 'signs in' do
         mock_ldap_authorization
         educator_sign_in(educator)

--- a/spec/fixtures/fake_students_export.txt
+++ b/spec/fixtures/fake_students_export.txt
@@ -1,4 +1,4 @@
 "state_id","local_id","full_name","home_language","program_assigned","limited_english_proficiency","sped_placement","disability","sped_level_of_need","plan_504","student_address","grade","registration_date","free_reduced_lunch","homeroom","school_local_id","enrollment_status"
-"1000000000","100","Fake Student, First","English","Sp Ed","Fluent","Full Inclusion","Specific LDs","Moderate","Not 504","155 9th St, San Francisco, CA","07","2008-02-20","Not Eligible","Homeroom 200","HEA","Active"
-"1000000001","101","Fake Student, Second","Vietnamese","Reg Ed","FLEP-Transitioning",\N,\N,\N,"Not 504","155 9th St, San Francisco, CA","07","2005-08-05","Free Lunch","Homeroom 200","SHS","Active"
-"1000000002","103","Fake Student, Second","Vietnamese","Reg Ed","FLEP-Transitioning",\N,\N,\N,"Not 504","155 9th St, San Francisco, CA","07","2005-08-05","Free Lunch","Homeroom 200","BRN","Active"
+"1000000000","100","Fake Student, First","English","Sp Ed","Fluent","Full Inclusion","Specific LDs","Moderate","Not 504","155 9th St, San Francisco, CA","07","2008-02-20","Not Eligible","HEA 200","HEA","Active"
+"1000000001","101","Fake Student, Second","Vietnamese","Reg Ed","FLEP-Transitioning",\N,\N,\N,"Not 504","155 9th St, San Francisco, CA","07","2005-08-05","Free Lunch","SHS 200","SHS","Active"
+"1000000002","103","Fake Student, Second","Vietnamese","Reg Ed","FLEP-Transitioning",\N,\N,\N,"Not 504","155 9th St, San Francisco, CA","07","2005-08-05","Free Lunch","BRN 200","BRN","Active"

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -135,34 +135,39 @@ RSpec.describe Educator do
   end
 
   describe '#allowed_homerooms' do
+    let!(:school) { FactoryGirl.create(:healey) }
+    let!(:other_school) { FactoryGirl.create(:brown) }
 
     context 'admin' do
-      let(:educator) { FactoryGirl.create(:educator, schoolwide_access: true) }
-      let!(:homeroom_101) { FactoryGirl.create(:homeroom) }
-      let!(:homeroom_102) { FactoryGirl.create(:homeroom) }
-      let!(:homeroom_103) { FactoryGirl.create(:homeroom, grade: '2') }
+      let(:educator) { FactoryGirl.create(:educator, schoolwide_access: true, school: school) }
+      let!(:homeroom_101) { FactoryGirl.create(:homeroom, school: school) }
+      let!(:homeroom_102) { FactoryGirl.create(:homeroom, school: school) }
+      let!(:homeroom_103) { FactoryGirl.create(:homeroom, grade: '2', school: school) }
 
-      it 'returns all homerooms' do
-        expect(educator.allowed_homerooms.sort).to eq [homeroom_101, homeroom_102, homeroom_103].sort
+      it 'returns all homerooms in the school' do
+        expect(educator.allowed_homerooms.sort).to eq [
+          homeroom_101, homeroom_102, homeroom_103
+        ].sort
       end
     end
 
     context 'homeroom teacher' do
-      let(:educator) { FactoryGirl.create(:educator) }
-      let!(:homeroom_101) { FactoryGirl.create(:homeroom, grade: 'K', educator: educator) }
-      let!(:homeroom_102) { FactoryGirl.create(:homeroom, grade: 'K') }
-      let!(:homeroom_103) { FactoryGirl.create(:homeroom, grade: '2') }
+      let(:educator) { FactoryGirl.create(:educator, school: school) }
+      let!(:homeroom_101) { FactoryGirl.create(:homeroom, grade: 'K', educator: educator, school: school) }
+      let!(:homeroom_102) { FactoryGirl.create(:homeroom, grade: 'K', school: school) }
+      let!(:homeroom_103) { FactoryGirl.create(:homeroom, grade: '2', school: school) }
+      let!(:homeroom_brn) { FactoryGirl.create(:homeroom, grade: '2', school: other_school) }
 
-      it 'returns the teacher\'s homeroom and other homerooms with the same grade level' do
+      it 'returns educator\'s homeroom plus other homerooms at same grade level in same school' do
         expect(educator.allowed_homerooms).to eq [homeroom_101, homeroom_102]
       end
     end
 
     context 'teacher with grade level access' do
-      let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['2']) }
-      let!(:homeroom_101) { FactoryGirl.create(:homeroom, grade: 'K') }
-      let!(:homeroom_102) { FactoryGirl.create(:homeroom, grade: 'K') }
-      let!(:homeroom_103) { FactoryGirl.create(:homeroom, grade: '2') }
+      let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['2'], school: school) }
+      let!(:homeroom_101) { FactoryGirl.create(:homeroom, grade: 'K', school: school) }
+      let!(:homeroom_102) { FactoryGirl.create(:homeroom, grade: 'K', school: school) }
+      let!(:homeroom_103) { FactoryGirl.create(:homeroom, grade: '2', school: school) }
 
       it 'returns all homerooms that match the grade level access' do
         expect(educator.allowed_homerooms).to eq [homeroom_103]
@@ -173,10 +178,11 @@ RSpec.describe Educator do
 
   describe '#allowed_homerooms_by_name' do
     context 'admin' do
-      let(:educator) { FactoryGirl.create(:educator, schoolwide_access: true) }
-      let!(:homeroom_101) { FactoryGirl.create(:homeroom, name: 'Muskrats') }
-      let!(:homeroom_102) { FactoryGirl.create(:homeroom, name: 'Hawks') }
-      let!(:homeroom_103) { FactoryGirl.create(:homeroom, name: 'Badgers') }
+      let(:school) { FactoryGirl.create(:healey) }
+      let(:educator) { FactoryGirl.create(:educator, schoolwide_access: true, school: school) }
+      let!(:homeroom_101) { FactoryGirl.create(:homeroom, name: 'Muskrats', school: school) }
+      let!(:homeroom_102) { FactoryGirl.create(:homeroom, name: 'Hawks', school: school) }
+      let!(:homeroom_103) { FactoryGirl.create(:homeroom, name: 'Badgers', school: school) }
 
       it 'returns all homerooms\', ordered alphabetically by name' do
         expect(educator.allowed_homerooms_by_name).to eq [homeroom_103, homeroom_102, homeroom_101]


### PR DESCRIPTION
Fixes #435:

+ Adds association between `Homeroom` and `School`.
+ Scopes educator homeroom access to the appropriate school.
+ Gets rid of a bunch of useless factories.
+ Adds multi-school example to the demo data.