### PR TITLE
Add simple name validation for services

### DIFF
--- a/app/assets/javascripts/student_profile/page_container.js
+++ b/app/assets/javascripts/student_profile/page_container.js
@@ -94,10 +94,15 @@
     },
 
     onClickSaveService: function(serviceParams) {
-      this.setState({ requests: merge(this.state.requests, { saveService: 'pending' }) });
-      this.api.saveService(this.state.student.id, serviceParams)
-        .done(this.onSaveServiceDone)
-        .fail(this.onSaveServiceFail);
+	// Very quick name validation, just check for a comma between two words
+	if ((/(\w+, \w|^$)/.test(serviceParams.providedByEducatorName))) {
+	    this.setState({ requests: merge(this.state.requests, { saveService: 'pending' }) });
+	    this.api.saveService(this.state.student.id, serviceParams)
+		.done(this.onSaveServiceDone)
+		.fail(this.onSaveServiceFail);
+	} else {
+	    this.setState({ requests: merge(this.state.requests, { saveService: 'Please use the form Last Name, First Name' }) });
+	}
     },
 
     onSaveServiceDone: function(response) {

--- a/app/assets/javascripts/student_profile/record_service.js
+++ b/app/assets/javascripts/student_profile/record_service.js
@@ -66,7 +66,7 @@
     getInitialState: function() {
       return {
         serviceTypeId: null,
-        providedByEducatorName: null,
+        providedByEducatorName: "",
         momentStarted: moment.utc() // TODO should thread through
       }
     },
@@ -196,8 +196,7 @@
           style: styles.cancelRecordServiceButton,
           onClick: this.onClickCancel
         }, 'Cancel'),
-        (this.props.requestState === 'pending') ? dom.span({}, 'Saving...') : null,
-        (this.props.requestState === 'error') ? dom.span({}, 'Try again!') : null
+        (this.props.requestState === 'pending') ? dom.span({}, 'Saving...') : this.props.requestState
       );
     }
   });

--- a/app/assets/javascripts/student_profile/services_list.js
+++ b/app/assets/javascripts/student_profile/services_list.js
@@ -155,8 +155,8 @@
     },
 
     renderEducatorName: function (educatorName) {
-      if (educatorName === null) {
-        return dom.div({}, 'No staff recorded');
+      if (educatorName === "" || educatorName === null) {
+	return dom.div({}, 'No staff recorded');
       } else {
         return dom.div({}, 'With ' + educatorName);
       };

--- a/app/assets/javascripts/student_profile/student_profile_page.js
+++ b/app/assets/javascripts/student_profile/student_profile_page.js
@@ -316,8 +316,8 @@
       var activeServices = this.props.feed.services.active;
       var educatorNamesFromServices = _.pluck(activeServices, 'provided_by_educator_name');
       var uniqueNames = _.unique(educatorNamesFromServices);
-      var nonNullNames = _.filter(uniqueNames, function(id) { return id !== null; });
-      var educatorNames = _.isEmpty( nonNullNames ) ? ["No staff"] : nonNullNames;
+      var nonEmptyNames = _.filter(uniqueNames, function(id) { return id !== "" && id !== null; });
+      var educatorNames = _.isEmpty( nonEmptyNames ) ? ["No staff"] : nonEmptyNames;
 
       var limit = 3;
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -5,8 +5,6 @@ class Service < ActiveRecord::Base
   has_many :discontinued_services
 
   validates_presence_of :recorded_by_educator_id, :student_id, :service_type_id, :recorded_at, :date_started
-  validates :provided_by_educator_name, allow_nil: true,
-            format: { with: /(\w+, \w+|^$)/, message: "Please use the form Last Name, First Name" }
 
   def discontinued?
     discontinued_services.size > 0

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -5,6 +5,8 @@ class Service < ActiveRecord::Base
   has_many :discontinued_services
 
   validates_presence_of :recorded_by_educator_id, :student_id, :service_type_id, :recorded_at, :date_started
+  validates :provided_by_educator_name, allow_nil: true,
+            format: { with: /(\w+, \w+|^$)/, message: "Please use the form Last Name, First Name" }
 
   def discontinued?
     discontinued_services.size > 0

--- a/spec/javascripts/student_profile/page_container_spec.js
+++ b/spec/javascripts/student_profile/page_container_spec.js
@@ -115,6 +115,12 @@ describe('PageContainer', function() {
 	    onProvidedByEducatorName: 'Teacher, Test'
 	});
 	expect(el).toContainText('Saving...');
+
+	// Name can also be blank
+	component.onClickSaveService({
+	    onProvidedByEducatorName: ''
+	});
+	expect(el).toContainText('Saving...');
     });
 
     // TODO(kr) the spec helper here was reaching into the react-select internals,

--- a/spec/javascripts/student_profile/page_container_spec.js
+++ b/spec/javascripts/student_profile/page_container_spec.js
@@ -102,6 +102,21 @@ describe('PageContainer', function() {
       });
     });
 
+    it('verifies that the educator name is in the correct format', function() {
+	var el = this.testEl;
+	var component = helpers.renderInto(el, {});
+
+	component.onClickSaveService({
+	    onProvidedByEducatorName: 'badinput'
+	});
+	expect(el).toContainText('Please use the form Last Name, First Name');
+
+	component.onClickSaveService({
+	    onProvidedByEducatorName: 'Teacher, Test'
+	});
+	expect(el).toContainText('Saving...');
+    });
+
     // TODO(kr) the spec helper here was reaching into the react-select internals,
     // which changed in 1.0.0, this needs to be updated.
     // it('can save an Attendance Contract service, mocking the action handlers', function() {


### PR DESCRIPTION
Fixes #414 - Educator names should be entered in the form Last Name, First Name. We should at the very least check that there's a comma in between two words.