### PR TITLE
Centralize student profile utility methods

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -59,6 +59,7 @@
 
 // student profile page:
 // pure ui components:
+  //= require ./student_profile/quad_converter
   //= require ./student_profile/risk_bubble
   //= require ./student_profile/service_color
   //= require ./student_profile/provided_by_educator_dropdown
@@ -67,7 +68,6 @@
   //= require ./student_profile/datepicker
   //= require ./student_profile/highcharts_wrapper
   //= require ./student_profile/sparkline
-  //= require ./student_profile/quad_converter
   //= require ./student_profile/scales
   //= require ./student_profile/academic_summary
   //= require ./student_profile/take_notes

--- a/app/assets/javascripts/student_profile/profile_bar_chart.js
+++ b/app/assets/javascripts/student_profile/profile_bar_chart.js
@@ -5,6 +5,7 @@
   var merge = window.shared.ReactHelpers.merge;
 
   var HighchartsWrapper = window.shared.HighchartsWrapper;
+  var QuadConverter = window.shared.QuadConverter;
 
   var styles = {
     title: {

--- a/app/assets/javascripts/student_profile/profile_chart.js
+++ b/app/assets/javascripts/student_profile/profile_chart.js
@@ -42,7 +42,6 @@
     },
 
     render: function() {
-      var self = this;
       return createEl(HighchartsWrapper, merge(this.baseOptions(), {
         title: {
           text: this.props.titleText,

--- a/app/assets/javascripts/student_profile/profile_chart.js
+++ b/app/assets/javascripts/student_profile/profile_chart.js
@@ -3,6 +3,7 @@
   var dom = window.shared.ReactHelpers.dom;
   var createEl = window.shared.ReactHelpers.createEl;
   var merge = window.shared.ReactHelpers.merge;
+  var QuadConverter = window.shared.QuadConverter;
 
   var ProfileChartSettings = window.ProfileChartSettings;
   var HighchartsWrapper = window.shared.HighchartsWrapper;
@@ -48,7 +49,10 @@
           align: 'left'
         },
         series: this.props.quadSeries.map(function(obj){
-          return {name: obj.name, data: self.quadsToPairs(obj.data || [])}
+          return {
+            name: obj.name,
+            data: obj.data ? _.map(obj.data, QuadConverter.toPair): []
+          }
         }),
         yAxis: this.props.yAxis
       }));
@@ -63,15 +67,5 @@
         })
       });
     },
-
-    quadsToPairs: function(quads) {
-      return quads.map(function(quad) {
-        var year = quad[0],
-            month = quad[1],
-            day = quad[2],
-            value = quad[3];
-        return [Date.UTC(year, month - 1, day), value]; // one-index --> zero-index on month
-      });
-    }
   });
 })();

--- a/app/assets/javascripts/student_profile/profile_details.js
+++ b/app/assets/javascripts/student_profile/profile_details.js
@@ -120,38 +120,38 @@
         });
       });
       _.each(this.props.chartData.mcas_series_ela_scaled, function(quad){
-        var score = quad[3];
+        // var score = quad[3];
         events.push({
           type: 'MCAS-ELA',
-          id: moment.utc(QuadConverter.toDate(quad)).format("MM-DD"),
-          message: name + ' scored a ' + score + ' on the ELA section of the MCAS.',
+          id: QuadConverter.toMoment(quad).format("MM-DD"),
+          message: name + ' scored a ' + QuadConverter.toValue(quad) +' on the ELA section of the MCAS.',
           date: QuadConverter.toDate(quad)
         });
       });
       _.each(this.props.chartData.mcas_series_math_scaled, function(quad){
-        var score = quad[3];
+        // var score = quad[3];
         events.push({
           type: 'MCAS-Math',
-          id: moment.utc(QuadConverter.toDate(quad)).format("MM-DD"),
-          message: name + ' scored a ' + score + ' on the Math section of the MCAS.',
+          id: QuadConverter.toMoment(quad).format("MM-DD"),
+          message: name + ' scored a ' + QuadConverter.toValue(quad) +' on the Math section of the MCAS.',
           date: QuadConverter.toDate(quad)
         });
       });
       _.each(this.props.chartData.star_series_reading_percentile, function(quad){
-        var score = quad[3];
+        // var score = quad[3];
         events.push({
           type: 'STAR-Reading',
-          id: moment.utc(QuadConverter.toDate(quad)).format("MM-DD"),
-          message: name + ' scored in the ' + score + 'th percentile on the Reading section of STAR.',
+          id: QuadConverter.toMoment(quad).format("MM-DD"),
+          message: name + ' scored in the ' + QuadConverter.toValue(quad) +'th percentile on the Reading section of STAR.',
           date: QuadConverter.toDate(quad)
         });
       });
       _.each(this.props.chartData.star_series_math_percentile, function(quad){
-        var score = quad[3];
+        // var score = quad[3];
         events.push({
           type: 'STAR-Math',
-          id: moment.utc(QuadConverter.toDate(quad)).format("MM-DD"),
-          message: name + ' scored in the ' + score + 'th percentile on the Math section of STAR.',
+          id: QuadConverter.toMoment(quad).format("MM-DD"),
+          message: name + ' scored in the ' + QuadConverter.toValue(quad) +'th percentile on the Math section of STAR.',
           date: QuadConverter.toDate(quad)
         });
       });

--- a/app/assets/javascripts/student_profile/profile_details.js
+++ b/app/assets/javascripts/student_profile/profile_details.js
@@ -237,22 +237,10 @@
       );
     },
 
-    toSchoolYear: function(date){
-      // Takes in a date, returns the start of the school year into which it falls.
-      var d = moment(date);
-      if (d.month() < 8){
-        // The school year starts on August 1st.
-        // So if the month is before August, it falls in the previous year.
-        return d.year() - 1;
-      } else {
-        return d.year();
-      }
-    },
-
     renderFullCaseHistory: function(){
       var self = this;
       var bySchoolYearDescending = _.toArray(
-        _.groupBy(this.getEvents(), function(event){ return self.toSchoolYear(event.date) })
+        _.groupBy(this.getEvents(), function(event){ return QuadConverter.toSchoolYear(event.date) })
       ).reverse();
 
       return dom.div({id: "full-case-history"},
@@ -263,7 +251,7 @@
 
     renderCardsForYear: function(eventsForYear){
       // Grab what school year we're in from any object in the list.
-      var year = this.toSchoolYear(eventsForYear[0].date);
+      var year = QuadConverter.toSchoolYear(eventsForYear[0].date);
       // Computes '2016 - 2017 School Year' for input 2016, etc.
       var schoolYearString = year.toString() + ' - ' + (year+1).toString() + ' School Year';
 

--- a/app/assets/javascripts/student_profile/quad_converter.js
+++ b/app/assets/javascripts/student_profile/quad_converter.js
@@ -2,6 +2,10 @@
   window.shared || (window.shared = {});
 
   var QuadConverter = window.shared.QuadConverter = {
+    // A quad is a 4-element array of numbers that represents numerical data on a given date.
+    // The first three elements are (year, month, date) and the last is the value.
+
+    // These functions are provided for getting data out of quads.
     toMoment: function(quad) {
       return moment.utc([quad[0], quad[1], quad[2]].join('-'), 'YYYY-M-D');
     },
@@ -17,14 +21,14 @@
     // Fills in data points for start of the school year (8/15) and for current day.
     // Also collapses multiple events on the same day.
     convertAttendanceEvents: function(attendanceEvents, nowDate, dateRange) {
-      var currentYearStart = this.schoolYearStart(moment.utc(nowDate));
+      var currentYearStart = this.toSchoolYear(nowDate);
       var schoolYearStarts = this._allSchoolYearStarts(dateRange);
       var sortedAttendanceEvents = _.sortBy(attendanceEvents, 'occurred_at');
 
       var quads = [];
       schoolYearStarts.sort().forEach(function(schoolYearStart) {
         var yearAttendanceEvents = sortedAttendanceEvents.filter(function(attendanceEvent) {
-          return this.schoolYearStart(moment.utc(attendanceEvent.occurred_at)) === schoolYearStart;
+          return this.toSchoolYear(attendanceEvent.occurred_at) === schoolYearStart;
         }, this);
         var cumulativeEventQuads = this._toCumulativeQuads(yearAttendanceEvents);
         var startOfYearQuad = [schoolYearStart, 8, 15, 0];
@@ -39,17 +43,19 @@
       return _.sortBy(quads, this.toMoment.bind(this));
     },
 
-    schoolYearStart: function(eventMoment) {
-      var year = eventMoment.year();
+    toSchoolYear: function(date) {
+      // date: A JS date object or Moment object.
+      // returns: Integer representing what the calendar year was in the fall of date's school year.
+      var momentObject = moment.utc(date);
+
+      var year = momentObject.year();
       var startOfSchoolYear = this.toMoment([year, 8, 15]);
-      var isEventDuringFall = eventMoment.clone().diff(startOfSchoolYear, 'days') > 0;
+      var isEventDuringFall = momentObject.diff(startOfSchoolYear, 'days') > 0;
       return (isEventDuringFall) ? year : year - 1;
     },
 
     _allSchoolYearStarts: function(dateRange) {
-      var schoolYearStarts = dateRange.map(function(date) {
-        return this.schoolYearStart(moment.utc(date));
-      }, this);
+      var schoolYearStarts = _.map(dateRange, this.toSchoolYear, this);
       return _.range(schoolYearStarts[0], schoolYearStarts[1] + 1);
     },
 

--- a/app/assets/javascripts/student_profile/quad_converter.js
+++ b/app/assets/javascripts/student_profile/quad_converter.js
@@ -18,6 +18,10 @@
       return quad[3];
     },
 
+    toPair: function(quad){
+      return [QuadConverter.toMoment(quad).valueOf(), QuadConverter.toValue(quad)];
+    },
+
     // Fills in data points for start of the school year (8/15) and for current day.
     // Also collapses multiple events on the same day.
     convertAttendanceEvents: function(attendanceEvents, nowDate, dateRange) {

--- a/app/assets/javascripts/student_profile/sparkline.js
+++ b/app/assets/javascripts/student_profile/sparkline.js
@@ -4,6 +4,8 @@
   var createEl = window.shared.ReactHelpers.createEl;
   var merge = window.shared.ReactHelpers.merge;
 
+  var QuadConverter = window.shared.QuadConverter;
+
   /*
   Project quads outside of the date range, since interpolation will connect with previous data points.
   */
@@ -40,7 +42,7 @@
         .domain(this.props.valueRange)
         .range([this.props.height - padding, padding]);
       var lineGenerator = d3.svg.line()
-        .x(function(d) { return x(this.quadDate(d)); }.bind(this))
+        .x(function(d) { return x(QuadConverter.toDate(d)); }.bind(this))
         .y(function(d) { return y(d[3]); })
         .interpolate('linear');
 
@@ -96,7 +98,7 @@
 
     delta: function(quads) {
       var filteredQuadValues = _.compact(quads.map(function(quad) {
-        var date = this.quadDate(quad);
+        var date = QuadConverter.toDate(quad);
         if (date > this.props.dateRange[0] && date < this.props.dateRange[1]) return null;
         return quad[3];
       }, this));
@@ -104,8 +106,8 @@
       return _.last(filteredQuadValues) - _.first(filteredQuadValues);
     },
 
-    quadDate: function(quad) { 
-      return new Date(quad[0], quad[1] - 1, quad[2]);
-    }
+    // quadDate: function(quad) { 
+    //   return new Date(quad[0], quad[1] - 1, quad[2]);
+    // }
   });
 })();

--- a/spec/javascripts/student_profile/quad_converter_spec.js
+++ b/spec/javascripts/student_profile/quad_converter_spec.js
@@ -17,12 +17,15 @@ describe('QuadConverter', function() {
     });
   });
 
-  describe('#schoolYearStart', function() {
-    it('aligns to school year', function() {
-      expect(QuadConverter.schoolYearStart(moment.utc('2013-09-12'))).toEqual(2013);
-      expect(QuadConverter.schoolYearStart(moment.utc('2014-05-12'))).toEqual(2013);
-      expect(QuadConverter.schoolYearStart(moment.utc('2014-08-19'))).toEqual(2014);
-      expect(QuadConverter.schoolYearStart(moment.utc('2014-11-19'))).toEqual(2014);
+  describe('#toSchoolYear', function() {
+    it('works with JS Date objects', function() {
+      expect(QuadConverter.toSchoolYear(moment.utc('2014-08-19').valueOf())).toEqual(2014);
+      expect(QuadConverter.toSchoolYear(moment.utc('2013-09-12').valueOf())).toEqual(2013);
+    });
+
+    it('works with Moment objects', function() {
+      expect(QuadConverter.toSchoolYear(moment.utc('2014-11-19'))).toEqual(2014);
+      expect(QuadConverter.toSchoolYear(moment.utc('2014-05-12'))).toEqual(2013);
     });
   });
 


### PR DESCRIPTION
Fixes #465. Probably `toSchoolYear()` shouldn't be in `quad_converter.js` since it has nothing to do with quads. But I ran into snakes and high water fixing that, so leaving it this way for now.