### PR TITLE
Added back h4 and h5 classes to type.scss file, making styling work a…

### DIFF
--- a/app/assets/stylesheets/type.scss
+++ b/app/assets/stylesheets/type.scss
@@ -30,6 +30,19 @@ h3 {
   color: $gray;
 }
 
+h4 {
+  font-size: 24px;
+  font-weight: 300;
+  color: $blue;
+}
+
+h5 {
+  font-size: 14px;
+  font-weight: 700;
+  color: $gray;
+  text-transform: uppercase;
+}
+
 h6 {
   font-size: 14px;
   font-weight: 700;


### PR DESCRIPTION
…s it used to again on the profile page. Fixes #457.

What happened was that @alexsoble moved some css declarations that affected `h4` and `h5` from `type.scss` to `about.scss.erb` because he was consolidating stuff, but that broke styling of h4s and h5s on the profile page. So I added those declarations back, but kept his other lovely code-shrinking changes.

My lovely svelte font is back!

<img width="519" alt="screen shot 2016-05-10 at 12 41 47 am" src="https://cloud.githubusercontent.com/assets/1514487/15135749/ff17e95a-1647-11e6-99d3-9ac117fa1670.png">
