### PR TITLE
Don't create homerooms for inactive students

### DIFF
--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -25,6 +25,7 @@ class StudentsImporter < Struct.new :school_scope, :client
   end
 
   def assign_student_to_homeroom(student, homeroom_name)
+    return unless student.active?
     homeroom = Homeroom.where(name: homeroom_name, school: student.school).first_or_create!
     homeroom.students << student
   end

--- a/app/models/homeroom.rb
+++ b/app/models/homeroom.rb
@@ -1,8 +1,8 @@
 class Homeroom < ActiveRecord::Base
   extend FriendlyId
   friendly_id :name, use: :slugged
-  validates :name, uniqueness: true
-  validates :slug, uniqueness: true
+  validates :name, uniqueness: true, presence: true
+  validates :slug, uniqueness: true, presence: true
   has_many :students, after_add: :update_grade
   has_many :student_risk_levels, through: :students
   belongs_to :educator

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -29,6 +29,10 @@ class Student < ActiveRecord::Base
     where(enrollment_status: 'Active')
   end
 
+  def active?
+    enrollment_status == 'Active'
+  end
+
   ## STUDENT ASSESSMENT RESULTS ##
 
   def latest_result_by_family_and_subject(family_name, subject_name)

--- a/spec/importers/file_importers/students_importer_spec.rb
+++ b/spec/importers/file_importers/students_importer_spec.rb
@@ -75,5 +75,17 @@ RSpec.describe StudentsImporter do
       end
     end
 
+    context 'student is inactive' do
+      let!(:student) { FactoryGirl.create(:student, enrollment_status: 'Inactive') }
+      let!(:new_homeroom_name) { '152K' }
+
+      it 'does not create a new homeroom' do
+        expect {
+          described_class.new.assign_student_to_homeroom(student, new_homeroom_name)
+        }.to change(Homeroom, :count).by(0)
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
## Notes

+ In addition to helping us fix #448, this has an extra benefit. It unblocks the data import process for the third school. The import task is trying to create a new homeroom with `name: nil` for inactive students at the third school, which violates the uniqueness constraint on homeroom name.