### PR TITLE
Deprecate Math intervention as a service type going forward

### DIFF
--- a/app/assets/javascripts/components/slice_panels.js
+++ b/app/assets/javascripts/components/slice_panels.js
@@ -166,7 +166,10 @@
       var activeServices = _.compact(_.flatten(_.pluck(students, 'active_services')));
       var allServiceTypeIds = _.unique(activeServices.map(function(service) {
         return parseInt(service.service_type_id, 10);
-      }));
+      }))
+
+      var allServiceTypeIds = _.pull(allServiceTypeIds, 508);  // Deprecated Math intervention service type
+
       var serviceItems = allServiceTypeIds.map(function(serviceTypeId) {
         var serviceName = this.props.serviceTypesIndex[serviceTypeId].name;
         return this.createItem(serviceName, Filters.ServiceType(serviceTypeId));

--- a/app/assets/javascripts/components/slice_panels.js
+++ b/app/assets/javascripts/components/slice_panels.js
@@ -166,7 +166,7 @@
       var activeServices = _.compact(_.flatten(_.pluck(students, 'active_services')));
       var allServiceTypeIds = _.unique(activeServices.map(function(service) {
         return parseInt(service.service_type_id, 10);
-      }))
+      }));
 
       var allServiceTypeIds = _.pull(allServiceTypeIds, 508);  // Deprecated Math intervention service type
 

--- a/app/assets/javascripts/student_profile/record_service.js
+++ b/app/assets/javascripts/student_profile/record_service.js
@@ -117,11 +117,8 @@
         dom.div({ style: { display: 'flex', justifyContent: 'flex-start' } },
           dom.div({ style: styles.buttonWidth },
             this.renderServiceButton(505),
-            this.renderServiceButton(506)
-          ),
-          dom.div({ style: styles.buttonWidth },
-            this.renderServiceButton(507),
-            this.renderServiceButton(508)
+            this.renderServiceButton(506),
+            this.renderServiceButton(507)
           ),
           dom.div({ style: styles.buttonWidth },
             this.renderServiceButton(502),

--- a/app/models/service_type.rb
+++ b/app/models/service_type.rb
@@ -8,7 +8,9 @@ class ServiceType < ActiveRecord::Base
       { id: 505, name: 'Counseling, in-house'},
       { id: 506, name: 'Counseling, outside'},
       { id: 507, name: 'Reading intervention'},
-      { id: 508, name: 'Math intervention'}
+      { id: 508, name: 'Math intervention'}     # Deprecated: No adding new Math interventions
+                                                # going forward. Focusing on shorter list of
+                                                # services with sharp, clear definitions.
     ])
   end
 end

--- a/spec/javascripts/student_profile/record_service_spec.js
+++ b/spec/javascripts/student_profile/record_service_spec.js
@@ -46,7 +46,6 @@ describe('RecordService', function() {
         'Counseling, in-house',
         'Counseling, outside',
         'Reading intervention',
-        'Math intervention',
         'Attendance Officer',
         'Attendance Contract',
         'Behavior Contract'


### PR DESCRIPTION
## What's new?

+ Profile page, record services area: Can't add new Math interventions
+ Profile page, display services area: Previously entered Math interventions will be shown
+ School overview page: Math interventions show up, are not filterable
+ #452