### PR TITLE
Show user input in services educator dropdown

### DIFF
--- a/app/assets/javascripts/student_profile/provided_by_educator_dropdown.js
+++ b/app/assets/javascripts/student_profile/provided_by_educator_dropdown.js
@@ -59,7 +59,7 @@
         source: '/educators/services_dropdown/' + this.props.studentId,
         delay: 0,
         minLength: 0,
-        autofocus: true,
+        autoFocus: true,
 
         select: function(event, ui) {
           self.props.onUserDropdownSelect(ui.item.value);

--- a/app/assets/javascripts/student_profile/provided_by_educator_dropdown.js
+++ b/app/assets/javascripts/student_profile/provided_by_educator_dropdown.js
@@ -54,13 +54,32 @@
     componentDidMount: function() {
       var self = this;
 
+      // TODO: We should write a spec for this!
       $(this.refs.ProvidedByEducatorDropdown).autocomplete({
         source: '/educators/services_dropdown/' + this.props.studentId,
         delay: 0,
         minLength: 0,
+        autofocus: true,
+
         select: function(event, ui) {
           self.props.onUserDropdownSelect(ui.item.value);
         },
+
+        // Display what the user is typing first
+        response: function(event, ui) {
+          if (event.target.value !== "") {
+            var currentName = {label: event.target.value,
+                               value: event.target.value};
+            ui.content.unshift(currentName);
+          }
+
+          // Don't show a duplicate
+          for (var i = 1; i < ui.content.length; i++) {
+            if (ui.content[i].value === event.target.value)
+              ui.content = ui.content.splice(i,1)
+          }
+        },
+
         open: function() {
           $('body').bind('click.closeProvidedByEducatorDropdownMenu', self.closeMenu);
         },


### PR DESCRIPTION
Fix for #439. We can remind users that this is a free-text input by displaying whatever they've already typed as an option, even if no other names match.

Spec for this incoming. In the meantime, gifs!

![teacher test](https://cloud.githubusercontent.com/assets/3846783/15380422/6bcdd584-1d44-11e6-9eda-03e2f07dc6f3.gif)

![teacher austin](https://cloud.githubusercontent.com/assets/3846783/15380429/713bb5fe-1d44-11e6-9f6b-e286b34c9c25.gif)

Notice that we also auto select the first option when they start typing. I thought it made the process feel a bit smoother. Any thoughts?