### PR TITLE
Make services in user manual line up with buttons

### DIFF
--- a/app/assets/javascripts/student_profile/interventions_details.js
+++ b/app/assets/javascripts/student_profile/interventions_details.js
@@ -129,15 +129,20 @@
         <br> \
         <p>The types of Services are:</p> \
         <ul> \
-          <li><b>Reading Teacher:</b> Student works with a reading specialist at least 4x/week for 30-40 minutes.</li> \
-          <li><b>Behavior/Attendance Contract:</b>This is usually done in cooperation with the attendance officer, \
+          <li><b>Attendance Officer:</b> This usually includes home visit(s), regular follow-up, \
+          and could later on lead to a formal attendance contract.</li> \
+          <li><b>Attendance Contract:</b> This is usually done in cooperation with the attendance officer, \
           school adjustment counselor, and/or principal. This is a more formal document that requires a parent and \
           student signature, along with regular checkpoints.</li> \
-         <li><b>Attendance Officer:</b> This usually includes home visit(s), regular follow-up, \
-         and could later on lead to a formal attendance contract.</li> \
-         <li><b>Counseling:</b> Student receives regular weekly or bi-weekly counseling from an SPS counselor or outside \
-         (ex. Riverside, Home for Little Wanderers). One time or infrequent check-ins by a counselor should \
-         just be recorded in Notes.</li> \
+          <li><b>Behavior Contract:</b> This is usually done in cooperation with the attendance officer, \
+          school adjustment counselor, and/or principal. This is a more formal document that requires a parent and \
+          student signature, along with regular checkpoints.</li> \
+          <li><b>Counseling, in-house:</b> Student receives regular weekly or bi-weekly counseling from an SPS counselor. \
+          One time or infrequent check-ins by a counselor should just be recorded in Notes.</li> \
+          <li><b>Counseling, outside:</b> Student receives regular weekly or bi-weekly counseling from an outside \
+          counselor, ex. Riverside, Home for Little Wanderers. One time or infrequent check-ins by a counselor should \
+          just be recorded in Notes.</li> \
+          <li><b>Reading Intervention:</b> Student works with a reading specialist at least 4x/week for 30-40 minutes.</li> \
         </ul> \
         <br> \
         <p>If your data fits into one of these categories, it's a Service. Otherwise, it's a Note.</p>"

--- a/app/assets/javascripts/student_profile/record_service.js
+++ b/app/assets/javascripts/student_profile/record_service.js
@@ -116,14 +116,14 @@
         dom.div({ style: { marginBottom: 5, display: 'inline' }}, 'Which service?'),
         dom.div({ style: { display: 'flex', justifyContent: 'flex-start' } },
           dom.div({ style: styles.buttonWidth },
+            this.renderServiceButton(503),
+            this.renderServiceButton(502),
+            this.renderServiceButton(504)
+          ),
+          dom.div({ style: styles.buttonWidth },
             this.renderServiceButton(505),
             this.renderServiceButton(506),
             this.renderServiceButton(507)
-          ),
-          dom.div({ style: styles.buttonWidth },
-            this.renderServiceButton(502),
-            this.renderServiceButton(503),
-            this.renderServiceButton(504)
           )
         )
       );

--- a/spec/javascripts/student_profile/record_service_spec.js
+++ b/spec/javascripts/student_profile/record_service_spec.js
@@ -43,13 +43,14 @@ describe('RecordService', function() {
 
       expect(el).toContainText('Which service?');
       expect(helpers.serviceTypes(el)).toEqual([
+        'Attendance Contract',
+        'Attendance Officer',
+        'Behavior Contract',
         'Counseling, in-house',
         'Counseling, outside',
-        'Reading intervention',
-        'Attendance Officer',
-        'Attendance Contract',
-        'Behavior Contract'
+        'Reading intervention'
       ]);
+
 
       expect(el).toContainText('Who is working with Tamyra?');
       // TODO (as): test staff dropdown autocomplete async


### PR DESCRIPTION
Descriptions for services:

![services helptext ars](https://cloud.githubusercontent.com/assets/3209501/15754102/2e84969e-28bc-11e6-9b7d-d66990dc3155.png)

Buttons:

![screen shot 2016-06-02 at 12 20 51 pm](https://cloud.githubusercontent.com/assets/3209501/15754167/7a55430c-28bc-11e6-8c9b-4605a837ec9a.png)

Uri checked it out and gave a thumbs-up.