### PR TITLE
Mixpanel report script on weekly usage

### DIFF
--- a/app/assets/javascripts/helpers/mixpanel_utils.js
+++ b/app/assets/javascripts/helpers/mixpanel_utils.js
@@ -10,7 +10,6 @@
 
       try {
         window.mixpanel.register({
-          'isDemoSite': Env.isDemoSite, // deprecated
           'deployment_key': Env.deploymentKey,
           'educator_id': currentEducator.id,
           'educator_is_admin': currentEducator.admin,

--- a/app/assets/javascripts/helpers/mixpanel_utils.js
+++ b/app/assets/javascripts/helpers/mixpanel_utils.js
@@ -4,9 +4,11 @@
   var Env = window.shared.Env;
 
   window.shared.MixpanelUtils = {
+    isMixpanelEnabled: function() {
+      return (window.mixpanel && Env.shouldReportAnalytics);
+    },
     registerUser: function(currentEducator) {
-      if (!window.mixpanel) return;
-      if (!Env.shouldReportAnalytics) return;
+      if (!Mixpanel.isMixpanelEnabled()) return;
 
       try {
         window.mixpanel.register({
@@ -21,7 +23,7 @@
       }
     },
     track: function(key, attrs) {
-      if (!window.mixpanel) return;
+      if (!Mixpanel.isMixpanelEnabled()) return;
       try {
         return window.mixpanel.track(key, attrs);
       }

--- a/scripts/mixpanel_report.rb
+++ b/scripts/mixpanel_report.rb
@@ -1,0 +1,122 @@
+require 'date'
+require 'json'
+
+# Querys the MixPanel API for aggregate, non-personally identifiable usage data.
+# Intended to be run weekly.
+class MixpanelReport
+  def initialize(api_secret)
+    @api_secret = api_secret
+  end
+
+  def run
+    event_name = 'PAGE_VISIT'
+    schools = [
+      { :name => 'Healey', :id => 2 },
+      { :name => 'West', :id => 6 },
+      { :name => 'East', :id => 5 }
+    ]
+    schools.each do |school|
+      puts school[:name]
+      print_summary_header
+      puts school_summary_table(event_name, school[:id])
+      puts
+    end
+
+    print_totals(event_name)
+  end
+
+  private
+  def print_totals(event_name)
+    puts 'TOTAL'
+    print_summary_header
+    visits = extract(event_name, query_for({
+      event: event_name,
+      unit: 'week',
+      where: where_string_with_defaults
+    }))
+    uniques = extract(event_name, query_for({
+      event: event_name,
+      type: 'unique',
+      unit: 'week',
+      where: where_string_with_defaults
+    }))
+    puts zip_series(visits, uniques)
+  end
+
+  def print_summary_header
+    puts '---------------------------------------------------'
+    puts "Date\t\t\tVisits\t\tUsers"
+  end
+
+  def school_summary_table(event_name, school_id)
+    visits = extract(event_name, page_visits_for_school(event_name, school_id))
+    uniques = extract(event_name, unique_educators_for_school(event_name, school_id))
+    zip_series(visits, uniques)
+  end
+
+  def zip_series(xs, ys)
+    rows = xs.merge(ys) {|date, x, y| [x, y] }
+    rows.keys.sort.map {|key| ([key] + rows[key]).join("\t\t") }
+  end
+
+  def extract(event_name, json)
+    json['data']['values'][event_name]
+  end
+
+  def unique_educators_for_school(event_name, school_id)
+    query_for({
+      event: event_name,
+      type: 'unique',
+      unit: 'week',
+      where: where_string_with_defaults([
+        [:educator_school_id, '==', school_id]
+      ])
+    })
+  end
+
+  def page_visits_for_school(event_name, school_id)
+    query_for({
+      event: event_name,
+      unit: 'week',
+      where: where_string_with_defaults([
+        [:deployment_key, '==', 'production'],
+        [:educator_id, '!=', 12],
+        [:educator_school_id, '==', school_id]
+      ])
+    })
+  end
+
+  def where_string_with_defaults(where_clauses = [])
+    where_string(where_clauses + [
+      [:deployment_key, '==', 'production'],
+      [:educator_id, '!=', 12],
+    ])
+  end
+
+  def where_string(where_clauses)
+    where_clauses.map do |property, op, value|
+      quoted_value = if value == value.to_s then "\"#{value}\"" else value end
+      ["properties[\"#{property}\"]", op, quoted_value].join ' '
+    end.join ' and '
+  end
+
+  def query_for(params)
+    to_date = Date.today
+    from_date = to_date - 28
+
+    params_list = params.keys.map do |key|
+      "-d #{key}='#{params[key]}'"
+    end
+    cmd = ([
+      "curl https://mixpanel.com/api/2.0/segmentation",
+      "-s",
+      "-u #{@api_secret}: ",
+      "-d from_date='#{from_date}' -d to_date='#{to_date}' "
+    ] + params_list).join ' '
+    output = `#{cmd}`
+    JSON.parse(output)
+  end
+end
+
+
+MixpanelReport.new(ENV['API_SECRET']).run


### PR DESCRIPTION
This queries the MixPanel API to make a report of how many total page visits we have for each school, and how many unique users per week.  This filters out the ldap user, and only considers events from deploys that send analytics events and where the DEPLOYMENT_KEY environment variable is set to `production`.  Might be better to just add this explanation to the output.

The idea here is that weekly active users is a good topline engagement measure, and that the breakdown across schools helps track the rollout and next steps if engagement drops.  This can be something that runs each week and emails out, and can be shared with the Code for Boston group as well, since there's no individual teacher or student data here.

Example output:

```
Healey
---------------------------------------------------
Date			Visits		Users
2016-05-09		13		2
2016-05-16		24		4
2016-05-23		4		2
2016-05-30		13		2
2016-06-06		9		3

West
---------------------------------------------------
Date			Visits		Users
2016-05-09		1		1
2016-05-16		4		1
2016-05-23		31		4
2016-05-30		2		1
2016-06-06		0		0

East
---------------------------------------------------
Date			Visits		Users
2016-05-09		0		0
2016-05-16		22		1
2016-05-23		4		1
2016-05-30		0		0
2016-06-06		19		5

TOTAL
---------------------------------------------------
Date			Visits		Users
2016-05-09		14		3
2016-05-16		50		6
2016-05-23		39		7
2016-05-30		15		3
2016-06-06		28		8
```

Verified manually with web UI data on mixpanel.com.