### PR TITLE
Not all dates are of Date class. At least one is ActiveSupport::TimeW…

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
 
   def format_date(date)
-    return "" unless date.class == Date
+    return "" unless date.respond_to?(:strftime)
 
     date.strftime("%m/%d/%Y")
   end


### PR DESCRIPTION
…ithZone. Check that whatever the date's class is, that it can respond to the strftime method.

@erose whoops. a bug snuck in with that last PR merge. could we merge the fix please?