### PR TITLE
Add rake task for emailing Mixpanel usage report out

### DIFF
--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -8,4 +8,16 @@ namespace :report do
   task data_integrity: :environment do
     IntegrityCheck.new.check!
   end
+
+  desc 'Query Mixpanel and email usage reports'
+  task mixpanel_usage: :environment do
+    mailgun_url = ENV['MAILGUN_URL']
+    api_secret = ENV['API_SECRET']
+
+    MixpanelReport.new(api_secret).run_and_email!(mailgun_url, [
+      'kevin.robinson.0@gmail.com',
+      'asoble@gmail.com',
+      'really.eli@gmail.com'
+    ])
+  end
 end


### PR DESCRIPTION
This adds a rake task that we can run weekly to query Mixpanel for aggregate usage data and then email it out using Mailgun.  It requires environment variables with those keys in order to work.