### PR TITLE
Fix the specs related to StudentSchoolYear factory

### DIFF
--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -92,7 +92,7 @@ describe StudentsController, :type => :controller do
           let!(:more_recent_incident) {
             FactoryGirl.create(
               :discipline_incident,
-              student_school_year: most_recent_school_year,
+              student_school_year: student.student_school_years.first,
               occurred_at: Time.now - 1.day
             )
           }

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -15,7 +15,11 @@ describe StudentsController, :type => :controller do
     let(:educator) { FactoryGirl.create(:educator_with_homeroom) }
     let(:student) { FactoryGirl.create(:student, :with_risk_level, school: school) }
     let(:homeroom) { student.homeroom }
-    let!(:student_school_year) { FactoryGirl.create(:student_school_year, student: student) }
+    let!(:student_school_year) {
+      student.student_school_years.first || StudentSchoolYear.create!(
+        student: student, school_year: SchoolYear.first_or_create!
+      )
+    }
 
     def make_request(options = { student_id: nil, format: :html })
       request.env['HTTPS'] = 'on'

--- a/spec/decorators/student_decorator_spec.rb
+++ b/spec/decorators/student_decorator_spec.rb
@@ -28,7 +28,11 @@ describe StudentDecorator do
 
 
   describe '#as_json_for_school_overview' do
-    before { FactoryGirl.create(:student_school_year, student: student) }
+    before {
+      student.student_school_years.first.present? || StudentSchoolYear.create!(
+        student: student, school_year: SchoolYear.first_or_create!
+      )
+    }
 
     context 'no events or student attributes' do
       let(:student) { FactoryGirl.create(:student, :with_risk_level).decorate }

--- a/spec/factories/discipline_incidents.rb
+++ b/spec/factories/discipline_incidents.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :discipline_incident do
     occurred_at { Time.now }
-    student_school_year
   end
 end

--- a/spec/factories/student_school_years.rb
+++ b/spec/factories/student_school_years.rb
@@ -1,6 +1,0 @@
-FactoryGirl.define do
-  factory :student_school_year do
-    student
-    school_year
-  end
-end

--- a/spec/models/absence_spec.rb
+++ b/spec/models/absence_spec.rb
@@ -1,7 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Absence do
-  let!(:student_school_year) { FactoryGirl.create(:student_school_year) }
+  let!(:student) { FactoryGirl.create(:student) }
+  let!(:student_school_year) {
+    student.student_school_years.first || StudentSchoolYear.create!(
+      student: student, school_year: SchoolYear.first_or_create!
+    )
+  }
+
 
   subject(:absence) { Absence.create!(student_school_year: student_school_year, occurred_at: Time.now) }
 

--- a/spec/models/discipline_incident_spec.rb
+++ b/spec/models/discipline_incident_spec.rb
@@ -1,7 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe DisciplineIncident do
-  let!(:student_school_year) { FactoryGirl.create(:student_school_year) }
+  let!(:student) { FactoryGirl.create(:student) }
+  let!(:student_school_year) {
+    student.student_school_years.first || StudentSchoolYear.create!(
+      student: student, school_year: SchoolYear.first_or_create!
+    )
+  }
 
   subject(:incident) { DisciplineIncident.create!(student_school_year: student_school_year, occurred_at: Time.now) }
 

--- a/spec/models/tardy_spec.rb
+++ b/spec/models/tardy_spec.rb
@@ -1,9 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe Tardy do
-  let!(:student_school_year) { FactoryGirl.create(:student_school_year) }
+  let!(:student) { FactoryGirl.create(:student) }
+  let!(:student_school_year) {
+    student.student_school_years.first || StudentSchoolYear.create!(
+      student: student, school_year: SchoolYear.first_or_create!
+    )
+  }
 
-  subject(:tardy) { Tardy.create!(student_school_year: student_school_year, occurred_at: Time.now) }
+  subject(:tardy) {
+    Tardy.create!(student_school_year: student_school_year, occurred_at: Time.now)
+  }
 
   it { is_expected.to belong_to :student_school_year }
   it { is_expected.to validate_presence_of :student_school_year }


### PR DESCRIPTION
# Notes

+ Part of fixing up #610.
+ You can see why this is making me think about #611.  ;0)
+ Seems like FactoryGirl-created `StudentSchoolYear` objects were trying to create `SchoolYear` objects that had already been created earlier in the FactoryGirl model-minting process, triggering validation errors in the specs.
+ Not quite sure why this FactoryGirl behavior has changed . . . maybe a gem upgrade?!? Will try to investigate later when if I have time; that said, not crucial because this seems to be an issue with the spec code only, not the feature code.
+ This PR removes the StudentSchoolYear factory.
+ Still some failing specs left in #610.