### PR TITLE
Slowly give teeth to student assessment validation

### DIFF
--- a/app/models/student_assessment.rb
+++ b/app/models/student_assessment.rb
@@ -14,21 +14,33 @@ class StudentAssessment < ActiveRecord::Base
   def valid_assessment_attributes
     case assessment.family
     when 'MCAS'
-      scale_score.present? &&
-      growth_percentile.present? &&
-      performance_level.present? &&
-      percentile_rank.nil?
+      errors.add(:scale_score, "invalid attributes") unless valid_mcas_attributes
     when 'STAR'
-      percentile_rank.present? &&
-      scale_score.nil? &&
-      growth_percentile.nil? &&
-      performance_level.nil?
+      errors.add(:scale_score, "invalid attributes") unless valid_star_attributes
     when 'DIBELS'
-      performance_level.present? &&
-      percentile_rank.nil? &&
-      scale_score.nil? &&
-      growth_percentile.nil?
+      errors.add(:scale_score, "invalid attributes") unless valid_dibels_attributes
     end
+  end
+
+  def valid_mcas_attributes
+    scale_score.present? &&
+    growth_percentile.present? &&
+    performance_level.present? &&
+    percentile_rank.nil?
+  end
+
+  def valid_star_attributes
+    percentile_rank.present? &&
+    scale_score.nil? &&
+    growth_percentile.nil? &&
+    performance_level.nil?
+  end
+
+  def valid_dibels_attributes
+    performance_level.present? &&
+    percentile_rank.nil? &&
+    scale_score.nil? &&
+    growth_percentile.nil?
   end
 
   def assign_to_school_year

--- a/app/models/student_assessment.rb
+++ b/app/models/student_assessment.rb
@@ -14,11 +14,11 @@ class StudentAssessment < ActiveRecord::Base
   def valid_assessment_attributes
     case assessment.family
     when 'MCAS'
-      errors.add(:scale_score, "invalid attributes") unless valid_mcas_attributes
+      # errors.add(:scale_score, "invalid attributes") unless valid_mcas_attributes
     when 'STAR'
-      errors.add(:scale_score, "invalid attributes") unless valid_star_attributes
+      # errors.add(:scale_score, "invalid attributes") unless valid_star_attributes
     when 'DIBELS'
-      errors.add(:scale_score, "invalid attributes") unless valid_dibels_attributes
+      # errors.add(:scale_score, "invalid attributes") unless valid_dibels_attributes
     end
   end
 


### PR DESCRIPTION
# Notes 

+ Break `valid_assessment_attributes` method into smaller chunks
+ Comment out `errors.add` methods for now so we can enforce these assessment-by-assessment; make more explicit that this isn't being enforced 