### PR TITLE
Adds eslint container (not in the build), for linting JS code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,40 @@
+{
+  "env": {
+    "browser": true
+  },
+  "plugins": [
+    "react"
+  ],
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended"
+  ],
+  "rules": {
+    "indent": ["error", 2],
+    "semi": ["error", "always"],
+    "comma-dangle": ["error", "only-multiline"],
+    "no-unused-vars": ["error", {
+      "args": "none"
+    }],
+    "no-use-before-define": "off",
+    "eol-last": "off",
+    "react/prefer-stateless-function": "off",
+    "react/prefer-es6-class": "off",
+    "react/sort-comp": ["error", {
+      order: [
+        'static-methods',
+        'mixins',
+        'lifecycle',
+        'everything-else',
+        '/^on.+$/',
+        'rendering'
+      ],
+      groups: {
+        rendering: [
+          'render',
+          '/^render.+$/'
+        ]
+      }
+    }]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /data
 coverage
 spec/logs/logs.txt
+node_modules
 
 # This holds configuration for testing production import scripts locally, so it shouldn't be checked into
 # source control.

--- a/app/assets/javascripts/components/collapsable_table.js
+++ b/app/assets/javascripts/components/collapsable_table.js
@@ -2,6 +2,7 @@
 
   window.shared || (window.shared = {});
   var dom = window.shared.ReactHelpers.dom;
+  var React = window.React;
   var createEl = window.shared.ReactHelpers.createEl;
   var merge = window.shared.ReactHelpers.merge;
 
@@ -11,8 +12,14 @@
   // Table for SlicePanels that shows a set of filters for a particular
   // dimension, and supports collapsing the list when there are no items
   // that fix particular values.
-  var CollapsableTable = window.shared.CollapsableTable = React.createClass({
+  window.shared.CollapsableTable = React.createClass({
     displayName: 'CollapsableTable',
+
+    propTypes: {
+      items: React.PropTypes.array.isRequired,
+      limit: React.PropTypes.number
+    },
+
     getDefaultProps: function() {
       return {
         minHeight: 132,

--- a/app/assets/javascripts/components/fixed_table.js
+++ b/app/assets/javascripts/components/fixed_table.js
@@ -1,9 +1,9 @@
 (function() {
 
   window.shared || (window.shared = {});
+  var React = window.React;
+  var _ = window._;
   var dom = window.shared.ReactHelpers.dom;
-  var createEl = window.shared.ReactHelpers.createEl;
-  var merge = window.shared.ReactHelpers.merge;
   var colors = window.shared.colors;
   var styles = window.shared.styles;
 
@@ -13,8 +13,16 @@
   Items are shown in the order they are passed, and there is
   no user interation to change the list of items.
   */
-  var FixedTable = window.shared.FixedTable = React.createClass({
+  window.shared.FixedTable = React.createClass({
     displayName: 'FixedTable',
+
+    propTypes: {
+      onFilterToggled: React.PropTypes.func.isRequired,
+      filters: React.PropTypes.array.isRequired,
+      title: React.PropTypes.string.isRequired,
+      items: React.PropTypes.array.isRequired,
+      children: React.PropTypes.element.isRequired
+    },
 
     onRowClicked: function(item, e) {
       this.props.onFilterToggled(item.filter);
@@ -43,7 +51,6 @@
         }, title),
         dom.table({},
           dom.tbody({}, items.map(function(item) {
-            var key = item.caption;
             var isFilterApplied = _.contains(selectedFilterIdentifiers, item.filter.identifier);
             return dom.tr({
               className: 'clickable-row',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 # This is based off https://docs.docker.com/compose/rails/
-
 rails:
   build: .
   volumes:
@@ -19,3 +18,10 @@ postgres:
     - "5432:5432"
   volumes:
     - /var/lib/postgresql/data
+
+tools:
+  build: ./scripts/tools
+  volumes:
+    - .:/mnt/somerville-teacher-tool
+  working_dir: /mnt/somerville-teacher-tool/scripts/tools
+  command: npm run lint-quiet

--- a/scripts/tools/Dockerfile
+++ b/scripts/tools/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:6.4.0
+
+RUN npm install
+CMD npm run lint

--- a/scripts/tools/package.json
+++ b/scripts/tools/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "studentinsights-tools",
+  "version": "0.1.0",
+  "scripts": {
+    "lint-quiet": "eslint --ext jsx --ext js -c ../../.eslintrc ../../app/assets/javascripts; exit 0",
+    "lint": "eslint --ext jsx --ext js -c ../../.eslintrc ../../app/assets/javascripts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/studentinsights/studentinsights.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/studentinsights/studentinsights/issues"
+  },
+  "devDependencies": {
+    "casperjs": "^1.1.3",
+    "eslint": "^3.3.1",
+    "eslint-plugin-react": "^6.1.2"
+  }
+}


### PR DESCRIPTION
This adds [eslint](http://eslint.org/) with some initial setup so we can use it for linting JS code and helping developers on the team with catching common errors like unused variables, missing propTypes in a React component, etc.  We could also use it to enforce other conventions like spacing, etc. if so desired.  This adds a new container so that this can be run locally and folks can try it out, and demonstrates cleaning up the linting errors in a few files as an example.

Usage:
`$ docker-compose build tools`
`$ docker-compose run tools`
<img width="697" alt="screen shot 2016-08-23 at 8 09 51 am" src="https://cloud.githubusercontent.com/assets/1056957/17895851/6ce655a8-691c-11e6-833b-fdfd9fd4dbcf.png">

There are about 1000 mechanical errors on various files, and an interested or enterprising pal from Code for Boston could learn about build tooling and help improve code quality if they were interested in working through a handful of files in a night.  All told, this could take one volunteer a few nights to burn through the whole codebase.  At that point we could add it to the build process and roll it out to everyone.

If anyone is interested, feel free to ping me with questions!
cc @alexsoble @erose FYI or if you have thoughts or feels