### PR TITLE
Revert "Allow toggling Scout from env variable"

### DIFF
--- a/config/scout_apm.yml
+++ b/config/scout_apm.yml
@@ -1,2 +1,0 @@
-production:
-  monitoring: ENV['SCOUT_MONITORING'] || true


### PR DESCRIPTION
Reverts studentinsights/studentinsights#654

This didn't work: https://travis-ci.org/studentinsights/studentinsights/builds/155354503 probably needs more config and may have to pull out the Heroku vars here.  Aborting for now.