### PR TITLE
Using as_json for now just in students/show.html.erb.

### DIFF
--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -1,2 +1,2 @@
 <div id="main"></div>
-<%= tag("div", id: "serialized-data", data: @serialized_data) %>
+<%= tag("div", id: "serialized-data", data: @serialized_data.as_json) %>


### PR DESCRIPTION
Fixes https://github.com/studentinsights/studentinsights/issues/656.

  * I noticed that student absence + tardy graphs were broken in production. All the data from the past was being rendered as though it happened today.
  * I noticed also in production that clicking on the Overview card didn't work and caused a JS type error. (https://rollbar.com/somerville-teacher-tool/somerville-teacher-tool/items/20/)
  * I checked the DOM and found that the date keys in `serialized_data` (e.g. `created_at`, `updated_at`) had serialized Ruby objects as their values, instead of date strings.
  * I flipped a shit.
  * I replicated this locally, and then experimented with serializing to JSON at a few different points. Eventually I put it in the view layer because the existing tests were expecting the controller layer to return Ruby objects.
  * This fixed both issues and left the specs working.

I'm wondering:
  * how was serialized_data getting serialized before? Is there some default Ruby serialization that the view template does?
  * what changed that caused this to be an issue recently?
  * if calling `as_json` in the view layer is the thing to do, shouldn't we do it everywhere else we serialize data as well? (In `students/restricted_notes.html.erb` and `shared/serialized_data.html.erb`).