### PR TITLE
Limit student autocomplete list for district-level admin

### DIFF
--- a/app/assets/javascripts/student_searchbar.js
+++ b/app/assets/javascripts/student_searchbar.js
@@ -1,6 +1,7 @@
 $(function() {
 
   $("#student-searchbar").autocomplete({
+    minLength: 2,
     source: function(request, response) {
       $.ajax({
         url: "/students/names",

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -76,7 +76,8 @@ class StudentsController < ApplicationController
       current_educator.is_authorized_for_student(student)
     end
     sorted_students = search_and_score(q, authorized_students)
-    @sorted_results = sorted_students.map {|student| student.decorate.presentation_for_autocomplete }
+    truncated_students = sorted_students.take(20)
+    @sorted_results = truncated_students.map {|student| student.decorate.presentation_for_autocomplete }
 
     respond_to do |format|
       format.json { render json: @sorted_results }


### PR DESCRIPTION
Addressing requests like this by limiting the autocomplete to not query until two characters, and to cap returned results at 20.

<img width="1105" alt="screen shot 2016-08-26 at 6 48 18 pm" src="https://cloud.githubusercontent.com/assets/1056957/18022539/b3c57dac-6bbd-11e6-899a-7a2fed2090be.png">
