### PR TITLE
Make link behavior more sensible on roster page

### DIFF
--- a/app/assets/javascripts/roster/roster_page.js
+++ b/app/assets/javascripts/roster/roster_page.js
@@ -124,7 +124,7 @@ $(function() {
     });
 
     // Turn table rows into links to student profiles
-    $('tbody td').click(function () {
+    $('tbody tr').click(function () {
       location.href = $(this).attr('href');
     });
 

--- a/app/views/homerooms/show.html.erb
+++ b/app/views/homerooms/show.html.erb
@@ -134,11 +134,9 @@
           <!-- ROWS -->
           <% @rows.select{|row| row[:enrollment_status] == "Active"}.each do |row| %>
 
-            <tr class="student-row">
+            <tr class="student-row" href="<%= student_url(row["id"]) %>">
               <td class="name">
-                <a href="<%= student_url(row["id"]) %>">
-                  <%= "#{row['first_name']} #{row['last_name']}" %>
-                </a>
+                <%= "#{row['first_name']} #{row['last_name']}" %>
               </td>
               <td class="risk risk-tooltip-circle" data-student-id="<%= row['id'] %> ">
                 <div class="warning-bubble risk-<%= row[:student_risk_level]['level'] || 'na' %>">


### PR DESCRIPTION
# Notes 

+ Take user to student profile when they click anywhere on a student row in the roster page, not just the student name.
+ The roster page UI doesn't indicate to the user in any way that clicking on the student name will create any sort of special outcome. The hover effect applies to the entire row. So make the behavior (opening student profile) correspond to the entire row too.