### PR TITLE
Include educators with no LASID in educators export file

### DIFF
--- a/x2_export/educators_export.sql
+++ b/x2_export/educators_export.sql
@@ -26,7 +26,6 @@ INNER JOIN person
 INNER JOIN user_info
   ON person.PSN_OID=user_info.USR_PSN_OID
 WHERE STF_STATUS = 'Active'
-AND STF_ID_LOCAL IS NOT NULL
   INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/educators_export.txt"
   FIELDS TERMINATED BY ','
   ENCLOSED BY '"'


### PR DESCRIPTION
# Issue 

+ https://github.com/studentinsights/studentinsights/issues/683#issuecomment-246809532

# Next step

+ Rewrite `EducatorRow` import class to use login_name/login ID instead of local_id to import new educator records