### PR TITLE
Make attendance summary columns reference current month

### DIFF
--- a/app/assets/javascripts/student_profile/student_profile_page.js
+++ b/app/assets/javascripts/student_profile/student_profile_page.js
@@ -476,15 +476,15 @@
           onClick: this.onColumnClicked.bind(this, columnKey)
       },
         this.renderAttendanceEventsSummary(attendanceData.discipline_incidents, Scales.disciplineIncidents.flexibleRange, {
-          caption: 'Discipline incidents',
+          caption: 'Discipline this month',
           thresholdValue: Scales.disciplineIncidents.threshold,
         }),
         this.renderAttendanceEventsSummary(attendanceData.absences, Scales.absences.flexibleRange, {
-          caption: 'Absences',
+          caption: 'Absences this month',
           thresholdValue: Scales.absences.threshold,
         }),
         this.renderAttendanceEventsSummary(attendanceData.tardies, Scales.tardies.flexibleRange, {
-          caption: 'Tardies',
+          caption: 'Tardies this month',
           thresholdValue: Scales.tardies.threshold,
         })
       ));

--- a/app/assets/javascripts/student_profile/student_profile_page.js
+++ b/app/assets/javascripts/student_profile/student_profile_page.js
@@ -492,8 +492,24 @@
 
     renderAttendanceEventsSummary: function(attendanceEvents, flexibleRangeFn, props) {
       var cumulativeQuads = QuadConverter.cumulativeByMonthFromEvents(attendanceEvents);
-      var value = (cumulativeQuads.length > 0) ? _.last(cumulativeQuads)[3] : 0;
       var valueRange = flexibleRangeFn(cumulativeQuads);
+
+      if (cumulativeQuads.length === 0) {
+        var value = 0;  // if there are no attendance events, this month's count is zero
+      } else {
+        var mostRecentQuad = _.last(cumulativeQuads);
+        // if the most recent month with events isn't this month, this month's count is zero:
+
+        var thisYear = moment().year();
+        var thisMonthToRuby = moment().month() + 1; // moment.js months are zero-indexed; quad months
+                                                    // start at 1,  so we need to adjust
+
+        if (mostRecentQuad[0] !== thisYear || mostRecentQuad[1] !== thisMonthToRuby)
+          var value = 0;
+        else {
+          var value = mostRecentQuad[3];   // get this month's count
+        }
+      };
 
       return this.wrapSummary(merge({
         title: props.title,

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -16,9 +16,9 @@ class StudentsController < ApplicationController
 
     @serialized_data = {
       current_educator: current_educator,
-      student: serialize_student_for_profile(student),
-      feed: student_feed(student, restricted_notes: false),
-      chart_data: chart_data,
+      student: serialize_student_for_profile(student),          # Risk level, school homeroom, most recent school year attendance/discipline counts
+      feed: student_feed(student, restricted_notes: false),     # Notes, services
+      chart_data: chart_data,                                   # STAR, MCAS, discipline, attendance charts
       dibels: student.student_assessments.by_family('DIBELS'),
       service_types_index: service_types_index,
       event_note_types_index: event_note_types_index,

--- a/spec/javascripts/student_profile/student_profile_page_spec.js
+++ b/spec/javascripts/student_profile/student_profile_page_spec.js
@@ -11,10 +11,12 @@ describe('StudentProfilePage', function() {
   var StudentProfilePage = window.shared.StudentProfilePage;
 
   var helpers = {
-    renderStudentProfilePage: function(el, grade, dibels) {
+    renderStudentProfilePage: function(el, grade, dibels, tardies, absences) {
       var serializedData = _.cloneDeep(Fixtures.studentProfile);
       if (grade) { serializedData["student"]["grade"] = grade; };
       if (dibels) { serializedData["dibels"] = dibels; };
+      if (tardies) { serializedData["attendanceData"]["tardies"] = tardies; };
+      if (absences) { serializedData["attendanceData"]["absences"] = absences; };
 
       var mergedProps = {
         serializedData: serializedData,
@@ -25,7 +27,38 @@ describe('StudentProfilePage', function() {
     }
   }
 
-  SpecSugar.withTestEl('#renderMcasElaSgpOrDibels', function() {
+  SpecSugar.withTestEl('renders attendance event summaries correctly', function() {
+
+    describe('student with no absences this month', function () {
+      it('displays zero absences', function () {
+        var el = this.testEl;
+        helpers.renderStudentProfilePage(el);   // fixture absences are way in the past,
+                                                // so should return zero for this month's absences
+
+        expect(el).toContainText('Absences this month:0');
+      });
+    });
+
+    describe('student with 3 absences this month', function () {
+      it('displays 3 absences', function () {
+        var el = this.testEl;
+        var nowString = moment().utc().toISOString();
+
+        var absences = [
+          { "occurred_at": nowString },
+          { "occurred_at": nowString },
+          { "occurred_at": nowString },
+        ]
+
+        helpers.renderStudentProfilePage(el, null, null, null, absences);
+
+        expect(el).toContainText('Absences this month:3');
+      });
+    });
+
+  });
+
+  SpecSugar.withTestEl('renders MCAS/DIBELS correctly according to grade level', function() {
 
     describe('student in grade 3', function() {
 


### PR DESCRIPTION
# Issue

+ Resolve #686.

# Screenshots

### Absences this month:

![screen shot 2016-09-17 at 5 46 20 pm](https://cloud.githubusercontent.com/assets/3209501/18611429/af5fb334-7cfe-11e6-9477-baff932e126c.png)

### No absences this month:

![screen shot 2016-09-17 at 5 45 27 pm](https://cloud.githubusercontent.com/assets/3209501/18611430/af672c90-7cfe-11e6-8666-298579000dcb.png)

# Open question

+ Do the mini bar charts below the summary numbers need their own labels? Or is it clear what they mean in context? A little user research with Somerville schools staff could help us decide.

