### PR TITLE
Remove leftover reference to RosterChart

### DIFF
--- a/app/assets/javascripts/roster/roster_page.js
+++ b/app/assets/javascripts/roster/roster_page.js
@@ -130,7 +130,6 @@ $(function() {
 
     // Make Risk Level summary chart
     var chartData = $('#chart-data');
-    RosterChart.fromChartData(chartData).render();
 
     // Replace blank cells with em dashes
     $('#roster-table tbody td').each(function() {


### PR DESCRIPTION
Addressing https://rollbar.com/somerville-teacher-tool/somerville-teacher-tool/items/26/

This is affecting users now but with a minimal impact now (empty table cells aren't replaced with em dashes).