### PR TITLE
Thread through CSV filename for IE instead of picking it off DOM element

### DIFF
--- a/app/assets/javascripts/components/slice_buttons.js
+++ b/app/assets/javascripts/components/slice_buttons.js
@@ -21,12 +21,12 @@
     },
 
     // IE hack; see http://msdn.microsoft.com/en-us/library/ie/hh779016.aspx
-    onClickDownload: function(csvText, e) {
+    onClickDownload: function(csvText, filename, e) {
       if (!window.navigator.msSaveOrOpenBlob) return;
 
       e.preventDefault();
       var blob = new Blob([csvText], {type: 'text/csv;charset=utf-8;'});
-      window.navigator.msSaveBlob(blob, e.target.download);
+      window.navigator.msSaveBlob(blob, filename);
     },
 
     componentDidMount: function() {
@@ -110,7 +110,7 @@
 
       return dom.a({
 	href: 'data:attachment/csv,' + encodeURIComponent(csvText),
-  onClick: this.onClickDownload.bind(this, csvText),
+  onClick: this.onClickDownload.bind(this, csvText, filename),
 	target: '_blank',
 	download: filename,
 	style: {


### PR DESCRIPTION
https://github.com/studentinsights/studentinsights/pull/713 looks good, but the filename doesn't work when trying to read it off the A element.

<img width="971" alt="screen shot 2016-09-29 at 11 01 30 pm" src="https://cloud.githubusercontent.com/assets/1056957/18979411/ad06a9dc-8698-11e6-8004-79e0aee51acd.png">
