### PR TITLE
Add call to mixpanel.identify to identify users by Student Insights id

### DIFF
--- a/app/assets/javascripts/helpers/mixpanel_utils.js
+++ b/app/assets/javascripts/helpers/mixpanel_utils.js
@@ -2,16 +2,18 @@
   // Define filter operations
   window.shared || (window.shared = {});
   var Env = window.shared.Env;
+  var mixpanel = window.mixpanel;
 
   var MixpanelUtils = window.shared.MixpanelUtils = {
     isMixpanelEnabled: function() {
-      return (window.mixpanel && Env.shouldReportAnalytics);
+      return (mixpanel && Env.shouldReportAnalytics);
     },
     registerUser: function(currentEducator) {
       if (!MixpanelUtils.isMixpanelEnabled()) return;
 
       try {
-        window.mixpanel.register({
+        mixpanel.identify(currentEducator.id);
+        mixpanel.register({
           'deployment_key': Env.deploymentKey,
           'educator_id': currentEducator.id,
           'educator_is_admin': currentEducator.admin,
@@ -25,7 +27,7 @@
     track: function(key, attrs) {
       if (!MixpanelUtils.isMixpanelEnabled()) return;
       try {
-        return window.mixpanel.track(key, attrs);
+        return mixpanel.track(key, attrs);
       }
       catch (err) {
         console.error(err);


### PR DESCRIPTION
This will change analytics numbers, but result in a slight improvement, since currently we're using the default generated distict_ids.  Those are unique by device.

This came up in investigating a spike in unique users that came up because: 1) the developer id changed so that the usage report didn't filter it out anymore, and 2) the automated pinger job runs repeatedly on a different container each time, and thus a different generated distinct_id for MixPanel each time.