### PR TITLE
Data migration to add new service types (SomerSession & SPELL)

### DIFF
--- a/db/migrate/20161007140922_add_new_service_types_for_bulk_upload.rb
+++ b/db/migrate/20161007140922_add_new_service_types_for_bulk_upload.rb
@@ -1,0 +1,11 @@
+class AddNewServiceTypesForBulkUpload < ActiveRecord::Migration
+  def change
+    if ServiceType.find_by_id(509).nil?
+      ServiceType.create({ id: 509, name: 'SomerSession' })
+    end
+
+    if ServiceType.find_by_id(510).nil?
+      ServiceType.create({ id: 510, name: 'Summer Program for English Language Learners' })
+    end
+  end
+end


### PR DESCRIPTION
# Note

+ These new services won't appear on the Student Profile UI, because they aren't explicitly rendered in `RecordService#renderWhichService`. SomerSession and SPELL data can only be added via a bulk services upload. This is intended behavior. 