### PR TITLE
 Design changes to discontinued services

### DIFF
--- a/app/assets/javascripts/student_profile/services_list.js
+++ b/app/assets/javascripts/student_profile/services_list.js
@@ -132,8 +132,7 @@
       return dom.div({
         key: service.id,
         style: merge(styles.service, {
-          background: serviceColor(service.service_type_id),
-          opacity: (wasDiscontinued) ? 0.25 : 1
+          background: serviceColor(service.service_type_id)
         })
       },
         dom.div({ style: { display: 'flex' } },
@@ -141,7 +140,7 @@
             dom.div({ style: { fontWeight: 'bold' } }, serviceText),
             this.renderEducatorName(providedByEducatorName),
             dom.div({},
-              'Since ',
+              'Started ',
               momentStarted.format('MMMM D, YYYY')
             ),
             dom.div({}, (wasDiscontinued)
@@ -155,9 +154,7 @@
     },
 
     renderEducatorName: function (educatorName) {
-      if (educatorName === "" || educatorName === null) {
-	return dom.div({}, 'No staff recorded');
-      } else {
+      if (educatorName !== "" && educatorName !== null) {
         return dom.div({}, 'With ' + educatorName);
       };
     },
@@ -165,7 +162,7 @@
     renderDiscontinuedInformation: function(service) {
       if (this.wasDiscontinued(service)) {
         return dom.div({},
-          dom.div({}, 'Discontinued'),
+          dom.div({}, 'Ended'),
           dom.div({}, moment.utc(service.discontinued_recorded_at).format('MMMM D, YYYY'))
         );
       }

--- a/app/assets/javascripts/student_profile/services_list.js
+++ b/app/assets/javascripts/student_profile/services_list.js
@@ -132,7 +132,8 @@
       return dom.div({
         key: service.id,
         style: merge(styles.service, {
-          background: serviceColor(service.service_type_id)
+          background: serviceColor(service.service_type_id),
+          opacity: (wasDiscontinued) ? 0.8 : 1
         })
       },
         dom.div({ style: { display: 'flex' } },

--- a/spec/javascripts/student_profile/services_list_spec.js
+++ b/spec/javascripts/student_profile/services_list_spec.js
@@ -63,7 +63,7 @@ describe('ServicesList', function() {
       helpers.renderInto(el, { servicesFeed: helpers.oneActiveServiceFeed() });
       expect(el).toContainText('Reading intervention');
       expect(el).toContainText('With');
-      expect(el).toContainText('Since April 3, 2016');
+      expect(el).toContainText('Started April 3, 2016');
       expect(el).toContainText('Discontinue');
     });
 
@@ -97,7 +97,7 @@ describe('ServicesList', function() {
           discontinued: [discontinuedService]
         }
       });
-      expect(el).toContainText('Discontinued');
+      expect(el).toContainText('Ended');
       expect(el).toContainText('April 5, 2016');
     });
   });


### PR DESCRIPTION
# Screenshots

## Before

![screen shot 2016-10-07 at 1 04 15 pm](https://cloud.githubusercontent.com/assets/3209501/19200760/56963484-8c90-11e6-8f5d-27f08dc3260b.png)

## After

![screen shot 2016-10-07 at 1 17 24 pm](https://cloud.githubusercontent.com/assets/3209501/19200776/69d16604-8c90-11e6-9863-521e06cb1528.png)

# Notes 

+ Scaled back the lower opacity on discontinued services, since some no-longer-active services are important for staff to know about
+ Change "discontinued" to "ended" in the UI, since some services naturally end (i.e. Summer School)
+ Remove "No staff recorded" language, ambiguous -- does this mean no staff recorded the service, or no staff were recorded as providing the service? Not clear.

