### PR TITLE
Add code comment about StudentsController#name

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -3,7 +3,11 @@ class StudentsController < ApplicationController
 
   rescue_from Exceptions::EducatorNotAuthorized, with: :redirect_unauthorized!
 
-  before_action :authorize!, except: [:names]
+  before_action :authorize!, except: [:names]   # The :names action is still subject to
+                                                # educator authentication via :authenticate_educator!
+                                                # inherited from ApplicationController.
+                                                # It then does further authorization filtering using
+                                                # current_educator.is_authorized_for_student.
 
   def authorize!
     student = Student.find(params[:id])


### PR DESCRIPTION
# Notes
- The `before_action :authorize!, except: [:names]` line makes it look at first glance as if the `:names` action is not authenticated, which isn't the case
- The `:names` action inherits authentication from `ApplicationController` and performs its own authorization based on `current_educator`
