### PR TITLE
Add sorting to watchlist in weekly update email

### DIFF
--- a/app/mailers/weekly_update_mailer.rb
+++ b/app/mailers/weekly_update_mailer.rb
@@ -82,7 +82,9 @@ class WeeklyUpdateMailer < ActionMailer::Base
       }
     end
 
-    watchlist
+    watchlist.sort_by do |watchlist_row|
+      watchlist_row[:days_since]
+    end.reverse
   end
 
   def events_in_the_last_week(student, method_name)


### PR DESCRIPTION
Addressing sort order in weekly updates, so students with longest time since MTSS/SST meetings come first.