### PR TITLE
Handle services scheduled to end in the future

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -31,11 +31,13 @@ class Service < ActiveRecord::Base
   end
 
   def self.active
-    select { |service| service.active? }
+    includes(:discontinued_services).where('discontinued_services.recorded_at > ?', DateTime.current)
+                                    .references(:discontinued_services)
   end
 
   def self.discontinued
-    select { |service| service.discontinued? }
+    includes(:discontinued_services).where('discontinued_services.recorded_at < ?', DateTime.current)
+                                    .references(:discontinued_services)
   end
 
   def self.provider_names

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -31,11 +31,11 @@ class Service < ActiveRecord::Base
   end
 
   def self.active
-    self.includes(:discontinued_services).where(:discontinued_services => { :id => nil })
+    select { |service| service.active? }
   end
 
   def self.discontinued
-    self.includes(:discontinued_services).where.not(:discontinued_services => { :id => nil })
+    select { |service| service.discontinued? }
   end
 
   def self.provider_names

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -8,20 +8,22 @@ class Service < ActiveRecord::Base
   validates_presence_of :recorded_by_educator_id, :student_id, :service_type_id, :recorded_at, :date_started
 
   def discontinued?
-    (discontinued_services.size > 0) && !has_scheduled_end_date?
+    (discontinued_services.size > 0) && !has_scheduled_end_date?  # If the end date is in the future
+                                                                  # the service isn't discontinued yet.
   end
 
   def has_scheduled_end_date?
     # Some services are scheduled to be discontinued in the future. When staff
     # enter new student services in the UI, they can't select a future end date yet.
     # But bulk-uploaded services can have a future end date. If a service has an
-    # end date in the future, we don't want it to show up as "discontinued"
+    # end date in the future, we don't want it to show up as "discontinued."
 
     end_date = discontinued_services.order(recorded_at: :desc)
                                     .first
                                     .recorded_at  # This attribute name isn't accurate
                                                   # anymore, we should change it to "date_ended"
-    return end_date > Date.current
+
+    return end_date > DateTime.current
   end
 
   def active?

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -8,7 +8,20 @@ class Service < ActiveRecord::Base
   validates_presence_of :recorded_by_educator_id, :student_id, :service_type_id, :recorded_at, :date_started
 
   def discontinued?
-    discontinued_services.size > 0
+    (discontinued_services.size > 0) && !has_scheduled_end_date?
+  end
+
+  def has_scheduled_end_date?
+    # Some services are scheduled to be discontinued in the future. When staff
+    # enter new student services in the UI, they can't select a future end date yet.
+    # But bulk-uploaded services can have a future end date. If a service has an
+    # end date in the future, we don't want it to show up as "discontinued"
+
+    end_date = discontinued_services.order(recorded_at: :desc)
+                                    .first
+                                    .recorded_at  # This attribute name isn't accurate
+                                                  # anymore, we should change it to "date_ended"
+    return end_date > Date.current
   end
 
   def active?

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -31,6 +31,14 @@ class Service < ActiveRecord::Base
   end
 
   def self.active
+    future_discontinue + never_discontinued
+  end
+
+  def self.never_discontinued
+    includes(:discontinued_services).where(:discontinued_services => { :id => nil })
+  end
+
+  def self.future_discontinue
     includes(:discontinued_services).where('discontinued_services.recorded_at > ?', DateTime.current)
                                     .references(:discontinued_services)
   end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe Service do
+  let!(:student) { FactoryGirl.create(:student) }
+  let!(:educator) { FactoryGirl.create(:educator) }
+
+  let!(:active_service) { FactoryGirl.create(:service, id: 70001) }
+  let!(:another_active_service) { FactoryGirl.create(:service, id: 70002) }
+
+  let!(:discontinued_now) {
+    service = FactoryGirl.create(:service, id: 70003)
+    DiscontinuedService.create(service: service, recorded_by_educator: educator, recorded_at: Time.now)
+    service
+  }
+
+  let!(:past_discontinued) {
+    service = FactoryGirl.create(:service, id: 70004)
+    DiscontinuedService.create(service: service, recorded_by_educator: educator, recorded_at: Time.now - 1.day)
+    service
+  }
+
+  let!(:future_discontinued) {
+    service = FactoryGirl.create(:service, id: 70005)
+    DiscontinuedService.create(service: service, recorded_by_educator: educator, recorded_at: Time.now + 1.day)
+    service
+  }
+
+  let!(:another_future_discontinued) {
+    service = FactoryGirl.create(:service, id: 70006)
+    DiscontinuedService.create(service: service, recorded_by_educator: educator, recorded_at: Time.now + 2.days)
+    service
+  }
+
+  describe '.active' do
+    it 'collects the correct services' do
+      active_ids = Service.active.map(&:id).sort
+      expect(active_ids).to eq [70001, 70002, 70005, 70006]
+    end
+  end
+
+  describe '.never_discontinued' do
+    it 'collects the correct services' do
+      never_discontinued_ids = Service.never_discontinued.pluck(:id).sort
+      expect(never_discontinued_ids).to eq [70001, 70002]
+    end
+  end
+
+  describe '.future_discontinue' do
+    it 'collects the correct services' do
+      future_discontinued_ids = Service.future_discontinue.pluck(:id).sort
+      expect(future_discontinued_ids).to eq [70005, 70006]
+    end
+  end
+
+  describe '.discontinued' do
+    it 'collects the correct services' do
+      discontinued_ids = Service.discontinued.pluck(:id).sort
+      expect(discontinued_ids).to eq [70003, 70004]
+    end
+  end
+
+end


### PR DESCRIPTION
# Problem

With the bulk upload feature, we now have a new type of service in the system: one that has a scheduled end date (`DiscontinuedService.recorded_at`) in the future. These events are being displayed as "discontinued" even though they aren't over yet.

# Fix

Tweak the way we calculate discontinued services so that it takes into account whether the date of the discontinued service is in the future or not.

# Note

This PR only touches the back-end of services. It effectively breaks services into 3 categories (never discontinued, discontinued in past, discontinuing in future) and then merges together {never discontinued} + {discontinuing in future} to send accurate data to the front-end. 

The next step will be to establish these three categories on the front end so we can adjust details for how each one is displayed.