### PR TITLE
Remove extra object creation in school overview page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'probability'
 gem 'rails-sanitize-js'
 gem 'react-rails', '~> 1.5.0'   # Provides React, handles swapping between dev/production builds.
                                 # See config/initializers/assets.rb
+gem 'memory_profiler'
 gem 'oj'
 gem 'oj_mimic_json'
 gem 'benchmark-memory'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,6 +312,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails (~> 5.0.3)
   launchy
+  memory_profiler
   net-sftp
   net-ssh
   oj

--- a/app/controllers/homerooms_controller.rb
+++ b/app/controllers/homerooms_controller.rb
@@ -42,14 +42,10 @@ class HomeroomsController < ApplicationController
   # filtering and slicing in the UI).
   # This may be slow if you're doing it for many students without eager includes.
   def fat_student_hash(student)
-    student_hash_for_slicing(student).merge({
+    HashWithIndifferentAccess.new(student_hash_for_slicing(student).merge({
       interventions: student.interventions,
       student_risk_level: student.student_risk_level.decorate.as_json_with_explanation,
-      discipline_incidents_count: student.most_recent_school_year.discipline_incidents.count,
-      absences_count: student.most_recent_school_year.absences.count,
-      tardies_count: student.most_recent_school_year.tardies.count,
-      homeroom_name: student.try(:homeroom).try(:name)
-    })
+    }))
   end
 
   def authorize_and_assign_homeroom

--- a/app/helpers/students_query_helper.rb
+++ b/app/helpers/students_query_helper.rb
@@ -3,13 +3,13 @@ module StudentsQueryHelper
   # filtering and slicing in the UI).
   # This may be slow if you're doing it for many students without eager includes.
   def student_hash_for_slicing(student)
-    HashWithIndifferentAccess.new(student.as_json.merge({
+    student.as_json.merge({
       student_risk_level: student.student_risk_level.as_json,
       discipline_incidents_count: student.most_recent_school_year.discipline_incidents.count,
       absences_count: student.most_recent_school_year.absences.count,
       tardies_count: student.most_recent_school_year.tardies.count,
       homeroom_name: student.try(:homeroom).try(:name)
-    }))
+    })
   end
 
   # Queries for Services and EventNotes for each student, and merges the results

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -11,7 +11,7 @@ describe SchoolsController, :type => :controller do
     # Read the instance variable and pull out the ids of students
     def extract_serialized_student_ids(controller)
       serialized_data = controller.instance_variable_get(:@serialized_data)
-      serialized_data[:students].map {|student_hash| student_hash[:id] }
+      serialized_data[:students].map {|student_hash| student_hash['id'] }
     end
 
     context 'districtwide access' do


### PR DESCRIPTION
Used `memory_profiler` to compare gathering data for the school overview page before and after this change. Investigated using demo data in local environment. 

# Code profiled:

```
serialized_data_for_school(current_educator, @school)
```

# Before:

### Cold:
Total allocated: 33895302 bytes (449354 objects)
Total retained:  2346972 bytes (28022 objects)

### Warm:
Total allocated: 26897215 bytes (381652 objects)
Total retained:  1578362 bytes (21559 objects)


# After

### Cold: 
Total allocated: 24145026 bytes (307703 objects)
Total retained:  1637463 bytes (18512 objects)

### Warm: 
Total allocated: 18006854 bytes (248581 objects)
Total retained:  929631 bytes (12500 objects)

# Change
Cold path: 30% decrease in memory allocated
Warm path: 33% decrease in memory allocated