### PR TITLE
Backgroundize data import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /data
 coverage
 spec/logs/logs.txt
+dump.rdb
 
 # Node.js
 node_modules

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'wicked_pdf'
 gem 'wkhtmltopdf-binary'
 gem 'selenium-webdriver'
+gem 'sidekiq'
 gem 'scout_apm'
 #code for browserstack api usage and storing the png to slack:
 #gem 'slack-ruby-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
+    concurrent-ruby (1.0.2)
     connection_pool (2.2.0)
     database_cleaner (1.5.3)
     datetime_picker_rails (0.0.7)
@@ -175,6 +176,8 @@ GEM
       slop (~> 3.4)
     puma (3.6.0)
     rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.6)
@@ -215,6 +218,7 @@ GEM
       execjs
       rails (>= 3.2)
       tilt
+    redis (3.3.2)
     request_store (1.3.1)
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
@@ -254,6 +258,11 @@ GEM
       websocket (~> 1.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
+    sidekiq (4.2.6)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (~> 3.2, >= 3.2.1)
     simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -334,6 +343,7 @@ DEPENDENCIES
   scout_apm
   selenium-webdriver
   shoulda-matchers
+  sidekiq
   simplecov
   spring
   sprockets (= 2.12.3)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: if [ "$DEMO_SITE" = true ]; then bundle exec puma -C config/puma.rb; else bin/qgsocksify bundle exec puma -C config/puma.rb; fi
+worker: bundle exec sidekiq

--- a/app/workers/console_output_worker.rb
+++ b/app/workers/console_output_worker.rb
@@ -1,0 +1,7 @@
+class ConsoleOutputWorker
+  include Sidekiq::Worker
+
+  def perform
+    puts "I love to work!"
+  end
+end

--- a/app/workers/import_worker.rb
+++ b/app/workers/import_worker.rb
@@ -3,6 +3,6 @@ class ImportWorker
 
   def perform
     load File.expand_path("#{Rails.root}/lib/tasks/import.thor", __FILE__)
-    Import::Start.new.invoke
+    Import::Start.new.invoke_all
   end
 end

--- a/app/workers/import_worker.rb
+++ b/app/workers/import_worker.rb
@@ -1,0 +1,8 @@
+class ImportWorker
+  include Sidekiq::Worker
+
+  def perform
+    load File.expand_path("#{Rails.root}/lib/tasks/import.thor", __FILE__)
+    Import::Start.new.invoke
+  end
+end

--- a/lib/tasks/chores.rake
+++ b/lib/tasks/chores.rake
@@ -14,4 +14,14 @@ namespace :chores do
   task update_student_risk_levels: :environment do
     StudentRiskLevel.find_each(&:update_risk_level!)
   end
+
+  desc 'Kick off background worker for data import'
+  task import_data_in_background: :environment do
+    ImportWorker.perform_async
+  end
+
+  desc 'Kick off console output for fun'
+  task console_output_in_background: :environment do
+    ConsoleOutputWorker.perform_async
+  end
 end


### PR DESCRIPTION
Learned something important in the [Heroku docs for the scheduler](https://devcenter.heroku.com/articles/scheduler#long-running-jobs):

> # Long-running jobs
> Scheduled jobs are meant to execute short running tasks or enqueue longer running tasks into a background job queue. Anything that takes longer than a couple of minutes to complete should use a worker dyno to run.
> A dyno started by scheduler will not run longer than it’s scheduling interval. For example, for a job that runs every 10 minutes, dynos will be terminated after running for approximately 10 minutes.
Note that there is some jitter in the dyno termination scheduling. This means that two dynos running the same job may overlap for a brief time when a new one is started.

The data import process is definitely a long-running job, so we should set up a background process on a worker dyno to run it. 