### PR TITLE
Improve date display for services 

### DIFF
--- a/app/assets/javascripts/student_profile/services_list.js
+++ b/app/assets/javascripts/student_profile/services_list.js
@@ -140,18 +140,41 @@
           dom.div({ style: { flex: 1 } },
             dom.div({ style: { fontWeight: 'bold' } }, serviceText),
             this.renderEducatorName(providedByEducatorName),
-            dom.div({},
-              'Started ',
-              momentStarted.format('MMMM D, YYYY')
-            ),
-            dom.div({}, (wasDiscontinued)
-              ? moment.utc(service.discontinued_recorded_at).from(moment.utc(service.date_started), true)
-              : moment.utc(service.date_started).fromNow(true))
+            this.renderDateStarted(service),
+            this.renderTimeSinceStarted(service)
           ),
           this.renderDiscontinuedInformation(service)
         ),
         dom.div({ style: merge(styles.userText, { paddingTop: 15 }) }, service.comment)
       );
+    },
+
+    renderDateStarted: function (service) {
+      var momentStarted = moment.utc(service.date_started);
+      var startedToday = moment().utc().subtract(1, 'day') < momentStarted;
+
+      if (startedToday) return dom.div({}, 'Started today');
+
+      return dom.div({}, 'Started ', momentStarted.format('MMMM D, YYYY'));
+    },
+
+    renderTimeSinceStarted: function (service) {
+      var wasDiscontinued = this.wasDiscontinued(service);
+      var momentStarted = moment.utc(service.date_started);
+
+      if (wasDiscontinued) {
+        return dom.div({},
+          moment.utc(service.discontinued_recorded_at).from(moment.utc(service.date_started), true)
+        );
+      } else {
+        var startedToday = moment().utc().subtract(1, 'day') < momentStarted;
+
+        if (startedToday) {
+          return;
+        } else {
+          return dom.div({}, moment.utc(service.date_started).fromNow(true));
+        };
+      };
     },
 
     renderEducatorName: function (educatorName) {

--- a/app/assets/javascripts/student_profile/services_list.js
+++ b/app/assets/javascripts/student_profile/services_list.js
@@ -140,8 +140,8 @@
           dom.div({ style: { flex: 1 } },
             dom.div({ style: { fontWeight: 'bold' } }, serviceText),
             this.renderEducatorName(providedByEducatorName),
-            this.renderDateStarted(service),
-            this.renderTimeSinceStarted(service)
+            this.renderDateStarted(service),          // When did the service start?
+            this.renderTimeSinceStarted(service)      // How long has it been going?
           ),
           this.renderDiscontinuedInformation(service)
         ),
@@ -153,8 +153,10 @@
       var momentStarted = moment.utc(service.date_started);
       var startedToday = moment().utc().subtract(1, 'day') < momentStarted;
 
+      // For services added today, return "Started today" instead of the date:
       if (startedToday) return dom.div({}, 'Started today');
 
+      // For services started earlier than today, show the date started:
       return dom.div({}, 'Started ', momentStarted.format('MMMM D, YYYY'));
     },
 
@@ -163,17 +165,18 @@
       var momentStarted = moment.utc(service.date_started);
 
       if (wasDiscontinued) {
+        // For discontinued services, display the length of time between start and discontinue dates
         return dom.div({},
           moment.utc(service.discontinued_recorded_at).from(moment.utc(service.date_started), true)
         );
       } else {
         var startedToday = moment().utc().subtract(1, 'day') < momentStarted;
 
-        if (startedToday) {
-          return;
-        } else {
-          return dom.div({}, moment.utc(service.date_started).fromNow(true));
-        };
+        // Don't show how long service has been going if it was added today
+        if (startedToday) return null;
+
+        // Show how long the service has been going
+        return dom.div({}, moment.utc(service.date_started).fromNow(true));
       };
     },
 


### PR DESCRIPTION
# Issues 

## New service 

When an educator adds a new service, the service list item looks like this: 

![screen shot 2016-11-27 at 11 27 11 am](https://cloud.githubusercontent.com/assets/3209501/20650458/7fc5e576-b494-11e6-950b-2c725ef4f612.png)

It should say "Started today"; the "17 hours" figure is meaningless. 
