### PR TITLE
Add missing validation for discontinued services

### DIFF
--- a/app/models/discontinued_service.rb
+++ b/app/models/discontinued_service.rb
@@ -3,4 +3,11 @@ class DiscontinuedService < ActiveRecord::Base
   belongs_to :recorded_by_educator, class_name: 'Educator'
 
   validates_presence_of :service_id, :recorded_by_educator_id, :recorded_at
+  validate :must_be_recorded_after_service_start_date
+
+  def must_be_recorded_after_service_start_date
+    if service.date_started > recorded_at
+      errors.add(:recorded_at, "must be after service start date")
+    end
+  end
 end

--- a/spec/models/discontinued_service_spec.rb
+++ b/spec/models/discontinued_service_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe DiscontinuedService do
+
+  describe '#must_be_recorded_after_service_start_date' do
+    let(:educator) { FactoryGirl.create(:educator) }
+
+    context 'recorded before service start date' do
+      let(:service) { FactoryGirl.create(:service) }
+      let(:discontinued_service) {
+        DiscontinuedService.new(
+          service: service,
+          recorded_by_educator: educator,
+          recorded_at: service.date_started - 1.day,
+        )
+      }
+      it 'is invalid' do
+        expect(discontinued_service).to be_invalid
+      end
+    end
+
+    context 'recorded after service start date' do
+      let(:service) { FactoryGirl.create(:service) }
+      let(:discontinued_service) {
+        DiscontinuedService.new(
+          service: service,
+          recorded_by_educator: educator,
+          recorded_at: service.date_started + 1.day,
+        )
+      }
+      it 'valid' do
+        expect(discontinued_service).to be_valid
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
# Notes 

+ Make sure discontinued service `recorded_at` date comes after the associated service's start date
+ Fix #772 