### PR TITLE
Fix bug with UI updating on event note save

### DIFF
--- a/app/assets/javascripts/student_profile/page_container.js
+++ b/app/assets/javascripts/student_profile/page_container.js
@@ -123,14 +123,14 @@
       // optimistically update the UI
       // essentially, find the eventNote that has eventNoteAttachmentId in attachments
       // remove it
-      var eventNote = _.find(this.state.feed.event_notes, function(eventNote) {
+      var eventNoteToUpdate = _.find(this.state.feed.event_notes, function(eventNote) {
         return _.findWhere(eventNote.attachments, { id: eventNoteAttachmentId });
       });
-      var updatedAttachments = eventNote.attachments.filter(function(eventNote) {
-        return eventNote.id !== eventNoteAttachmentId;
+      var updatedAttachments = eventNoteToUpdate.attachments.filter(function(attachment) {
+        return attachment.id !== eventNoteAttachmentId;
       });
       var updatedEventNotes = this.state.feed.event_notes.map(function(eventNote) {
-        return (eventNote.id !== eventNote.id)
+        return (eventNote.id !== eventNoteToUpdate.id)
           ? eventNote
           : merge(eventNote, { attachments: updatedAttachments });
       });


### PR DESCRIPTION
# Notes

+ We were trying to compare `eventNote.id !== eventNote.id`, which isn't the best comparison because it always evaluates to false
+ This was causing all event note attachment links to disappear when any event note attachment link was deleted
+ Fix #785

# After bugfix GIF
![deleting-notes-2](https://cloud.githubusercontent.com/assets/3209501/21082526/b00252f6-bfa2-11e6-8ad5-55186a9f9c89.gif)
