### PR TITLE
Change services filter on school overview

### DIFF
--- a/app/assets/javascripts/components/slice_panels.js
+++ b/app/assets/javascripts/components/slice_panels.js
@@ -163,8 +163,8 @@
 
     serviceItems: function() {
       var students = this.props.allStudents;
-      var activeServices = _.compact(_.flatten(_.pluck(students, 'active_services')));
-      var allServiceTypeIds = _.unique(activeServices.map(function(service) {
+      var pastYearServices = _.compact(_.flatten(_.pluck(students, 'past_year_services')));
+      var allServiceTypeIds = _.unique(pastYearServices.map(function(service) {
         return parseInt(service.service_type_id, 10);
       }));
 

--- a/app/assets/javascripts/components/slice_panels.js
+++ b/app/assets/javascripts/components/slice_panels.js
@@ -135,7 +135,7 @@
     renderInterventionsColumn: function() {
       return dom.div({ className: 'column interventions-column' },
         this.renderTable({
-          title: 'Services',
+          title: 'Services (past year)',
           items: this.serviceItems(),
           limit: 4
         }),

--- a/app/helpers/students_query_helper.rb
+++ b/app/helpers/students_query_helper.rb
@@ -18,17 +18,20 @@ module StudentsQueryHelper
     student_ids = student_hashes.map {|student_hash| student_hash[:id] }
     all_event_notes = EventNote.where(student_id: student_ids)
     all_active_services = Service.where(student_id: student_ids).active
+    past_year_services = Service.where(student_id: student_ids).past_year
     all_interventions = Intervention.where(student_id: student_ids)
 
     student_hashes.map do |student_hash|
       for_student = {
         event_notes: all_event_notes.select {|event_note| event_note.student_id == student_hash[:id] },
         active_services: all_active_services.select {|service| service.student_id == student_hash[:id] },
-        interventions: all_interventions.select {|intervention| intervention.student_id == student_hash[:id] }
+        interventions: all_interventions.select {|intervention| intervention.student_id == student_hash[:id] },
+        past_year_services: past_year_services.select {|service| service.student_ids == student_hash[:id] }
       }
       student_hash.merge({
         event_notes: for_student[:event_notes].map {|x| serialize_event_note(x) },
         active_services: for_student[:active_services].map {|x| serialize_service(x) },
+        past_year_services: for_student[:past_year_services].map {|x| serialize_service(x) },
         interventions: for_student[:interventions].map {|x| serialize_intervention(x) },
       })
     end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -34,6 +34,11 @@ class Service < ActiveRecord::Base
     future_discontinue + never_discontinued
   end
 
+  def self.past_year
+    one_year_ago = Date.today - 1.year
+    where("date_started > ?", one_year_ago)
+  end
+
   def self.never_discontinued
     includes(:discontinued_services).where(:discontinued_services => { :id => nil })
   end

--- a/spec/javascripts/components/slice_panels_spec.js
+++ b/spec/javascripts/components/slice_panels_spec.js
@@ -11,7 +11,7 @@ describe('SlicePanels', function() {
   var FixtureConstantIndexes = window.shared.FixtureConstantIndexes;
   var FixtureStudents = window.shared.FixtureStudents;
 
-  var helpers = { 
+  var helpers = {
     renderInto: function(el, props) {
       var mergedProps = merge({
         filters: [],
@@ -61,7 +61,7 @@ describe('SlicePanels', function() {
         ['STAR Reading', 'MCAS ELA Score', 'MCAS ELA SGP'],
         ['STAR Math', 'MCAS Math Score', 'MCAS Math SGP'],
         ['Discipline incidents', 'Absences', 'Tardies'],
-        ['Services', 'Notes', 'Program', 'Homeroom']
+        ['Services (past year)', 'Notes', 'Program', 'Homeroom']
       ]);
 
     });

--- a/spec/javascripts/fixtures/fixture_students.js
+++ b/spec/javascripts/fixtures/fixture_students.js
@@ -109,7 +109,8 @@
         "updated_at": "2016-03-18T00:33:49.613Z"
       }
     ],
-    "active_services": [
+    "active_services": [],
+    "past_year_services": [
       {
         "id": 1,
         "student_id": 1,
@@ -286,6 +287,7 @@
       }
     ],
     "active_services": [],
+    "past_year_services": [],
     "interventions": []
   }];
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -31,17 +31,25 @@ RSpec.describe Service do
     service
   }
 
+  let!(:yesterday_service) {
+    FactoryGirl.create(:service, date_started: Date.today - 1.day, id: 70007)
+  }
+
+  let!(:ten_months_ago_service) {
+    FactoryGirl.create(:service, date_started: Date.today - 10.months, id: 70008)
+  }
+
   describe '.active' do
     it 'collects the correct services' do
       active_ids = Service.active.map(&:id).sort
-      expect(active_ids).to eq [70001, 70002, 70005, 70006]
+      expect(active_ids).to eq [70001, 70002, 70005, 70006, 70007, 70008]
     end
   end
 
   describe '.never_discontinued' do
     it 'collects the correct services' do
       never_discontinued_ids = Service.never_discontinued.pluck(:id).sort
-      expect(never_discontinued_ids).to eq [70001, 70002]
+      expect(never_discontinued_ids).to eq [70001, 70002, 70007, 70008]
     end
   end
 
@@ -56,6 +64,13 @@ RSpec.describe Service do
     it 'collects the correct services' do
       discontinued_ids = Service.discontinued.pluck(:id).sort
       expect(discontinued_ids).to eq [70003, 70004]
+    end
+  end
+
+  describe '.past_year' do
+    it 'collects the correct services' do
+      past_year_ids = Service.past_year.pluck(:id).sort
+      expect(past_year_ids).to eq [70007, 70008]
     end
   end
 


### PR DESCRIPTION
# What's the change?

Change the school overview filter from "active services" (i.e. services being administered at this moment") to "past year services" (i.e. services administered within the past year).

# Why do we need it?

As we're bulk-uploading services, some of them are services that have "ended" already — for example, Summer School which ends when the school year begins. But we still want these services to be showing up on the school overview page.

# Issue

 #778