### PR TITLE
Backgroundize student searchbar database queries

### DIFF
--- a/app/assets/javascripts/student_searchbar.js
+++ b/app/assets/javascripts/student_searchbar.js
@@ -1,41 +1,20 @@
 $(function() {
 
-  if ($("#student-searchbar").length > 0) {
+  if ($('#student-searchbar').length > 0) {
 
-    $("#student-searchbar").autocomplete({
-      minLength: 2,
-      source: function(request, response) {
-        $.ajax({
-          url: "/students/names",
-          data: {
-            q: request.term
+    $.get({
+      url: '/students/names',
+      success: function (data) {
+        $("#student-searchbar").autocomplete({
+          minLength: 2,
+          source: data,
+          select: function(e, ui) {
+            window.location.pathname = '/students/' + ui.item.id;
           },
-          success: function(data) {
-
-            if (data.length === 0) {
-              data = [{ label: 'No matching students', value: null }];
-            };
-
-            response(data);
-          }
         });
-      },
-      focus: function(e, ui) {
-        e.preventDefault();
-        $(this).val(ui.item.label);
-      },
-      select: function(e, ui) {
-        e.preventDefault();
+      }
+    })
 
-        if (ui.item.label === 'No matching students') {
-          $(this).val('');
-        } else {
-          window.location.pathname = '/students/' + ui.item.value;
-        }
-
-      },
-    });
-
-  }
+  };
 
 });

--- a/app/assets/javascripts/student_searchbar.js
+++ b/app/assets/javascripts/student_searchbar.js
@@ -1,37 +1,41 @@
 $(function() {
 
-  $("#student-searchbar").autocomplete({
-    minLength: 2,
-    source: function(request, response) {
-      $.ajax({
-        url: "/students/names",
-        data: {
-          q: request.term
-        },
-        success: function(data) {
+  if ($("#student-searchbar").length > 0) {
 
-          if (data.length === 0) {
-            data = [{ label: 'No matching students', value: null }];
-          };
+    $("#student-searchbar").autocomplete({
+      minLength: 2,
+      source: function(request, response) {
+        $.ajax({
+          url: "/students/names",
+          data: {
+            q: request.term
+          },
+          success: function(data) {
 
-          response(data);
+            if (data.length === 0) {
+              data = [{ label: 'No matching students', value: null }];
+            };
+
+            response(data);
+          }
+        });
+      },
+      focus: function(e, ui) {
+        e.preventDefault();
+        $(this).val(ui.item.label);
+      },
+      select: function(e, ui) {
+        e.preventDefault();
+
+        if (ui.item.label === 'No matching students') {
+          $(this).val('');
+        } else {
+          window.location.pathname = '/students/' + ui.item.value;
         }
-      });
-    },
-    focus: function(e, ui) {
-      e.preventDefault();
-      $(this).val(ui.item.label);
-    },
-    select: function(e, ui) {
-      e.preventDefault();
 
-      if (ui.item.label === 'No matching students') {
-        $(this).val('');
-      } else {
-        window.location.pathname = '/students/' + ui.item.value;
-      }
+      },
+    });
 
-    },
-  });
+  }
 
 });

--- a/app/assets/javascripts/student_searchbar.js
+++ b/app/assets/javascripts/student_searchbar.js
@@ -6,7 +6,6 @@ $(function() {
       url: '/students/names',
       success: function (data) {
         $("#student-searchbar").autocomplete({
-          minLength: 2,
           source: data,
           select: function(e, ui) {
             window.location.pathname = '/students/' + ui.item.id;

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -75,16 +75,19 @@ class StudentsController < ApplicationController
 
   # Used by the search bar to query for student names
   def names
-    q = params[:q]
     authorized_students = Student.with_school.select do |student|
       current_educator.is_authorized_for_student(student)
     end
-    sorted_students = search_and_score(q, authorized_students)
-    truncated_students = sorted_students.take(20)
-    @sorted_results = truncated_students.map {|student| student.decorate.presentation_for_autocomplete }
+
+    students_for_searchbar = authorized_students.map do |student|
+      {
+        label: "#{student.first_name} #{student.last_name} - #{student.school.local_id} - #{student.grade}",
+        id: student.id
+      }
+    end
 
     respond_to do |format|
-      format.json { render json: @sorted_results }
+      format.json { render json: students_for_searchbar }
     end
   end
 

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -122,33 +122,6 @@ class StudentsController < ApplicationController
     }).stringify_keys
   end
 
-  def search_and_score(query, students)
-    search_tokens = query.split(' ')
-    students_with_scores = students.flat_map do |student|
-      score = calculate_student_score(student, search_tokens)
-      if score > 0 then [{ student: student, score: score }] else [] end
-    end
-
-    students_with_scores.sort_by {|ss| -1 * ss[:score] }.map {|ss| ss[:student] }
-  end
-
-  # range: [0.0, 1.0]
-  def calculate_student_score(student, search_tokens)
-    student_tokens = [student.first_name, student.last_name].compact
-
-    search_token_scores = []
-    search_tokens.each do |search_token|
-      student_tokens.each do |student_token|
-        if search_token.upcase == student_token[0..search_token.length - 1].upcase
-          search_token_scores << 1
-          break
-        end
-      end
-    end
-
-    (search_token_scores.sum.to_f / search_tokens.length)
-  end
-
   # The feed of mutable data that changes most frequently and is owned by Student Insights.
   # restricted_notes: If false display non-restricted notes, if true display only restricted notes.
   def student_feed(student, restricted_notes: false)

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -363,40 +363,6 @@ describe StudentsController, :type => :controller do
     end
   end
 
-  describe '#calculate_student_score' do
-    context 'happy path' do
-      let(:search_tokens) { ['don', 'kenob'] }
-      it 'is 0.0 when no matches' do
-        result = controller.send(:calculate_student_score, Student.new(first_name: 'Mickey', last_name: 'Mouse'), search_tokens)
-        expect(result).to eq 0.0
-      end
-
-      it 'is 0.5 when first name only matches' do
-        result = controller.send(:calculate_student_score, Student.new(first_name: 'Donald', last_name: 'Mouse'), search_tokens)
-        expect(result).to eq 0.5
-      end
-
-      it 'is 0.5 when last name only matches' do
-        result = controller.send(:calculate_student_score, Student.new(first_name: 'zzz', last_name: 'Kenobiliiii'), search_tokens)
-        expect(result).to eq 0.5
-      end
-
-      it 'is 1.0 when both names match' do
-        result = controller.send(:calculate_student_score, Student.new(first_name: 'Donald', last_name: 'Kenobi'), search_tokens)
-        expect(result).to eq 1.0
-      end
-    end
-
-    it 'works for bug test case' do
-      search_tokens = ['al','p']
-      aladdin_score = controller.send(:calculate_student_score, Student.new(first_name: 'Aladdin', last_name: 'Poppins'), search_tokens)
-      pluto_score = controller.send(:calculate_student_score, Student.new(first_name: 'Pluto', last_name: 'Poppins'), search_tokens)
-      expect(aladdin_score).to be > pluto_score
-      expect(aladdin_score).to eq 1
-      expect(pluto_score).to eq 0.5
-    end
-  end
-
   describe '#student_feed' do
     let(:student) { FactoryGirl.create(:student) }
     let(:educator) { FactoryGirl.create(:educator, :admin) }

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -306,53 +306,42 @@ describe StudentsController, :type => :controller do
   describe '#names' do
     let(:school) { FactoryGirl.create(:healey) }
 
-    def make_request(query)
+    def make_request
       request.env['HTTPS'] = 'on'
-      get :names, q: query, format: :json
+      get :names, format: :json
     end
 
     context 'admin educator logged in' do
       let!(:educator) { FactoryGirl.create(:educator, :admin, school: school) }
       before { sign_in(educator) }
-      context 'query matches student name' do
-        let!(:juan) { FactoryGirl.create(:student, first_name: 'Juan', school: school, grade: '5') }
-        let!(:jacob) { FactoryGirl.create(:student, first_name: 'Jacob', grade: '5') }
+      let!(:juan) {
+        FactoryGirl.create(:student, first_name: 'Juan', last_name: 'P', school: school, grade: '5')
+      }
 
-        it 'is successful' do
-          make_request('j')
-          expect(response).to be_success
-        end
-        it 'returns student name and id' do
-          make_request('j')
-          expect(assigns(:sorted_results)).to eq [{ label: "Juan - HEA - 5", value: juan.id }]
-        end
-      end
-      context 'does not match student name' do
-        it 'is successful' do
-          make_request('j')
-          expect(response).to be_success
-        end
-        it 'returns an empty array' do
-          make_request('j')
-          expect(assigns(:sorted_results)).to eq []
-        end
+      let!(:jacob) {
+        FactoryGirl.create(:student, first_name: 'Jacob', grade: '5')
+      }
+
+      it 'returns an array of student labels and ids that match the educator\'s students' do
+        make_request
+        expect(response).to be_success
+        expect(JSON.parse(response.body)).to eq [{ "label" => "Juan P - HEA - 5", "id" => juan.id }]
       end
     end
     context 'educator without authorization to students' do
       let!(:educator) { FactoryGirl.create(:educator) }
       before { sign_in(educator) }
-      context 'query matches student name' do
-        let(:healey) { FactoryGirl.create(:healey) }
-        let!(:juan) { FactoryGirl.create(:student, first_name: 'Juan', school: healey, grade: '5') }
-        it 'returns an empty array' do
-          make_request('j')
-          expect(assigns(:sorted_results)).to eq []
-        end
+      let(:healey) { FactoryGirl.create(:healey) }
+      let!(:juan) { FactoryGirl.create(:student, first_name: 'Juan', school: healey, grade: '5') }
+
+      it 'returns an empty array' do
+        make_request
+        expect(JSON.parse(response.body)).to eq []
       end
     end
     context 'educator not logged in' do
       it 'is not successful' do
-        make_request('j')
+        make_request
         expect(response.status).to eq 401
         expect(response.body).to include "You need to sign in before continuing."
       end


### PR DESCRIPTION
## What is this? 

Implementing an excellent suggestion from @kevinrobinson that we pull in data to power the student searchbar once, instead of querying the database every time an educator types another letter in the searchbar. 

## Future optimization 

This PR aims to cut down the queries to one per page; better would be one per user session.

## Issue

Fixes #759. 