### PR TITLE
Cache student risk level to students table

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -217,6 +217,12 @@ class Student < ActiveRecord::Base
     else
       create_student_risk_level!
     end
+
+    # Cache risk level to the student table
+    if self.risk_level != student_risk_level.level
+      self.risk_level = student_risk_level.level
+      self.save
+    end
   end
 
 end

--- a/db/migrate/20161221152824_add_student_risk_level_cache_to_students_table.rb
+++ b/db/migrate/20161221152824_add_student_risk_level_cache_to_students_table.rb
@@ -1,0 +1,5 @@
+class AddStudentRiskLevelCacheToStudentsTable < ActiveRecord::Migration
+  def change
+    add_column :students, :risk_level, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161202194656) do
+ActiveRecord::Schema.define(version: 20161221152824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -323,6 +323,7 @@ ActiveRecord::Schema.define(version: 20161202194656) do
     t.integer  "most_recent_star_math_percentile"
     t.string   "enrollment_status"
     t.datetime "date_of_birth"
+    t.integer  "risk_level"
   end
 
   add_index "students", ["homeroom_id"], name: "index_students_on_homeroom_id", using: :btree

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -184,27 +184,31 @@ RSpec.describe Student do
     end
   end
 
-  describe '#create_risk_level' do
-    context 'create a non-ELL student' do
-      let(:student) { FactoryGirl.create(:student) }
-      it 'creates a risk level' do
-        expect { student.create_student_risk_level! }.to change(StudentRiskLevel, :count).by 1
+  describe '#update_risk_level' do
+    context 'no pre-existing risk level' do
+      context 'non-ELL student with no test results' do
+        let(:student) { FactoryGirl.create(:student) }
+        it 'creates a risk level' do
+          expect { student.update_risk_level }.to change(StudentRiskLevel, :count).by 1
+        end
+        it 'assigns correct level' do
+          student.update_risk_level
+          student_risk_level = student.student_risk_level
+          expect(student_risk_level.level).to eq nil
+          expect(student.risk_level).to eq nil
+        end
       end
-      it 'assigns correct level' do
-        student.create_student_risk_level!
-        student_risk_level = student.student_risk_level
-        expect(student_risk_level.level).to eq nil
-      end
-    end
-    context 'create an ELL student' do
-      let(:student) { FactoryGirl.build(:limited_english_student) }
-      it 'creates a risk level' do
-        expect { student.create_student_risk_level! }.to change(StudentRiskLevel, :count).by 1
-      end
-      it 'assigns correct level' do
-        student.create_student_risk_level!
-        student_risk_level = student.student_risk_level
-        expect(student_risk_level.level).to eq 3
+      context 'ELL student with no test results' do
+        let(:student) { FactoryGirl.build(:limited_english_student) }
+        it 'creates a risk level' do
+          expect { student.update_risk_level }.to change(StudentRiskLevel, :count).by 1
+        end
+        it 'assigns correct level' do
+          student.update_risk_level
+          student_risk_level = student.student_risk_level
+          expect(student_risk_level.level).to eq 3
+          expect(student.risk_level).to eq 3
+        end
       end
     end
   end


### PR DESCRIPTION
# What's new? 

+ This PR sets up database and back-end changes to cache `risk_level` on the students table. I'll merge this and populate `risk_levels` for existing students in production. Then I'll change the school overview code so it reads from the new cached value instead of having to do a query on StudentRiskLevel.

# Issue 

+ #790 
