### PR TITLE
Treat risk level like any other student attribute on school overview

### DIFF
--- a/app/assets/javascripts/components/slice_panels.js
+++ b/app/assets/javascripts/components/slice_panels.js
@@ -227,8 +227,9 @@
     },
 
     renderRiskLevel: function() {
+      var key = 'risk_level';
       var items = [0, 1, 2, 3].map(function(value) {
-        return this.createItem(value, Filters.RiskLevel(value));
+        return this.createItem(value, Filters.Equal(key, value));
       }, this);
 
       return this.renderTable({

--- a/app/assets/javascripts/helpers/filters.js
+++ b/app/assets/javascripts/helpers/filters.js
@@ -80,14 +80,6 @@
         key: 'years_enrolled'
       };
     },
-    RiskLevel: function(value) {
-      return {
-        identifier: ['risk_level', value].join(':'),
-        filterFn: function(student) {
-          return (student.student_risk_level && student.student_risk_level.level === value);
-        }
-      };
-    },
 
     // Has to parse from string back to numeric
     createFromIdentifier: function(identifier) {

--- a/app/helpers/students_query_helper.rb
+++ b/app/helpers/students_query_helper.rb
@@ -4,7 +4,6 @@ module StudentsQueryHelper
   # This may be slow if you're doing it for many students without eager includes.
   def student_hash_for_slicing(student)
     student.as_json.merge({
-      student_risk_level: student.student_risk_level.as_json,
       discipline_incidents_count: student.most_recent_school_year.discipline_incidents.count,
       absences_count: student.most_recent_school_year.absences.count,
       tardies_count: student.most_recent_school_year.tardies.count,


### PR DESCRIPTION
# What's new?

+ Read from the cached value instead of querying the database for StudentRiskLevel objects
+ Should fix #790 