### PR TITLE
Stop looking at historial STAR data on every import

### DIFF
--- a/app/importers/sources/somerville_star_importers.rb
+++ b/app/importers/sources/somerville_star_importers.rb
@@ -12,12 +12,7 @@ class SomervilleStarImporters
 
   def file_importer_classes
     [
-      StarReadingImporter,
-      StarReadingImporter::HistoricalImporter,
       StarReadingImporter::RecentImporter,
-
-      StarMathImporter,
-      StarMathImporter::HistoricalImporter,
       StarMathImporter::RecentImporter,
     ]
   end

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -38,11 +38,7 @@ RSpec.describe Import do
         BehaviorImporter,
         EducatorsImporter,
         AttendanceImporter,
-        StarReadingImporter,
-        StarReadingImporter::HistoricalImporter,
         StarReadingImporter::RecentImporter,
-        StarMathImporter,
-        StarMathImporter::HistoricalImporter,
         StarMathImporter::RecentImporter,
       ]
     }


### PR DESCRIPTION
# What is this?

+ According to our partners at STAR, the "Generic SM Extract.csv" file naming convention is the active one
+ So that's the only one we want to be reading when it comes to the regular, nightly data import process