### PR TITLE
Add summer services list to school overview

### DIFF
--- a/app/assets/javascripts/components/slice_panels.js
+++ b/app/assets/javascripts/components/slice_panels.js
@@ -140,6 +140,10 @@
           limit: 4
         }),
         this.renderTable({
+          title: 'Summer',
+          items: this.summerItems()
+        }),
+        this.renderTable({
           title: 'Notes',
           items: this.mergedNoteItems(),
           limit: 4
@@ -179,6 +183,21 @@
       });
 
       return [this.createItem('None', Filters.ServiceType(null))].concat(sortedItems);
+    },
+
+    summerItems: function () {
+      var students = this.props.allStudents;
+      var summerServices = _.compact(_.flatten(_.pluck(students, 'summer_services')));
+      var allSummerServiceTypeIds = _.unique(summerServices.map(function(service) {
+        return parseInt(service.service_type_id, 10);
+      }));
+
+      var serviceItems = allSummerServiceTypeIds.map(function(serviceTypeId) {
+        var serviceName = this.props.serviceTypesIndex[serviceTypeId].name;
+        return this.createItem(serviceName, Filters.ServiceType(serviceTypeId));
+      }, this);
+
+      return [this.createItem('None', Filters.ServiceType(null))].concat(serviceItems);
     },
 
     // TODO(kr) add other note types

--- a/app/demo_data/fake_service_generator.rb
+++ b/app/demo_data/fake_service_generator.rb
@@ -1,14 +1,14 @@
 class FakeServiceGenerator
 
   def initialize(student)
-    @date = DateTime.new(2010, 9, 1)
+    @date = Date.today
     @student = student
     @drawn_service_type_ids = Set.new
     @all_service_type_ids = ServiceType.all.map(&:id).to_set
   end
 
   def next
-    @date += rand(30..60)  # days
+    @date -= rand(30..60)  # days
     educator = Educator.where(admin: true).first
     service_type_id = (@all_service_type_ids - @drawn_service_type_ids).to_a.sample
     @drawn_service_type_ids.add(service_type_id)

--- a/app/models/service_type.rb
+++ b/app/models/service_type.rb
@@ -17,4 +17,11 @@ class ServiceType < ActiveRecord::Base
       { id: 512, name: 'Freedom School' },
     ])
   end
+
+  def self.add_summer_program_status_to_service_types
+    [509, 510, 512].each do |id|
+      ServiceType.find(id).update!({ summer_program: true })
+    end
+  end
+
 end

--- a/app/models/service_type.rb
+++ b/app/models/service_type.rb
@@ -10,9 +10,11 @@ class ServiceType < ActiveRecord::Base
       { id: 505, name: 'Counseling, in-house'},
       { id: 506, name: 'Counseling, outside'},
       { id: 507, name: 'Reading intervention'},
-      { id: 508, name: 'Math intervention'}     # Deprecated: No adding new Math interventions
-                                                # going forward. Focusing on shorter list of
-                                                # services with sharp, clear definitions.
+      { id: 508, name: 'Math intervention'},
+      { id: 509, name: 'SomerSession' },
+      { id: 510, name: 'Summer Program for English Language Learners' },
+      { id: 511, name: 'Afterschool Tutoring' },
+      { id: 512, name: 'Freedom School' },
     ])
   end
 end

--- a/db/seeds/database_constants.rb
+++ b/db/seeds/database_constants.rb
@@ -9,6 +9,7 @@ class DatabaseConstants
     Assessment.seed_somerville_assessments
     InterventionType.seed_somerville_intervention_types
     EventNoteType.seed_somerville_event_note_types
+    ServiceType.seed_somerville_service_types
     nil
   end
 end

--- a/db/seeds/database_constants.rb
+++ b/db/seeds/database_constants.rb
@@ -9,7 +9,6 @@ class DatabaseConstants
     Assessment.seed_somerville_assessments
     InterventionType.seed_somerville_intervention_types
     EventNoteType.seed_somerville_event_note_types
-    ServiceType.seed_somerville_service_types
     nil
   end
 end

--- a/db/seeds/database_constants.rb
+++ b/db/seeds/database_constants.rb
@@ -10,6 +10,7 @@ class DatabaseConstants
     InterventionType.seed_somerville_intervention_types
     EventNoteType.seed_somerville_event_note_types
     ServiceType.seed_somerville_service_types
+    ServiceType.add_summer_program_status_to_service_types
     nil
   end
 end

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -64,6 +64,10 @@ describe StudentsController, :type => :controller do
             506 => {:id=>506, :name=>"Counseling, outside"},
             507 => {:id=>507, :name=>"Reading intervention"},
             508 => {:id=>508, :name=>"Math intervention"},
+            509 => {:id=>509, :name=>"SomerSession"},
+            510 => {:id=>510, :name=>"Summer Program for English Language Learners"},
+            511 => {:id=>511, :name=>"Afterschool Tutoring"},
+            512 => {:id=>512, :name=>"Freedom School"},
           })
 
           expect(serialized_data[:event_note_types_index]).to eq({

--- a/spec/importers/student_services/student_services_file_spec.rb
+++ b/spec/importers/student_services/student_services_file_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe StudentServicesFile do
     let!(:student_101) { FactoryGirl.create(:student, local_id: '101') }
     let!(:student_102) { FactoryGirl.create(:student, local_id: '102') }
     let!(:administrator) { FactoryGirl.create(:educator) }
-    let!(:somer_session) { ServiceType.create({ id: 509, name: 'SomerSession' }) }
 
     before do
       allow_any_instance_of(

--- a/spec/javascripts/components/slice_panels_spec.js
+++ b/spec/javascripts/components/slice_panels_spec.js
@@ -11,7 +11,7 @@ describe('SlicePanels', function() {
   var FixtureConstantIndexes = window.shared.FixtureConstantIndexes;
   var FixtureStudents = window.shared.FixtureStudents;
 
-  var helpers = { 
+  var helpers = {
     renderInto: function(el, props) {
       var mergedProps = merge({
         filters: [],
@@ -56,14 +56,13 @@ describe('SlicePanels', function() {
       expect($(el).find('.SlicePanels').length).toEqual(1);
       expect($(el).find('.column').length).toEqual(6);
       expect(helpers.columnTitlesMatrix(el)).toEqual([
-        ['Disability', 'Low Income', 'LEP'],
-        ['Grade', 'Years enrolled', 'Risk level'],
-        ['STAR Reading', 'MCAS ELA Score', 'MCAS ELA SGP'],
-        ['STAR Math', 'MCAS Math Score', 'MCAS Math SGP'],
-        ['Discipline incidents', 'Absences', 'Tardies'],
-        ['Services', 'Notes', 'Program', 'Homeroom']
+        [ 'Disability', 'Low Income', 'LEP' ],
+        [ 'Grade', 'Years enrolled', 'Risk level' ],
+        [ 'STAR Reading', 'MCAS ELA Score', 'MCAS ELA SGP' ],
+        [ 'STAR Math', 'MCAS Math Score', 'MCAS Math SGP' ],
+        [ 'Discipline incidents', 'Absences', 'Tardies' ],
+        [ 'Services', 'Summer', 'Notes', 'Program', 'Homeroom' ]
       ]);
-
     });
 
     it('renders attributes for slicing based on student data', function() {
@@ -74,12 +73,12 @@ describe('SlicePanels', function() {
       });
 
       expect(helpers.rowsPerColumnMatrix(el)).toEqual([
-         [5, 1, 1],
-         [1, 1, 5],
-         [5, 5, 5],
-         [5, 5, 5],
-         [5, 5, 5],
-         [4, 4, 2, 1]
+        [ 5, 1, 1 ],
+        [ 1, 1, 5 ],
+        [ 5, 5, 5 ],
+        [ 5, 5, 5 ],
+        [ 5, 5, 5 ],
+        [ 4, 1, 4, 2, 1 ]
       ]);
     });
   });


### PR DESCRIPTION
# What's new?

+ Break out summer services separately in the school overview 

# Why?

+ So we can give a sense of which students got summer services, even if those services aren't currently "active"

# Screenshot
![screen shot 2016-12-23 at 7 39 27 am](https://cloud.githubusercontent.com/assets/3209501/21455087/0e1c0564-c8e3-11e6-8b23-e79bad069866.png)

# Issue

+ Fix #778