### PR TITLE
Make demo seed data use precompute path for school overview

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -74,3 +74,4 @@ end
 Student.update_risk_levels
 Student.update_student_school_years
 Student.update_recent_student_assessments
+PrecomputeStudentHashesJob.new(STDOUT).precompute_all!(Time.now)


### PR DESCRIPTION
# What's this

+ Run the precompute task after seeding the database with demo data
+ This makes the demo data more similar to production for the school overview page, which gets precomputed in production 