### PR TITLE
Fix JS warnings in teaspoon specs

### DIFF
--- a/app/assets/javascripts/components/fixed_table.js
+++ b/app/assets/javascripts/components/fixed_table.js
@@ -21,7 +21,7 @@
       filters: React.PropTypes.array.isRequired,
       title: React.PropTypes.string.isRequired,
       items: React.PropTypes.array.isRequired,
-      children: React.PropTypes.element.isRequired
+      children: React.PropTypes.element,
     },
 
     onRowClicked: function(item, e) {

--- a/app/assets/javascripts/components/slice_buttons.js
+++ b/app/assets/javascripts/components/slice_buttons.js
@@ -6,15 +6,14 @@
 
   var SliceButtons = window.shared.SliceButtons = React.createClass({
     displayName: 'SliceButtons',
-      
+
     propTypes: {
       students: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
       filters: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
       filtersHash: React.PropTypes.object.isRequired,
-      activeFiltersIdentifier: React.PropTypes.object.isRequired,
       clearFilters: React.PropTypes.func.isRequired
     },
-    
+
     // Key code 27 is the ESC key
     onKeyDown: function(e) {
       if (e.keyCode == 27) this.props.clearFilters();

--- a/spec/javascripts/components/slice_buttons_spec.js
+++ b/spec/javascripts/components/slice_buttons_spec.js
@@ -11,13 +11,12 @@ describe('SliceButtons', function() {
   var FixtureConstantIndexes = window.shared.FixtureConstantIndexes;
   var FixtureStudents = window.shared.FixtureStudents;
 
-  var helpers = { 
+  var helpers = {
     renderInto: function(el, props) {
       var mergedProps = merge({
         students: [],
         filters: [],
         filtersHash: {},
-        activeFiltersIdentifier: '',
         clearFilters: jasmine.createSpy('clearFilters')
       }, props || {});
       return ReactDOM.render(createEl(SliceButtons, mergedProps), el);

--- a/spec/javascripts/student_profile/student_profile_page_spec.js
+++ b/spec/javascripts/student_profile/student_profile_page_spec.js
@@ -41,7 +41,7 @@ describe('StudentProfilePage', function() {
     describe('student with no absences this school year', function () {
       it('displays zero absences', function () {
         var el = this.testEl;
-        helpers.renderStudentProfilePage(el, null, null, 0);
+        helpers.renderStudentProfilePage(el, null, [], 0);
         expect(el).toContainText('Absences this school year:0');
       });
     });

--- a/spec/javascripts/student_profile/student_profile_page_spec.js
+++ b/spec/javascripts/student_profile/student_profile_page_spec.js
@@ -29,7 +29,8 @@ describe('StudentProfilePage', function() {
       var mergedProps = {
         serializedData: serializedData,
         nowMomentFn: function() { return Fixtures.nowMoment; },
-        queryParams: {}
+        queryParams: {},
+        history: SpecSugar.history()
       };
       return ReactDOM.render(createEl(PageContainer, mergedProps), el);
     }


### PR DESCRIPTION
Fix up a bunch of warnings:

```
The command "bundle exec rspec spec" exited with 0.
6.91s$ bundle exec teaspoon
Starting the Teaspoon server...
[23940] Puma starting in cluster mode...
[23940] * Version 3.6.0 (ruby 2.3.0-p0), codename: Sleepy Sunday Serenity
[23940] * Min threads: 5, max threads: 5
[23940] * Environment: test
[23940] * Process workers: 2
[23940] * Preloading application
[23940] * Listening on tcp://127.0.0.1:38636
[23940] Use Ctrl-C to stop
[23940] - Worker 0 (pid: 23945) booted, phase: 0
Teaspoon running default suite at http://127.0.0.1:38636/teaspoon/default
[23940] - Worker 1 (pid: 23950) booted, phase: 0
Warning: Failed propType: Invalid prop `activeFiltersIdentifier` of type `string` supplied to `SliceButtons`, expected `object`.
  # development-with-addons/react.js:2170 -- warning
.Warning: Failed propType: Required prop `children` was not specified in `FixedTable`. Check the render method of `CollapsableTable`.
  # development-with-addons/react.js:2170 -- warning
.......................Warning: Failed propType: Required prop `onEventNoteAttachmentDeleted` was not specified in `NotesList`.
  # development-with-addons/react.js:2170 -- warning
.....................Warning: Failed propType: Required prop `attachments` was not specified in `NoteCard`. Check the render method of `NotesList`.
  # development-with-addons/react.js:2170 -- warning
........Warning: Failed propType: Required prop `history` was not specified in `PageContainer`.
  # development-with-addons/react.js:2170 -- warning
Warning: Failed propType: Required prop `dibels` was not specified in `StudentProfilePage`. Check the render method of `PageContainer`.
  # development-with-addons/react.js:2170 -- warning
.......
Finished in 1.46000 seconds
60 examples, 0 failures
[23945] ! Detected parent died, dying[23950] ! Detected parent died, dying
```