### PR TITLE
Set better pemissions on seed data admin account

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -217,8 +217,7 @@ class Educator < ActiveRecord::Base
 
   def has_access_to_all_students?
     restricted_to_sped_students == false &&
-    restricted_to_english_language_learners == false &&
-    schoolwide_access == true
+    restricted_to_english_language_learners == false
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,6 +33,7 @@ Educator.create!([{
   email: "demo-admin@example.com",
   password: "demo-password",
   districtwide_access: true,
+  admin: true,
 }, {
   email: "fake-fifth-grade@example.com",
   full_name: 'Teacher, Sarah',

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -32,15 +32,9 @@ RSpec.describe Educator do
       end
     end
     context 'admin without access to all students' do
-      let(:admin) { FactoryGirl.build(:educator, :admin, schoolwide_access: false) }
+      let(:admin) { FactoryGirl.build(:educator, :admin, restricted_to_sped_students: true) }
       it 'is invalid' do
         expect(admin).to be_invalid
-      end
-    end
-    context 'non-admin, no specific permissions set' do
-      let(:educator) { FactoryGirl.build(:educator) }
-      it 'is valid' do
-        expect(educator).to be_valid
       end
     end
   end


### PR DESCRIPTION
# Notes 

+ Make sure :admin is set to true so that "demo-admin@example.com" can do admin functions with the fake data
+ Remove an outdated validation requirement from back before districtwide access existed in the app and there was only one school