### PR TITLE
Fix bug with trying to save notes on older interventions

### DIFF
--- a/app/assets/javascripts/student_profile/editable_text_component.js
+++ b/app/assets/javascripts/student_profile/editable_text_component.js
@@ -1,15 +1,6 @@
 (function() {
   window.shared || (window.shared = {});
   var dom = window.shared.ReactHelpers.dom;
-  var styles = {
-    noteText: {
-      marginTop: 5,
-      padding: 0,
-      fontFamily: "'Open Sans', sans-serif",
-      fontSize: 14,
-      whiteSpace: 'pre-wrap'
-    }
-  };
 
   var sanitize = new Sanitize({
     elements: ['br', 'div', 'p']
@@ -91,7 +82,15 @@
 
     propTypes: {
       text: React.PropTypes.string.isRequired,
-      onBlurText: React.PropTypes.func.isRequired
+      onBlurText: React.PropTypes.func.isRequired,
+      className: React.PropTypes.string,
+      style: React.PropTypes.object
+    },
+
+    getDefaultProps: function() {
+      return {
+        style: {}
+      };
     },
 
     getInitialState: function() {
@@ -149,8 +148,8 @@
       return (
         dom.div({
           contentEditable: true,
-          className: 'note-text',
-          style: styles.noteText,
+          className: this.props.className,
+          style: this.props.style,
           ref: function(ref) { this.contentEditableEl = ref; }.bind(this),
           dangerouslySetInnerHTML: { __html: textToSanitizedHTML(this.state.text) },
           onInput: this.onModifyText,

--- a/app/assets/javascripts/student_profile/note_card.js
+++ b/app/assets/javascripts/student_profile/note_card.js
@@ -24,6 +24,13 @@
       paddingLeft: 5,
       display: 'inline-block'
     },
+    noteText: {
+      marginTop: 5,
+      padding: 0,
+      fontFamily: "'Open Sans', sans-serif",
+      fontSize: 14,
+      whiteSpace: 'pre-wrap'
+    }
   };
 
   // This renders a single card for a Note of any type.
@@ -48,7 +55,9 @@
       this.props.onEventNoteAttachmentDeleted(eventNoteAttachmentId);
     },
 
-    onBlurText: function (textValue) {
+    onBlurText: function(textValue) {
+      if (!this.props.onSave) return;
+
       this.props.onSave({
         id: this.props.eventNoteId,
         eventNoteTypeId: this.props.eventNoteTypeId,
@@ -68,12 +77,27 @@
             educator: this.props.educatorsIndex[this.props.educatorId]
           }))
         ),
-        createEl(EditableTextComponent, {
-          text: this.props.text,
-          onBlurText: this.onBlurText
-        }),
+        this.renderTextArea(),
         this.renderAttachmentUrls()
       );
+    },
+
+    // If an onSave callback is provided, the text is editable.
+    // If not (eg., for older interventions), 
+    renderTextArea: function() {
+      if (this.props.onSave) {
+        return createEl(EditableTextComponent, {
+          style: styles.noteText,
+          className: 'note-text',
+          text: this.props.text,
+          onBlurText: this.onBlurText
+        });
+      } else {
+        return dom.div({
+          style: styles.noteText,
+          className: 'note-text'
+        }, this.props.text);
+      }
     },
 
     renderAttachmentUrls: function() {


### PR DESCRIPTION
This is happening from `NoteCard` being used in a write-only way with older interventions.  This guards for that.  Addresses https://rollbar.com/somerville-teacher-tool/somerville-teacher-tool/items/33/?item_page=0&#instances