### PR TITLE
Validate that student registration dates can't be in the future

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -19,6 +19,7 @@ class Student < ActiveRecord::Base
   validates_presence_of :local_id
   validates_uniqueness_of :local_id
   validate :valid_grade
+  validate :registration_date_cannot_be_in_future
 
   after_create :update_student_school_years
 
@@ -26,6 +27,12 @@ class Student < ActiveRecord::Base
 
   def valid_grade
     errors.add(:grade, "must be a valid grade") unless grade.in?(VALID_GRADES)
+  end
+
+  def registration_date_cannot_be_in_future
+    if registration_date && (registration_date > DateTime.now)
+      errors.add(:registration_date, "cannot be in future")
+    end
   end
 
   def self.with_school

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -2,6 +2,27 @@ require 'rails_helper'
 
 RSpec.describe Student do
 
+  describe '#registration_date_cannot_be_in_future' do
+    context 'no registration date' do
+      let(:student) { FactoryGirl.build(:student) }
+      it 'is valid' do
+        expect(student).to be_valid
+      end
+    end
+    context 'future registration date' do
+      let(:student) { FactoryGirl.build(:student, registration_date: Time.now + 1.year) }
+      it 'is invalid' do
+        expect(student).to be_invalid
+      end
+    end
+    context 'past registration date' do
+      let(:student) { FactoryGirl.build(:student, :registered_last_year) }
+      it 'is valid' do
+        expect(student).to be_valid
+      end
+    end
+  end
+
   describe '#latest_result_by_family_and_subject' do
     let(:student) { FactoryGirl.create(:student) }
     let(:assessment_family) { "MCAS" }


### PR DESCRIPTION
# Why? 

+ We had one of these come down the assembly line from X2 (probably a data entry error) and it messed with some calculations the school overview dashboard was trying to make