### PR TITLE
Fix end dates for uploaded services

### DIFF
--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -49,7 +49,7 @@ class ServiceUploadsController < ApplicationController
 
         discontinued_service = DiscontinuedService.new(
           service: service,
-          recorded_at: recorded_at,
+          recorded_at: date_ended,
           recorded_by_educator: current_educator,
         )
 

--- a/spec/controllers/service_uploads_controller_spec.rb
+++ b/spec/controllers/service_uploads_controller_spec.rb
@@ -31,11 +31,8 @@ RSpec.describe ServiceUploadsController, type: :controller do
       }
 
       it 'creates two services' do
-        expect {
-          make_post_request(params)
-        }.to change {
-          Service.count
-        }.by 2
+        expect { make_post_request(params) }.to change { Service.count }.by(2)
+                                            .and change { DiscontinuedService.count }.by(2)
       end
 
       it 'returns the correct JSON' do


### PR DESCRIPTION
# Bugfix

+ DiscontinuedService model uses `recorded_at` to describe when the service ended . . . This is kind of confusing because in the service upload case, the upload is being "recorded" today but the service may have discontinued last month or earlier. 