### PR TITLE
Use non-destructive save for student import process

### DIFF
--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -33,11 +33,11 @@ class StudentsImporter < Struct.new :school_scope, :client, :log, :progress_bar
     student.enrollment_status = 'High School'
     student.grade = 'HS'
     student.school = nil
-    student.save!
+    student.save
   end
 
   def handle_elementary_student(student, row)
-    if student.save!
+    if student.save
       assign_student_to_homeroom(student, row[:homeroom])
       student.create_student_risk_level!
     end

--- a/spec/importers/file_importers/students_importer_spec.rb
+++ b/spec/importers/file_importers/students_importer_spec.rb
@@ -74,7 +74,9 @@ RSpec.describe StudentsImporter do
       context 'missing state id' do
         let(:row) { { state_id: nil, full_name: 'Hoag, George', home_language: 'English', grade: '1', homeroom: '101' } }
         it 'raises an error' do
-          expect{ described_class.new.import_row(row) }.to raise_error ActiveRecord::RecordInvalid
+          expect{ described_class.new.import_row(row) }.not_to raise_error
+
+          # TODO -- expect it to notify us or print something out ...
         end
       end
     end


### PR DESCRIPTION
# Why 

+ We don't want a single invalid record blocking the entire import
+ Better would be to catch the errors, save them, send them out as emails to me/Uri/John Breslin ...