### PR TITLE
Show students with nil hispanic/latino

### DIFF
--- a/app/assets/javascripts/components/slice_panels.js
+++ b/app/assets/javascripts/components/slice_panels.js
@@ -52,6 +52,7 @@
           items: [
             this.createItem('Yes', Filters.Equal('hispanic_latino', true)),
             this.createItem('No', Filters.Equal('hispanic_latino', false)),
+            this.createItem('None', Filters.Equal('hispanic_latino', null)),
           ]
         }),
         this.renderSimpleTable('Gender', 'gender', {})

--- a/spec/javascripts/components/slice_panels_spec.js
+++ b/spec/javascripts/components/slice_panels_spec.js
@@ -73,7 +73,7 @@ describe('SlicePanels', function() {
       });
 
       expect(helpers.rowsPerColumnMatrix(el)).toEqual([
-        [ 5, 1, 1, 2, 2, 0 ],
+        [ 5, 1, 1, 2, 3, 0 ],
         [ 1, 1, 5 ],
         [ 5, 5, 5 ],
         [ 5, 5, 5 ],


### PR DESCRIPTION
# Why 

+ A bunch of students in X2 have "nil" for Hispanic/Latino status
+ We're showing students with "nil" Gender and Race in X2 as "None", so we should do the same with Hispanic/Latino in the overview dashboard for consistency