### PR TITLE
Add new service types: X-Block and Community Schools

### DIFF
--- a/app/models/service_type.rb
+++ b/app/models/service_type.rb
@@ -15,6 +15,8 @@ class ServiceType < ActiveRecord::Base
       { id: 510, name: 'Summer Program for English Language Learners' },
       { id: 511, name: 'Afterschool Tutoring' },
       { id: 512, name: 'Freedom School' },
+      { id: 513, name: 'Community Schools' },
+      { id: 514, name: 'X-Block' },
     ])
   end
 

--- a/db/migrate/20170207173755_add_service_types_for_community_schools_and_x_block.rb
+++ b/db/migrate/20170207173755_add_service_types_for_community_schools_and_x_block.rb
@@ -1,0 +1,11 @@
+class AddServiceTypesForCommunitySchoolsAndXBlock < ActiveRecord::Migration
+  def change
+    if ServiceType.find_by_id(513).nil?
+      ServiceType.create({ id: 513, name: 'Community Schools' })
+    end
+
+    if ServiceType.find_by_id(514).nil?
+      ServiceType.create({ id: 514, name: 'X-Block' })
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170204021435) do
+ActiveRecord::Schema.define(version: 20170207173755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/service_types_controller_spec.rb
+++ b/spec/controllers/service_types_controller_spec.rb
@@ -20,13 +20,15 @@ describe ServiceTypesController, :type => :controller do
            "Attendance Contract",
            "Attendance Officer",
            "Behavior Contract",
+           "Community Schools",
            "Counseling, in-house",
            "Counseling, outside",
            "Freedom School",
            "Math intervention",
            "Reading intervention",
            "SomerSession",
-           "Summer Program for English Language Learners"
+           "Summer Program for English Language Learners",
+           "X-Block"
           ]
       end
     end

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -68,6 +68,8 @@ describe StudentsController, :type => :controller do
             510 => {:id=>510, :name=>"Summer Program for English Language Learners"},
             511 => {:id=>511, :name=>"Afterschool Tutoring"},
             512 => {:id=>512, :name=>"Freedom School"},
+            513 => {:id=>513, :name=>"Community Schools"},
+            514 => {:id=>514, :name=>"X-Block"},
           })
 
           expect(serialized_data[:event_note_types_index]).to eq({

--- a/spec/reports/students_spreadsheet_spec.rb
+++ b/spec/reports/students_spreadsheet_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe StudentsSpreadsheet do
     describe '#flat_row_hash' do
       it 'creates expected fields' do
         flat_row_hash = StudentsSpreadsheet.new.send(:flat_row_hash, school.students.first, ServiceType.all)
-        expect(flat_row_hash.keys).to eq([
+        expect(flat_row_hash.keys.sort).to eq([
            "id",
            "grade",
            "free_reduced_lunch",
@@ -63,6 +63,7 @@ RSpec.describe StudentsSpreadsheet do
            "Attendance Officer (active_service_date_started)",
            "Attendance Contract (active_service_date_started)",
            "Behavior Contract (active_service_date_started)",
+           "Community Schools (active_service_date_started)",
            "Counseling, in-house (active_service_date_started)",
            "Counseling, outside (active_service_date_started)",
            "Reading intervention (active_service_date_started)",
@@ -74,7 +75,9 @@ RSpec.describe StudentsSpreadsheet do
            "SST Meeting (last_event_note_recorded_at)",
            "MTSS Meeting (last_event_note_recorded_at)",
            "Parent conversation (last_event_note_recorded_at)",
-           "Something else (last_event_note_recorded_at)"]
+           "Something else (last_event_note_recorded_at)",
+           "X-Block (active_service_date_started)",
+         ].sort
         )
       end
     end


### PR DESCRIPTION
# Why? 

+ So that Uri can import new bulk CSVs for these services!
+ Question... Every time new service types are added, we need to update integration tests in three different places. Would it be useful to cut down the duplication?