### PR TITLE
Show student date of birth & age on student profile

### DIFF
--- a/app/assets/javascripts/student_profile/student_profile_header.js
+++ b/app/assets/javascripts/student_profile/student_profile_header.js
@@ -14,10 +14,15 @@
     },
     nameTitle: {
       fontSize: 28,
-      fontWeight: 'bold'
+      fontWeight: 'bold',
+      marginRight: 5
     },
     titleItem: {
       fontSize: 24,
+      padding: 5
+    },
+    subtitleItem: {
+      fontSize: 22,
       padding: 5
     }
   };
@@ -43,16 +48,18 @@
           }, student.first_name + ' ' + student.last_name),
           dom.div({ style: { display: 'inline-block' } },
             this.bulletSpacer(),
+            dom.a({
+              href: Routes.school(student.school_id),
+              style: styles.subtitleItem
+            }, student.school_name),
+            this.bulletSpacer(),
             this.homeroomOrEnrollmentStatus(),
             this.bulletSpacer(),
             dom.span({
-              style: styles.titleItem
+              style: styles.subtitleItem
             }, 'Grade ' + student.grade),
             this.bulletSpacer(),
-            dom.a({
-              href: Routes.school(student.school_id),
-              style: styles.titleItem
-            }, student.school_name)
+            this.dateOfBirth()
           )
         ),
         dom.div({
@@ -70,7 +77,7 @@
     },
 
     bulletSpacer: function() {
-      return dom.span({ style: styles.titleItem }, '•');
+      return dom.span({ style: styles.subtitleItem }, '•');
     },
 
     homeroomOrEnrollmentStatus: function() {
@@ -79,12 +86,22 @@
         return dom.a({
           className: 'homeroom-link',
           href: Routes.homeroom(student.homeroom_id),
-          style: styles.titleItem
+          style: styles.subtitleItem
         }, 'Homeroom ' + student.homeroom_name);
       } else {
-        return dom.span({ style: styles.titleItem }, student.enrollment_status);
+        return dom.span({ style: styles.subtitleItem }, student.enrollment_status);
       }
-    }
+    },
+
+    dateOfBirth: function () {
+      var student =  this.props.student;
+      var momentDOB = moment.utc(student.date_of_birth);
+      var ageInWords = ' (' + moment().diff(momentDOB, 'years') + ' years old)';
+
+      return dom.span({ style: styles.subtitleItem },
+        momentDOB.format('D/M/YYYY'), ageInWords
+      );
+    },
 
   });
 })();

--- a/app/assets/javascripts/student_profile/student_profile_header.js
+++ b/app/assets/javascripts/student_profile/student_profile_header.js
@@ -96,6 +96,8 @@
     dateOfBirth: function () {
       var student =  this.props.student;
       var momentDOB = moment.utc(student.date_of_birth);
+      if (!momentDOB) return null;
+
       var ageInWords = ' (' + moment().diff(momentDOB, 'years') + ' years old)';
 
       return dom.span({ style: styles.subtitleItem },

--- a/app/assets/javascripts/student_profile/student_profile_header.js
+++ b/app/assets/javascripts/student_profile/student_profile_header.js
@@ -99,7 +99,7 @@
       var ageInWords = ' (' + moment().diff(momentDOB, 'years') + ' years old)';
 
       return dom.span({ style: styles.subtitleItem },
-        momentDOB.format('D/M/YYYY'), ageInWords
+        momentDOB.format('M/D/YYYY'), ageInWords
       );
     },
 

--- a/spec/javascripts/student_profile/fixtures.js
+++ b/spec/javascripts/student_profile/fixtures.js
@@ -119,6 +119,7 @@
       "hispanic_latino": false,
       "race": "A",
       "free_reduced_lunch": "Not Eligible",
+      "date_of_birth": "2008-05-23T00:00:00.000Z",
       "created_at": "2016-02-11T14:41:52.437Z",
       "updated_at": "2016-02-11T14:41:59.433Z",
       "homeroom_id": 2,

--- a/spec/javascripts/student_profile/student_profile_header_spec.js
+++ b/spec/javascripts/student_profile/student_profile_header_spec.js
@@ -29,9 +29,13 @@ describe('StudentProfileHeader', function() {
     it('renders note-taking area with homeroom', function() {
       var el = this.testEl;
       helpers.renderActiveStudent(el);
+      var yearsOld = moment().diff(Fixtures.studentProfile.student.date_of_birth, 'years') // TODO (ARS): mock moment.utc() for spec
+                                                                                           // so we don't have to calculate this
 
       expect(el).toContainText('Daisy Poppins');
       expect(el).toContainText('Arthur D Healey');
+      expect(el).toContainText('5/23/2008');
+      expect(el).toContainText('(' + yearsOld + ' years old)');
       expect($(el).find('a.homeroom-link')).toContainText('102');
     });
   });


### PR DESCRIPTION
# Notes 

+ Via Uri: DOB and age useful data points to include in profile, useful to know if student is 6 yrs old for attendance purposes
+ Shrink other non-name header items to make room in the Student Profile header
+ Side effect: Makes the demo data look even more ridiculous, 3rd graders are 6 years old. This speaks to the kind of issue @jhilde opened up in #835.

# Screenshot (nonsense demo data)

![screen shot 2017-02-07 at 4 09 13 pm](https://cloud.githubusercontent.com/assets/3209501/22711609/d2b135c6-ed4f-11e6-8c56-0343be185e75.png)
