### PR TITLE
Upgrade React to 15.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'net-sftp'
 gem 'net-ssh'
 gem 'probability'
 gem 'rails-sanitize-js'
-gem 'react-rails', '1.5.0' # Provides React, handles swapping between dev/production builds.  See config/initializers/assets.rb
+gem 'react-rails' # Provides React, handles swapping between dev/production builds.  See config/initializers/assets.rb
 gem 'memory_profiler'
 gem 'oj'
 gem 'oj_mimic_json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     public_suffix (2.0.5)
-    puma (3.7.0)
+    puma (3.7.1)
     rack (2.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -234,12 +234,12 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
-    react-rails (1.5.0)
+    react-rails (1.10.0)
       babel-transpiler (>= 0.7.0)
       coffee-script-source (~> 1.8)
       connection_pool
       execjs
-      rails (>= 3.2)
+      railties (>= 3.2)
       tilt
     request_store (1.3.2)
     responders (2.3.0)
@@ -361,7 +361,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-sanitize-js
   rails_12factor
-  react-rails (= 1.5.0)
+  react-rails
   rspec-rails
   rubystats
   sass-rails (~> 5.0)

--- a/app/assets/javascripts/helpers/prop_types.js
+++ b/app/assets/javascripts/helpers/prop_types.js
@@ -1,18 +1,7 @@
 (function() {
   window.shared || (window.shared = {});
 
-  // Allow a prop to be null, if the prop type explicitly allows this.
-  // Then fall back to another validator if a value is passed.
-  var nullable = function(validator) {
-    return function(props, propName, componentName) {
-      if (props[propName] === null) return null;
-      return validator(props, propName, componentName);
-    };
-  };
-
   var PropTypes = window.shared.PropTypes = {
-    nullable: nullable,
-
     // UI actions, stepping stone to Flux
     actions: React.PropTypes.shape({
       onColumnClicked: React.PropTypes.func.isRequired,
@@ -21,7 +10,7 @@
       onClickDiscontinueService: React.PropTypes.func.isRequired
     }),
     requests: React.PropTypes.shape({
-      saveNote: nullable(React.PropTypes.string).isRequired
+      saveNote: React.PropTypes.string // or null
     }),
     api: React.PropTypes.shape({
       saveNotes: React.PropTypes.func.isRequired

--- a/app/assets/javascripts/student_profile/academic_summary.js
+++ b/app/assets/javascripts/student_profile/academic_summary.js
@@ -44,8 +44,8 @@
 
     propTypes: {
       caption: React.PropTypes.string.isRequired,
-      value: PropTypes.nullable(React.PropTypes.number.isRequired),
-      sparkline: React.PropTypes.element.isRequired
+      sparkline: React.PropTypes.element.isRequired,
+      value: React.PropTypes.number // value or null
     },
 
     render: function() {
@@ -64,7 +64,7 @@
 
     propTypes: {
       caption: React.PropTypes.string.isRequired,
-      value: PropTypes.nullable(React.PropTypes.string.isRequired)
+      value: React.PropTypes.string // or null
     },
 
     getDibelsHelpContent: function(){

--- a/app/assets/javascripts/student_profile/educator.js
+++ b/app/assets/javascripts/student_profile/educator.js
@@ -14,7 +14,7 @@
 
     propTypes: {
       educator: React.PropTypes.shape({
-        full_name: PropTypes.nullable(React.PropTypes.string.isRequired),
+        full_name: React.PropTypes.string, // or null
         email: React.PropTypes.string.isRequired
       }).isRequired
     },

--- a/app/assets/javascripts/student_profile/record_service.js
+++ b/app/assets/javascripts/student_profile/record_service.js
@@ -54,7 +54,7 @@
       studentId: React.PropTypes.number.isRequired,
       onSave: React.PropTypes.func.isRequired,
       onCancel: React.PropTypes.func.isRequired,
-      requestState: PropTypes.nullable(React.PropTypes.string.isRequired),
+      requestState: React.PropTypes.string, // or null
 
       // context
       nowMoment: React.PropTypes.object.isRequired,

--- a/app/assets/javascripts/student_profile/take_notes.js
+++ b/app/assets/javascripts/student_profile/take_notes.js
@@ -60,13 +60,13 @@
       onSave: React.PropTypes.func.isRequired,
       onCancel: React.PropTypes.func.isRequired,
       currentEducator: React.PropTypes.object.isRequired,
-      requestState: PropTypes.nullable(React.PropTypes.string.isRequired)
+      requestState: React.PropTypes.string // or null
     },
 
     getInitialState: function() {
       return {
         eventNoteTypeId: null,
-        text: null,
+        text: '',
         attachmentUrls: []
       }
     },

--- a/spec/javascripts/student_profile/page_container_spec.js
+++ b/spec/javascripts/student_profile/page_container_spec.js
@@ -57,7 +57,7 @@ describe('PageContainer', function() {
     },
 
     editNoteAndSave: function(el, uiParams) {
-      var $noteCard = $(el).find('.NotesList .NoteCard[data-reactid*=event_note]').first();
+      var $noteCard = $(el).find('.NotesList .NoteCard').first();
       var $text = $noteCard.find('.note-text');
       $text.html(uiParams.text);
       React.addons.TestUtils.Simulate.input($text.get(0));
@@ -127,6 +127,7 @@ describe('PageContainer', function() {
     it('can edit notes for SST meetings, mocking the action handlers', function() {
       var el = this.testEl;
       var component = helpers.renderInto(el);
+
       helpers.editNoteAndSave(el, {
         eventNoteTypeText: 'SST Meeting',
         text: 'world!'


### PR DESCRIPTION
This is on top of the Rails 5 change here: https://github.com/studentinsights/studentinsights/pull/855; that needs to be merged first.

The only substantive change is that calling `propType` functions directly raises a warning, which we did to indicate "maybe types" where a prop key was always required, but a null value was allowed.  This PR removes that and adds a comment in places where it was.