### PR TITLE
Some small JS fixes for service uploads

### DIFF
--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -80,21 +80,24 @@ class ServiceUploadsController < ApplicationController
   end
 
   def index
-    @serialized_data = { service_uploads: ServiceUpload.order(created_at: :desc).as_json(
-      only: [:created_at, :file_name, :id],
-      include: {
-        services: {
-          only: [],
-          include: {
-            student: {
-              only: [:first_name, :last_name, :id]
-            },
-            service_type: {
-              only: [:name]
+    @serialized_data = {
+      current_educator: current_educator,
+      service_uploads: ServiceUpload.order(created_at: :desc).as_json(
+        only: [:created_at, :file_name, :id],
+        include: {
+          services: {
+            only: [],
+            include: {
+              student: {
+                only: [:first_name, :last_name, :id]
+              },
+              service_type: {
+                only: [:name]
+              }
             }
           }
         }
-      }),
+      ),
       service_type_names: ServiceType.pluck(:name)
     }
   end

--- a/spec/javascripts/service_uploads/service_uploads_page_spec.js
+++ b/spec/javascripts/service_uploads/service_uploads_page_spec.js
@@ -9,7 +9,7 @@ describe('ServiceUploadsPage', function() {
   var helpers = {
     renderInto: function(el, props) {
       return ReactDOM.render(createEl(ServiceUploadsPage, props), el);
-    },
+    }
   };
 
   SpecSugar.withTestEl('integration tests', function() {
@@ -53,6 +53,20 @@ describe('ServiceUploadsPage', function() {
 
       expect(el).toContainText('bulk_upload.csv'); // Renders the file name
       expect(el).toContainText('Extra Tutoring');  // Renders the service type name
+    });
+
+    it('tolerates cancelling file upload', function() {
+      var el = this.testEl;
+      var instance = helpers.renderInto(el, {
+        serializedData: {
+          serviceUploads: [],
+          serviceTypeNames: ['Extra Tutoring', 'After-School Art Class'],
+        }
+      });
+
+      var fileInputEl = $(el).find('input[type=file]').get(0);
+      React.addons.TestUtils.Simulate.change(fileInputEl);
+      expect(instance.state.formData.file_name).toEqual(undefined);
     });
 
   });


### PR DESCRIPTION
This fixes https://rollbar.com/somerville-teacher-tool/somerville-teacher-tool/items/35/?item_page=0&#instances, which can be triggered when cancelling the upload dialog and adds a spec for it.

It also passes in `currentEducator` in serializedData, which `MixPanelUtils#registerUser` expects.

Finally, this removes a bit of state for `missingFields` that needed to be managed and kept consistent and instead computes it as needed in `isMissingRequiredFields` instead.