### PR TITLE
Indicate event notes revisions count

### DIFF
--- a/app/assets/javascripts/student_profile/note_card.js
+++ b/app/assets/javascripts/student_profile/note_card.js
@@ -47,7 +47,14 @@
       educatorsIndex: React.PropTypes.object.isRequired,
       attachments: React.PropTypes.array.isRequired,
       onSave: React.PropTypes.func,
-      onEventNoteAttachmentDeleted: React.PropTypes.func
+      onEventNoteAttachmentDeleted: React.PropTypes.func,
+      numberOfRevisions: React.PropTypes.number
+    },
+
+    getDefaultProps: function() {
+      return {
+        numberOfRevisions: 0
+      };
     },
 
     // No feedback, fire and forget
@@ -77,27 +84,47 @@
             educator: this.props.educatorsIndex[this.props.educatorId]
           }))
         ),
-        this.renderTextArea(),
+        (this.props.onSave) ? this.renderSaveableTextArea() : this.renderStaticTextArea(),
         this.renderAttachmentUrls()
       );
     },
 
-    // If an onSave callback is provided, the text is editable.
-    // If not (eg., for older interventions), 
-    renderTextArea: function() {
-      if (this.props.onSave) {
-        return createEl(EditableTextComponent, {
+    renderSaveableTextArea: function() {
+      return dom.div({},
+        createEl(EditableTextComponent, {
           style: styles.noteText,
           className: 'note-text',
           text: this.props.text,
           onBlurText: this.onBlurText
-        });
-      } else {
-        return dom.div({
-          style: styles.noteText,
-          className: 'note-text'
-        }, this.props.text);
-      }
+        }),
+        this.renderNumberOfRevisions()
+      );
+    },
+
+    renderNumberOfRevisions: function () {
+      var numberOfRevisions = this.props.numberOfRevisions;
+      if (numberOfRevisions === 0) return null;
+
+      return dom.div({
+        style: {
+          color: '#aaa',
+          fontSize: 13,
+          marginTop: 13
+        }
+      },
+        ((numberOfRevisions === 1)
+          ? 'Revised 1 time'
+          : 'Revised ' + numberOfRevisions + ' times')
+      );
+    },
+
+    // If an onSave callback is provided, the text is editable.
+    // If not (eg., for older interventions),
+    renderStaticTextArea: function () {
+      return dom.div({
+        style: styles.noteText,
+        className: 'note-text'
+      }, this.props.text);
     },
 
     renderAttachmentUrls: function() {

--- a/app/assets/javascripts/student_profile/notes_list.js
+++ b/app/assets/javascripts/student_profile/notes_list.js
@@ -63,6 +63,7 @@
         badge: this.renderEventNoteTypeBadge(eventNote.event_note_type_id),
         educatorId: eventNote.educator_id,
         text: eventNote.text || '',
+        numberOfRevisions: eventNote.event_note_revisions.length,
         attachments: eventNote.attachments,
         educatorsIndex: this.props.educatorsIndex,
         onSave: this.props.onSaveNote,

--- a/app/helpers/serialize_data_helper.rb
+++ b/app/helpers/serialize_data_helper.rb
@@ -25,14 +25,15 @@ module SerializeDataHelper
   end
 
   def serialize_event_note_without_attachments(event_note)
-    event_note.as_json.symbolize_keys.slice(*[
+    event_note.as_json(include: :event_note_revisions).symbolize_keys.slice(*[
       :id,
       :student_id,
       :educator_id,
       :event_note_type_id,
       :text,
       :recorded_at,
-      :is_restricted
+      :is_restricted,
+      :event_note_revisions
     ])
   end
 

--- a/app/models/event_note.rb
+++ b/app/models/event_note.rb
@@ -2,6 +2,7 @@ class EventNote < ActiveRecord::Base
   belongs_to :educator
   belongs_to :student
   belongs_to :event_note_type
+  has_many   :event_note_revisions
 
   has_many :event_note_attachments, dependent: :destroy
   accepts_nested_attributes_for :event_note_attachments

--- a/spec/controllers/event_notes_controller_spec.rb
+++ b/spec/controllers/event_notes_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe EventNotesController, :type => :controller do  
+describe EventNotesController, :type => :controller do
   let(:school) { FactoryGirl.create(:school) }
 
   describe '#create' do
@@ -42,6 +42,7 @@ describe EventNotesController, :type => :controller do
             'text',
             'recorded_at',
             'is_restricted',
+            'event_note_revisions',
             'attachments'
           ]
         end
@@ -108,7 +109,8 @@ describe EventNotesController, :type => :controller do
             'text',
             'recorded_at',
             'is_restricted',
-            'attachments',
+            'event_note_revisions',
+            'attachments'
           ]
           expect(JSON.parse(response.body)["is_restricted"]).to eq true
         end

--- a/spec/javascripts/student_profile/fixtures.js
+++ b/spec/javascripts/student_profile/fixtures.js
@@ -20,6 +20,7 @@
         "created_at": "2016-02-26T22:20:55.416Z",
         "updated_at": "2016-02-26T22:20:55.416Z",
         "is_restricted": false,
+        "event_note_revisions": [],
         "attachments": [
           { id: 42, url: "https://www.example.com/studentwork" },
           { id: 47, url: "https://www.example.com/morestudentwork" }
@@ -35,6 +36,7 @@
         "created_at": "2016-02-27T19:23:26.836Z",
         "updated_at": "2016-02-27T19:23:26.836Z",
         "is_restricted": true,
+        "event_note_revisions": [],
         "attachments": []
       }
     ],
@@ -496,6 +498,7 @@
           "recorded_at": "2016-02-11T21:28:02.102Z",
           "created_at": "2016-02-11T21:28:02.103Z",
           "updated_at": "2016-02-11T21:28:02.103Z",
+          "event_note_revisions": [],
           "attachments": []
         },
         {
@@ -507,6 +510,7 @@
           "recorded_at": "2016-02-11T21:29:18.166Z",
           "created_at": "2016-02-11T21:29:18.167Z",
           "updated_at": "2016-02-11T21:29:18.167Z",
+          "event_note_revisions": [],
           "attachments": []
         },
         {
@@ -518,6 +522,7 @@
           "recorded_at": "2016-02-11T21:29:30.287Z",
           "created_at": "2016-02-11T21:29:30.288Z",
           "updated_at": "2016-02-11T21:29:30.288Z",
+          "event_note_revisions": [],
           "attachments": []
         }
       ],

--- a/spec/javascripts/student_profile/note_card_spec.js
+++ b/spec/javascripts/student_profile/note_card_spec.js
@@ -50,6 +50,17 @@ describe('NoteCard', function() {
       expect(helpers.getNoteHTML(el)).toEqual('hello');
     });
 
+    it('renders number of revisions', function() {
+      var el = this.testEl;
+
+      helpers.renderInto(el, {
+        text: 'hello',
+        numberOfRevisions: 1
+      });
+
+      expect(el).toContainText('Revised 1 time');
+    });
+
     it('escapes HTML-meaningful characters in text', function() {
       var el = this.testEl;
 

--- a/spec/javascripts/student_profile/restricted_notes_page_container_spec.js
+++ b/spec/javascripts/student_profile/restricted_notes_page_container_spec.js
@@ -28,7 +28,8 @@ describe('RestrictedNotesPageContainer', function() {
           event_note_type_id: 301,
           student_id: 23,
           educator_id: 1,
-          attachments: []
+          attachments: [],
+          event_note_revisions: []
         })
       );
       return mockApi;


### PR DESCRIPTION
# What is this change? 

+ This mini-feature came out of a discussion with Jill at the Healey, she said that as a principal she really wants a way to see in the UI which event notes have been revised

# What does this look like?

![event-note-revision-screenshot](https://cloud.githubusercontent.com/assets/3209501/23321418/12e9bd22-faa5-11e6-93f6-ac282328cb53.png)
