### PR TITLE
Trim out whitespace when parsing uploaded CSV rows

### DIFF
--- a/app/assets/javascripts/service_uploads/service_uploads_page.js
+++ b/app/assets/javascripts/service_uploads/service_uploads_page.js
@@ -177,7 +177,7 @@
       if (!file || !file.name) return;
 
       this.setState({ formData: merge(this.state.formData, { file_name: file.name }) });
-      
+
       var reader = new FileReader();
       reader.onload = this.onFileReaderLoaded.bind(this, reader);
       reader.readAsText(file);
@@ -188,13 +188,14 @@
       var rows = text.split("\n");
       var headerRow = rows.shift().split(",");
 
-      if (headerRow[0] !== 'LASID') {
+      if (headerRow[0].trim() !== 'LASID') {
         this.setState({ missingLasidHeader: true });
         return;
       };
 
-      var student_lasids = rows.map(function(row) { return row.split(",")[0]; })
+      var student_lasids = rows.map(function(row) { return row.split(",")[0].trim(); })
                                .filter(function (lasid) { return lasid !== '' });
+
       this.validateLASIDs(student_lasids);
     },
 


### PR DESCRIPTION
# Why

+ CSV files appear to present data differently Windows machines vs. Macs when parsed client-side with the `FileReader` API. 
+ Uri and I got different results when using the service upload page on our machines, even when both of us used Chrome.
+ I used a tiny Windows VM on Azure to investigate & debug. Turns out in Windows the CSV parses rows with an extra trailing space, so `"LASID"` was read in as `"LASID "`. `"LASID" !== "LASID "`
+ Verified that `trim()` fixes the issue on the Windows VM.