### PR TITLE
Fix error in Educator Permissions controller _collection.html.erb

### DIFF
--- a/app/views/admin/application/_collection.html.erb
+++ b/app/views/admin/application/_collection.html.erb
@@ -26,9 +26,11 @@ to display a collection of resources in an HTML table.
         cell-label--<%= attr_type.html_class %>
         cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>
         " scope="col">
-        <%= link_to(params.merge(
-          collection_presenter.order_params_for(attr_name)
-        )) do %>
+        <%= link_to(
+          collection_presenter.order_params_for(attr_name).merge(
+            search: params["search"]
+          )
+        ) do %>
         <%= t(
           "helpers.label.#{resource_name}.#{attr_name}",
           default: attr_name.to_s,


### PR DESCRIPTION
# Notes 

+ Educator permissions dashboard was throwing this 500 error as described in #882: `Attempting to generate a URL from non-sanitized request parameters`

+ The URL generation feature on the dashboard is for creating links that allow users to combine multiple filters on a collection, for example, combining a search query with a directionality ordering (i.e. "educators whose names start with "A", ordered by school)

+ Instead of merging in any/all params to the URL, whitelist search only. There may be other params that a user might want besides search & directionality ordering but to be honest right now I cant think of any. And since Rails is commanding us to whitelist, whitelist we will do.

+ Close #882.