### PR TITLE
Option to override missing LASIDs for service uploads

### DIFF
--- a/app/assets/javascripts/service_uploads/new_service_upload.js
+++ b/app/assets/javascripts/service_uploads/new_service_upload.js
@@ -51,7 +51,8 @@
         ),
         createEl(ServiceTypeDropdown, {
           onUserTypingServiceType: this.props.onUserTypingServiceType,
-          onUserSelectServiceType: this.props.onUserSelectServiceType
+          onUserSelectServiceType: this.props.onUserSelectServiceType,
+          value: this.props.formData.service_type_name || ''
         }),
         dom.input({
           type: 'file',

--- a/app/assets/javascripts/service_uploads/new_service_upload.js
+++ b/app/assets/javascripts/service_uploads/new_service_upload.js
@@ -146,6 +146,8 @@
         return 'Uploading...';
       } else if (this.props.serverSideErrors.length > 0) {
         return 'Error Uploading';
+      } else if (this.props.incorrectLasids.length > 0) {
+        return 'Confirm Upload Despite LASID Mismatches?';
       } else {
         return 'Confirm Upload';
       };

--- a/app/assets/javascripts/service_uploads/new_service_upload.js
+++ b/app/assets/javascripts/service_uploads/new_service_upload.js
@@ -92,7 +92,7 @@
             title: this.renderConfimationButtonHelptext(),
             style: {
               fontSize: 18,
-              background: this.disableUploadButton() ? '#ccc' : undefined,
+              background: this.uploadButtonColor(),
               textAlign: 'center'
             }
           }, this.uploadButtonText())
@@ -139,6 +139,18 @@
         this.renderClientSideErrors(),
         this.renderServerSideErrors()
       );
+    },
+
+    uploadButtonColor: function () {
+      if (this.disableUploadButton()) {
+        return '#ccc';
+      } else if (this.props.serverSideErrors.length > 0) {
+        return 'red';
+      } else if (this.props.incorrectLasids.length > 0) {
+        return 'orange';
+      } else {
+        return undefined;
+      }
     },
 
     uploadButtonText: function () {

--- a/app/assets/javascripts/service_uploads/new_service_upload.js
+++ b/app/assets/javascripts/service_uploads/new_service_upload.js
@@ -40,9 +40,15 @@
         dom.h1({}, 'Upload new services file'),
         this.renderErrors(),
         dom.div({ style: { marginTop: 30 } }, 'Start Date'),
-        this.renderDatepicker(this.props.onSelectStartDate),
+        this.renderDatepicker(
+          this.props.onSelectStartDate,
+          this.props.formData.date_started || ''
+        ),
         dom.div({ style: { marginTop: 20 } }, 'End Date'),
-        this.renderDatepicker(this.props.onSelectEndDate),
+        this.renderDatepicker(
+          this.props.onSelectEndDate,
+          this.props.formData.date_ended || ''
+        ),
         createEl(ServiceTypeDropdown, {
           onUserTypingServiceType: this.props.onUserTypingServiceType,
           onUserSelectServiceType: this.props.onUserSelectServiceType
@@ -272,14 +278,15 @@
       };
     },
 
-    renderDatepicker: function (onChangeFn) {
+    renderDatepicker: function (onChangeFn, value) {
       return createEl(Datepicker, {
+        onChange: onChangeFn,
+        value: value,
         styles: { input: {
           fontSize: 14,
           padding: 5,
           width: '50%'
         } },
-        onChange: onChangeFn,
         datepickerOptions: {
           showOn: 'both',
           dateFormat: 'mm/dd/yy',

--- a/app/assets/javascripts/service_uploads/service_type_dropdown.js
+++ b/app/assets/javascripts/service_uploads/service_type_dropdown.js
@@ -3,7 +3,6 @@
   var dom = window.shared.ReactHelpers.dom;
   var createEl = window.shared.ReactHelpers.createEl;
   var merge = window.shared.ReactHelpers.merge;
-  var Datepicker = window.shared.Datepicker;
 
   var ServiceTypeDropdown = window.shared.ServiceTypeDropdown = React.createClass({
 

--- a/app/assets/javascripts/service_uploads/service_type_dropdown.js
+++ b/app/assets/javascripts/service_uploads/service_type_dropdown.js
@@ -9,6 +9,7 @@
     propTypes: {
       onUserTypingServiceType: React.PropTypes.func.isRequired,
       onUserSelectServiceType: React.PropTypes.func.isRequired,
+      value: React.PropTypes.string.isRequired
     },
 
     render: function () {
@@ -21,7 +22,8 @@
             width: '50%'
           },
           ref: 'ServiceTypeDropdown',
-          onChange: this.props.onUserTypingServiceType
+          onChange: this.props.onUserTypingServiceType,
+          value: this.props.value
         }),
         dom.a({
           style: {

--- a/app/assets/javascripts/service_uploads/service_uploads_page.js
+++ b/app/assets/javascripts/service_uploads/service_uploads_page.js
@@ -158,7 +158,13 @@
           if (data.service_upload) {
             this.setState({
               serviceUploads: [data.service_upload].concat(this.state.serviceUploads),
-              uploadingInProgress: false
+              uploadingInProgress: false,
+              formData: {},
+              studentLasidsReceivedFromBackend: false,
+              incorrectLasids: [],
+              missingLasidHeader: false,
+              lasidAuthorizationError: false,
+              serverSideErrors: [],
             });
           };
 

--- a/app/assets/javascripts/student_profile/datepicker.js
+++ b/app/assets/javascripts/student_profile/datepicker.js
@@ -7,7 +7,7 @@
   // This must be read lazily, since these options require the DOM
   // to be ready and some specific HTML to be on the page.
   var datepickerOptionsFn = function() { return window.datepicker_options || {}; };
- 
+
   var styles = {
     datepicker: {},
     input: {}
@@ -20,7 +20,7 @@
     displayName: 'Datepicker',
 
     propTypes: {
-      defaultValue: React.PropTypes.string,
+      value: React.PropTypes.string,
       onChange: React.PropTypes.func.isRequired,
       styles: React.PropTypes.shape({
         datepicker: React.PropTypes.object,
@@ -31,7 +31,6 @@
 
     getDefaultProps: function() {
       return {
-        defaultValue: '',
         styles: styles
       };
     },
@@ -49,7 +48,7 @@
     onDateSelected: function(dateText) {
       this.props.onChange(dateText);
     },
-    
+
     onDateChanged: function(e) {
       this.props.onChange(e.target.value);
     },
@@ -59,8 +58,8 @@
         dom.input({
           className: 'datepicker',
           style: this.props.styles.input,
-          defaultValue: this.props.defaultValue,
-          onChange: this.onDateChanged
+          onChange: this.onDateChanged,
+          value: this.props.value
         })
       );
     }

--- a/app/assets/javascripts/student_profile/record_service.js
+++ b/app/assets/javascripts/student_profile/record_service.js
@@ -164,7 +164,7 @@
         dom.div({ style: { marginTop: 20 } }, 'When did they start?'),
         createEl(Datepicker, {
           styles: { input: styles.datepickerInput },
-          defaultValue: (this.state.momentStarted && this.state.momentStarted.format('MM/DD/YYYY')),
+          value: this.state.momentStarted.format('MM/DD/YYYY'),
           onChange: this.onDateChanged,
           datepickerOptions: {
             showOn: 'both',

--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -33,9 +33,7 @@ class ServiceUploadsController < ApplicationController
     params['student_lasids'].map do |student_lasid|
       student = Student.find_by_local_id(student_lasid)
 
-      if student.nil?
-        errors << "Could not find student with LASID #{student_lasid}."
-      else
+      if student.present?
         service = Service.create!(
           student: student,
           service_upload: service_upload,

--- a/spec/controllers/service_uploads_controller_spec.rb
+++ b/spec/controllers/service_uploads_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ServiceUploadsController, type: :controller do
 
     def make_post_request(params)
       request.env['HTTPS'] = 'on'
-      post :create, params: params.merge(format: :json) 
+      post :create, params: params.merge(format: :json)
     end
 
     let(:response_json) { JSON.parse(response.body) }
@@ -122,12 +122,10 @@ RSpec.describe ServiceUploadsController, type: :controller do
         }
       }
 
-      it 'returns the correct JSON' do
+      it 'returns the correct JSON: '\
+         '(no error b/c this means Uri confirmed the LASID mismatch was OK)' do
         make_post_request(params)
-        expect(response_json['errors']).to eq [
-          "Could not find student with LASID 111.",
-          "Could not find student with LASID 222."
-        ]
+        expect(response_json['errors']).to eq []
       end
     end
 


### PR DESCRIPTION
# What does this do? 

+ Exploring the services data files with Uri, we found a file where many of the LASIDs don't match, because they represent students at the Capuano Early Childhood Center (pre-K). We don't use or import any pre-K data into Insights.
+ Uri wants to be able to upload data files even when LASIDs don't match, if those mis-matches are Capuano students, for example.
+ This UI shows Uri a list of mismatched LASIDs, which may represent real mistakes (LASID typos) or may represent Capuano students. Uri can see the mismatched LASIDs and decide whether or not to upload. If upload is confirmed, simply do nothing on the server side when a LASID mismatches.

# GIF (missing LASID override feature) 

![service-upload-wrong-lasids](https://cloud.githubusercontent.com/assets/3209501/24275069/19b87cd8-1003-11e7-81bb-100511fc1884.gif)

# GIF (all valid LASIDS path, for comparison)

![valid-service-upload](https://cloud.githubusercontent.com/assets/3209501/24275070/1b3f320e-1003-11e7-9a68-cbfdda6e3f6b.gif)

# UI notes 

+ Went with orange for the gentle warning color on the LASID override button -- not blue success, but not red error warning. Dunno if there's a better color choice for this.

# Code notes 

+ Made the `ServiceTypeDropdown` and `Datepicker` components fully controlled in order to gracefully reset them after a service file is successfully uploaded. 

# Also 

+ Fixes #856 -- make the form reset nicely on file upload.
+ Key step to finishing #820 -- let's see how this works when Uri uses it with real data!