### PR TITLE
Fixing Student Report bugs

### DIFF
--- a/app/assets/javascripts/student_profile/profile_details.jsx
+++ b/app/assets/javascripts/student_profile/profile_details.jsx
@@ -149,7 +149,7 @@
 
     onClickGenerateStudentReport: function(event) {
       const sections = $('#section:checked').map(function() {return this.value;}).get().join(',');
-      window.location = this.props.student.id + '/sped_referral.pdf?sections=' + sections + '&from_date=' + filterFromDate.format('MM/DD/YYYY') + '&to_date=' + filterToDate.format('MM/DD/YYYY');
+      window.location = this.props.student.id + '/student_report.pdf?sections=' + sections + '&from_date=' + filterFromDate.format('MM/DD/YYYY') + '&to_date=' + filterToDate.format('MM/DD/YYYY');
       return null;
     },
 
@@ -278,7 +278,7 @@
           </div>
           <br/>
           <button
-            style={styles.spedButton}
+            style={styles.studentReportButton}
             className="btn btn-warning"
             onClick={this.onClickGenerateStudentReport}>
             Generate Student Report

--- a/app/views/students/student_report.pdf.erb
+++ b/app/views/students/student_report.pdf.erb
@@ -212,6 +212,7 @@ ul, li {
 
 <div class="scripts">
   <%= wicked_pdf_javascript_include_tag 'application' %>
+  <%= wicked_pdf_javascript_include_tag 'helpers/graph_helpers' %>
   <%= wicked_pdf_javascript_include_tag 'student_profile/pdf/student_profile_pdf' %>
   <script>
     $(window.shared.StudentProfilePdf.load);


### PR DESCRIPTION
Looks like my manual jsx transformation reverted the renaming of sped_report to student_report. Quick fix.

Looking into adding an integration test for the student_report and running into some roadblocks. Will ping @alexsoble and @kevinrobinson.

I also noticed that the graphs were again only showing up in the debug version, not the pdf version. There is some strange funkiness with the wicked_pdf_javascript_include_tag. Including application.js brings in all the external stuff but doesn't seem to bring in our files. Each local js file needs to be included separately. So I added the helpers/graph_helpers which has the common graphing code.