### PR TITLE
Allow PDF debug param in production

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -64,7 +64,7 @@ class StudentsController < ApplicationController
           title: 'Student Report', 
           footer: { center: footer, font_name: 'Open Sans', font_size: 9}, 
           javascript_delay: 1000,
-          show_as_html: Rails.env.development? && params.key?('debug')
+          show_as_html: params.key?('debug')
         })
       end
     end


### PR DESCRIPTION
This generates an HTML file, no harm in this and it may help debug what's leading to scripts not loading in the PDF generation process.