### PR TITLE
Allow adjusting delay in PDF JS

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -63,7 +63,7 @@ class StudentsController < ApplicationController
           pdf: 'student_report', 
           title: 'Student Report', 
           footer: { center: footer, font_name: 'Open Sans', font_size: 9}, 
-          javascript_delay: 1000,
+          javascript_delay: params.key('delay_ms') || 1000,
           show_as_html: params.key?('debug')
         })
       end


### PR DESCRIPTION
See if this reveals anything interesting.  Confirmed that `&debug` reliably works in production, but without it not seeing charts.