### PR TITLE
Adding Percentile to the end of STAR Assessments for clarity

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -196,7 +196,11 @@ class StudentsController < ApplicationController
 
     @student_assessments = student_assessments_by_date.each_with_object({}) do |student_assessment, hash|
       test = student_assessment.assessment
-      test_name = "#{test.family} #{test.subject}"
+      test_name = case test.family
+        when "STAR" then "#{test.family} #{test.subject} Percentile"
+        else "#{test.family} #{test.subject}"
+      end
+      
       hash[test_name] ||= []
 
       result = case test.family


### PR DESCRIPTION
Uri had requested this quick UI change to make it clear that STAR assessments are using percentile. 

@kevinrobinson @alexsoble Uri is demoing this to assistant principals tomorrow, would be great to ship tonight. ;-)

