### PR TITLE
Use Browserify Rails to allow import/export

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'pg'
 gem 'puma'
 
 gem 'activerecord-import'
+gem 'browserify-rails'
 gem 'devise'
 gem 'devise_ldap_authenticatable'
 
@@ -14,7 +15,7 @@ gem 'devise_ldap_authenticatable'
 # - https://github.com/drapergem/draper/issues/697
 # - https://github.com/drapergem/draper/issues/681
 gem 'draper', "3.0.0.pre1"
-gem 'activemodel-serializers-xml' 
+gem 'activemodel-serializers-xml'
 
 gem 'friendly_id', '~> 5.1.0'
 gem 'handlebars_assets'
@@ -75,7 +76,7 @@ group :development, :test do
   gem 'timecop'
   gem 'rails-controller-testing'
   gem 'coffee-rails'
-  gem 'bourbon', '~> 4.3.2' 
+  gem 'bourbon', '~> 4.3.2'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,10 @@ GEM
     bourbon (4.3.2)
       sass (~> 3.4)
       thor (~> 0.19)
+    browserify-rails (4.1.0)
+      addressable (>= 2.4.0)
+      railties (>= 4.0.0, < 5.1)
+      sprockets (>= 3.6.0)
     builder (3.2.3)
     capybara (2.12.1)
       addressable
@@ -331,6 +335,7 @@ DEPENDENCIES
   benchmark-memory
   better_errors
   bourbon (~> 4.3.2)
+  browserify-rails
   capybara
   coffee-rails
   database_cleaner
@@ -380,5 +385,8 @@ DEPENDENCIES
   wicked_pdf
   wkhtmltopdf-binary
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.13.5

--- a/app/assets/javascripts/student_profile/educator.jsx
+++ b/app/assets/javascripts/student_profile/educator.jsx
@@ -1,39 +1,37 @@
-(function() {
-  window.shared || (window.shared = {});
-  const dom = window.shared.ReactHelpers.dom;
-  const createEl = window.shared.ReactHelpers.createEl;
-  const merge = window.shared.ReactHelpers.merge;
+window.shared || (window.shared = {});
+const dom = window.shared.ReactHelpers.dom;
+const createEl = window.shared.ReactHelpers.createEl;
+const merge = window.shared.ReactHelpers.merge;
 
-  const PropTypes = window.shared.PropTypes;
+const PropTypes = window.shared.PropTypes;
 
-  /*
-  Canonical display of an educator, showing their name as a link to email them.
-  */
-  const Educator = window.shared.Educator = React.createClass({
-    displayName: 'Educator',
+/*
+Canonical display of an educator, showing their name as a link to email them.
+*/
+export default React.createClass({
+  displayName: 'Educator',
 
-    propTypes: {
-      educator: React.PropTypes.shape({
-        full_name: React.PropTypes.string, // or null
-        email: React.PropTypes.string.isRequired
-      }).isRequired
-    },
+  propTypes: {
+    educator: React.PropTypes.shape({
+      full_name: React.PropTypes.string, // or null
+      email: React.PropTypes.string.isRequired
+    }).isRequired
+  },
 
-    // Turns SIS format (Watson, Joe) -> Joe Watson
-    educatorName: function(educator) {
-      if (educator.full_name === null) return educator.email.split('@')[0] + '@';
-      const parts = educator.full_name.split(', ');
-      return parts[1] + ' ' + parts[0];
-    },
+  // Turns SIS format (Watson, Joe) -> Joe Watson
+  educatorName: function(educator) {
+    if (educator.full_name === null) return educator.email.split('@')[0] + '@';
+    const parts = educator.full_name.split(', ');
+    return parts[1] + ' ' + parts[0];
+  },
 
-    render: function() {
-      const educator = this.props.educator;
-      const educatorName = this.educatorName(educator);
-      return (
-        <a className="Educator" href={'mailto:' + educator.email}>
-          {educatorName}
-        </a>
-      );
-    }
-  });
-})();
+  render: function() {
+    const educator = this.props.educator;
+    const educatorName = this.educatorName(educator);
+    return (
+      <a className="Educator" href={'mailto:' + educator.email}>
+        {educatorName}
+      </a>
+    );
+  }
+});

--- a/app/assets/javascripts/student_profile/note_card.jsx
+++ b/app/assets/javascripts/student_profile/note_card.jsx
@@ -1,9 +1,11 @@
+import Educator from './educator.jsx';
+
+
 (function() {
   window.shared || (window.shared = {});
   const dom = window.shared.ReactHelpers.dom;
   const createEl = window.shared.ReactHelpers.createEl;
 
-  const Educator = window.shared.Educator;
   const EditableTextComponent = window.shared.EditableTextComponent;
   const moment = window.moment;
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,8 +27,10 @@ module SomervilleTeacherTool
         "#{config.root}/lib"
       ]
 
+      config.browserify_rails.commandline_options = "-t [ babelify --presets [ react es2015 ] ]"
+
       config.eager_load_paths = (config.eager_load_paths + class_paths).uniq
-      class_paths.each do |class_path| 
+      class_paths.each do |class_path|
         config.autoload_paths << class_path
       end
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "studentinsights",
+  "version": "0.1.0",
+  "dependencies": {},
+  "devDependencies": {
+    "babel-eslint": "^6.0.4",
+    "babel-plugin-react-transform": "^2.0.2",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-2": "^6.5.0",
+    "babelify": "^7.3.0",
+    "browserify": "^13.0.1",
+    "browserify-incremental": "^3.1.1"
+  }
+}


### PR DESCRIPTION
# Notes 

+ `react-rails` got us JSX but can't do `import` or `export`
+ Use browserify-rails for that (slow to compile in development)
+ Merging this in to check that it doesn't break production so that we can then go ahead and convert everything to use `import` and `export`