### PR TITLE
Add eslint, convert one spec to use import and update browserify-rails config for specs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,15 +1,19 @@
 {
   "env": {
-    "browser": true
+    "browser": true,
+    "es6": true
   },
   "globals": {
     "_": true,
+    "moment": true,
     "$": true,
     "React": true
   },
-  "plugins": [
-    "react"
-  ],
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module"
+  },
+  "plugins": ["react"],
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
   - wget https://studentinsights-public.s3.amazonaws.com/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
   - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
   - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
+  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   - npm install
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-language: node_js
-node_js:
-  - 7
-
 language: ruby
 rvm:
   - ruby-2.3.0
@@ -48,6 +44,7 @@ env:
     # For AWS deploy, add in credentials for uploading to S3 and pushing to Docker Hub here:
     - secure: CVsj/OoauR/2rTan1fAriyW/b92DahJsQ3zh7MAHAeQZ3atRQq4cYxd6fRSO4zoAOeTTTHp4hQ3YX+Uo765bNXsUJLKiKT8Wnin+eOG8nMGxzmKM6oxuWIt552pbwvhuX3+GS8QDT1sbHAdedlDng/97BhXeZTuzgVXN6Zigdo8=
     - secure: jSWLU8N9ui5BZ7PmWmY08BrrOx1BN1IEdYhrTnv5RDWMbUyGTu62hyXOseKMy1b+URaWSiklkxLBK0uVm1oSYf/MYiDhNwFTqPn8eH7AK7MJcxSOaJ4ce0eCEeTy56Wnbljjt0jYeGMFS05uBGhUT82vYvXq4l4h7pCORJWXaPA=
+    - TRAVIS_NODE_VERSION="7"
 
 notifications:
   webhooks: http://project-monitor.codeforamerica.org/projects/somerville-teacher-tool/status

--- a/app/assets/javascripts/components/fixed_table.jsx
+++ b/app/assets/javascripts/components/fixed_table.jsx
@@ -96,7 +96,7 @@
         return '< 1%';
       } else {
         return Math.round(100 * percentage) + '%';
-      };
+      }
     },
 
     renderBar: function(percentage, width) {

--- a/app/assets/javascripts/components/star_charts_page.jsx
+++ b/app/assets/javascripts/components/star_charts_page.jsx
@@ -471,7 +471,7 @@ $(function() {
               {horizontalTicks.map(function(percentile) {
                 const opacity = isStudentSelected ? 0.7 : 0.3;
                 const offset = percentile > 0 ? '-2.4em' : '1em';
-                 return (
+                return (
                    <text
                      key={percentile}
                      x={x(percentile)}
@@ -487,7 +487,7 @@ $(function() {
                        {percentile + '%'}
                      </tspan>
                    </text>
-                 );
+                );
               }, this)}
               <text
                 x={x(1)}
@@ -505,7 +505,7 @@ $(function() {
               </text>
               {verticalTicks.map(function(percentile) {
                 const opacity = isStudentSelected ? 0.7 : 0.3;
-                 return (
+                return (
                    <text
                      key={percentile}
                      x={x(1)}
@@ -520,7 +520,7 @@ $(function() {
                        {percentile}
                      </tspan>
                    </text>
-                 );
+                );
               }, this)}
               {students.map(function(student) {
                 const percentile = _.last(student.star_results).percentile_rank;

--- a/app/assets/javascripts/datepicker_config.js
+++ b/app/assets/javascripts/datepicker_config.js
@@ -11,7 +11,7 @@ $(function() {
       buttonText: "Select date",
       dateFormat: 'yy-mm-dd',
       minDate: 0    // intervention end date cannot be earlier than today
-    }
+    };
 
     $(".datepicker").datepicker(window.datepicker_options);
 

--- a/app/assets/javascripts/helpers/feed_helpers.jsx
+++ b/app/assets/javascripts/helpers/feed_helpers.jsx
@@ -29,8 +29,8 @@
     matchesMergedNoteType: function(mergedNote, mergedNoteType, mergedNoteTypeId) {
       if (mergedNote.type !== mergedNoteType) return false;
       switch (mergedNote.type) {
-        case 'event_notes': return (mergedNote.event_note_type_id === mergedNoteTypeId);
-        case 'deprecated_interventions': return (mergedNote.intervention_type_id === mergedNoteTypeId);
+      case 'event_notes': return (mergedNote.event_note_type_id === mergedNoteTypeId);
+      case 'deprecated_interventions': return (mergedNote.intervention_type_id === mergedNoteTypeId);
       }
 
       return false;

--- a/app/assets/javascripts/roster/roster_page.js
+++ b/app/assets/javascripts/roster/roster_page.js
@@ -43,16 +43,16 @@ $(function() {
 
     // Show/hide column groups
     var roster_columns = {
-        'name': 'Name',
-        'risk': 'Risk',
-        'program': 'Program',
-        'sped': 'SPED & Disability',
-        'language': 'Language',
-        'free-reduced': 'Free/Reduced Lunch',
-        'star_math': 'STAR Math',
-        'star_reading': 'STAR Reading',
-        'mcas_math': 'MCAS Math',
-        'mcas_ela': 'MCAS ELA',
+      'name': 'Name',
+      'risk': 'Risk',
+      'program': 'Program',
+      'sped': 'SPED & Disability',
+      'language': 'Language',
+      'free-reduced': 'Free/Reduced Lunch',
+      'star_math': 'STAR Math',
+      'star_reading': 'STAR Reading',
+      'mcas_math': 'MCAS Math',
+      'mcas_ela': 'MCAS ELA',
         // 'access': 'Access',
         // 'dibels': 'DIBELS',
         // 'attendance': 'Attendance',
@@ -64,7 +64,7 @@ $(function() {
 
     $.each(roster_columns, function(key, column){
       var newColumnTemplate = columnTemplate.clone(),
-      isselected = columns_selected.indexOf(key) !== -1;
+        isselected = columns_selected.indexOf(key) !== -1;
       newColumnTemplate
         .find("input")
           .attr("name", key)
@@ -77,7 +77,7 @@ $(function() {
         .find("label")
           .text(column)
         .end()
-        .appendTo("#column-listing")
+        .appendTo("#column-listing");
     });
 
     // "Click off" for column select
@@ -107,7 +107,7 @@ $(function() {
       var content = $.trim($(this).html());
       if (content.length === 0) {
         $(this).html('—');
-      };
+      }
     });
 
   }

--- a/app/assets/javascripts/school_overview/school_overview_page.jsx
+++ b/app/assets/javascripts/school_overview/school_overview_page.jsx
@@ -14,7 +14,7 @@
   function calculateYearsEnrolled (registration_date) {
     if (registration_date === null) return null;
     return Math.floor((new Date() - new Date(registration_date)) / (1000 * 60 * 60 * 24 * 365));
-  };
+  }
 
   const SchoolOverviewPage = React.createClass({
     displayName: 'SchoolOverviewPage',
@@ -223,4 +223,4 @@
   });
 
   window.shared.SchoolOverviewPage = SchoolOverviewPage;
-})(window)
+})(window);

--- a/app/assets/javascripts/service_uploads/new_service_upload.jsx
+++ b/app/assets/javascripts/service_uploads/new_service_upload.jsx
@@ -118,7 +118,7 @@
         return 'File Selected';
       } else {
         return 'Select CSV to Upload';
-      };
+      }
     },
 
     renderFileName: function () {
@@ -178,7 +178,7 @@
         return 'Confirm Upload Despite LASID Mismatches?';
       } else {
         return 'Confirm Upload';
-      };
+      }
     },
 
     disableUploadButton: function () {
@@ -202,19 +202,19 @@
 
       if (!parsed_date_started.isValid()) {
         errors.push('Start date invalid, please use MM/DD/YYYY format.');
-      };
+      }
 
       if (!parsed_date_ended.isValid()) {
         errors.push('End date invalid, please use MM/DD/YYYY format.');
-      };
+      }
 
       if (parsed_date_ended.isBefore(parsed_date_started)) {
         errors.push('Start date can\'t be after end date.');
-      };
+      }
 
       if (this.props.serviceTypeNames.indexOf(this.props.formData.service_type_name) === -1) {
         errors.push('Please select a valid service type.');
-      };
+      }
 
       return errors;
     },
@@ -270,7 +270,7 @@
       formFields.map(function (formField) {
         if (formData[formField] === undefined) {
           missingFormFieldNames.push(formFieldsToNames[formField]);
-        };
+        }
       });
 
       return 'Oooh, we are missing ' + missingFormFieldNames.join(' ');
@@ -319,7 +319,7 @@
             The first CSV column should be the LASID one.
           </div>
         );
-      };
+      }
     },
 
     renderDatepicker: function (onChangeFn, value) {

--- a/app/assets/javascripts/service_uploads/service_upload_detail.jsx
+++ b/app/assets/javascripts/service_uploads/service_upload_detail.jsx
@@ -106,11 +106,11 @@
             </a>
           </span>
         );
-      };
+      }
     },
 
     toggleDeletionConfirmation: function () {
-      this.setState({ showDeletionConfirmation: !this.state.showDeletionConfirmation })
+      this.setState({ showDeletionConfirmation: !this.state.showDeletionConfirmation });
     },
 
     renderStudentLinks: function () {
@@ -143,7 +143,7 @@
     },
 
     toggleShowStudents: function () {
-      this.setState({ showStudentLinks: !(this.state.showStudentLinks) })
+      this.setState({ showStudentLinks: !(this.state.showStudentLinks) });
     },
 
     dataCellStyle: function () {

--- a/app/assets/javascripts/service_uploads/service_uploads_page.jsx
+++ b/app/assets/javascripts/service_uploads/service_uploads_page.jsx
@@ -170,14 +170,14 @@
               lasidAuthorizationError: false,
               serverSideErrors: [],
             });
-          };
+          }
 
           if (data.errors) {
             this.setState({
               serverSideErrors: data.errors,
               uploadingInProgress: false
             });
-          };
+          }
         }.bind(this)
       });
     },
@@ -201,10 +201,10 @@
       if (headerRow[0].trim() !== 'LASID') {
         this.setState({ missingLasidHeader: true });
         return;
-      };
+      }
 
       const student_lasids = rows.map(function(row) { return row.split(",")[0].trim(); })
-                               .filter(function (lasid) { return lasid !== '' });
+                               .filter(function (lasid) { return lasid !== ''; });
 
       this.validateLASIDs(student_lasids);
     },
@@ -226,8 +226,8 @@
           } else {
             this.setState({
               lasidAuthorizationError: true
-            })
-          };
+            });
+          }
         }.bind(this)
       });
     }

--- a/app/assets/javascripts/session_timeout_warning.js
+++ b/app/assets/javascripts/session_timeout_warning.js
@@ -1,7 +1,7 @@
 (function(root) {
   var Env = window.shared.Env;
 
-  var SessionTimeoutWarning = function () {}
+  var SessionTimeoutWarning = function () {};
 
   SessionTimeoutWarning.prototype.count = function () {
     root.setTimeout(this.show, Env.sessionTimeoutInSeconds * 1000);
@@ -13,7 +13,7 @@
 
   root.SessionTimeoutWarning = SessionTimeoutWarning;
 
-})(window)
+})(window);
 
 $(function() {
 

--- a/app/assets/javascripts/sorts/reverse_number_sort.js
+++ b/app/assets/javascripts/sorts/reverse_number_sort.js
@@ -1,21 +1,21 @@
 (function(){
 
   var cleanNumber = function(i) {
-    var n = parseFloat(i.replace(/[^\-?0-9.]/g, ''));
-    return isNaN(n) ? null : n;
-  },
+      var n = parseFloat(i.replace(/[^\-?0-9.]/g, ''));
+      return isNaN(n) ? null : n;
+    },
 
-  compareNumberReverse = function(a, b) {
+    compareNumberReverse = function(a, b) {
     // Treat null as always greater
-    if (a === null) return 1;
-    if (b === null) return -1;
-    return a - b;
-  };
+      if (a === null) return 1;
+      if (b === null) return -1;
+      return a - b;
+    };
 
   Tablesort.extend('reverse_number', function(item) {
     return item.match(/^-?(\d)*-?([,\.]){0,1}-?(\d)+([E,e][\-+][\d]+)?%?$/);
   }, function(a, b) {
-      return compareNumberReverse(cleanNumber(a), cleanNumber(b));
+    return compareNumberReverse(cleanNumber(a), cleanNumber(b));
   });
 
 }());

--- a/app/assets/javascripts/sorts/sorts.js
+++ b/app/assets/javascripts/sorts/sorts.js
@@ -1,19 +1,19 @@
 (function(){
-    function enumSort(values) {
+  function enumSort(values) {
         // For quick lookup, build a map:
-        var position = {};
-        $.each(values, function(idx, val) { position[val] = idx; });
+    var position = {};
+    $.each(values, function(idx, val) { position[val] = idx; });
 
-        return {
-            test: function(item) {
-                return position[$.trim(item)] !== undefined;
-            },
-            compare: function(itemA, itemB) {
+    return {
+      test: function(item) {
+        return position[$.trim(item)] !== undefined;
+      },
+      compare: function(itemA, itemB) {
                 // These are flipped in order so that the default order is ascending.
-                return position[$.trim(itemB)] - position[$.trim(itemA)];
-            }
-        };
-    }
+        return position[$.trim(itemB)] - position[$.trim(itemA)];
+      }
+    };
+  }
 
     /**
      * Registers a new table sorter under the given name. Values should be an
@@ -22,14 +22,14 @@
      * @param {String} name
      * @param {String[]} values
      */
-    function makeEnumSort(name, values) {
-        var sort = enumSort(values);
-        Tablesort.extend(name, sort.test, sort.compare);
-    }
+  function makeEnumSort(name, values) {
+    var sort = enumSort(values);
+    Tablesort.extend(name, sort.test, sort.compare);
+  }
 
-    makeEnumSort("disability", ["None", "Low < 2", "Low >= 2", "Moderate", "High"]);
-    makeEnumSort("prog_assign_sort", ["Reg Ed", "2Way English", "2Way Spanish", "Sp Ed"]);
-    makeEnumSort("mcas_sort", ["W", "NI", "P", "A"]);
-    makeEnumSort("fluency_sort", ["FLEP-Transitioning", "FLEP", "Fluent"]);
-    makeEnumSort("need_sort", ["—", "Low < 2", "Low >= 2", "Moderate", "High"]);
+  makeEnumSort("disability", ["None", "Low < 2", "Low >= 2", "Moderate", "High"]);
+  makeEnumSort("prog_assign_sort", ["Reg Ed", "2Way English", "2Way Spanish", "Sp Ed"]);
+  makeEnumSort("mcas_sort", ["W", "NI", "P", "A"]);
+  makeEnumSort("fluency_sort", ["FLEP-Transitioning", "FLEP", "Fluent"]);
+  makeEnumSort("need_sort", ["—", "Low < 2", "Low >= 2", "Moderate", "High"]);
 }());

--- a/app/assets/javascripts/student_profile/editable_text_component.jsx
+++ b/app/assets/javascripts/student_profile/editable_text_component.jsx
@@ -121,7 +121,7 @@
         this.contentEditableEl
         && expectedHTML !== this.contentEditableEl.innerHTML
       ) {
-       this.contentEditableEl.innerHTML = expectedHTML;
+        this.contentEditableEl.innerHTML = expectedHTML;
       }
     },
 
@@ -139,7 +139,7 @@
     onBlurText: function(event) {
       if (!this.isDirty) return null;
 
-      this.props.onBlurText(this.state.text)
+      this.props.onBlurText(this.state.text);
 
       this.isDirty = false;
     },

--- a/app/assets/javascripts/student_profile/note_card.jsx
+++ b/app/assets/javascripts/student_profile/note_card.jsx
@@ -1,6 +1,5 @@
 import Educator from './educator.jsx';
 
-
 (function() {
   window.shared || (window.shared = {});
   const dom = window.shared.ReactHelpers.dom;

--- a/app/assets/javascripts/student_profile/notes_details.jsx
+++ b/app/assets/javascripts/student_profile/notes_details.jsx
@@ -1,11 +1,10 @@
+import TakeNotes from './take_notes.jsx';
+
 (function() {
   window.shared || (window.shared = {});
-  const dom = window.shared.ReactHelpers.dom;
-  const createEl = window.shared.ReactHelpers.createEl;
-  const merge = window.shared.ReactHelpers.merge;
 
   const PropTypes = window.shared.PropTypes;
-  const TakeNotes = window.shared.TakeNotes;
+  
   const NotesList = window.shared.NotesList;
   const HelpBubble = window.shared.HelpBubble;
 
@@ -27,16 +26,16 @@
   they are receiving, and allowing users to enter new information about
   these as well.
   */
-  const NotesDetails = window.shared.NotesDetails = React.createClass({
+  window.shared.NotesDetails = React.createClass({
     propTypes: {
       student: React.PropTypes.object.isRequired,
       eventNoteTypesIndex: React.PropTypes.object.isRequired,
       educatorsIndex: React.PropTypes.object.isRequired,
-      eventNoteTypesIndex: React.PropTypes.object.isRequired,
       currentEducator: React.PropTypes.object.isRequired,
       actions: React.PropTypes.shape({
         onClickSaveNotes: React.PropTypes.func.isRequired,
-        onEventNoteAttachmentDeleted: React.PropTypes.func
+        onEventNoteAttachmentDeleted: React.PropTypes.func,
+        onDeleteEventNoteAttachment: React.PropTypes.func
       }),
       feed: PropTypes.feed.isRequired,
       requests: React.PropTypes.object.isRequired,
@@ -50,7 +49,7 @@
     getInitialState: function() {
       return {
         isTakingNotes: false,
-      }
+      };
     },
 
     onClickTakeNotes: function(event) {
@@ -64,21 +63,6 @@
     onClickSaveNotes: function(eventNoteParams, event) {
       this.props.actions.onClickSaveNotes(eventNoteParams);
       this.setState({ isTakingNotes: false });
-    },
-
-    renderRestrictedNotesButtonIfAppropriate: function(){
-      if (this.props.currentEducator.can_view_restricted_notes && !this.props.showingRestrictedNotes){
-        return (
-          <a
-            className="btn btn-warning"
-            style={styles.restrictedNotesButton}
-            href={'/students/' + this.props.student.id + '/restricted_notes'}>
-            {'Restricted Notes (' + this.props.student.restricted_notes_count + ')'}
-          </a>
-        );
-      } else {
-        return null;
-      }
     },
 
     render: function() {
@@ -129,6 +113,21 @@
           </button>
         </div>
       );
+    },
+
+    renderRestrictedNotesButtonIfAppropriate() {
+      if (this.props.currentEducator.can_view_restricted_notes && !this.props.showingRestrictedNotes){
+        return (
+          <a
+            className="btn btn-warning"
+            style={styles.restrictedNotesButton}
+            href={'/students/' + this.props.student.id + '/restricted_notes'}>
+            {'Restricted Notes (' + this.props.student.restricted_notes_count + ')'}
+          </a>
+        );
+      } else {
+        return null;
+      }
     }
   });
 })();

--- a/app/assets/javascripts/student_profile/notes_list.jsx
+++ b/app/assets/javascripts/student_profile/notes_list.jsx
@@ -44,11 +44,11 @@
           {(mergedNotes.length === 0) ? <div style={styles.noItems}>
             No notes
           </div> : mergedNotes.map(function(mergedNote) {
-          switch (mergedNote.type) {
+            switch (mergedNote.type) {
             case 'event_notes': return this.renderEventNote(mergedNote);
             case 'deprecated_interventions': return this.renderDeprecatedIntervention(mergedNote);
-          }
-        }, this)}
+            }
+          }, this)}
         </div>
       );
     },

--- a/app/assets/javascripts/student_profile/page_container.jsx
+++ b/app/assets/javascripts/student_profile/page_container.jsx
@@ -151,12 +151,12 @@
     onClickSaveService: function(serviceParams) {
       // Very quick name validation, just check for a comma between two words
       if ((/(\w+, \w|^$)/.test(serviceParams.providedByEducatorName))) {
-          this.setState({ requests: merge(this.state.requests, { saveService: 'pending' }) });
-          this.api.saveService(this.state.student.id, serviceParams)
+        this.setState({ requests: merge(this.state.requests, { saveService: 'pending' }) });
+        this.api.saveService(this.state.student.id, serviceParams)
             .done(this.onSaveServiceDone)
             .fail(this.onSaveServiceFail);
       } else {
-          this.setState({ requests: merge(this.state.requests, { saveService: 'Please use the form Last Name, First Name' }) });
+        this.setState({ requests: merge(this.state.requests, { saveService: 'Please use the form Last Name, First Name' }) });
       }
     },
 

--- a/app/assets/javascripts/student_profile/pdf/student_profile_pdf.js
+++ b/app/assets/javascripts/student_profile/pdf/student_profile_pdf.js
@@ -30,7 +30,7 @@
             formatter: function(){
               var val = this.y;
               if (val < 1) {
-                  return '';
+                return '';
               }
               return val;
             },
@@ -45,15 +45,15 @@
         stackLabels: {
           enabled: true,
           style: {
-              fontWeight: 'bold',
-              color: (Highcharts.theme && Highcharts.theme.textColor) || 'gray'
+            fontWeight: 'bold',
+            color: (Highcharts.theme && Highcharts.theme.textColor) || 'gray'
           },
           formatter: function(){
-              var val = this.total;
-              if (val < 1) {
-                  return '';
-              }
-              return val;
+            var val = this.total;
+            if (val < 1) {
+              return '';
+            }
+            return val;
           },
         },
         min: 0,
@@ -62,7 +62,7 @@
       series: dataSeries
     });
 
-  };
+  }
 
   window.shared.StudentProfilePdf = {
     load: function() {

--- a/app/assets/javascripts/student_profile/profile_bar_chart.jsx
+++ b/app/assets/javascripts/student_profile/profile_bar_chart.jsx
@@ -40,7 +40,7 @@
   // Used for grouping events on the chart.
   function defaultMonthKeyFn(event) {
     return moment.utc(event.occurred_at).date(1).format('YYYYMMDD');
-  };
+  }
 
   // Component for all charts in the profile page.
   window.shared.ProfileBarChart = React.createClass({
@@ -63,7 +63,7 @@
         phaselines: [],
         nowMomentUTC: moment.utc(),
         monthKeyFn: defaultMonthKeyFn
-      }
+      };
     },
 
     // Compute the month range that's relevant for the current date and months back we're showing
@@ -95,10 +95,10 @@
             ]}
             title={{text: ''}}
             yAxis={{
-                min: 0,
-                max: 20,
-                allowDecimals: false,
-                title: {text: this.props.titleText}
+              min: 0,
+              max: 20,
+              allowDecimals: false,
+              title: {text: this.props.titleText}
             }}
             tooltip={{
               formatter: this.createUnsafeTooltipFormatter(monthBuckets, this.props),
@@ -164,7 +164,7 @@
           htmlstring += "<br>";
         });
         return htmlstring;
-      }
+      };
     }
   });
 })();

--- a/app/assets/javascripts/student_profile/profile_chart.jsx
+++ b/app/assets/javascripts/student_profile/profile_chart.jsx
@@ -64,7 +64,7 @@
             series: this.props.quadSeries.map(function(obj){
               return {
                 name: obj.name,
-                data: obj.data  ? _.map(obj.data, QuadConverter.toPair): []
+                data: obj.data ? _.map(obj.data, QuadConverter.toPair): []
               }
             }),
             yAxis: this.props.yAxis
@@ -130,7 +130,7 @@
         return  this.baseOptionsForStar();
       } else {
         return this.baseOptionsForNonKF();
-      };
+      }
     },
 
     baseOptionsForStar: function () {

--- a/app/assets/javascripts/student_profile/profile_chart_settings.jsx
+++ b/app/assets/javascripts/student_profile/profile_chart_settings.jsx
@@ -93,7 +93,7 @@
         fillOpacity: 0
       }
     }
-  }
+  };
 
   ProfileChartSettings.x_axis_datetime = {
     type: 'datetime',
@@ -102,13 +102,13 @@
       week: '%b %e %Y',
       year: '%b %e %Y'
     }
-  }
+  };
 
   ProfileChartSettings.x_axis_schoolyears = {
     type: 'linear',
     categories: [],
     dateTimeLabelFormats: {}
-  }
+  };
 
   ProfileChartSettings.default_yaxis = {
     allowDecimals: false,
@@ -121,7 +121,7 @@
     plotLines: [],
     min: undefined,
     max: undefined
-  }
+  };
 
   ProfileChartSettings.mcas_level_bands = [{
     color: '#E7EBED',
@@ -167,7 +167,7 @@
         color: '#999999'
       }
     }
-  }]
+  }];
 
   ProfileChartSettings.default_mcas_score_yaxis = {
     allowDecimals: false,
@@ -180,7 +180,7 @@
     plotLines: [],
     min: 200,
     max: 280
-  }
+  };
 
   ProfileChartSettings.percentile_yaxis =  {
     allowDecimals: false,
@@ -193,7 +193,7 @@
     plotLines: [],
     min: 0,
     max: 100
-  }
+  };
 
   ProfileChartSettings.benchmark_plotline = [{
     color: '#B90504',
@@ -221,6 +221,6 @@
     }
   }];
 
-  root.ProfileChartSettings = ProfileChartSettings
+  root.ProfileChartSettings = ProfileChartSettings;
 
-})(window)
+})(window);

--- a/app/assets/javascripts/student_profile/profile_details.jsx
+++ b/app/assets/javascripts/student_profile/profile_details.jsx
@@ -26,7 +26,7 @@
       return {
         filterFromDate: QuadConverter.firstDayOfSchool(QuadConverter.toSchoolYear(moment())-1),
         filterToDate: moment()
-      }
+      };
     },
 
     getEvents: function(){
@@ -126,7 +126,7 @@
           id: obj.id,
           message: this.getMessageForServiceType(obj.service_type_id),
           date: moment(obj.date_started).toDate()
-        })
+        });
       }.bind(this));
 
       _.each(this.props.dibels, function(obj) {
@@ -290,10 +290,10 @@
     renderFullCaseHistory: function(){
       const self = this;
       const bySchoolYearDescending = _.toArray(
-        _.groupBy(this.getEvents(), function(event){ return QuadConverter.toSchoolYear(event.date) })
+        _.groupBy(this.getEvents(), function(event){ return QuadConverter.toSchoolYear(event.date); })
       ).reverse();
 
-     return (
+      return (
         <div id="full-case-history">
           <div className="ServicesHeader" style={styles.fullCaseHistoryHeading}>
             <h4 style={styles.fullCaseHistoryTitle}>

--- a/app/assets/javascripts/student_profile/provided_by_educator_dropdown.jsx
+++ b/app/assets/javascripts/student_profile/provided_by_educator_dropdown.jsx
@@ -75,14 +75,14 @@
         response: function(event, ui) {
           if (event.target.value !== "") {
             const currentName = {label: event.target.value,
-                               value: event.target.value};
+              value: event.target.value};
             ui.content.unshift(currentName);
           }
 
           // Don't show a duplicate
           for (let i = 1; i < ui.content.length; i++) {
             if (ui.content[i].value === event.target.value)
-              ui.content = ui.content.splice(i,1)
+              ui.content = ui.content.splice(i,1);
           }
         },
 

--- a/app/assets/javascripts/student_profile/record_service.jsx
+++ b/app/assets/javascripts/student_profile/record_service.jsx
@@ -68,7 +68,7 @@
         serviceTypeId: null,
         providedByEducatorName: "",
         momentStarted: moment.utc() // TODO should thread through
-      }
+      };
     },
 
     onDateChanged: function(dateText) {

--- a/app/assets/javascripts/student_profile/risk_bubble.jsx
+++ b/app/assets/javascripts/student_profile/risk_bubble.jsx
@@ -24,7 +24,7 @@
       padding: 5,
       marginTop: 3
     }
-};
+  };
 
   const RiskBubble = window.shared.RiskBubble = React.createClass({
     displayName: 'RiskBubble',

--- a/app/assets/javascripts/student_profile/service_color.jsx
+++ b/app/assets/javascripts/student_profile/service_color.jsx
@@ -11,13 +11,13 @@
   // Map service_type_id to a themed color.
   const serviceColor = window.shared.serviceColor = function(serviceTypeId) {
     const map = {
-     507: Colors.orange,
-     502: Colors.green,
-     503: Colors.green,
-     504: Colors.green,
-     505: Colors.gray,
-     506: Colors.gray,
-     508: Colors.purple
+      507: Colors.orange,
+      502: Colors.green,
+      503: Colors.green,
+      504: Colors.green,
+      505: Colors.gray,
+      506: Colors.gray,
+      508: Colors.purple
     };
     return map[serviceTypeId] || null;
   };

--- a/app/assets/javascripts/student_profile/services_details.jsx
+++ b/app/assets/javascripts/student_profile/services_details.jsx
@@ -36,7 +36,7 @@
     getInitialState: function() {
       return {
         isAddingService: false
-      }
+      };
     },
 
     onClickRecordService: function(event) {

--- a/app/assets/javascripts/student_profile/services_list.jsx
+++ b/app/assets/javascripts/student_profile/services_list.jsx
@@ -205,7 +205,7 @@
             {moment.utc(service.date_started).fromNow(true)}
           </div>
         );
-      };
+      }
     },
 
     renderEducatorName: function (educatorName) {
@@ -215,7 +215,7 @@
             {'With ' + educatorName}
           </div>
         );
-      };
+      }
     },
 
     renderDiscontinuedInformation: function(service) {
@@ -226,7 +226,7 @@
         var description = 'Ending';
       } else {
         var description = 'Ended';
-      };
+      }
 
       if (this.wasDiscontinued(service)) {
         return (
@@ -241,7 +241,7 @@
         );
       }
 
-      return this.renderDiscontinueButton(service)
+      return this.renderDiscontinueButton(service);
     },
 
     // Toggles when in confirmation state

--- a/app/assets/javascripts/student_profile/student_profile_page.jsx
+++ b/app/assets/javascripts/student_profile/student_profile_page.jsx
@@ -66,7 +66,7 @@
       borderRadius: '5px 5px 5px 5px',
       border: '1px solid #ccc',
       width: '20%',
-     },
+    },
     selectedColumn: {
       borderStyle: 'solid',
       borderColor: '#3177c9',
@@ -241,7 +241,7 @@
 
     renderSectionDetails: function() {
       switch (this.props.selectedColumnKey) {
-        case 'profile': return (
+      case 'profile': return (
           <ProfileDetails
             student={this.props.student}
             feed={this.props.feed}
@@ -250,12 +250,12 @@
             chartData={this.props.chartData}
             attendanceData={this.props.attendanceData}
             serviceTypesIndex={this.props.serviceTypesIndex} />
-        );
-        case 'ela': return <ELADetails chartData={this.props.chartData} student={this.props.student} />;
-        case 'math': return <MathDetails chartData={this.props.chartData} student={this.props.student} />;
-        case 'attendance':
-          var attendanceData = this.props.attendanceData;
-          return (
+      );
+      case 'ela': return <ELADetails chartData={this.props.chartData} student={this.props.student} />;
+      case 'math': return <MathDetails chartData={this.props.chartData} student={this.props.student} />;
+      case 'attendance':
+        var attendanceData = this.props.attendanceData;
+        return (
             <AttendanceDetails
               disciplineIncidents={attendanceData.discipline_incidents}
               absences={attendanceData.absences}
@@ -263,9 +263,9 @@
               student={this.props.student}
               feed={this.props.feed}
               serviceTypesIndex={this.props.serviceTypesIndex} />
-          );
-        case 'interventions':
-          return (
+        );
+      case 'interventions':
+        return (
             <div className="InterventionsDetails" style={{display: 'flex'}}>
               <NotesDetails
                 student={this.props.student}
@@ -288,7 +288,7 @@
                 actions={this.props.actions}
                 requests={this.props.requests} />
             </div>
-          );
+        );
       }
       return null;
     },
@@ -304,7 +304,7 @@
 
       if (this.props.access) {
         demographicsElements.push('ACCESS Composite score: ' + this.props.access.composite);
-      };
+      }
 
       return (
         <div
@@ -336,11 +336,11 @@
             className="interventions-column"
             style={merge(styles.column, styles.academicColumn, styles.interventionsColumn, this.selectedColumnStyles(columnKey))}>
             {this.padElements(styles.summaryWrapper, [
-            this.renderPlacement(student),
-            this.renderServices(student),
-            this.renderStaff(student),
-            this.renderSped(student)
-          ])}
+              this.renderPlacement(student),
+              this.renderServices(student),
+              this.renderStaff(student),
+              this.renderSped(student)
+            ])}
           </div>
         </div>
       );
@@ -425,13 +425,13 @@
 
     spedLevelText: function(student) {
       switch (student.sped_level_of_need) {
-        case "Low < 2": return "less than 2 hours / week"
-        case "Low >= 2": return "2-5 hours / week";
-        case "Moderate": return "6-14 hours / week";
-        case "High": return "15+ hours / week";
-        default: return "None"
-     }
-   },
+      case "Low < 2": return "less than 2 hours / week";
+      case "Low >= 2": return "2-5 hours / week";
+      case "Moderate": return "6-14 hours / week";
+      case "High": return "15+ hours / week";
+      default: return "None";
+      }
+    },
 
     renderELAColumn: function() {
       const student = this.props.student;
@@ -488,7 +488,7 @@
           caption: 'MCAS ELA SGP',
           value: student.most_recent_mcas_ela_growth,
           sparkline: this.renderSparkline(chartData.mcas_series_ela_growth || [])
-        })
+        });
       }
     },
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,8 +28,7 @@ module SomervilleTeacherTool
       ]
 
       config.browserify_rails.commandline_options = "-t [ babelify --presets [ react es2015 ] ]"
-      # config.browserify_rails.paths << "#{config.root}/spec/javascripts"
-      config.browserify_rails.paths << -> (p) { p.start_with?(Rails.root.join("spec/javascripts").to_s) }
+      # config.browserify_rails.paths << -> (p) { p.start_with?(Rails.root.join("spec/javascripts").to_s) }
 
       config.eager_load_paths = (config.eager_load_paths + class_paths).uniq
       class_paths.each do |class_path|

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,8 @@ module SomervilleTeacherTool
       ]
 
       config.browserify_rails.commandline_options = "-t [ babelify --presets [ react es2015 ] ]"
+      # config.browserify_rails.paths << "#{config.root}/spec/javascripts"
+      config.browserify_rails.paths << -> (p) { p.start_with?(Rails.root.join("spec/javascripts").to_s) }
 
       config.eager_load_paths = (config.eager_load_paths + class_paths).uniq
       class_paths.each do |class_path|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "studentinsights",
   "version": "0.1.0",
+  "scripts": {
+    "lint": "eslint --fix --ext jsx --ext js -c .eslintrc app/assets/javascripts spec/javascripts; exit 0",
+    "lint-cli": "eslint --ext jsx --ext js -c .eslintrc app/assets/javascripts spec/javascripts"
+  },
   "dependencies": {
     "babel-eslint": "^6.0.4",
     "babel-plugin-react-transform": "^2.0.2",
@@ -9,6 +13,8 @@
     "babel-preset-stage-2": "^6.5.0",
     "babelify": "^7.3.0",
     "browserify": "^13.0.1",
-    "browserify-incremental": "^3.1.1"
+    "browserify-incremental": "^3.1.1",
+    "eslint": "^3.3.1",
+    "eslint-plugin-react": "^6.1.2"
   }
 }

--- a/spec/javascripts/helpers/graph_helpers_spec.js
+++ b/spec/javascripts/helpers/graph_helpers_spec.js
@@ -14,7 +14,7 @@ describe('Graph Helpers', function() {
 
   describe('#monthKeys', function() {
     it('works looking back four years', function(){
-      var nowMomentUTC = moment.utc("20170211", "YYYYMMDD");;
+      var nowMomentUTC = moment.utc("20170211", "YYYYMMDD");
       var monthKeys = GraphHelpers.monthKeys(nowMomentUTC, 48);
       expect(monthKeys.length).toEqual(48 + 1);
       expect(monthKeys[0]).toEqual('20130201');
@@ -33,8 +33,8 @@ describe('Graph Helpers', function() {
       expect(monthKeys.length).toEqual(12 + 1);
       expect(monthBuckets.length).toEqual(monthKeys.length);
       expect(_.compact(_.map(monthBuckets, 'length')).length).toEqual(2);
-      expect(monthBuckets[7]).toEqual([namedEvents.C])
-      expect(monthBuckets[12]).toEqual([namedEvents.A, namedEvents.B])
+      expect(monthBuckets[7]).toEqual([namedEvents.C]);
+      expect(monthBuckets[12]).toEqual([namedEvents.A, namedEvents.B]);
     });
   });
 

--- a/spec/javascripts/school_overview/school_overview_page_spec.js
+++ b/spec/javascripts/school_overview/school_overview_page_spec.js
@@ -6,9 +6,9 @@ describe('SchoolOverviewPage', function() {
 
   describe('#filterWithOr', function() {
     beforeEach(function() {
-      this.mari = { name: 'Mari', classroom: '101' }    // stubby student object
-      this.mark = { name: 'Mark', classroom: '101' }    // stubby student object
-      this.marv = { name: 'Marv', classroom: '102' }    // stubby student object
+      this.mari = { name: 'Mari', classroom: '101' };    // stubby student object
+      this.mark = { name: 'Mark', classroom: '101' };    // stubby student object
+      this.marv = { name: 'Marv', classroom: '102' };    // stubby student object
 
       // Test filters
       this.MariFilter = Filters.Equal('name', 'Mari');
@@ -55,8 +55,8 @@ describe('SchoolOverviewPage', function() {
   describe('#filterWithAnd', function() {
     beforeEach(function() {
       this.page = new SchoolOverviewPage({initialFilters: []});
-      this.mari = { name: 'Mari' }    // stubby student object
-      this.mark = { name: 'Mark' }    // stubby student object
+      this.mari = { name: 'Mari' };    // stubby student object
+      this.mark = { name: 'Mark' };    // stubby student object
     });
 
     describe('with array of two arrays of students that intersect', function() {

--- a/spec/javascripts/student_profile/notes_list_spec.js
+++ b/spec/javascripts/student_profile/notes_list_spec.js
@@ -44,9 +44,9 @@ describe('NotesList', function() {
       expect(el).not.toContainText('SST Meeting');
 
       // Notes attachments expectations
-      expect(el).toContainText("link: https://www.example.com/morestudentwork")
-      expect(el).toContainText("link: https://www.example.com/studentwork")
-      expect(el).toContainText("(remove)")
+      expect(el).toContainText("link: https://www.example.com/morestudentwork");
+      expect(el).toContainText("link: https://www.example.com/studentwork");
+      expect(el).toContainText("(remove)");
     });
   });
 });

--- a/spec/javascripts/student_profile/profile_chart_spec.js
+++ b/spec/javascripts/student_profile/profile_chart_spec.js
@@ -3,7 +3,7 @@ describe('ProfileBarCharts', function() {
 
   describe('#getSchoolYearStartPositions', function(){
     it('works when current grade is 5', function(){
-        expect(
+      expect(
             ProfileChart.prototype.getSchoolYearStartPositions(24, moment.utc("2016-09-10"), 5)
         ).toEqual(
             _.object([
@@ -15,7 +15,7 @@ describe('ProfileBarCharts', function() {
     }),
 
     it('works when current grade is 1', function() {
-        expect(
+      expect(
             ProfileChart.prototype.getSchoolYearStartPositions(24, moment.utc("2016-09-10"), 1)
         ).toEqual(
             _.object([
@@ -24,6 +24,6 @@ describe('ProfileBarCharts', function() {
                 [moment.utc("2014-08-15").valueOf(), ""]
             ])
         );
-    })
+    });
   });
 });

--- a/spec/javascripts/student_profile/student_profile_header_spec.js
+++ b/spec/javascripts/student_profile/student_profile_header_spec.js
@@ -29,7 +29,7 @@ describe('StudentProfileHeader', function() {
     it('renders note-taking area with homeroom', function() {
       var el = this.testEl;
       helpers.renderActiveStudent(el);
-      var yearsOld = moment().diff(Fixtures.studentProfile.student.date_of_birth, 'years') // TODO (ARS): mock moment.utc() for spec
+      var yearsOld = moment().diff(Fixtures.studentProfile.student.date_of_birth, 'years'); // TODO (ARS): mock moment.utc() for spec
                                                                                            // so we don't have to calculate this
 
       expect(el).toContainText('Daisy Poppins');

--- a/spec/javascripts/student_profile/student_profile_page_spec.js
+++ b/spec/javascripts/student_profile/student_profile_page_spec.js
@@ -15,15 +15,15 @@ describe('StudentProfilePage', function() {
       var serializedData = _.cloneDeep(Fixtures.studentProfile);
       if (grade !== undefined) {
         serializedData["student"]["grade"] = grade;
-      };
+      }
 
       if (dibels !== undefined) {
         serializedData["dibels"] = dibels;
-      };
+      }
 
       if (absencesCount !== undefined) {
         serializedData["student"]["absences_count"] = absencesCount;
-      };
+      }
 
 
       var mergedProps = {
@@ -34,7 +34,7 @@ describe('StudentProfilePage', function() {
       };
       return ReactDOM.render(createEl(PageContainer, mergedProps), el);
     }
-  }
+  };
 
   SpecSugar.withTestEl('renders attendance event summaries correctly', function() {
 

--- a/spec/javascripts/student_profile/take_notes_spec.js
+++ b/spec/javascripts/student_profile/take_notes_spec.js
@@ -1,46 +1,46 @@
 //= require ./fixtures
+import TakeNotes from '../../../app/assets/javascripts/student_profile/take_notes.jsx';
 
 describe('TakeNotes', function() {
-  var dom = window.shared.ReactHelpers.dom;
   var createEl = window.shared.ReactHelpers.createEl;
   var merge = window.shared.ReactHelpers.merge;
 
-  var TakeNotes = window.shared.TakeNotes;
+  
   var SpecSugar = window.shared.SpecSugar;
   var Fixtures = window.shared.Fixtures;
   var eventNotesFixture = [
     {"id":4,
-    "student_id":24,
-    "educator_id":1,
-    "event_note_type_id":301,
-    "text":"cool!",
-    "recorded_at":"2016-02-15T18:42:45.937Z",
-    "created_at":"2016-02-15T18:42:45.943Z",
-    "updated_at":"2016-02-15T18:42:45.943Z"},
+      "student_id":24,
+      "educator_id":1,
+      "event_note_type_id":301,
+      "text":"cool!",
+      "recorded_at":"2016-02-15T18:42:45.937Z",
+      "created_at":"2016-02-15T18:42:45.943Z",
+      "updated_at":"2016-02-15T18:42:45.943Z"},
     {"id":5,
-    "student_id":24,
-    "educator_id":1,
-    "event_note_type_id":301,
-    "text":"this tiss thie this tiss thie this tiss thie this tiss thie this tiss thie this tiss thie this tiss thie ",
-    "recorded_at":"2016-02-15T20:01:02.086Z",
-    "created_at":"2016-02-15T20:01:02.087Z",
-    "updated_at":"2016-02-15T20:01:02.087Z"},
+      "student_id":24,
+      "educator_id":1,
+      "event_note_type_id":301,
+      "text":"this tiss thie this tiss thie this tiss thie this tiss thie this tiss thie this tiss thie this tiss thie ",
+      "recorded_at":"2016-02-15T20:01:02.086Z",
+      "created_at":"2016-02-15T20:01:02.087Z",
+      "updated_at":"2016-02-15T20:01:02.087Z"},
     {"id":6,
-    "student_id":24,
-    "educator_id":1,
-    "event_note_type_id":5,
-    "text":"okay!",
-    "recorded_at":"2016-02-15T20:03:28.232Z",
-    "created_at":"2016-02-15T20:03:28.233Z",
-    "updated_at":"2016-02-15T20:03:28.233Z"},
+      "student_id":24,
+      "educator_id":1,
+      "event_note_type_id":5,
+      "text":"okay!",
+      "recorded_at":"2016-02-15T20:03:28.232Z",
+      "created_at":"2016-02-15T20:03:28.233Z",
+      "updated_at":"2016-02-15T20:03:28.233Z"},
     {"id":7,
-    "student_id":24,
-    "educator_id":1,
-    "event_note_type_id":2,
-    "text":"yep :)",
-    "recorded_at":"2016-02-15T20:03:36.699Z",
-    "created_at":"2016-02-15T20:03:36.700Z",
-    "updated_at":"2016-02-15T20:03:36.700Z"}
+      "student_id":24,
+      "educator_id":1,
+      "event_note_type_id":2,
+      "text":"yep :)",
+      "recorded_at":"2016-02-15T20:03:36.699Z",
+      "created_at":"2016-02-15T20:03:36.700Z",
+      "updated_at":"2016-02-15T20:03:36.700Z"}
   ];
 
   var helpers = {

--- a/spec/javascripts/support/jasmine-jquery.js
+++ b/spec/javascripts/support/jasmine-jquery.js
@@ -28,100 +28,100 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 (function (root, factory) {
-     if (typeof module !== 'undefined' && module.exports) {
-        factory(root, root.jasmine, require('jquery'));
-    } else {
-        factory(root, root.jasmine, root.jQuery);
-    }
+  if (typeof module !== 'undefined' && module.exports) {
+    factory(root, root.jasmine, require('jquery'));
+  } else {
+    factory(root, root.jasmine, root.jQuery);
+  }
 }((function() {return this; })(), function (window, jasmine, $) { "use strict";
 
   jasmine.spiedEventsKey = function (selector, eventName) {
-    return [$(selector).selector, eventName].toString()
-  }
+    return [$(selector).selector, eventName].toString();
+  };
 
   jasmine.getFixtures = function () {
-    return jasmine.currentFixtures_ = jasmine.currentFixtures_ || new jasmine.Fixtures()
-  }
+    return jasmine.currentFixtures_ = jasmine.currentFixtures_ || new jasmine.Fixtures();
+  };
 
   jasmine.getStyleFixtures = function () {
-    return jasmine.currentStyleFixtures_ = jasmine.currentStyleFixtures_ || new jasmine.StyleFixtures()
-  }
+    return jasmine.currentStyleFixtures_ = jasmine.currentStyleFixtures_ || new jasmine.StyleFixtures();
+  };
 
   jasmine.Fixtures = function () {
-    this.containerId = 'jasmine-fixtures'
-    this.fixturesCache_ = {}
-    this.fixturesPath = 'spec/javascripts/fixtures'
-  }
+    this.containerId = 'jasmine-fixtures';
+    this.fixturesCache_ = {};
+    this.fixturesPath = 'spec/javascripts/fixtures';
+  };
 
   jasmine.Fixtures.prototype.set = function (html) {
-    this.cleanUp()
-    return this.createContainer_(html)
-  }
+    this.cleanUp();
+    return this.createContainer_(html);
+  };
 
   jasmine.Fixtures.prototype.appendSet= function (html) {
-    this.addToContainer_(html)
-  }
+    this.addToContainer_(html);
+  };
 
   jasmine.Fixtures.prototype.preload = function () {
-    this.read.apply(this, arguments)
-  }
+    this.read.apply(this, arguments);
+  };
 
   jasmine.Fixtures.prototype.load = function () {
-    this.cleanUp()
-    this.createContainer_(this.read.apply(this, arguments))
-  }
+    this.cleanUp();
+    this.createContainer_(this.read.apply(this, arguments));
+  };
 
   jasmine.Fixtures.prototype.appendLoad = function () {
-    this.addToContainer_(this.read.apply(this, arguments))
-  }
+    this.addToContainer_(this.read.apply(this, arguments));
+  };
 
   jasmine.Fixtures.prototype.read = function () {
     var htmlChunks = []
-      , fixtureUrls = arguments
+      , fixtureUrls = arguments;
 
     for(var urlCount = fixtureUrls.length, urlIndex = 0; urlIndex < urlCount; urlIndex++) {
-      htmlChunks.push(this.getFixtureHtml_(fixtureUrls[urlIndex]))
+      htmlChunks.push(this.getFixtureHtml_(fixtureUrls[urlIndex]));
     }
 
-    return htmlChunks.join('')
-  }
+    return htmlChunks.join('');
+  };
 
   jasmine.Fixtures.prototype.clearCache = function () {
-    this.fixturesCache_ = {}
-  }
+    this.fixturesCache_ = {};
+  };
 
   jasmine.Fixtures.prototype.cleanUp = function () {
-    $('#' + this.containerId).remove()
-  }
+    $('#' + this.containerId).remove();
+  };
 
   jasmine.Fixtures.prototype.sandbox = function (attributes) {
-    var attributesToSet = attributes || {}
-    return $('<div id="sandbox" />').attr(attributesToSet)
-  }
+    var attributesToSet = attributes || {};
+    return $('<div id="sandbox" />').attr(attributesToSet);
+  };
 
   jasmine.Fixtures.prototype.createContainer_ = function (html) {
     var container = $('<div>')
     .attr('id', this.containerId)
-    .html(html)
+    .html(html);
 
-    $(document.body).append(container)
-    return container
-  }
+    $(document.body).append(container);
+    return container;
+  };
 
   jasmine.Fixtures.prototype.addToContainer_ = function (html){
-    var container = $(document.body).find('#'+this.containerId).append(html)
+    var container = $(document.body).find('#'+this.containerId).append(html);
 
     if (!container.length) {
-      this.createContainer_(html)
+      this.createContainer_(html);
     }
-  }
+  };
 
   jasmine.Fixtures.prototype.getFixtureHtml_ = function (url) {
     if (typeof this.fixturesCache_[url] === 'undefined') {
-      this.loadFixtureIntoCache_(url)
+      this.loadFixtureIntoCache_(url);
     }
-    return this.fixturesCache_[url]
-  }
+    return this.fixturesCache_[url];
+  };
 
   jasmine.Fixtures.prototype.loadFixtureIntoCache_ = function (relativeUrl) {
     var self = this
@@ -133,126 +133,126 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         url: url,
         dataType: 'html',
         success: function (data, status, $xhr) {
-          htmlText = $xhr.responseText
+          htmlText = $xhr.responseText;
         }
       }).fail(function ($xhr, status, err) {
-          throw new Error('Fixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
-      })
+        throw new Error('Fixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')');
+      });
 
-      var scripts = $($.parseHTML(htmlText, true)).find('script[src]') || [];
+    var scripts = $($.parseHTML(htmlText, true)).find('script[src]') || [];
 
-      scripts.each(function(){
-        $.ajax({
-            async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
-            cache: false,
-            dataType: 'script',
-            url: $(this).attr('src'),
-            success: function (data, status, $xhr) {
-                htmlText += '<script>' + $xhr.responseText + '</script>'
-            },
-            error: function ($xhr, status, err) {
-                throw new Error('Script could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
-            }
-        });
-      })
+    scripts.each(function(){
+      $.ajax({
+        async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+        cache: false,
+        dataType: 'script',
+        url: $(this).attr('src'),
+        success: function (data, status, $xhr) {
+          htmlText += '<script>' + $xhr.responseText + '</script>';
+        },
+        error: function ($xhr, status, err) {
+          throw new Error('Script could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')');
+        }
+      });
+    });
 
-      self.fixturesCache_[relativeUrl] = htmlText;
-  }
+    self.fixturesCache_[relativeUrl] = htmlText;
+  };
 
   jasmine.Fixtures.prototype.makeFixtureUrl_ = function (relativeUrl){
-    return this.fixturesPath.match('/$') ? this.fixturesPath + relativeUrl : this.fixturesPath + '/' + relativeUrl
-  }
+    return this.fixturesPath.match('/$') ? this.fixturesPath + relativeUrl : this.fixturesPath + '/' + relativeUrl;
+  };
 
   jasmine.Fixtures.prototype.proxyCallTo_ = function (methodName, passedArguments) {
-    return this[methodName].apply(this, passedArguments)
-  }
+    return this[methodName].apply(this, passedArguments);
+  };
 
 
   jasmine.StyleFixtures = function () {
-    this.fixturesCache_ = {}
-    this.fixturesNodes_ = []
-    this.fixturesPath = 'spec/javascripts/fixtures'
-  }
+    this.fixturesCache_ = {};
+    this.fixturesNodes_ = [];
+    this.fixturesPath = 'spec/javascripts/fixtures';
+  };
 
   jasmine.StyleFixtures.prototype.set = function (css) {
-    this.cleanUp()
-    this.createStyle_(css)
-  }
+    this.cleanUp();
+    this.createStyle_(css);
+  };
 
   jasmine.StyleFixtures.prototype.appendSet = function (css) {
-    this.createStyle_(css)
-  }
+    this.createStyle_(css);
+  };
 
   jasmine.StyleFixtures.prototype.preload = function () {
-    this.read_.apply(this, arguments)
-  }
+    this.read_.apply(this, arguments);
+  };
 
   jasmine.StyleFixtures.prototype.load = function () {
-    this.cleanUp()
-    this.createStyle_(this.read_.apply(this, arguments))
-  }
+    this.cleanUp();
+    this.createStyle_(this.read_.apply(this, arguments));
+  };
 
   jasmine.StyleFixtures.prototype.appendLoad = function () {
-    this.createStyle_(this.read_.apply(this, arguments))
-  }
+    this.createStyle_(this.read_.apply(this, arguments));
+  };
 
   jasmine.StyleFixtures.prototype.cleanUp = function () {
     while(this.fixturesNodes_.length) {
-      this.fixturesNodes_.pop().remove()
+      this.fixturesNodes_.pop().remove();
     }
-  }
+  };
 
   jasmine.StyleFixtures.prototype.createStyle_ = function (html) {
     var styleText = $('<div></div>').html(html).text()
-      , style = $('<style>' + styleText + '</style>')
+      , style = $('<style>' + styleText + '</style>');
 
-    this.fixturesNodes_.push(style)
-    $('head').append(style)
-  }
+    this.fixturesNodes_.push(style);
+    $('head').append(style);
+  };
 
-  jasmine.StyleFixtures.prototype.clearCache = jasmine.Fixtures.prototype.clearCache
-  jasmine.StyleFixtures.prototype.read_ = jasmine.Fixtures.prototype.read
-  jasmine.StyleFixtures.prototype.getFixtureHtml_ = jasmine.Fixtures.prototype.getFixtureHtml_
-  jasmine.StyleFixtures.prototype.loadFixtureIntoCache_ = jasmine.Fixtures.prototype.loadFixtureIntoCache_
-  jasmine.StyleFixtures.prototype.makeFixtureUrl_ = jasmine.Fixtures.prototype.makeFixtureUrl_
-  jasmine.StyleFixtures.prototype.proxyCallTo_ = jasmine.Fixtures.prototype.proxyCallTo_
+  jasmine.StyleFixtures.prototype.clearCache = jasmine.Fixtures.prototype.clearCache;
+  jasmine.StyleFixtures.prototype.read_ = jasmine.Fixtures.prototype.read;
+  jasmine.StyleFixtures.prototype.getFixtureHtml_ = jasmine.Fixtures.prototype.getFixtureHtml_;
+  jasmine.StyleFixtures.prototype.loadFixtureIntoCache_ = jasmine.Fixtures.prototype.loadFixtureIntoCache_;
+  jasmine.StyleFixtures.prototype.makeFixtureUrl_ = jasmine.Fixtures.prototype.makeFixtureUrl_;
+  jasmine.StyleFixtures.prototype.proxyCallTo_ = jasmine.Fixtures.prototype.proxyCallTo_;
 
   jasmine.getJSONFixtures = function () {
-    return jasmine.currentJSONFixtures_ = jasmine.currentJSONFixtures_ || new jasmine.JSONFixtures()
-  }
+    return jasmine.currentJSONFixtures_ = jasmine.currentJSONFixtures_ || new jasmine.JSONFixtures();
+  };
 
   jasmine.JSONFixtures = function () {
-    this.fixturesCache_ = {}
-    this.fixturesPath = 'spec/javascripts/fixtures/json'
-  }
+    this.fixturesCache_ = {};
+    this.fixturesPath = 'spec/javascripts/fixtures/json';
+  };
 
   jasmine.JSONFixtures.prototype.load = function () {
-    this.read.apply(this, arguments)
-    return this.fixturesCache_
-  }
+    this.read.apply(this, arguments);
+    return this.fixturesCache_;
+  };
 
   jasmine.JSONFixtures.prototype.read = function () {
-    var fixtureUrls = arguments
+    var fixtureUrls = arguments;
 
     for(var urlCount = fixtureUrls.length, urlIndex = 0; urlIndex < urlCount; urlIndex++) {
-      this.getFixtureData_(fixtureUrls[urlIndex])
+      this.getFixtureData_(fixtureUrls[urlIndex]);
     }
 
-    return this.fixturesCache_
-  }
+    return this.fixturesCache_;
+  };
 
   jasmine.JSONFixtures.prototype.clearCache = function () {
-    this.fixturesCache_ = {}
-  }
+    this.fixturesCache_ = {};
+  };
 
   jasmine.JSONFixtures.prototype.getFixtureData_ = function (url) {
-    if (!this.fixturesCache_[url]) this.loadFixtureIntoCache_(url)
-    return this.fixturesCache_[url]
-  }
+    if (!this.fixturesCache_[url]) this.loadFixtureIntoCache_(url);
+    return this.fixturesCache_[url];
+  };
 
   jasmine.JSONFixtures.prototype.loadFixtureIntoCache_ = function (relativeUrl) {
     var self = this
-      , url = this.fixturesPath.match('/$') ? this.fixturesPath + relativeUrl : this.fixturesPath + '/' + relativeUrl
+      , url = this.fixturesPath.match('/$') ? this.fixturesPath + relativeUrl : this.fixturesPath + '/' + relativeUrl;
 
     $.ajax({
       async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
@@ -260,358 +260,358 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       dataType: 'json',
       url: url,
       success: function (data) {
-        self.fixturesCache_[relativeUrl] = data
+        self.fixturesCache_[relativeUrl] = data;
       },
       error: function ($xhr, status, err) {
-        throw new Error('JSONFixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
+        throw new Error('JSONFixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')');
       }
-    })
-  }
+    });
+  };
 
   jasmine.JSONFixtures.prototype.proxyCallTo_ = function (methodName, passedArguments) {
-    return this[methodName].apply(this, passedArguments)
-  }
+    return this[methodName].apply(this, passedArguments);
+  };
 
-  jasmine.jQuery = function () {}
+  jasmine.jQuery = function () {};
 
   jasmine.jQuery.browserTagCaseIndependentHtml = function (html) {
-    return $('<div/>').append(html).html()
-  }
+    return $('<div/>').append(html).html();
+  };
 
   jasmine.jQuery.elementToString = function (element) {
-    return $(element).map(function () { return this.outerHTML; }).toArray().join(', ')
-  }
+    return $(element).map(function () { return this.outerHTML; }).toArray().join(', ');
+  };
 
   var data = {
-      spiedEvents: {}
+    spiedEvents: {}
     , handlers:    []
-  }
+  };
 
   jasmine.jQuery.events = {
     spyOn: function (selector, eventName) {
       var handler = function (e) {
-        var calls = (typeof data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] !== 'undefined') ? data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : 0
+        var calls = (typeof data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] !== 'undefined') ? data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : 0;
         data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = {
           args: jasmine.util.argsToArray(arguments),
           calls: ++calls
-        }
-      }
+        };
+      };
 
-      $(selector).on(eventName, handler)
-      data.handlers.push(handler)
+      $(selector).on(eventName, handler);
+      data.handlers.push(handler);
 
       return {
         selector: selector,
         eventName: eventName,
         handler: handler,
         reset: function (){
-          delete data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+          delete data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)];
         },
         calls: {
           count: function () {
-              return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] ?
+            return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] ?
                 data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : 0;
           },
           any: function () {
-              return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] ?
+            return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] ?
                 !!data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : false;
           }
         }
-      }
+      };
     },
 
     args: function (selector, eventName) {
-      var actualArgs = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].args
+      var actualArgs = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].args;
 
       if (!actualArgs) {
-        throw "There is no spy for " + eventName + " on " + selector.toString() + ". Make sure to create a spy using spyOnEvent."
+        throw "There is no spy for " + eventName + " on " + selector.toString() + ". Make sure to create a spy using spyOnEvent.";
       }
 
-      return actualArgs
+      return actualArgs;
     },
 
     wasTriggered: function (selector, eventName) {
-      return !!(data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)])
+      return !!(data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]);
     },
 
     wasTriggeredWith: function (selector, eventName, expectedArgs, util, customEqualityTesters) {
-      var actualArgs = jasmine.jQuery.events.args(selector, eventName).slice(1)
+      var actualArgs = jasmine.jQuery.events.args(selector, eventName).slice(1);
 
       if (Object.prototype.toString.call(expectedArgs) !== '[object Array]')
-        actualArgs = actualArgs[0]
+        actualArgs = actualArgs[0];
 
-      return util.equals(actualArgs, expectedArgs, customEqualityTesters)
+      return util.equals(actualArgs, expectedArgs, customEqualityTesters);
     },
 
     wasPrevented: function (selector, eventName) {
       var spiedEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
         , args = (jasmine.util.isUndefined(spiedEvent)) ? {} : spiedEvent.args
-        , e = args ? args[0] : undefined
+        , e = args ? args[0] : undefined;
 
-      return e && e.isDefaultPrevented()
+      return e && e.isDefaultPrevented();
     },
 
     wasStopped: function (selector, eventName) {
       var spiedEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
         , args = (jasmine.util.isUndefined(spiedEvent)) ? {} : spiedEvent.args
-        , e = args ? args[0] : undefined
+        , e = args ? args[0] : undefined;
 
-      return e && e.isPropagationStopped()
+      return e && e.isPropagationStopped();
     },
 
     cleanUp: function () {
-      data.spiedEvents = {}
-      data.handlers    = []
+      data.spiedEvents = {};
+      data.handlers    = [];
     }
-  }
+  };
 
   var hasProperty = function (actualValue, expectedValue) {
     if (expectedValue === undefined)
-      return actualValue !== undefined
+      return actualValue !== undefined;
 
-    return actualValue === expectedValue
-  }
+    return actualValue === expectedValue;
+  };
 
   beforeEach(function () {
     jasmine.addMatchers({
       toHaveClass: function () {
         return {
           compare: function (actual, className) {
-            return { pass: $(actual).hasClass(className) }
+            return { pass: $(actual).hasClass(className) };
           }
-        }
+        };
       },
 
       toHaveCss: function () {
         return {
           compare: function (actual, css) {
-            var stripCharsRegex = /[\s;\"\']/g
+            var stripCharsRegex = /[\s;\"\']/g;
             for (var prop in css) {
               var value = css[prop]
               // see issue #147 on gh
-              ;if ((value === 'auto') && ($(actual).get(0).style[prop] === 'auto')) continue
-              var actualStripped = $(actual).css(prop).replace(stripCharsRegex, '')
-              var valueStripped = value.replace(stripCharsRegex, '')
-              if (actualStripped !== valueStripped) return { pass: false }
+              ;if ((value === 'auto') && ($(actual).get(0).style[prop] === 'auto')) continue;
+              var actualStripped = $(actual).css(prop).replace(stripCharsRegex, '');
+              var valueStripped = value.replace(stripCharsRegex, '');
+              if (actualStripped !== valueStripped) return { pass: false };
             }
-            return { pass: true }
+            return { pass: true };
           }
-        }
+        };
       },
 
       toBeVisible: function () {
         return {
           compare: function (actual) {
-            return { pass: $(actual).is(':visible') }
+            return { pass: $(actual).is(':visible') };
           }
-        }
+        };
       },
 
       toBeHidden: function () {
         return {
           compare: function (actual) {
-            return { pass: $(actual).is(':hidden') }
+            return { pass: $(actual).is(':hidden') };
           }
-        }
+        };
       },
 
       toBeSelected: function () {
         return {
           compare: function (actual) {
-            return { pass: $(actual).is(':selected') }
+            return { pass: $(actual).is(':selected') };
           }
-        }
+        };
       },
 
       toBeChecked: function () {
         return {
           compare: function (actual) {
-            return { pass: $(actual).is(':checked') }
+            return { pass: $(actual).is(':checked') };
           }
-        }
+        };
       },
 
       toBeEmpty: function () {
         return {
           compare: function (actual) {
-            return { pass: $(actual).is(':empty') }
+            return { pass: $(actual).is(':empty') };
           }
-        }
+        };
       },
 
       toBeInDOM: function () {
         return {
           compare: function (actual) {
-            return { pass: $.contains(document.documentElement, $(actual)[0]) }
+            return { pass: $.contains(document.documentElement, $(actual)[0]) };
           }
-        }
+        };
       },
 
       toExist: function () {
         return {
           compare: function (actual) {
-            return { pass: $(actual).length }
+            return { pass: $(actual).length };
           }
-        }
+        };
       },
 
       toHaveLength: function () {
         return {
           compare: function (actual, length) {
-            return { pass: $(actual).length === length }
+            return { pass: $(actual).length === length };
           }
-        }
+        };
       },
 
       toHaveAttr: function () {
         return {
           compare: function (actual, attributeName, expectedAttributeValue) {
-            return { pass: hasProperty($(actual).attr(attributeName), expectedAttributeValue) }
+            return { pass: hasProperty($(actual).attr(attributeName), expectedAttributeValue) };
           }
-        }
+        };
       },
 
       toHaveProp: function () {
         return {
           compare: function (actual, propertyName, expectedPropertyValue) {
-            return { pass: hasProperty($(actual).prop(propertyName), expectedPropertyValue) }
+            return { pass: hasProperty($(actual).prop(propertyName), expectedPropertyValue) };
           }
-        }
+        };
       },
 
       toHaveId: function () {
         return {
           compare: function (actual, id) {
-            return { pass: $(actual).attr('id') == id }
+            return { pass: $(actual).attr('id') == id };
           }
-        }
+        };
       },
 
       toHaveHtml: function () {
         return {
           compare: function (actual, html) {
-            return { pass: $(actual).html() == jasmine.jQuery.browserTagCaseIndependentHtml(html) }
+            return { pass: $(actual).html() == jasmine.jQuery.browserTagCaseIndependentHtml(html) };
           }
-        }
+        };
       },
 
       toContainHtml: function () {
         return {
           compare: function (actual, html) {
             var actualHtml = $(actual).html()
-              , expectedHtml = jasmine.jQuery.browserTagCaseIndependentHtml(html)
+              , expectedHtml = jasmine.jQuery.browserTagCaseIndependentHtml(html);
 
-            return { pass: (actualHtml.indexOf(expectedHtml) >= 0) }
+            return { pass: (actualHtml.indexOf(expectedHtml) >= 0) };
           }
-        }
+        };
       },
 
       toHaveText: function () {
         return {
           compare: function (actual, text) {
-            var actualText = $(actual).text()
-            var trimmedText = $.trim(actualText)
+            var actualText = $(actual).text();
+            var trimmedText = $.trim(actualText);
 
             if (text && $.isFunction(text.test)) {
-              return { pass: text.test(actualText) || text.test(trimmedText) }
+              return { pass: text.test(actualText) || text.test(trimmedText) };
             } else {
-              return { pass: (actualText == text || trimmedText == text) }
+              return { pass: (actualText == text || trimmedText == text) };
             }
           }
-        }
+        };
       },
 
       toContainText: function () {
         return {
           compare: function (actual, text) {
-            var trimmedText = $.trim($(actual).text())
+            var trimmedText = $.trim($(actual).text());
 
             if (text && $.isFunction(text.test)) {
-              return { pass: text.test(trimmedText) }
+              return { pass: text.test(trimmedText) };
             } else {
-              return { pass: trimmedText.indexOf(text) != -1 }
+              return { pass: trimmedText.indexOf(text) != -1 };
             }
           }
-        }
+        };
       },
 
       toHaveValue: function () {
         return {
           compare: function (actual, value) {
-            return { pass: $(actual).val() === value }
+            return { pass: $(actual).val() === value };
           }
-        }
+        };
       },
 
       toHaveData: function () {
         return {
           compare: function (actual, key, expectedValue) {
-            return { pass: hasProperty($(actual).data(key), expectedValue) }
+            return { pass: hasProperty($(actual).data(key), expectedValue) };
           }
-        }
+        };
       },
 
       toContainElement: function () {
         return {
           compare: function (actual, selector) {
-            return { pass: $(actual).find(selector).length }
+            return { pass: $(actual).find(selector).length };
           }
-        }
+        };
       },
 
       toBeMatchedBy: function () {
         return {
           compare: function (actual, selector) {
-            return { pass: $(actual).filter(selector).length }
+            return { pass: $(actual).filter(selector).length };
           }
-        }
+        };
       },
 
       toBeDisabled: function () {
         return {
           compare: function (actual, selector) {
-            return { pass: $(actual).is(':disabled') }
+            return { pass: $(actual).is(':disabled') };
           }
-        }
+        };
       },
 
       toBeFocused: function (selector) {
         return {
           compare: function (actual, selector) {
-            return { pass: $(actual)[0] === $(actual)[0].ownerDocument.activeElement }
+            return { pass: $(actual)[0] === $(actual)[0].ownerDocument.activeElement };
           }
-        }
+        };
       },
 
       toHandle: function () {
         return {
           compare: function (actual, event) {
             if ( !actual || actual.length === 0 ) return { pass: false };
-            var events = $._data($(actual).get(0), "events")
+            var events = $._data($(actual).get(0), "events");
 
             if (!events || !event || typeof event !== "string") {
-              return { pass: false }
+              return { pass: false };
             }
 
             var namespaces = event.split(".")
               , eventType = namespaces.shift()
               , sortedNamespaces = namespaces.slice(0).sort()
-              , namespaceRegExp = new RegExp("(^|\\.)" + sortedNamespaces.join("\\.(?:.*\\.)?") + "(\\.|$)")
+              , namespaceRegExp = new RegExp("(^|\\.)" + sortedNamespaces.join("\\.(?:.*\\.)?") + "(\\.|$)");
 
             if (events[eventType] && namespaces.length) {
               for (var i = 0; i < events[eventType].length; i++) {
-                var namespace = events[eventType][i].namespace
+                var namespace = events[eventType][i].namespace;
 
                 if (namespaceRegExp.test(namespace))
-                  return { pass: true }
+                  return { pass: true };
               }
             } else {
-              return { pass: (events[eventType] && events[eventType].length > 0) }
+              return { pass: (events[eventType] && events[eventType].length > 0) };
             }
 
-            return { pass: false }
+            return { pass: false };
           }
-        }
+        };
       },
 
       toHandleWith: function () {
@@ -619,29 +619,29 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           compare: function (actual, eventName, eventHandler) {
             if ( !actual || actual.length === 0 ) return { pass: false };
             var normalizedEventName = eventName.split('.')[0]
-              , stack = $._data($(actual).get(0), "events")[normalizedEventName]
+              , stack = $._data($(actual).get(0), "events")[normalizedEventName];
 
             for (var i = 0; i < stack.length; i++) {
-              if (stack[i].handler == eventHandler) return { pass: true }
+              if (stack[i].handler == eventHandler) return { pass: true };
             }
 
-            return { pass: false }
+            return { pass: false };
           }
-        }
+        };
       },
 
       toHaveBeenTriggeredOn: function () {
         return {
           compare: function (actual, selector) {
-            var result = { pass: jasmine.jQuery.events.wasTriggered(selector, actual) }
+            var result = { pass: jasmine.jQuery.events.wasTriggered(selector, actual) };
 
             result.message = result.pass ?
               "Expected event " + $(actual) + " not to have been triggered on " + selector :
-              "Expected event " + $(actual) + " to have been triggered on " + selector
+              "Expected event " + $(actual) + " to have been triggered on " + selector;
 
             return result;
           }
-        }
+        };
       },
 
       toHaveBeenTriggered: function (){
@@ -649,53 +649,53 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           compare: function (actual) {
             var eventName = actual.eventName
               , selector = actual.selector
-              , result = { pass: jasmine.jQuery.events.wasTriggered(selector, eventName) }
+              , result = { pass: jasmine.jQuery.events.wasTriggered(selector, eventName) };
 
             result.message = result.pass ?
             "Expected event " + eventName + " not to have been triggered on " + selector :
-              "Expected event " + eventName + " to have been triggered on " + selector
+              "Expected event " + eventName + " to have been triggered on " + selector;
 
-            return result
+            return result;
           }
-        }
+        };
       },
 
       toHaveBeenTriggeredOnAndWith: function (j$, customEqualityTesters) {
         return {
           compare: function (actual, selector, expectedArgs) {
             var wasTriggered = jasmine.jQuery.events.wasTriggered(selector, actual)
-              , result = { pass: wasTriggered && jasmine.jQuery.events.wasTriggeredWith(selector, actual, expectedArgs, j$, customEqualityTesters) }
+              , result = { pass: wasTriggered && jasmine.jQuery.events.wasTriggeredWith(selector, actual, expectedArgs, j$, customEqualityTesters) };
 
-              if (wasTriggered) {
-                var actualArgs = jasmine.jQuery.events.args(selector, actual, expectedArgs)[1]
-                result.message = result.pass ?
+            if (wasTriggered) {
+              var actualArgs = jasmine.jQuery.events.args(selector, actual, expectedArgs)[1];
+              result.message = result.pass ?
                   "Expected event " + actual + " not to have been triggered with " + jasmine.pp(expectedArgs) + " but it was triggered with " + jasmine.pp(actualArgs) :
-                  "Expected event " + actual + " to have been triggered with " + jasmine.pp(expectedArgs) + "  but it was triggered with " + jasmine.pp(actualArgs)
+                  "Expected event " + actual + " to have been triggered with " + jasmine.pp(expectedArgs) + "  but it was triggered with " + jasmine.pp(actualArgs);
 
-              } else {
+            } else {
                 // todo check on this
-                result.message = result.pass ?
+              result.message = result.pass ?
                   "Expected event " + actual + " not to have been triggered on " + selector :
-                  "Expected event " + actual + " to have been triggered on " + selector
-              }
+                  "Expected event " + actual + " to have been triggered on " + selector;
+            }
 
-              return result
+            return result;
           }
-        }
+        };
       },
 
       toHaveBeenPreventedOn: function () {
         return {
           compare: function (actual, selector) {
-            var result = { pass: jasmine.jQuery.events.wasPrevented(selector, actual) }
+            var result = { pass: jasmine.jQuery.events.wasPrevented(selector, actual) };
 
             result.message = result.pass ?
               "Expected event " + actual + " not to have been prevented on " + selector :
-              "Expected event " + actual + " to have been prevented on " + selector
+              "Expected event " + actual + " to have been prevented on " + selector;
 
-            return result
+            return result;
           }
-        }
+        };
       },
 
       toHaveBeenPrevented: function () {
@@ -703,29 +703,29 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           compare: function (actual) {
             var eventName = actual.eventName
               , selector = actual.selector
-              , result = { pass: jasmine.jQuery.events.wasPrevented(selector, eventName) }
+              , result = { pass: jasmine.jQuery.events.wasPrevented(selector, eventName) };
 
             result.message = result.pass ?
               "Expected event " + eventName + " not to have been prevented on " + selector :
-              "Expected event " + eventName + " to have been prevented on " + selector
+              "Expected event " + eventName + " to have been prevented on " + selector;
 
-            return result
+            return result;
           }
-        }
+        };
       },
 
       toHaveBeenStoppedOn: function () {
         return {
           compare: function (actual, selector) {
-            var result = { pass: jasmine.jQuery.events.wasStopped(selector, actual) }
+            var result = { pass: jasmine.jQuery.events.wasStopped(selector, actual) };
 
             result.message = result.pass ?
               "Expected event " + actual + " not to have been stopped on " + selector :
-              "Expected event " + actual + " to have been stopped on " + selector
+              "Expected event " + actual + " to have been stopped on " + selector;
 
             return result;
           }
-        }
+        };
       },
 
       toHaveBeenStopped: function () {
@@ -733,109 +733,109 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           compare: function (actual) {
             var eventName = actual.eventName
               , selector = actual.selector
-              , result = { pass: jasmine.jQuery.events.wasStopped(selector, eventName) }
+              , result = { pass: jasmine.jQuery.events.wasStopped(selector, eventName) };
 
             result.message = result.pass ?
               "Expected event " + eventName + " not to have been stopped on " + selector :
-              "Expected event " + eventName + " to have been stopped on " + selector
+              "Expected event " + eventName + " to have been stopped on " + selector;
 
-            return result
+            return result;
           }
-        }
+        };
       }
-    })
+    });
 
     jasmine.getEnv().addCustomEqualityTester(function(a, b) {
-     if (a && b) {
-       if (a instanceof $ || jasmine.isDomNode(a)) {
-         var $a = $(a)
+      if (a && b) {
+        if (a instanceof $ || jasmine.isDomNode(a)) {
+          var $a = $(a);
 
-         if (b instanceof $)
-           return $a.length == b.length && a.is(b)
+          if (b instanceof $)
+            return $a.length == b.length && a.is(b);
 
-         return $a.is(b);
-       }
+          return $a.is(b);
+        }
 
-       if (b instanceof $ || jasmine.isDomNode(b)) {
-         var $b = $(b)
+        if (b instanceof $ || jasmine.isDomNode(b)) {
+          var $b = $(b);
 
-         if (a instanceof $)
-           return a.length == $b.length && $b.is(a)
+          if (a instanceof $)
+            return a.length == $b.length && $b.is(a);
 
-         return $(b).is(a);
-       }
-     }
-    })
+          return $(b).is(a);
+        }
+      }
+    });
 
     jasmine.getEnv().addCustomEqualityTester(function (a, b) {
-     if (a instanceof $ && b instanceof $ && a.size() == b.size())
-        return a.is(b)
-    })
-  })
+      if (a instanceof $ && b instanceof $ && a.size() == b.size())
+        return a.is(b);
+    });
+  });
 
   afterEach(function () {
-    jasmine.getFixtures().cleanUp()
-    jasmine.getStyleFixtures().cleanUp()
-    jasmine.jQuery.events.cleanUp()
-  })
+    jasmine.getFixtures().cleanUp();
+    jasmine.getStyleFixtures().cleanUp();
+    jasmine.jQuery.events.cleanUp();
+  });
 
   window.readFixtures = function () {
-    return jasmine.getFixtures().proxyCallTo_('read', arguments)
-  }
+    return jasmine.getFixtures().proxyCallTo_('read', arguments);
+  };
 
   window.preloadFixtures = function () {
-    jasmine.getFixtures().proxyCallTo_('preload', arguments)
-  }
+    jasmine.getFixtures().proxyCallTo_('preload', arguments);
+  };
 
   window.loadFixtures = function () {
-    jasmine.getFixtures().proxyCallTo_('load', arguments)
-  }
+    jasmine.getFixtures().proxyCallTo_('load', arguments);
+  };
 
   window.appendLoadFixtures = function () {
-    jasmine.getFixtures().proxyCallTo_('appendLoad', arguments)
-  }
+    jasmine.getFixtures().proxyCallTo_('appendLoad', arguments);
+  };
 
   window.setFixtures = function (html) {
-    return jasmine.getFixtures().proxyCallTo_('set', arguments)
-  }
+    return jasmine.getFixtures().proxyCallTo_('set', arguments);
+  };
 
   window.appendSetFixtures = function () {
-    jasmine.getFixtures().proxyCallTo_('appendSet', arguments)
-  }
+    jasmine.getFixtures().proxyCallTo_('appendSet', arguments);
+  };
 
   window.sandbox = function (attributes) {
-    return jasmine.getFixtures().sandbox(attributes)
-  }
+    return jasmine.getFixtures().sandbox(attributes);
+  };
 
   window.spyOnEvent = function (selector, eventName) {
-    return jasmine.jQuery.events.spyOn(selector, eventName)
-  }
+    return jasmine.jQuery.events.spyOn(selector, eventName);
+  };
 
   window.preloadStyleFixtures = function () {
-    jasmine.getStyleFixtures().proxyCallTo_('preload', arguments)
-  }
+    jasmine.getStyleFixtures().proxyCallTo_('preload', arguments);
+  };
 
   window.loadStyleFixtures = function () {
-    jasmine.getStyleFixtures().proxyCallTo_('load', arguments)
-  }
+    jasmine.getStyleFixtures().proxyCallTo_('load', arguments);
+  };
 
   window.appendLoadStyleFixtures = function () {
-    jasmine.getStyleFixtures().proxyCallTo_('appendLoad', arguments)
-  }
+    jasmine.getStyleFixtures().proxyCallTo_('appendLoad', arguments);
+  };
 
   window.setStyleFixtures = function (html) {
-    jasmine.getStyleFixtures().proxyCallTo_('set', arguments)
-  }
+    jasmine.getStyleFixtures().proxyCallTo_('set', arguments);
+  };
 
   window.appendSetStyleFixtures = function (html) {
-    jasmine.getStyleFixtures().proxyCallTo_('appendSet', arguments)
-  }
+    jasmine.getStyleFixtures().proxyCallTo_('appendSet', arguments);
+  };
 
   window.loadJSONFixtures = function () {
-    return jasmine.getJSONFixtures().proxyCallTo_('load', arguments)
-  }
+    return jasmine.getJSONFixtures().proxyCallTo_('load', arguments);
+  };
 
   window.getJSONFixture = function (url) {
-    return jasmine.getJSONFixtures().proxyCallTo_('read', arguments)[url]
-  }
+    return jasmine.getJSONFixtures().proxyCallTo_('read', arguments)[url];
+  };
 }));

--- a/spec/javascripts/support/spec_sugar.js
+++ b/spec/javascripts/support/spec_sugar.js
@@ -32,7 +32,7 @@
     changeReactSelect: function($selectEl, optionText) {
       React.addons.TestUtils.Simulate.mouseDown($selectEl.find('.Select-arrow-zone').get(0));
       React.addons.TestUtils.Simulate.focus($selectEl.find('input:last').get(0));
-      $selectEl.find('.Select-option:contains(' + optionText + ')').click()
+      $selectEl.find('.Select-option:contains(' + optionText + ')').click();
       return undefined;
     },
 


### PR DESCRIPTION
This adds eslint into the `package.json` so you can do:

```
$ npm run lint
...

/Users/krob/github/studentinsights/app/assets/javascripts/helpers/profile_details_style.jsx
  103:7  error  Duplicate key 'margin'        no-dupe-keys
  104:7  error  Duplicate key 'borderRadius'  no-dupe-keys

/Users/krob/github/studentinsights/app/assets/javascripts/helpers/prop_types.jsx
  4:9  error  'PropTypes' is assigned a value but never used  no-unused-vars

...

✖ 683 problems (683 errors, 0 warnings)
```

We'll chip away at fixing these (or codemod them) and then move this into the build.  We can also add docs for adding inline lint errors to Sublime too so folks can see helpful warnings like this:

<img width="645" alt="screen shot 2017-04-07 at 5 42 58 pm" src="https://cloud.githubusercontent.com/assets/1056957/24820919/a9e2d06c-1bb9-11e7-864a-5db38adef853.png">
<img width="371" alt="screen shot 2017-04-07 at 5 43 25 pm" src="https://cloud.githubusercontent.com/assets/1056957/24820933/b8529704-1bb9-11e7-8c23-18d2d267b5ce.png">

I also ran `eslint --fix` so the noisy change here is those whitespace or semicolon fixes.