### PR TITLE
Handle null in star chart tooltip formatter

### DIFF
--- a/app/assets/javascripts/student_profile/profile_chart_settings.jsx
+++ b/app/assets/javascripts/student_profile/profile_chart_settings.jsx
@@ -77,11 +77,16 @@
     },
     tooltip: {
        formatter: function () {
-        return  Highcharts.dateFormat('%A, %b %e, %Y', new Date(this.x)) +
-                '<br>Percentile Rank:<b> ' +
-                  this.y +
-                '</b><br>Grade Level Equivalent: <b>' +
-                  this.points[0].point.gradeLevelEquivalent + '</b>';
+        var date = Highcharts.dateFormat('%A, %b %e, %Y', new Date(this.x))
+        var percentileRank = this.y
+        var gradeLevelEquivalent = this.points[0].point.gradeLevelEquivalent
+
+        if ( gradeLevelEquivalent === null ) {
+          return date + '<br>Percentile Rank:<b> ' + percentileRank
+        } else {
+          return date + '<br>Percentile Rank:<b> ' + percentileRank +
+                 '</b><br>Grade Level Equivalent: <b>' + gradeLevelEquivalent
+        }
       },
       shared: true
     },


### PR DESCRIPTION
(continuation of conversation at end of [PR 889](https://github.com/studentinsights/studentinsights/pull/889))

hey @alexsoble - I've handled null within the formatter function.  

The decimals are rendering for me locally...

![screen shot 2017-04-07 at 2 12 37 pm](https://cloud.githubusercontent.com/assets/19398192/24822893/8b5e5468-1bbe-11e7-9292-caf19355be70.png)

... is there a way we could pair on Monday to find where the decimal place is being lost on production?