### PR TITLE
Disable HighCharts animations in PDF

### DIFF
--- a/app/assets/javascripts/student_profile/pdf/student_profile_pdf.js
+++ b/app/assets/javascripts/student_profile/pdf/student_profile_pdf.js
@@ -22,6 +22,10 @@
         enabled: false
       },
       plotOptions: {
+        // This sets charts to render immediately, so we can 
+        // synchronously set window.status and pass control back
+        // to wkhtmltopdf to render the PDF.
+        series: { animation: false },
         column: {
           stacking: stacking,
           dataLabels: {


### PR DESCRIPTION
With animations, and with setting `window.status` synchronously, the PDF is generated before the animations complete.  This turns off animations for the PDF.  Fixing https://github.com/studentinsights/studentinsights/pull/894#issuecomment-292378792.

## Before
<img width="723" alt="screen shot 2017-04-10 at 8 03 31 am" src="https://cloud.githubusercontent.com/assets/1056957/24860849/7610f054-1dc4-11e7-852a-ca0f17558dda.png">

## After
<img width="724" alt="screen shot 2017-04-10 at 8 03 20 am" src="https://cloud.githubusercontent.com/assets/1056957/24860882/9a1a0ce2-1dc4-11e7-87e6-1eabb6768a62.png">
