### PR TITLE
Add nil values for STAR grade_equivalent to the demo data

### DIFF
--- a/app/demo_data/fake_star_math_result_generator.rb
+++ b/app/demo_data/fake_star_math_result_generator.rb
@@ -16,7 +16,7 @@ class FakeStarMathResultGenerator
     @math_percentile = [0, @math_percentile, 100].sort[1]
     @test_date += @star_period_days + rand(-10..10)  # days
     @grade_equivalent = [
-      "10.80", "5.30", "5.70", "6.70", "4.00", "5.70", "2.60"
+      nil, nil, nil, nil, "0.00", "4.00", "5.70", "2.60"
     ].sample
 
     return {

--- a/app/demo_data/fake_star_reading_result_generator.rb
+++ b/app/demo_data/fake_star_reading_result_generator.rb
@@ -17,7 +17,7 @@ class FakeStarReadingResultGenerator
     @instructional_reading_level += rand(-1..1)
     @test_date += @star_period_days + rand(-10..10)  # days
     @grade_equivalent = [
-      "10.80", "5.30", "5.70", "6.70", "4.00", "5.70", "2.60"
+      nil, nil, nil, nil, "0.00", "4.00", "5.70", "2.60"
     ].sample
 
     return {


### PR DESCRIPTION
# Why?

+ In production, a lot of the STAR data points have `nil` for STAR grade_equivalent (24015 `nil`, 9271 non-`nil`)
+ These values are still showing up as "0", which we need to debug
+ Adding a bunch of `nil` values to the demo data to support debugging