### PR TITLE
Handle grade level equivalent as nil on server side

### DIFF
--- a/app/assets/javascripts/student_profile/profile_chart_settings.jsx
+++ b/app/assets/javascripts/student_profile/profile_chart_settings.jsx
@@ -81,7 +81,7 @@
         var percentileRank = this.y
         var gradeLevelEquivalent = this.points[0].point.gradeLevelEquivalent
 
-        if ( gradeLevelEquivalent === null ) {
+        if ( gradeLevelEquivalent === undefined ) {
           return date + '<br>Percentile Rank:<b> ' + percentileRank
         } else {
           return date + '<br>Percentile Rank:<b> ' + percentileRank +

--- a/app/charts/student_profile_chart.rb
+++ b/app/charts/student_profile_chart.rb
@@ -17,7 +17,11 @@ class StudentProfileChart < Struct.new :student
   def percentile_ranks_to_highcharts(student_assessments)
     return if student_assessments.blank?
     student_assessments.map do |s|
-      [s.date_taken.year, s.date_taken.month, s.date_taken.day, s.percentile_rank, s.grade_equivalent.to_f]
+      if s.grade_equivalent == nil
+        [s.date_taken.year, s.date_taken.month, s.date_taken.day, s.percentile_rank]
+      else
+        [s.date_taken.year, s.date_taken.month, s.date_taken.day, s.percentile_rank, s.grade_equivalent]
+      end
     end
   end
 

--- a/spec/charts/student_profile_chart_spec.rb
+++ b/spec/charts/student_profile_chart_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe StudentProfileChart do
     let(:student_profile_chart) { StudentProfileChart.new }
     it 'converts the student assessment to highcharts format' do
       result = student_profile_chart.percentile_ranks_to_highcharts(input)
-      expect(result).to eq [[2015, 6, 19, 8, 0]]
+      expect(result).to eq [[2015, 6, 19, 8]]
     end
   end
 


### PR DESCRIPTION
@alexsoble - It looks like the `.to_f` was changing `nil` to `0.0`.  I added logic on the server side to create the original 'quad' if the grade_level_equivalent is `nil`.

![image](https://cloud.githubusercontent.com/assets/19398192/25283883/e7e23576-267a-11e7-9b11-5ac9035e229c.png)

and handled `undefined` instead of `null` in `profile_chart_setting.jsx`.

All seems to be well.

![image](https://cloud.githubusercontent.com/assets/19398192/25283949/2bbfaf12-267b-11e7-8fda-29c2fa8791d7.png)
