### PR TITLE
Adding symbolic link for node's executable for browserify-rails.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ VOLUME /mnt/somerville-teacher-tool
 WORKDIR /mnt/somerville-teacher-tool
 RUN bundle install
 
+RUN ln -s /usr/bin/nodejs /usr/bin/node
+
 COPY . /mnt/somerville-teacher-tool
 
 EXPOSE 3000


### PR DESCRIPTION
When @alexsoble added browserify-rails in #900, it broke the docker config. Turns out the node package installs node as nodejs because of some odd name conflict. Browserify-rails seems to be doing a /usr/bin/env node so it doesn't find the executable. Fix is a simple symbolic link to create /usr/bin/node from /usr/bin/nodejs.