### PR TITLE
Show date of last SST Meeting in School Overview Table

### DIFF
--- a/app/assets/javascripts/components/students_table.jsx
+++ b/app/assets/javascripts/components/students_table.jsx
@@ -1,139 +1,134 @@
-(function(root) {
-  window.shared || (window.shared = {});
-  const Filters = window.shared.Filters;
-  const Routes = window.shared.Routes;
-  const styles = window.shared.styles;
-  const colors = window.shared.colors;
-  const merge = window.shared.ReactHelpers.merge;
+window.shared || (window.shared = {});
+const Filters = window.shared.Filters;
+const Routes = window.shared.Routes;
+const styles = window.shared.styles;
+const colors = window.shared.colors;
+const merge = window.shared.ReactHelpers.merge;
 
-  const StudentsTable = React.createClass({
-    displayName: 'StudentsTable',
+export default React.createClass({
+  displayName: 'StudentsTable',
 
-    propTypes: {
-      students: React.PropTypes.arrayOf(React.PropTypes.object).isRequired
-    },
+  propTypes: {
+    students: React.PropTypes.arrayOf(React.PropTypes.object).isRequired
+  },
 
-    componentDidMount: function() {
-      new Tablesort(document.querySelector('.students-table'), { descending: false });
-    },
+  componentDidMount: function() {
+    new Tablesort(document.querySelector('.students-table'), { descending: false });
+  },
 
-    mergeInDateOfLastSST (student) {
-      const eventNotes = student.event_notes;
-      const sstNotes = eventNotes.filter((note) => {
-        return note.event_note_type_id === 300 });
+  mergeInDateOfLastSST (student) {
+    const eventNotes = student.event_notes;
+    const sstNotes = eventNotes.filter((note) => {
+      return note.event_note_type_id === 300 });
 
-      if (sstNotes.length === 0) return merge(student, { dateOfLastSST: null });
+    if (sstNotes.length === 0) return merge(student, { dateOfLastSST: null });
 
-      const sstNoteDates = sstNotes.map(note => moment.utc(note.recorded_at)).sort();
-      const latestSstDate = _.last(sstNoteDates).format('M/D/YY');
+    const sstNoteDates = sstNotes.map(note => moment.utc(note.recorded_at)).sort();
+    const latestSstDate = _.last(sstNoteDates).format('M/D/YY');
 
-      return merge(student, { dateOfLastSST: latestSstDate });
-    },
+    return merge(student, { dateOfLastSST: latestSstDate });
+  },
 
-    studentsWithDateOfLastSST () {
-      return this.props.students.map(student => this.mergeInDateOfLastSST(student));
-    },
+  studentsWithDateOfLastSST () {
+    return this.props.students.map(student => this.mergeInDateOfLastSST(student));
+  },
 
-    render: function() {
-      return (
-        <div className='StudentsTable'>
-          <table className='students-table' style={{ width: '100%' }}>
-            <thead>
-              <tr>
-                {this.renderHeader('Name', { className: 'sort-default' }) /* className is read by Tablesort */}
-                {this.renderHeader('Last SST')}
-                {this.renderHeader('Grade')}
-                {this.renderHeader('Disability', { 'data-sort-method': "disability" })}
-                {this.renderHeader('Low Income')}
-                {this.renderHeader('LEP')}
-                {this.renderHeader('STAR Reading')}
-                {this.renderHeader('MCAS ELA')}
-                {this.renderHeader('STAR Math')}
-                {this.renderHeader('MCAS Math')}
-                {this.renderHeader('Discipline Incidents')}
-                {this.renderHeader('Absences')}
-                {this.renderHeader('Tardies')}
-                {this.renderHeader('Services')}
-                {this.renderHeader('Program', { 'data-sort-method': 'prog_assign_sort' })}
-                {this.renderHeader('Homeroom')}
-              </tr>
-            </thead>
-            <tbody>
-              {this.studentsWithDateOfLastSST().map(function(student) {
-                return (
-                  <tr key={student.id}>
-                    <td>
-                      <a href={Routes.studentProfile(student.id)}>
-                        {student.first_name + ' ' + student.last_name}
-                      </a>
-                    </td>
-                    <td>{student.dateOfLastSST}</td>
-                    <td>{student.grade}</td>
-                    <td>{this.renderUnless('None', student.sped_level_of_need)}</td>
-                    <td style={{width: '2.5em'}}>{this.renderUnless('Not Eligible', student.free_reduced_lunch)}</td>
-                    <td style={{width: '2.5em'}}>{this.renderUnless('Fluent', student.limited_english_proficiency)}</td>
-                    {this.renderNumberCell(student.most_recent_star_reading_percentile)}
-                    {this.renderNumberCell(student.most_recent_mcas_ela_scaled)}
-                    {this.renderNumberCell(student.most_recent_star_math_percentile)}
-                    {this.renderNumberCell(student.most_recent_mcas_math_scaled)}
-                    {this.renderNumberCell(this.renderCount(student.discipline_incidents_count))}
-                    {this.renderNumberCell(this.renderCount(student.absences_count))}
-                    {this.renderNumberCell(this.renderCount(student.tardies_count))}
-                    {this.renderNumberCell(this.renderCount(student.active_services.length))}
-                    <td>
-                      {this.renderUnless('Reg Ed', student.program_assigned)}
-                    </td>
-                    <td>
-                      <a href={Routes.homeroom(student.homeroom_id)}>
-                        {student.homeroom_name}
-                      </a>
-                    </td>
-                  </tr>
-                );
-              }, this)}
-            </tbody>
-          </table>
-        </div>
-      );
-    },
+  render: function() {
+    return (
+      <div className='StudentsTable'>
+        <table className='students-table' style={{ width: '100%' }}>
+          <thead>
+            <tr>
+              {this.renderHeader('Name', { className: 'sort-default' }) /* className is read by Tablesort */}
+              {this.renderHeader('Last SST')}
+              {this.renderHeader('Grade')}
+              {this.renderHeader('Disability', { 'data-sort-method': "disability" })}
+              {this.renderHeader('Low Income')}
+              {this.renderHeader('LEP')}
+              {this.renderHeader('STAR Reading')}
+              {this.renderHeader('MCAS ELA')}
+              {this.renderHeader('STAR Math')}
+              {this.renderHeader('MCAS Math')}
+              {this.renderHeader('Discipline Incidents')}
+              {this.renderHeader('Absences')}
+              {this.renderHeader('Tardies')}
+              {this.renderHeader('Services')}
+              {this.renderHeader('Program', { 'data-sort-method': 'prog_assign_sort' })}
+              {this.renderHeader('Homeroom')}
+            </tr>
+          </thead>
+          <tbody>
+            {this.studentsWithDateOfLastSST().map(function(student) {
+              return (
+                <tr key={student.id}>
+                  <td>
+                    <a href={Routes.studentProfile(student.id)}>
+                      {student.first_name + ' ' + student.last_name}
+                    </a>
+                  </td>
+                  <td>{student.dateOfLastSST}</td>
+                  <td>{student.grade}</td>
+                  <td>{this.renderUnless('None', student.sped_level_of_need)}</td>
+                  <td style={{width: '2.5em'}}>{this.renderUnless('Not Eligible', student.free_reduced_lunch)}</td>
+                  <td style={{width: '2.5em'}}>{this.renderUnless('Fluent', student.limited_english_proficiency)}</td>
+                  {this.renderNumberCell(student.most_recent_star_reading_percentile)}
+                  {this.renderNumberCell(student.most_recent_mcas_ela_scaled)}
+                  {this.renderNumberCell(student.most_recent_star_math_percentile)}
+                  {this.renderNumberCell(student.most_recent_mcas_math_scaled)}
+                  {this.renderNumberCell(this.renderCount(student.discipline_incidents_count))}
+                  {this.renderNumberCell(this.renderCount(student.absences_count))}
+                  {this.renderNumberCell(this.renderCount(student.tardies_count))}
+                  {this.renderNumberCell(this.renderCount(student.active_services.length))}
+                  <td>
+                    {this.renderUnless('Reg Ed', student.program_assigned)}
+                  </td>
+                  <td>
+                    <a href={Routes.homeroom(student.homeroom_id)}>
+                      {student.homeroom_name}
+                    </a>
+                  </td>
+                </tr>
+              );
+            }, this)}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
 
-    renderNumberCell: function(children) {
-      return (
-        <td style={{textAlign: 'right', width: '5em', paddingRight: '3em'}}>
-          {children}
-        </td>
-      );
-    },
+  renderNumberCell: function(children) {
+    return (
+      <td style={{textAlign: 'right', width: '5em', paddingRight: '3em'}}>
+        {children}
+      </td>
+    );
+  },
 
-    renderUnless: function(ignoredValue, value) {
-      const valueText = (value === null || value === undefined) ? 'None' : value;
-      return (
-        <span style={{opacity: (valueText === ignoredValue) ? 0.1 : 1 }}>
-          {valueText}
-        </span>
-      );
-    },
+  renderUnless: function(ignoredValue, value) {
+    const valueText = (value === null || value === undefined) ? 'None' : value;
+    return (
+      <span style={{opacity: (valueText === ignoredValue) ? 0.1 : 1 }}>
+        {valueText}
+      </span>
+    );
+  },
 
-    renderCount: function(count) {
-      return (count === 0) ? null : count;
-    },
+  renderCount: function(count) {
+    return (count === 0) ? null : count;
+  },
 
-    renderHeader: function(caption, options) {
-      const pieces = caption.split(' ');
+  renderHeader: function(caption, options) {
+    const pieces = caption.split(' ');
 
-      const className = (options ? options['className'] : null);
-      const dataSortMethod = (options ? options['data-sort-method'] : null);
+    const className = (options ? options['className'] : null);
+    const dataSortMethod = (options ? options['data-sort-method'] : null);
 
-      return (
-        <th className={className} data={{'sort-method': dataSortMethod}}>
-          {pieces[0]}
-          <br/>
-          {pieces[1]}
-        </th>
-      );
-    }
-  });
-
-  root.StudentsTable = StudentsTable;
-
-})(window);
+    return (
+      <th className={className} data={{'sort-method': dataSortMethod}}>
+        {pieces[0]}
+        <br/>
+        {pieces[1]}
+      </th>
+    );
+  }
+});

--- a/app/assets/javascripts/components/students_table.jsx
+++ b/app/assets/javascripts/components/students_table.jsx
@@ -40,9 +40,9 @@ export default React.createClass({
           <thead>
             <tr>
               {this.renderHeader('Name', { className: 'sort-default' }) /* className is read by Tablesort */}
-              {this.renderHeader('Last SST')}
+              {this.renderHeader('Last SST', { 'data-sort-method': 'sst_date' })}
               {this.renderHeader('Grade')}
-              {this.renderHeader('Disability', { 'data-sort-method': "disability" })}
+              {this.renderHeader('Disability', { 'data-sort-method': 'disability' })}
               {this.renderHeader('Low Income')}
               {this.renderHeader('LEP')}
               {this.renderHeader('STAR Reading')}
@@ -124,7 +124,7 @@ export default React.createClass({
     const dataSortMethod = (options ? options['data-sort-method'] : null);
 
     return (
-      <th className={className} data={{'sort-method': dataSortMethod}}>
+      <th className={className} data-sort-method={dataSortMethod}>
         {pieces[0]}
         <br/>
         {pieces[1]}

--- a/app/assets/javascripts/components/students_table.jsx
+++ b/app/assets/javascripts/components/students_table.jsx
@@ -12,8 +12,12 @@ export default React.createClass({
     students: React.PropTypes.arrayOf(React.PropTypes.object).isRequired
   },
 
-  componentDidMount: function() {
-    new Tablesort(document.querySelector('.students-table'), { descending: false });
+  getInitialState () {
+    return {
+      sortBy: 'first_name',
+      sortType: 'string',
+      sortDesc: true
+    };
   },
 
   mergeInDateOfLastSST (student) {
@@ -33,32 +37,133 @@ export default React.createClass({
     return this.props.students.map(student => this.mergeInDateOfLastSST(student));
   },
 
-  render: function() {
+  sortByDate (a, b, sortBy) {
+    const dateA = moment(a[sortBy], 'MM/D/YY')
+    const dateB = moment(b[sortBy], 'MM/D/YY')
+
+    if (!dateA.isValid() && !dateB.isValid()) return 0;
+
+    if (!dateB.isValid() || dateA.isAfter(dateB)) return -1;
+    if (!dateA.isValid() || dateA.isBefore(dateB)) return 1;
+
+    return 0;
+  },
+
+  sortByString (a, b, sortBy) {
+    const stringA = a[sortBy].toUpperCase(); // ignore upper and lowercase
+    const stringB = b[sortBy].toUpperCase(); // ignore upper and lowercase
+
+    if (stringA < stringB) return -1;
+    if (stringA > stringB) return 1;
+    return 0;
+  },
+
+  sortByNumber (a, b, sortBy) {
+    const numA = parseInt(a[sortBy]);
+    const numB = parseInt(b[sortBy]);
+
+    if (!Number.isInteger(numA) && !Number.isInteger(numB)) return 0;
+
+    if (!Number.isInteger(numA) || numA > numB) return -1;
+    if (!Number.isInteger(numB) || numA < numB) return 1;
+
+    return 0;
+  },
+
+  sortByCustomEnum (a, b, sortBy, customEnum) {
+    const indexA = customEnum.indexOf(a[sortBy]);
+    const indexB = customEnum.indexOf(b[sortBy]);
+
+    if (indexA > indexB) return 1;
+    if (indexB > indexA) return -1;
+    return 0;
+  },
+
+  sortByActiveServices (a, b) {
+    const numA = a.active_services.length;
+    const numB = b.active_services.length;
+
+    if (numA > numB) return 1;
+    if (numB > numA) return -1;
+    return 0;
+  },
+
+  orderedStudents () {
+    const sortedStudents = this.sortedStudents();
+
+    if (!this.state.sortDesc) return sortedStudents.reverse();
+
+    return sortedStudents;
+  },
+
+  sortedStudents () {
+    const students = this.studentsWithDateOfLastSST();
+    const sortBy = this.state.sortBy;
+    const sortType = this.state.sortType;
+    let customEnum;
+
+    switch(sortType) {
+      case 'string':
+        return students.sort((a, b) => this.sortByString(a, b, sortBy));
+      case 'number':
+        return students.sort((a, b) => this.sortByNumber(a, b, sortBy));
+      case 'date':
+        return students.sort((a, b) => this.sortByDate(a, b, sortBy));
+      case 'free_reduced_lunch':
+        return students.sort((a, b) => this.sortByString(a, b, sortBy));
+      case 'grade':
+        customEnum = ['PK', 'KF', '1', '2', '3', '4', '5', '6', '7', '8'];
+        return students.sort((a, b) => this.sortByCustomEnum(a, b, sortBy, customEnum))
+      case 'sped_level_of_need':
+        customEnum = ['—', 'Low < 2', 'Low >= 2', 'Moderate', 'High'];
+        return students.sort((a, b) => this.sortByCustomEnum(a, b, sortBy, customEnum));
+      case 'limited_english_proficiency':
+        customEnum = ['FLEP-Transitioning', 'FLEP', 'Fluent'];
+        return students.sort((a, b) => this.sortByCustomEnum(a, b, sortBy, customEnum));
+      case 'program_assigned':
+        customEnum = ['Reg Ed', '2Way English', '2Way Spanish', 'Sp Ed'];
+        return students.sort((a, b) => this.sortByCustomEnum(a, b, sortBy, customEnum));
+      case 'active_services':
+        return students.sort((a, b) => this.sortByActiveServices(a, b));
+      default:
+        return students;
+    }
+  },
+
+  onClickHeader (sortBy, sortType) {
+    if (sortBy === this.state.sortBy) {
+      this.setState({ sortDesc: !this.state.sortDesc });
+    } else {
+      this.setState({ sortBy: sortBy, sortType: sortType });
+    }
+  },
+
+  render () {
     return (
       <div className='StudentsTable'>
         <table className='students-table' style={{ width: '100%' }}>
           <thead>
             <tr>
-              {this.renderHeader('Name', { className: 'sort-default' }) /* className is read by Tablesort */}
-              {this.renderHeader('Last SST', { 'data-sort-method': 'sst_date' })}
-              {this.renderHeader('Grade')}
-              {this.renderHeader('Disability', { 'data-sort-method': 'disability' })}
-              {this.renderHeader('Low Income')}
-              {this.renderHeader('LEP')}
-              {this.renderHeader('STAR Reading')}
-              {this.renderHeader('MCAS ELA')}
-              {this.renderHeader('STAR Math')}
-              {this.renderHeader('MCAS Math')}
-              {this.renderHeader('Discipline Incidents')}
-              {this.renderHeader('Absences')}
-              {this.renderHeader('Tardies')}
-              {this.renderHeader('Services')}
-              {this.renderHeader('Program', { 'data-sort-method': 'prog_assign_sort' })}
-              {this.renderHeader('Homeroom')}
+              {this.renderHeader('Name', 'first_name', 'string')}
+              {this.renderHeader('Last SST', 'dateOfLastSST', 'date')}
+              {this.renderHeader('Grade', 'grade', 'grade')}
+              {this.renderHeader('Disability', 'sped_level_of_need', 'sped_level_of_need')}
+              {this.renderHeader('Low Income', 'free_reduced_lunch', 'free_reduced_lunch')}
+              {this.renderHeader('LEP', 'limited_english_proficiency', 'limited_english_proficiency')}
+              {this.renderHeader('STAR Reading', 'most_recent_star_reading_percentile', 'number')}
+              {this.renderHeader('MCAS ELA', 'most_recent_mcas_ela_scaled', 'number')}
+              {this.renderHeader('STAR Math', 'most_recent_star_math_percentile', 'number')}
+              {this.renderHeader('MCAS Math', 'most_recent_mcas_math_scaled', 'number')}
+              {this.renderHeader('Discipline Incidents', 'discipline_incidents_count', 'number')}
+              {this.renderHeader('Absences', 'absences_count', 'number')}
+              {this.renderHeader('Tardies', 'tardies_count', 'number')}
+              {this.renderHeader('Services', 'active_services', 'active_services')}
+              {this.renderHeader('Program', 'program_assigned', 'program_assigned')}
+              {this.renderHeader('Homeroom', 'homeroom_id', 'number')}
             </tr>
           </thead>
           <tbody>
-            {this.studentsWithDateOfLastSST().map(function(student) {
+            {this.orderedStudents().map(student => {
               return (
                 <tr key={student.id}>
                   <td>
@@ -96,7 +201,7 @@ export default React.createClass({
     );
   },
 
-  renderNumberCell: function(children) {
+  renderNumberCell (children) {
     return (
       <td style={{textAlign: 'right', width: '5em', paddingRight: '3em'}}>
         {children}
@@ -104,7 +209,7 @@ export default React.createClass({
     );
   },
 
-  renderUnless: function(ignoredValue, value) {
+  renderUnless (ignoredValue, value) {
     const valueText = (value === null || value === undefined) ? 'None' : value;
     return (
       <span style={{opacity: (valueText === ignoredValue) ? 0.1 : 1 }}>
@@ -113,18 +218,27 @@ export default React.createClass({
     );
   },
 
-  renderCount: function(count) {
+  renderCount (count) {
     return (count === 0) ? null : count;
   },
 
-  renderHeader: function(caption, options) {
+  headerClassName (sortBy) {
+    // Using tablesort classes here for the cute CSS carets,
+    // not for the acutal table sorting JS (that logic is handled by this class).
+
+    if (sortBy !== this.state.sortBy) return 'sort-header';
+
+    if (this.state.sortDesc) return 'sort-header sort-down';
+
+    return 'sort-header sort-up';
+  },
+
+  renderHeader (caption, sortBy, sortType) {
     const pieces = caption.split(' ');
 
-    const className = (options ? options['className'] : null);
-    const dataSortMethod = (options ? options['data-sort-method'] : null);
-
     return (
-      <th className={className} data-sort-method={dataSortMethod}>
+      <th onClick={this.onClickHeader.bind(null, sortBy, sortType)}
+          className={this.headerClassName(sortBy)}>
         {pieces[0]}
         <br/>
         {pieces[1]}

--- a/app/assets/javascripts/components/students_table.jsx
+++ b/app/assets/javascripts/components/students_table.jsx
@@ -17,6 +17,23 @@
       new Tablesort(document.querySelector('.students-table'), { descending: false });
     },
 
+    mergeInDateOfLastSST (student) {
+      const eventNotes = student.event_notes;
+      const sstNotes = eventNotes.filter((note) => {
+        return note.event_note_type_id === 300 });
+
+      if (sstNotes.length === 0) return merge(student, { dateOfLastSST: null });
+
+      const sstNoteDates = sstNotes.map(note => moment.utc(note.recorded_at)).sort();
+      const latestSstDate = _.last(sstNoteDates).format('M/D/YY');
+
+      return merge(student, { dateOfLastSST: latestSstDate });
+    },
+
+    studentsWithDateOfLastSST () {
+      return this.props.students.map(student => this.mergeInDateOfLastSST(student));
+    },
+
     render: function() {
       return (
         <div className='StudentsTable'>
@@ -24,6 +41,7 @@
             <thead>
               <tr>
                 {this.renderHeader('Name', { className: 'sort-default' }) /* className is read by Tablesort */}
+                {this.renderHeader('Last SST')}
                 {this.renderHeader('Grade')}
                 {this.renderHeader('Disability', { 'data-sort-method': "disability" })}
                 {this.renderHeader('Low Income')}
@@ -41,7 +59,7 @@
               </tr>
             </thead>
             <tbody>
-              {this.props.students.map(function(student) {
+              {this.studentsWithDateOfLastSST().map(function(student) {
                 return (
                   <tr key={student.id}>
                     <td>
@@ -49,18 +67,11 @@
                         {student.first_name + ' ' + student.last_name}
                       </a>
                     </td>
-                    <td>
-                      {student.grade}
-                    </td>
-                    <td>
-                      {this.renderUnless('None', student.sped_level_of_need)}
-                    </td>
-                    <td style={{width: '2.5em'}}>
-                      {this.renderUnless('Not Eligible', student.free_reduced_lunch)}
-                    </td>
-                    <td style={{width: '2.5em'}}>
-                      {this.renderUnless('Fluent', student.limited_english_proficiency)}
-                    </td>
+                    <td>{student.dateOfLastSST}</td>
+                    <td>{student.grade}</td>
+                    <td>{this.renderUnless('None', student.sped_level_of_need)}</td>
+                    <td style={{width: '2.5em'}}>{this.renderUnless('Not Eligible', student.free_reduced_lunch)}</td>
+                    <td style={{width: '2.5em'}}>{this.renderUnless('Fluent', student.limited_english_proficiency)}</td>
                     {this.renderNumberCell(student.most_recent_star_reading_percentile)}
                     {this.renderNumberCell(student.most_recent_mcas_ela_scaled)}
                     {this.renderNumberCell(student.most_recent_star_math_percentile)}

--- a/app/assets/javascripts/school_overview/school_overview_page.jsx
+++ b/app/assets/javascripts/school_overview/school_overview_page.jsx
@@ -1,3 +1,5 @@
+import StudentsTable from '../components/students_table.jsx';
+
 (function(root) {
   window.shared || (window.shared = {});
   const MixpanelUtils = window.shared.MixpanelUtils;
@@ -163,7 +165,7 @@
         page_key: 'SCHOOL_OVERVIEW_DASHBOARD',
         filter_identifier: toggledFilter.identifier
       });
-      
+
       const withoutToggledFilter = this.state.filters.filter(function(filter) {
         return filter.identifier !== toggledFilter.identifier;
       });

--- a/spec/javascripts/components/students_table_spec.jsx
+++ b/spec/javascripts/components/students_table_spec.jsx
@@ -1,0 +1,39 @@
+import SpecSugar from '../support/spec_sugar.jsx';
+import StudentsTable from '../../../app/assets/javascripts/components/students_table.jsx';
+
+describe('StudentsTable', function() {
+  const ReactDOM = window.ReactDOM;
+
+  const helpers = {
+    renderInto: function(el, props) {
+      ReactDOM.render(<StudentsTable {...props} />, el);
+    }
+  };
+
+  SpecSugar.withTestEl('high-level integration test', function() {
+    it('renders the right date', function() {
+
+      const props = {
+        students: [
+          { event_notes:
+            [
+              { "recorded_at": "2010-11-30T00:00:00.000Z",
+                "event_note_type_id": 301 },
+              { "recorded_at": "2010-11-28T00:00:00.000Z",
+                "event_note_type_id": 300 }
+            ],
+            active_services: [],
+            id: '1'
+          }
+        ]
+      };
+
+      const el = this.testEl;
+      helpers.renderInto(el, props);
+
+      expect(el).toContainText('11/28/10');
+      expect(el).not.toContainText('11/30/10');
+    });
+  });
+
+});


### PR DESCRIPTION
# GIF (demo data)

![date-of-latest-sst](https://cloud.githubusercontent.com/assets/3209501/25725112/3e7309ba-30e4-11e7-8b42-473dd8aafeaa.gif)

# What this does

+ Adds a column to the School Overview students table that shows when each student's last SST Note was entered
+ Uri mentioned that this would help them figure out which students aren't getting SST notes who possibly should be
+ Use `import/export` instead of `window.shared` for StudentsTable component 
+ Replace the Tablesorter plugin with hand-rolled sorting since Tablesorter wasn't able to handle a date sort and was super buggy / unnecessary in general (still being used on the Homepage view though)