### PR TITLE
Sketch out super basic Rails-y page to show Import records

### DIFF
--- a/app/controllers/import_records_controller.rb
+++ b/app/controllers/import_records_controller.rb
@@ -1,0 +1,16 @@
+class ImportRecordsController < ApplicationController
+  # Authentication by default inherited from ApplicationController.
+
+  before_action :authorize_for_districtwide_access_admin # Extra authentication layer
+
+  def authorize_for_districtwide_access_admin
+    unless current_educator.admin? && current_educator.districtwide_access?
+      render json: { error: "You don't have the correct authorization." }
+    end
+  end
+
+  def index
+    @import_records = ImportRecord.all
+  end
+
+end

--- a/app/models/import_record.rb
+++ b/app/models/import_record.rb
@@ -1,2 +1,11 @@
 class ImportRecord < ActiveRecord::Base
+
+  def completed?
+    record.time_ended.present?
+  end
+
+  def time_to_complete
+    record.time_ended - record.time_started
+  end
+
 end

--- a/app/models/import_record.rb
+++ b/app/models/import_record.rb
@@ -1,11 +1,11 @@
 class ImportRecord < ActiveRecord::Base
 
   def completed?
-    record.time_ended.present?
+    time_ended.present?
   end
 
   def time_to_complete
-    record.time_ended - record.time_started
+    time_ended - time_started
   end
 
 end

--- a/app/views/import_records/index.html.erb
+++ b/app/views/import_records/index.html.erb
@@ -1,0 +1,3 @@
+<% @import_records.all do |record| %>
+  <div>Completed in <%= record.time_ended - record.time_started %>.</div>
+<% end %>

--- a/app/views/import_records/index.html.erb
+++ b/app/views/import_records/index.html.erb
@@ -1,3 +1,7 @@
 <% @import_records.all do |record| %>
-  <div>Completed in <%= record.time_ended - record.time_started %>.</div>
+  <% if record.completed? %>
+    <div>Completed in <%= distance_of_time_in_words(time_to_complete) %>.</div>
+  <% else %>
+    <div>Process did not complete.</div>
+  <% end %>
 <% end %>

--- a/app/views/import_records/index.html.erb
+++ b/app/views/import_records/index.html.erb
@@ -1,6 +1,6 @@
-<% @import_records.all do |record| %>
+<% @import_records.each do |record| %>
   <% if record.completed? %>
-    <div>Completed in <%= distance_of_time_in_words(time_to_complete) %>.</div>
+    <div>Completed in <%= distance_of_time_in_words(record.time_to_complete) %>.</div>
   <% else %>
     <div>Process did not complete.</div>
   <% end %>

--- a/app/views/import_records/index.html.erb
+++ b/app/views/import_records/index.html.erb
@@ -1,7 +1,16 @@
 <% @import_records.each do |record| %>
-  <% if record.completed? %>
-    <div>Completed in <%= distance_of_time_in_words(record.time_to_complete) %>.</div>
-  <% else %>
-    <div>Process did not complete.</div>
-  <% end %>
+  <div style="border: 1px solid #eee; padding: 15px; margin: 15px;">
+    <div style="margin-bottom: 15px; border-bottom: 1px solid #eee; font-size: 18px;">
+      <%= record.created_at.strftime("%m/%d/%Y") %>
+    </div>
+    <% if record.completed? %>
+      <div>
+        Completed in <%= distance_of_time_in_words(record.time_to_complete) %>.
+      </div>
+    <% else %>
+      <div>
+        Process did not complete.
+      </div>
+    <% end %>
+  </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
   resources :event_note_attachments, only: [:destroy]
   resources :service_uploads, only: [:create, :index, :destroy]
   resources :homerooms, only: [:show]
+  resources :import_records, only: [:index]
 
   resources :schools, only: [:show] do
     get :star_reading, on: :member

--- a/spec/controllers/import_records_controller_spec.rb
+++ b/spec/controllers/import_records_controller_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe ImportRecordsController, type: :controller do
+
+  describe '#index' do
+    def make_request
+      request.env['HTTPS'] = 'on'
+      get :index
+    end
+
+    context 'educator signed in' do
+
+      before { sign_in(educator) }
+
+      context 'educator w districtwide access' do
+        let(:educator) { FactoryGirl.create(:educator, districtwide_access: true, admin: true) }
+        it 'can access the page' do
+          make_request
+          expect(response).to be_success
+        end
+      end
+
+      context 'educator w/o districtwide access' do
+        let(:educator) { FactoryGirl.create(:educator) }
+        it 'cannot access the page; gets redirected' do
+          make_request
+          expect(JSON.parse(response.body)).to eq({ "error" => "You don't have the correct authorization." })
+        end
+      end
+    end
+
+    context 'not signed in' do
+      it 'redirects' do
+        make_request
+        expect(response).to redirect_to(new_educator_session_url)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
# Notes 

+ Want to make a nicer interface for debugging/detecting any issues or changes in the nightly data import process
+ Next steps would include adding specific counts for which records were imported (i.e. how many STAR assessments, how many MCAS assessments) ...
+ ... and setting up email or SMS alerts if an error is raised during the import process

# Screenshot (made up data)

![screen shot 2017-05-18 at 10 37 47 am](https://cloud.githubusercontent.com/assets/3209501/26210703/180e8ed4-3bb6-11e7-93e2-71bdee1a5c85.png)
