### PR TITLE
Add student foreign key to attendance and discipline events

### DIFF
--- a/app/importers/rows/attendance_row.rb
+++ b/app/importers/rows/attendance_row.rb
@@ -8,11 +8,13 @@ class AttendanceRow < Struct.new(:row)
   class NullRelation
     class NullEvent
       def save!; end
+      def assign_attributes(_); end
     end
 
     def find_or_initialize_by(_)
       NullEvent.new
     end
+
   end
 
   def self.build(row)
@@ -20,15 +22,15 @@ class AttendanceRow < Struct.new(:row)
   end
 
   def build
-    attendance_event_class.find_or_initialize_by(
+    attendance_event = attendance_event_class.find_or_initialize_by(
       occurred_at: row[:event_date]
     )
 
-    attendance_event_class.assign_attributes(
+    attendance_event.assign_attributes(
       student: student
     )
 
-    attendance_event_class
+    attendance_event
   end
 
   private

--- a/app/importers/rows/attendance_row.rb
+++ b/app/importers/rows/attendance_row.rb
@@ -23,6 +23,12 @@ class AttendanceRow < Struct.new(:row)
     attendance_event_class.find_or_initialize_by(
       occurred_at: row[:event_date]
     )
+
+    attendance_event_class.assign_attributes(
+      student: student
+    )
+
+    attendance_event_class
   end
 
   private

--- a/app/importers/rows/behavior_row.rb
+++ b/app/importers/rows/behavior_row.rb
@@ -1,6 +1,6 @@
 class BehaviorRow < Struct.new(:row)
   # Represents a row in a CSV export from Somerville's Aspen X2 student information system.
-  # 
+  #
   # Expects the following headers:
   #
   #  :state_id, :local_id, :incident_code, :event_date, :incident_time,
@@ -20,6 +20,7 @@ class BehaviorRow < Struct.new(:row)
       has_exact_time: has_exact_time?,
       incident_location: row[:incident_location],
       incident_description: row[:incident_description],
+      student: student
     )
 
     discipline_incident

--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -1,4 +1,7 @@
 class Absence < ActiveRecord::Base
+  belongs_to :student
   belongs_to :student_school_year
-  validates_presence_of :student_school_year, :occurred_at
+  validates_presence_of :student,
+                        :student_school_year,
+                        :occurred_at
 end

--- a/app/models/discipline_incident.rb
+++ b/app/models/discipline_incident.rb
@@ -1,4 +1,7 @@
 class DisciplineIncident < ActiveRecord::Base
+  belongs_to :student
   belongs_to :student_school_year
-  validates_presence_of :student_school_year, :occurred_at
+  validates_presence_of :student,
+                        :student_school_year,
+                        :occurred_at
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -14,6 +14,10 @@ class Student < ActiveRecord::Base
   has_many :interventions, dependent: :destroy
   has_many :event_notes, dependent: :destroy
   has_many :services, dependent: :destroy
+  has_many :tardies, dependent: :destroy
+  has_many :absences, dependent: :destroy
+  has_many :discipline_incidents, dependent: :destroy
+
   has_one :student_risk_level, dependent: :destroy
 
   validates_presence_of :local_id

--- a/app/models/tardy.rb
+++ b/app/models/tardy.rb
@@ -1,4 +1,7 @@
 class Tardy < ActiveRecord::Base
+  belongs_to :student
   belongs_to :student_school_year
-  validates_presence_of :student_school_year, :occurred_at
+  validates_presence_of :student,
+                        :student_school_year,
+                        :occurred_at
 end

--- a/db/migrate/20170602060046_add_references_from_events_to_students.rb
+++ b/db/migrate/20170602060046_add_references_from_events_to_students.rb
@@ -1,0 +1,7 @@
+class AddReferencesFromEventsToStudents < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :absences, :student, index: true, foreign_key: true
+    add_reference :tardies, :student, index: true, foreign_key: true
+    add_reference :discipline_incidents, :student, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170327145319) do
+ActiveRecord::Schema.define(version: 20170602060046) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 20170327145319) do
     t.datetime "occurred_at",            null: false
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
+    t.integer  "student_id"
+    t.index ["student_id"], name: "index_absences_on_student_id", using: :btree
     t.index ["student_school_year_id"], name: "index_absences_on_student_school_year_id", using: :btree
   end
 
@@ -67,6 +69,8 @@ ActiveRecord::Schema.define(version: 20170327145319) do
     t.datetime "occurred_at",            null: false
     t.boolean  "has_exact_time"
     t.integer  "student_school_year_id", null: false
+    t.integer  "student_id"
+    t.index ["student_id"], name: "index_discipline_incidents_on_student_id", using: :btree
     t.index ["student_school_year_id"], name: "index_discipline_incidents_on_student_school_year_id", using: :btree
   end
 
@@ -334,7 +338,12 @@ ActiveRecord::Schema.define(version: 20170327145319) do
     t.datetime "occurred_at",            null: false
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
+    t.integer  "student_id"
+    t.index ["student_id"], name: "index_tardies_on_student_id", using: :btree
     t.index ["student_school_year_id"], name: "index_tardies_on_student_school_year_id", using: :btree
   end
 
+  add_foreign_key "absences", "students"
+  add_foreign_key "discipline_incidents", "students"
+  add_foreign_key "tardies", "students"
 end

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -90,7 +90,7 @@ class Import
           FileImport.new(file_importer).import
         end
       rescue => error
-        ImportErrorMailer.error_report(error).deliver_now
+        ImportErrorMailer.error_report(error).deliver_now if Rails.env.production?
         raise error
       end
     end
@@ -102,7 +102,7 @@ class Import
         Student.update_recent_student_assessments
         Homeroom.destroy_empty_homerooms
       rescue => error
-        ImportErrorMailer.error_report(error).deliver_now
+        ImportErrorMailer.error_report(error).deliver_now if Rails.env.production?
         raise error
       end
     end

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -105,6 +105,7 @@ describe StudentsController, :type => :controller do
             FactoryGirl.create(
               :discipline_incident,
               student_school_year: student.student_school_years.first,
+              student: student,
               occurred_at: Time.now - 1.day
             )
           }
@@ -113,6 +114,7 @@ describe StudentsController, :type => :controller do
             FactoryGirl.create(
               :discipline_incident,
               student_school_year: most_recent_school_year,
+              student: student,
               occurred_at: Time.now - 2.days
             )
           }
@@ -553,7 +555,11 @@ describe StudentsController, :type => :controller do
           current_student_school_year = student.student_school_years.find_or_create_by(school_year: current_school_year)
 
           # Add an absence in the current school year
-          current_absence = FactoryGirl.create(:absence, student_school_year: current_student_school_year)
+          current_absence = FactoryGirl.create(
+            :absence,
+            student_school_year: current_student_school_year,
+            student: student
+          )
 
           expect(assigns(:student_school_years)).not_to include(old_student_school_year)
           expect(assigns(:student_school_years)).to include(current_student_school_year)

--- a/spec/models/absence_spec.rb
+++ b/spec/models/absence_spec.rb
@@ -8,8 +8,13 @@ RSpec.describe Absence, type: :model do
     )
   }
 
-
-  subject(:absence) { Absence.create!(student_school_year: student_school_year, occurred_at: Time.now) }
+  subject(:absence) {
+    Absence.create!(
+      student_school_year: student_school_year,
+      occurred_at: Time.now,
+      student: student
+    )
+  }
 
   it { is_expected.to belong_to :student_school_year }
   it { is_expected.to validate_presence_of :student_school_year }

--- a/spec/models/discipline_incident_spec.rb
+++ b/spec/models/discipline_incident_spec.rb
@@ -8,7 +8,13 @@ RSpec.describe DisciplineIncident do
     )
   }
 
-  subject(:incident) { DisciplineIncident.create!(student_school_year: student_school_year, occurred_at: Time.now) }
+  subject(:incident) {
+    DisciplineIncident.create!(
+      student_school_year: student_school_year,
+      occurred_at: Time.now,
+      student: student
+    )
+  }
 
   it { is_expected.to belong_to :student_school_year }
   it { is_expected.to validate_presence_of :student_school_year }

--- a/spec/models/tardy_spec.rb
+++ b/spec/models/tardy_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe Tardy do
   }
 
   subject(:tardy) {
-    Tardy.create!(student_school_year: student_school_year, occurred_at: Time.now)
+    Tardy.create!(
+      student_school_year: student_school_year,
+      occurred_at: Time.now,
+      student: student
+    )
   }
 
   it { is_expected.to belong_to :student_school_year }


### PR DESCRIPTION
# What does this do?

+ Associate attendance and discipline events directly onto the students table so that we can eventually drop the student school years table

# Issue 

+ #611 