### PR TITLE
Write methods that calculate event totals by school year...

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -51,6 +51,26 @@ class Student < ActiveRecord::Base
     enrollment_status == 'Active'
   end
 
+  ## ABSENCES / TARDIES ##
+
+  def most_recent_school_year_discipline_incidents_count
+    discipline_incidents.where(
+      'occurred_at > ?', start_of_this_school_year
+    ).count
+  end
+
+  def most_recent_school_year_absences_count
+    absences.where(
+      'occurred_at > ?', start_of_this_school_year
+    ).count
+  end
+
+  def most_recent_school_year_tardies_count
+    tardies.where(
+      'occurred_at > ?', start_of_this_school_year
+    ).count
+  end
+
   ## STUDENT ASSESSMENT RESULTS ##
 
   def latest_result_by_family_and_subject(family_name, subject_name)
@@ -284,5 +304,23 @@ class Student < ActiveRecord::Base
       "warning-bubble sped-risk-bubble tooltip"
     end
   end
+
+  private
+
+    def this_year
+      DateTime.now.year
+    end
+
+    def august_of_this_year
+      DateTime.new(this_year, 8, 1)
+    end
+
+    def start_of_this_school_year
+      if august_of_this_year > DateTime.now
+        DateTime.new(this_year - 1, 8, 1)
+      else
+        august_of_this_year
+      end
+    end
 
 end

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -23,6 +23,79 @@ RSpec.describe Student do
     end
   end
 
+  describe '#most_recent_school_year_absences_count' do
+    let(:student) { FactoryGirl.create(:student) }
+    let(:school_year) { FactoryGirl.create(:school_year) }
+    let(:student_school_year) {
+      StudentSchoolYear.create(student: student, school_year: school_year)
+    }
+
+    context 'no absences ever' do
+
+      it 'returns zero' do
+        expect(student.most_recent_school_year_absences_count).to eq(0)
+      end
+    end
+
+    context 'no absences this school year, one last year' do
+      let!(:absence) {
+        FactoryGirl.create(:absence,
+          student: student,
+          student_school_year: student_school_year,
+          occurred_at: DateTime.new(2016, 9, 1)
+        )
+      }
+
+      it 'returns zero' do
+        Timecop.freeze(DateTime.new(2017, 9, 1)) do
+          expect(student.most_recent_school_year_absences_count).to eq(0)
+        end
+      end
+    end
+
+    context 'two absences this school year (first half of year)' do
+      before do
+        FactoryGirl.create(:absence,
+          student: student,
+          student_school_year: student_school_year,
+          occurred_at: DateTime.new(2017, 9, 1)
+        )
+        FactoryGirl.create(:absence,
+          student: student,
+          student_school_year: student_school_year,
+          occurred_at: DateTime.new(2017, 9, 2)
+        )
+      end
+
+      it 'returns two' do
+        Timecop.freeze(DateTime.new(2018, 6, 1)) do
+          expect(student.most_recent_school_year_absences_count).to eq(2)
+        end
+      end
+    end
+
+    context 'two absences this school year (second half of year)' do
+      before do
+        FactoryGirl.create(:absence,
+          student: student,
+          student_school_year: student_school_year,
+          occurred_at: DateTime.new(2018, 5, 1)
+        )
+        FactoryGirl.create(:absence,
+          student: student,
+          student_school_year: student_school_year,
+          occurred_at: DateTime.new(2018, 5, 2)
+        )
+      end
+
+      it 'returns two' do
+        Timecop.freeze(DateTime.new(2018, 6, 1)) do
+          expect(student.most_recent_school_year_absences_count).to eq(2)
+        end
+      end
+    end
+  end
+
   describe '#latest_result_by_family_and_subject' do
     let(:student) { FactoryGirl.create(:student) }
     let(:assessment_family) { "MCAS" }


### PR DESCRIPTION
+ ... without leaning on the unnecessary StudentSchoolYear model.

# What does this PR do?

+ This PR adds methods and tests them but doesn't implement them yet; I want to run these manually against production data in the Rails console to make sure they give the same numbers as the existing methods that thread through `student_school_year`.

# Issue

+ #611