### PR TITLE
Remove association between attendance/discipline events and student school year

### DIFF
--- a/app/charts/student_profile_chart.rb
+++ b/app/charts/student_profile_chart.rb
@@ -63,9 +63,6 @@ class StudentProfileChart < Struct.new :student
       star_reading_results: student.star_reading_results,
       mcas_mathematics_results: student.mcas_mathematics_results,
       mcas_ela_results: student.mcas_ela_results,
-      absences_count_by_school_year: student.student_school_years.map {|year| year.absences.length },
-      tardies_count_by_school_year: student.student_school_years.map {|year| year.tardies.length },
-      discipline_incidents_by_school_year: student.student_school_years.map {|year| year.discipline_incidents.length },
       school_year_names: student.student_school_years.pluck(:name),
       interventions: student.interventions
     }

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -177,7 +177,7 @@ class StudentsController < ApplicationController
     @services = @student.services.includes(:discontinued_services).where("date_started <= ? AND (discontinued_services.recorded_at >= ? OR discontinued_services.recorded_at IS NULL)", @filter_to_date, @filter_from_date).order('date_started, discontinued_services.recorded_at').references(:discontinued_services)
 
     # Load student school years for the filtered dates
-    @student_school_years = @student.events_by_student_school_years
+    @student_school_years = @student.events_by_student_school_years(@filter_from_date, @filter_to_date)
 
     # Sort the discipline incidents by occurrance date
     @discipline_incidents = @student.discipline_incidents.sort_by(&:occurred_at).select do |hash|

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -37,7 +37,11 @@ class StudentsController < ApplicationController
       event_note_types_index: event_note_types_index,
       educators_index: Educator.to_index,
       access: student.latest_access_results,
-      attendance_data: student_profile_attendance_data(student.student_school_years)
+      attendance_data: {
+        discipline_incidents: student.discipline_incidents.order(occurred_at: :desc),
+        tardies: student.tardies.order(occurred_at: :desc),
+        absences: student.absences.order(occurred_at: :desc)
+      }
     }
   end
 
@@ -111,22 +115,6 @@ class StudentsController < ApplicationController
   end
 
   private
-
-  def student_profile_attendance_data(student_school_years)
-    return {
-      discipline_incidents: flatmap_and_sort(student_school_years) {|year| year.discipline_incidents },
-      tardies: flatmap_and_sort(student_school_years) {|year| year.tardies },
-      absences: flatmap_and_sort(student_school_years) {|year| year.absences }
-    }
-  end
-
-  # Takes a list of student_school_years, yields each one to the block provided, then flattens
-  # and sorts the results.
-  def flatmap_and_sort(student_school_years)
-    student_school_years.map do |student_school_year|
-      yield student_school_year
-    end.flatten.sort_by(&:occurred_at).reverse
-  end
 
   def serialize_student_for_profile(student)
     student.as_json.merge({

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -176,16 +176,8 @@ class StudentsController < ApplicationController
     # Load services for the student for the filtered dates
     @services = @student.services.includes(:discontinued_services).where("date_started <= ? AND (discontinued_services.recorded_at >= ? OR discontinued_services.recorded_at IS NULL)", @filter_to_date, @filter_from_date).order('date_started, discontinued_services.recorded_at').references(:discontinued_services)
 
-    # Load for absences, tardies, and discipline incidents for the filtered dates
+    # Load student school years for the filtered dates
     @student_school_years = @student.events_by_student_school_years
-
-    @absences = @student.absences.sort_by(&:occurred_at).select do |hash|
-      hash[:occurred_at] >= @filter_from_date && hash[:occurred_at] <= @filter_to_date
-    end
-
-    @tardies = @student.tardies.sort_by(&:occurred_at).select do |hash|
-      hash[:occurred_at] >= @filter_from_date && hash[:occurred_at] <= @filter_to_date
-    end
 
     # Sort the discipline incidents by occurrance date
     @discipline_incidents = @student.discipline_incidents.sort_by(&:occurred_at).select do |hash|

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -179,6 +179,14 @@ class StudentsController < ApplicationController
     # Load for absences, tardies, and discipline incidents for the filtered dates
     @student_school_years = @student.events_by_student_school_years
 
+    @absences = @student.absences.sort_by(&:occurred_at).select do |hash|
+      hash[:occurred_at] >= @filter_from_date && hash[:occurred_at] <= @filter_to_date
+    end
+
+    @tardies = @student.tardies.sort_by(&:occurred_at).select do |hash|
+      hash[:occurred_at] >= @filter_from_date && hash[:occurred_at] <= @filter_to_date
+    end
+
     # Sort the discipline incidents by occurrance date
     @discipline_incidents = @student.discipline_incidents.sort_by(&:occurred_at).select do |hash|
       hash[:occurred_at] >= @filter_from_date && hash[:occurred_at] <= @filter_to_date

--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -36,6 +36,8 @@ class FakeStudent
     "Disney", "Duck", "Kenobi", "Mouse", "Pan", "Poppins", "Skywalker", "White"
   ]
 
+  FIVE_YEARS_OF_SECONDS = 157766400
+
   def base_data
     {
       school: @school,
@@ -171,19 +173,12 @@ class FakeStudent
 
     events_for_year = DemoDataUtil.sample_from_distribution(d)
     events_for_year.times do
-      # Randomly determine the school year it occurred.
-      year = [0, 1, 2, 3, 4, 5].sample
-      date_begin = Time.local(2010 + year, 8, 1)
-      date_end = Time.local(2011 + year, 7, 31)
+      # Randomly determine when it occurred.
+      occurred_at = Time.at(DateTime.now.to_i - (rand * FIVE_YEARS_OF_SECONDS))
 
       attendance_event = [Absence.new, Tardy.new].sample
-      attendance_event.student_school_year = @student.student_school_years.first
-
-      # Make sure event isn't listed as having happened in the future.
-      occurred_at = Time.at(date_begin + rand * (date_end.to_f - date_begin.to_f))
-      if occurred_at < Time.new then
-        attendance_event.occurred_at = occurred_at
-      end
+      attendance_event.occurred_at = occurred_at
+      attendance_event.student = student
 
       attendance_event.save
     end
@@ -200,19 +195,15 @@ class FakeStudent
 
     events_for_year = DemoDataUtil.sample_from_distribution(d)
     events_for_year.times do
-      # Randomly determine the school year it occurred.
-      n = [0, 1, 2, 3, 4, 5].sample
-      date_begin = Time.local(2010 + n, 8, 1)
-      date_end = Time.local(2011 + n, 7, 31)
+      # Randomly determine when it occurred.
+      occurred_at = Time.at(DateTime.now.to_i - (rand * FIVE_YEARS_OF_SECONDS))
 
-      discipline_incident = DisciplineIncident.new(FakeDisciplineIncident.data)
-      discipline_incident.student_school_year = @student.student_school_years.first
-
-      # Make sure event isn't listed as having happened in the future.
-      occurred_at = Time.at(date_begin + rand * (date_end.to_f - date_begin.to_f))
-      if occurred_at < Time.new then
-        discipline_incident.occurred_at = occurred_at
-      end
+      discipline_incident = DisciplineIncident.new(
+        FakeDisciplineIncident.data.merge({
+          occurred_at: occurred_at,
+          student: student
+        })
+      )
 
       discipline_incident.save
     end

--- a/app/importers/rows/attendance_row.rb
+++ b/app/importers/rows/attendance_row.rb
@@ -14,7 +14,6 @@ class AttendanceRow < Struct.new(:row)
     def find_or_initialize_by(_)
       NullEvent.new
     end
-
   end
 
   def self.build(row)
@@ -26,18 +25,14 @@ class AttendanceRow < Struct.new(:row)
       occurred_at: row[:event_date]
     )
 
-    attendance_event.assign_attributes(
-      student: student
-    )
-
-    attendance_event
+    return attendance_event
   end
 
   private
 
   def attendance_event_class
-    return student_school_year.absences if row[:absence].to_i == 1
-    return student_school_year.tardies if row[:tardy].to_i == 1
+    return student.absences if row[:absence].to_i == 1
+    return student.tardies if row[:tardy].to_i == 1
     NullRelation.new
   end
 
@@ -45,11 +40,4 @@ class AttendanceRow < Struct.new(:row)
     Student.find_by_local_id!(row[:local_id])
   end
 
-  def school_year
-    DateToSchoolYear.new(row[:event_date]).convert
-  end
-
-  def student_school_year
-    student.student_school_years.find_or_create_by(school_year: school_year)
-  end
 end

--- a/app/importers/rows/behavior_row.rb
+++ b/app/importers/rows/behavior_row.rb
@@ -11,7 +11,7 @@ class BehaviorRow < Struct.new(:row)
   end
 
   def build
-    discipline_incident = student_school_year.discipline_incidents.find_or_initialize_by(
+    discipline_incident = student.discipline_incidents.find_or_initialize_by(
       occurred_at: occurred_at,
       incident_code: row[:incident_code]
     )
@@ -20,7 +20,6 @@ class BehaviorRow < Struct.new(:row)
       has_exact_time: has_exact_time?,
       incident_location: row[:incident_location],
       incident_description: row[:incident_description],
-      student: student
     )
 
     discipline_incident
@@ -43,14 +42,6 @@ class BehaviorRow < Struct.new(:row)
   end
 
   def student
-    Student.find_by_local_id! row[:local_id]
-  end
-
-  def school_year
-    DateToSchoolYear.new(occurred_at).convert
-  end
-
-  def student_school_year
-    student.student_school_years.find_or_create_by(school_year: school_year)
+    Student.find_by_local_id!(row[:local_id])
   end
 end

--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -1,7 +1,4 @@
 class Absence < ActiveRecord::Base
   belongs_to :student
-  belongs_to :student_school_year
-  validates_presence_of :student,
-                        :student_school_year,
-                        :occurred_at
+  validates_presence_of :student, :occurred_at
 end

--- a/app/models/discipline_incident.rb
+++ b/app/models/discipline_incident.rb
@@ -1,7 +1,4 @@
 class DisciplineIncident < ActiveRecord::Base
   belongs_to :student
-  belongs_to :student_school_year
-  validates_presence_of :student,
-                        :student_school_year,
-                        :occurred_at
+  validates_presence_of :student, :occurred_at
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -71,8 +71,10 @@ class Student < ActiveRecord::Base
     ).count
   end
 
-  def events_by_student_school_years
-    StudentSchoolYearSorter.new(student: self).sort
+  def events_by_student_school_years(filter_to_date, filter_from_date)
+    sorter = StudentSchoolYearSorter.new(student: self)
+
+    sorter.sort_and_filter(filter_to_date, filter_from_date)
   end
 
   ## STUDENT ASSESSMENT RESULTS ##

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -71,26 +71,8 @@ class Student < ActiveRecord::Base
     ).count
   end
 
-  def events
-    [
-      discipline_incidents,
-      absences,
-      tardies,
-    ].flatten
-  end
-
   def events_by_student_school_years
-    events.inject({}) do |memo, event|
-      school_year_name = find_school_year_name(event)
-
-      if memo[school_year_name]
-        memo[school_year_name] << event
-      else
-        memo[school_year_name] = [event]
-      end
-
-      memo
-    end
+    StudentSchoolYearSorter.new(student: self).sort
   end
 
   ## STUDENT ASSESSMENT RESULTS ##
@@ -342,18 +324,6 @@ class Student < ActiveRecord::Base
         DateTime.new(this_year - 1, 8, 1)
       else
         august_of_this_year
-      end
-    end
-
-    def find_school_year_name(event)
-      occurred_at = event.occurred_at
-      month = occurred_at.month
-      year = occurred_at.year
-
-      if month >= 8
-        "#{year}-#{year + 1}"
-      elsif month >= 1 && month <= 7
-        "#{year - 1}-#{year}"
       end
     end
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -71,6 +71,28 @@ class Student < ActiveRecord::Base
     ).count
   end
 
+  def events
+    [
+      discipline_incidents,
+      absences,
+      tardies,
+    ].flatten
+  end
+
+  def events_by_student_school_years
+    events.inject({}) do |memo, event|
+      school_year_name = find_school_year_name(event)
+
+      if memo[school_year_name]
+        memo[school_year_name] << event
+      else
+        memo[school_year_name] = [event]
+      end
+
+      memo
+    end
+  end
+
   ## STUDENT ASSESSMENT RESULTS ##
 
   def latest_result_by_family_and_subject(family_name, subject_name)
@@ -320,6 +342,18 @@ class Student < ActiveRecord::Base
         DateTime.new(this_year - 1, 8, 1)
       else
         august_of_this_year
+      end
+    end
+
+    def find_school_year_name(event)
+      occurred_at = event.occurred_at
+      month = occurred_at.month
+      year = occurred_at.year
+
+      if month >= 8
+        "#{year}-#{year + 1}"
+      elsif month >= 1 && month <= 7
+        "#{year - 1}-#{year}"
       end
     end
 

--- a/app/models/student_school_year_events.rb
+++ b/app/models/student_school_year_events.rb
@@ -1,0 +1,34 @@
+class StudentSchoolYearEvents
+
+  def initialize(name:, events:)
+    @name = name
+    @events = events
+  end
+
+  def name
+    @name
+  end
+
+  def add_event(event)
+    @events << event
+  end
+
+  def absences
+    @events.select  { |e| e.class == Absence }
+           .sort_by { |e| e.occurred_at }
+           .reverse
+  end
+
+  def tardies
+    @events.select { |e| e.class == Tardy }
+           .sort_by { |e| e.occurred_at }
+           .reverse
+  end
+
+  def discipline_incidents
+    @events.select  { |e| e.class == DisciplineIncident }
+           .sort_by { |e| e.occurred_at }
+           .reverse
+  end
+
+end

--- a/app/models/student_school_year_events.rb
+++ b/app/models/student_school_year_events.rb
@@ -19,8 +19,20 @@ class StudentSchoolYearEvents
            .reverse
   end
 
+  def filtered_absences(filter_from, filter_to)
+    @events.select  { |e| e.class == Absence && e.occurred_at > filter_from && e.occurred_at < filter_to }
+           .sort_by { |e| e.occurred_at }
+           .reverse
+  end
+
   def tardies
     @events.select { |e| e.class == Tardy }
+           .sort_by { |e| e.occurred_at }
+           .reverse
+  end
+
+  def filtered_tardies(filter_from, filter_to)
+    @events.select { |e| e.class == Tardy && e.occurred_at > filter_from && e.occurred_at < filter_to }
            .sort_by { |e| e.occurred_at }
            .reverse
   end

--- a/app/models/student_school_year_sorter.rb
+++ b/app/models/student_school_year_sorter.rb
@@ -18,7 +18,7 @@ class StudentSchoolYearSorter
         )
       end
 
-      memo
+      memo.sort_by { |student_school_year| student_school_year.name }.reverse
     end
   end
 

--- a/app/models/student_school_year_sorter.rb
+++ b/app/models/student_school_year_sorter.rb
@@ -5,8 +5,10 @@ class StudentSchoolYearSorter
   end
 
   def sort
-    events.inject([]) do |memo, event|
-      school_year_name = find_school_year_name(event)
+    @sorted_school_years ||= events.inject([]) do |memo, event|
+      occurred_at = event.occurred_at
+
+      school_year_name = find_school_year_name(occurred_at.month, occurred_at.year)
 
       school_year_events = memo.detect { |sy| sy.name == school_year_name }
 
@@ -22,6 +24,17 @@ class StudentSchoolYearSorter
     end
   end
 
+  def sort_and_filter(filter_to_date, filter_from_date)
+    first_included_school_year_name = find_school_year_name(filter_to_date.month, filter_to_date.year)
+    last_included_school_year_name = find_school_year_name(filter_from_date.month, filter_from_date.year)
+
+    sort.select do |school_year|
+      # '2014-2015'.to_i => 2014
+      school_year.name.to_i >= first_included_school_year_name.to_i &&
+        school_year.name.to_i <= last_included_school_year_name.to_i
+    end
+  end
+
   private
 
     def events
@@ -32,11 +45,7 @@ class StudentSchoolYearSorter
       ].flatten
     end
 
-    def find_school_year_name(event)
-      occurred_at = event.occurred_at
-      month = occurred_at.month
-      year = occurred_at.year
-
+    def find_school_year_name(month, year)
       if month >= 8
         "#{year}-#{year + 1}"
       elsif month >= 1 && month <= 7

--- a/app/models/student_school_year_sorter.rb
+++ b/app/models/student_school_year_sorter.rb
@@ -1,0 +1,47 @@
+class StudentSchoolYearSorter
+
+  def initialize(student:)
+    @student = student
+  end
+
+  def sort
+    events.inject([]) do |memo, event|
+      school_year_name = find_school_year_name(event)
+
+      school_year_events = memo.detect { |sy| sy.name == school_year_name }
+
+      if school_year_events
+        school_year_events.add_event(event)
+      else
+        memo << StudentSchoolYearEvents.new(
+          name: school_year_name, events: [event]
+        )
+      end
+
+      memo
+    end
+  end
+
+  private
+
+    def events
+      [
+        @student.discipline_incidents,
+        @student.absences,
+        @student.tardies,
+      ].flatten
+    end
+
+    def find_school_year_name(event)
+      occurred_at = event.occurred_at
+      month = occurred_at.month
+      year = occurred_at.year
+
+      if month >= 8
+        "#{year}-#{year + 1}"
+      elsif month >= 1 && month <= 7
+        "#{year - 1}-#{year}"
+      end
+    end
+
+end

--- a/app/models/tardy.rb
+++ b/app/models/tardy.rb
@@ -1,7 +1,4 @@
 class Tardy < ActiveRecord::Base
   belongs_to :student
-  belongs_to :student_school_year
-  validates_presence_of :student,
-                        :student_school_year,
-                        :occurred_at
+  validates_presence_of :student, :occurred_at
 end

--- a/app/reports/students_spreadsheet.rb
+++ b/app/reports/students_spreadsheet.rb
@@ -34,9 +34,9 @@ class StudentsSpreadsheet
 
     additional_student_fields = {
       student_risk_level: student.student_risk_level.level,
-      discipline_incidents_count: student.most_recent_school_year.discipline_incidents.count,
-      absences_count: student.most_recent_school_year.absences.count,
-      tardies_count: student.most_recent_school_year.tardies.count,
+      discipline_incidents_count: student.most_recent_school_year_discipline_incidents_count,
+      absences_count: student.most_recent_school_year_absences_count,
+      tardies_count: student.most_recent_school_year_tardies_count,
       homeroom_name: student.try(:homeroom).try(:name)
     }
 

--- a/app/views/students/student_report.pdf.erb
+++ b/app/views/students/student_report.pdf.erb
@@ -22,7 +22,7 @@ ul, li {
 
 
 <div style="width: 768px;">
- 
+
 <!-- Demographic Information -->
 <div style="float: left; width: 512px;">
   <div>
@@ -89,7 +89,7 @@ ul, li {
     <% @services.each do |service| %>
       <div style="float: left; width:370px; padding:5px">
         <ul>
-          <li><span style="font-weight:bold;"><%= format_date(service.date_started) %> - 
+          <li><span style="font-weight:bold;"><%= format_date(service.date_started) %> -
             <% if service.discontinued_services.count > 0%>
               <%= "#{format_date(service.discontinued_services.last.try(:recorded_at))}" %>
             <% else %>
@@ -113,7 +113,7 @@ ul, li {
 <br style="clear: left;" /><br/>
 <% end %>
 
- 
+
 <% if @sections.include?("attendance") %>
 <p>
   <h4>Attendance record:</h4>
@@ -125,7 +125,7 @@ ul, li {
     </tr>
     <% @student_school_years.each do |year| %>
       <tr>
-        <td><%= year.name %></td>
+        <td><%= name %></td>
         <td>
           <ul>
           <% year.absences.where('occurred_at BETWEEN ? AND ?', @filter_from_date, @filter_to_date).order(:occurred_at).each do |absence| %>

--- a/app/views/students/student_report.pdf.erb
+++ b/app/views/students/student_report.pdf.erb
@@ -128,14 +128,14 @@ ul, li {
         <td><%= year.name %></td>
         <td>
           <ul>
-          <% @absences.each do |absence| %>
+          <% year.absences.each do |absence| %>
             <li><%= format_date(absence.occurred_at) %></li>
           <% end %>
           </ul>
         </td>
         <td>
           <ul>
-          <% @tardies.each do |tardy| %>
+          <% year.tardies.each do |tardy| %>
             <li><%= format_date(tardy.occurred_at) %></li>
           <% end %>
           </ul>

--- a/app/views/students/student_report.pdf.erb
+++ b/app/views/students/student_report.pdf.erb
@@ -128,14 +128,14 @@ ul, li {
         <td><%= year.name %></td>
         <td>
           <ul>
-          <% year.absences.each do |absence| %>
+          <% year.filtered_absences(@filter_from_date, @filter_to_date).each do |absence| %>
             <li><%= format_date(absence.occurred_at) %></li>
           <% end %>
           </ul>
         </td>
         <td>
           <ul>
-          <% year.tardies.each do |tardy| %>
+          <% year.filtered_tardies(@filter_from_date, @filter_to_date).each do |tardy| %>
             <li><%= format_date(tardy.occurred_at) %></li>
           <% end %>
           </ul>

--- a/app/views/students/student_report.pdf.erb
+++ b/app/views/students/student_report.pdf.erb
@@ -125,17 +125,17 @@ ul, li {
     </tr>
     <% @student_school_years.each do |year| %>
       <tr>
-        <td><%= name %></td>
+        <td><%= year.name %></td>
         <td>
           <ul>
-          <% year.absences.where('occurred_at BETWEEN ? AND ?', @filter_from_date, @filter_to_date).order(:occurred_at).each do |absence| %>
+          <% @absences.each do |absence| %>
             <li><%= format_date(absence.occurred_at) %></li>
           <% end %>
           </ul>
         </td>
         <td>
           <ul>
-          <% year.tardies.where('occurred_at BETWEEN ? AND ?', @filter_from_date, @filter_to_date).order(:occurred_at).each do |tardy| %>
+          <% @tardies.each do |tardy| %>
             <li><%= format_date(tardy.occurred_at) %></li>
           <% end %>
           </ul>

--- a/db/migrate/20170613224011_remove_association_between_events_and_student_school_year.rb
+++ b/db/migrate/20170613224011_remove_association_between_events_and_student_school_year.rb
@@ -1,0 +1,9 @@
+class RemoveAssociationBetweenEventsAndStudentSchoolYear < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :absences, :student_school_year_id
+
+    remove_column :tardies, :student_school_year_id
+
+    remove_column :discipline_incidents, :student_school_year_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,19 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170602060046) do
+ActiveRecord::Schema.define(version: 20170613224011) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "absences", force: :cascade do |t|
-    t.integer  "student_school_year_id", null: false
-    t.datetime "occurred_at",            null: false
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "occurred_at", null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
     t.integer  "student_id"
     t.index ["student_id"], name: "index_absences_on_student_id", using: :btree
-    t.index ["student_school_year_id"], name: "index_absences_on_student_school_year_id", using: :btree
   end
 
   create_table "assessment_families", force: :cascade do |t|
@@ -62,16 +60,14 @@ ActiveRecord::Schema.define(version: 20170602060046) do
 
   create_table "discipline_incidents", force: :cascade do |t|
     t.string   "incident_code"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
     t.string   "incident_location"
     t.text     "incident_description"
-    t.datetime "occurred_at",            null: false
+    t.datetime "occurred_at",          null: false
     t.boolean  "has_exact_time"
-    t.integer  "student_school_year_id", null: false
     t.integer  "student_id"
     t.index ["student_id"], name: "index_discipline_incidents_on_student_id", using: :btree
-    t.index ["student_school_year_id"], name: "index_discipline_incidents_on_student_school_year_id", using: :btree
   end
 
   create_table "discontinued_services", force: :cascade do |t|
@@ -334,13 +330,11 @@ ActiveRecord::Schema.define(version: 20170602060046) do
   end
 
   create_table "tardies", force: :cascade do |t|
-    t.integer  "student_school_year_id", null: false
-    t.datetime "occurred_at",            null: false
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "occurred_at", null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
     t.integer  "student_id"
     t.index ["student_id"], name: "index_tardies_on_student_id", using: :btree
-    t.index ["student_school_year_id"], name: "index_tardies_on_student_school_year_id", using: :btree
   end
 
   add_foreign_key "absences", "students"

--- a/spec/importers/file_importers/attendance_importer_spec.rb
+++ b/spec/importers/file_importers/attendance_importer_spec.rb
@@ -7,17 +7,20 @@ RSpec.describe AttendanceImporter do
   describe '#import_row' do
 
     context 'one row for one student on one date' do
-
-      let(:student) { FactoryGirl.create(:student, local_id: '1') }
+      let!(:student) { FactoryGirl.create(:student, local_id: '1') }
       let(:date) { DateTime.parse('2005-09-16') }
-      let(:school_year) { DateToSchoolYear.new(date).convert }
-      let!(:student_school_year) { StudentSchoolYear.create(student: student, school_year: school_year) }
 
       context 'row with absence' do
-        let(:row) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
+        let(:row) {
+          { event_date: date, local_id: '1', absence: '1', tardy: '0' }
+        }
 
         it 'creates an absence' do
-          expect { described_class.new.import_row(row) }.to change { Absence.count }.by 1
+          expect {
+            described_class.new.import_row(row)
+          }.to change {
+            Absence.count
+          }.by 1
         end
 
         it 'creates only 1 absence if run twice' do
@@ -30,28 +33,26 @@ RSpec.describe AttendanceImporter do
         it 'increments the student school year absences by 1' do
           expect {
             described_class.new.import_row(row)
-          }.to change { StudentSchoolYear.last.absences.size }.by 1
+          }.to change {
+            student.reload.absences.size
+          }.by 1
         end
 
         it 'does not increment the student school year tardies' do
           expect {
             described_class.new.import_row(row)
-          }.to change { StudentSchoolYear.last.tardies.size }.by 0
+          }.to change {
+            student.tardies.size
+          }.by 0
         end
       end
     end
 
     context 'multiple rows for different students on the same date' do
 
-      let(:edwin) { FactoryGirl.create(:student, local_id: '1', first_name: 'Edwin') }
-      let(:kristen) { FactoryGirl.create(:student, local_id: '2', first_name: 'Kristen') }
+      let!(:edwin) { FactoryGirl.create(:student, local_id: '1', first_name: 'Edwin') }
+      let!(:kristen) { FactoryGirl.create(:student, local_id: '2', first_name: 'Kristen') }
       let(:date) { DateTime.parse('2005-09-16') }
-      let(:school_year) { DateToSchoolYear.new(date).convert }
-
-      before do
-        StudentSchoolYear.create(student: edwin, school_year: school_year)
-        StudentSchoolYear.create(student: kristen, school_year: school_year)
-      end
 
       let(:row_for_edwin) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
       let(:row_for_kristen) { { event_date: date, local_id: '2', absence: '1', tardy: '0' } }
@@ -66,10 +67,8 @@ RSpec.describe AttendanceImporter do
     end
 
     context 'multiple rows for same student on same date' do
-      let(:student) { FactoryGirl.create(:student, local_id: '1') }
+      let!(:student) { FactoryGirl.create(:student, local_id: '1') }
       let(:date) { DateTime.parse('2005-09-16') }
-      let(:school_year) { DateToSchoolYear.new(date).convert }
-      let!(:student_school_year) { StudentSchoolYear.create(student: student, school_year: school_year) }
 
       let(:first_row) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
       let(:second_row) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
@@ -84,11 +83,8 @@ RSpec.describe AttendanceImporter do
     end
 
     context 'multiple rows for same student on different dates' do
-      let(:student) { FactoryGirl.create(:student, local_id: '1') }
+      let!(:student) { FactoryGirl.create(:student, local_id: '1') }
       let(:date) { DateTime.parse('2005-09-16') }
-      let(:school_year) { DateToSchoolYear.new(date).convert }
-      let!(:student_school_year) { StudentSchoolYear.create(student: student, school_year: school_year) }
-
       let(:first_row) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
       let(:second_row) { { event_date: date + 1.day, local_id: '1', absence: '1', tardy: '0' } }
       let(:third_row) { { event_date: date + 2.days, local_id: '1', absence: '1', tardy: '0' } }

--- a/spec/importers/file_importers/behavior_importer_spec.rb
+++ b/spec/importers/file_importers/behavior_importer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BehaviorImporter do
   describe '#import_row' do
     let(:importer) { described_class.new }
     before { importer.import_row(row) }
-    let(:incidents) { student.reload.most_recent_school_year.discipline_incidents }
+    let(:incidents) { student.discipline_incidents }
     let(:incident) { incidents.last }
 
     context 'typical row' do

--- a/spec/importers/rows/attendance_row_spec.rb
+++ b/spec/importers/rows/attendance_row_spec.rb
@@ -44,10 +44,5 @@ RSpec.describe AttendanceRow do
         expect { row.build.save! }.not_to change(Tardy, :count)
       end
     end
-
-    it 'creates the appropriate school year' do
-      expect { row.build }.to change(SchoolYear, :count).by(1)
-      expect(SchoolYear.last.name).to eq('1981-1982')
-    end
   end
 end

--- a/spec/importers/rows/behavior_row_spec.rb
+++ b/spec/importers/rows/behavior_row_spec.rb
@@ -17,10 +17,5 @@ RSpec.describe BehaviorRow do
     it 'records a discipline incident' do
       expect { row.build.save! }.to change(DisciplineIncident, :count).by(1)
     end
-
-    it 'creates the appropriate school year' do
-      expect { row.build }.to change(SchoolYear, :count).by(1)
-      expect(SchoolYear.last.name).to eq('1981-1982')
-    end
   end
 end

--- a/spec/models/absence_spec.rb
+++ b/spec/models/absence_spec.rb
@@ -2,21 +2,15 @@ require 'rails_helper'
 
 RSpec.describe Absence, type: :model do
   let!(:student) { FactoryGirl.create(:student) }
-  let!(:student_school_year) {
-    student.student_school_years.first || StudentSchoolYear.create!(
-      student: student, school_year: SchoolYear.first_or_create!
-    )
-  }
 
   subject(:absence) {
     Absence.create!(
-      student_school_year: student_school_year,
       occurred_at: Time.now,
       student: student
     )
   }
 
-  it { is_expected.to belong_to :student_school_year }
-  it { is_expected.to validate_presence_of :student_school_year }
+  it { is_expected.to belong_to :student }
+  it { is_expected.to validate_presence_of :student }
   it { is_expected.to validate_presence_of :occurred_at }
 end

--- a/spec/models/discipline_incident_spec.rb
+++ b/spec/models/discipline_incident_spec.rb
@@ -2,21 +2,15 @@ require 'rails_helper'
 
 RSpec.describe DisciplineIncident do
   let!(:student) { FactoryGirl.create(:student) }
-  let!(:student_school_year) {
-    student.student_school_years.first || StudentSchoolYear.create!(
-      student: student, school_year: SchoolYear.first_or_create!
-    )
-  }
 
   subject(:incident) {
     DisciplineIncident.create!(
-      student_school_year: student_school_year,
       occurred_at: Time.now,
       student: student
     )
   }
 
-  it { is_expected.to belong_to :student_school_year }
-  it { is_expected.to validate_presence_of :student_school_year }
+  it { is_expected.to belong_to :student }
+  it { is_expected.to validate_presence_of :student }
   it { is_expected.to validate_presence_of :occurred_at }
 end

--- a/spec/models/student_school_year_events_spec.rb
+++ b/spec/models/student_school_year_events_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe StudentSchoolYearEvents, type: :model do
+  let(:student) { FactoryGirl.create(:student) }
+
+  let(:events) {
+    [
+      Absence.create!(student: student, occurred_at: DateTime.new(2016, 8, 15)),
+      Absence.create!(student: student, occurred_at: DateTime.new(2016, 8, 20)),
+      Absence.create!(student: student, occurred_at: DateTime.new(2016, 8, 25)),
+    ]
+  }
+
+  subject {
+    StudentSchoolYearEvents.new(name: '2016-2017', events: events)
+  }
+
+  describe '#filtered_absences' do
+    let(:filter_from_date) { DateTime.new(2016, 8, 1) }
+    let(:filter_to_date) { DateTime.new(2016, 8, 22) }
+    let(:filtered) {
+      subject.filtered_absences(filter_from_date, filter_to_date)
+    }
+
+    it 'filters absences correctly' do
+      expect(filtered.count).to eq 2
+    end
+
+  end
+
+end

--- a/spec/models/student_school_year_events_spec.rb
+++ b/spec/models/student_school_year_events_spec.rb
@@ -18,12 +18,14 @@ RSpec.describe StudentSchoolYearEvents, type: :model do
   describe '#filtered_absences' do
     let(:filter_from_date) { DateTime.new(2016, 8, 1) }
     let(:filter_to_date) { DateTime.new(2016, 8, 22) }
+
     let(:filtered) {
       subject.filtered_absences(filter_from_date, filter_to_date)
     }
 
     it 'filters absences correctly' do
       expect(filtered.count).to eq 2
+      expect(filtered.map { |f| f.occurred_at.day }).to eq [20, 15]
     end
 
   end

--- a/spec/models/student_school_year_sorter_spec.rb
+++ b/spec/models/student_school_year_sorter_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe StudentSchoolYearSorter, type: :model do
+
+  describe "#sort" do
+    let(:student) { FactoryGirl.create(:student) }
+
+    before do
+      Absence.create!(student: student, occurred_at: DateTime.new(2016, 6, 1))
+
+      Tardy.create!(student: student, occurred_at: DateTime.new(2016, 6, 2))
+      Tardy.create!(student: student, occurred_at: DateTime.new(2016, 6, 3))
+
+      Absence.create!(student: student, occurred_at: DateTime.new(2016, 8, 15))
+      Absence.create!(student: student, occurred_at: DateTime.new(2016, 8, 20))
+      Absence.create!(student: student, occurred_at: DateTime.new(2016, 8, 25))
+
+      Tardy.create!(student: student, occurred_at: DateTime.new(2016, 9, 15))
+      Tardy.create!(student: student, occurred_at: DateTime.new(2016, 9, 20))
+    end
+
+    let(:sort) {
+      described_class.new(student: student).sort
+    }
+
+    it "sorts into two student school years" do
+      expect(sort.count).to eq 2
+    end
+
+    it "gets the name right" do
+      expect(sort.first.name).to eq "2016-2017"
+      expect(sort.second.name).to eq "2015-2016"
+    end
+
+    it "puts the right events into the first (most recent) school year" do
+      absences = sort.first.absences
+      expect(absences.count).to eq 3
+      expect(absences.map { |a| a.occurred_at.day }).to eq([25, 20, 15])
+
+      tardies = sort.first.tardies
+      expect(tardies.count).to eq 2
+      expect(tardies.map { |a| a.occurred_at.day }).to eq([20, 15])
+    end
+
+    it "puts the right events into the second (less recent) school year" do
+      expect(sort.second.absences.count).to eq 1
+      expect(sort.second.tardies.count).to eq 2
+    end
+
+  end
+
+end

--- a/spec/models/student_school_year_spec.rb
+++ b/spec/models/student_school_year_spec.rb
@@ -1,9 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe StudentSchoolYear do
-  it { is_expected.to have_many(:absences) }
-  it { is_expected.to have_many(:tardies) }
-  it { is_expected.to have_many(:discipline_incidents) }
-  it { is_expected.to have_many(:interventions) }
-  it { is_expected.to have_many(:student_assessments) }
-end

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -25,10 +25,6 @@ RSpec.describe Student do
 
   describe '#most_recent_school_year_absences_count' do
     let(:student) { FactoryGirl.create(:student) }
-    let(:school_year) { FactoryGirl.create(:school_year) }
-    let(:student_school_year) {
-      StudentSchoolYear.create(student: student, school_year: school_year)
-    }
 
     context 'no absences ever' do
 
@@ -41,7 +37,6 @@ RSpec.describe Student do
       let!(:absence) {
         FactoryGirl.create(:absence,
           student: student,
-          student_school_year: student_school_year,
           occurred_at: DateTime.new(2016, 9, 1)
         )
       }
@@ -57,12 +52,10 @@ RSpec.describe Student do
       before do
         FactoryGirl.create(:absence,
           student: student,
-          student_school_year: student_school_year,
           occurred_at: DateTime.new(2017, 9, 1)
         )
         FactoryGirl.create(:absence,
           student: student,
-          student_school_year: student_school_year,
           occurred_at: DateTime.new(2017, 9, 2)
         )
       end
@@ -78,12 +71,10 @@ RSpec.describe Student do
       before do
         FactoryGirl.create(:absence,
           student: student,
-          student_school_year: student_school_year,
           occurred_at: DateTime.new(2018, 5, 1)
         )
         FactoryGirl.create(:absence,
           student: student,
-          student_school_year: student_school_year,
           occurred_at: DateTime.new(2018, 5, 2)
         )
       end

--- a/spec/models/tardy_spec.rb
+++ b/spec/models/tardy_spec.rb
@@ -2,21 +2,15 @@ require 'rails_helper'
 
 RSpec.describe Tardy do
   let!(:student) { FactoryGirl.create(:student) }
-  let!(:student_school_year) {
-    student.student_school_years.first || StudentSchoolYear.create!(
-      student: student, school_year: SchoolYear.first_or_create!
-    )
-  }
 
   subject(:tardy) {
     Tardy.create!(
-      student_school_year: student_school_year,
       occurred_at: Time.now,
       student: student
     )
   }
 
-  it { is_expected.to belong_to :student_school_year }
-  it { is_expected.to validate_presence_of :student_school_year }
+  it { is_expected.to belong_to :student }
+  it { is_expected.to validate_presence_of :student }
   it { is_expected.to validate_presence_of :occurred_at }
 end


### PR DESCRIPTION
# What does this do?

+ Change the data model so that `Absence`, `Tardy`, and `DisciplineIncident` all have a foreign key relationship directly to `Student` and not to `StudentSchoolYear`

# Issue 

+ Takes us one step closer to #611 