### PR TITLE
Remove association between student assessments and school years

### DIFF
--- a/app/models/student_assessment.rb
+++ b/app/models/student_assessment.rb
@@ -1,10 +1,6 @@
 class StudentAssessment < ActiveRecord::Base
   belongs_to :assessment
   belongs_to :student
-  belongs_to :school_year
-  belongs_to :student_school_year
-  before_save :assign_to_school_year
-  after_create :assign_to_student_school_year
   delegate :family, :subject, to: :assessment
   delegate :grade, to: :student
   validates_presence_of :date_taken, :student, :assessment
@@ -41,17 +37,6 @@ class StudentAssessment < ActiveRecord::Base
     percentile_rank.nil? &&
     scale_score.nil? &&
     growth_percentile.nil?
-  end
-
-  def assign_to_school_year
-    self.school_year = DateToSchoolYear.new(date_taken).convert
-  end
-
-  def assign_to_student_school_year
-    self.student_school_year = StudentSchoolYear.where({
-      student_id: student.id, school_year_id: school_year.id
-    }).first_or_create!
-    save
   end
 
   def self.order_by_date_taken_desc

--- a/db/migrate/20170616185340_remove_assoc_between_student_assessments_and_school_years.rb
+++ b/db/migrate/20170616185340_remove_assoc_between_student_assessments_and_school_years.rb
@@ -1,0 +1,6 @@
+class RemoveAssocBetweenStudentAssessmentsAndSchoolYears < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :student_assessments, :school_year_id
+    remove_column :student_assessments, :student_school_year_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170613224011) do
+ActiveRecord::Schema.define(version: 20170616185340) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -261,11 +261,8 @@ ActiveRecord::Schema.define(version: 20170613224011) do
     t.datetime "updated_at"
     t.integer  "percentile_rank"
     t.decimal  "instructional_reading_level"
-    t.integer  "school_year_id"
     t.integer  "assessment_id"
-    t.integer  "student_school_year_id"
     t.string   "grade_equivalent"
-    t.index ["school_year_id"], name: "index_student_assessments_on_school_year_id", using: :btree
     t.index ["student_id"], name: "index_student_assessments_on_student_id", using: :btree
   end
 

--- a/spec/models/student_assessment_spec.rb
+++ b/spec/models/student_assessment_spec.rb
@@ -81,20 +81,6 @@ RSpec.describe StudentAssessment, type: :model do
     end
   end
 
-  describe '#assign_to_school_year' do
-    context 'has date taken' do
-      let(:student_assessment) { FactoryGirl.create(:student_assessment) }
-      it 'assigns the school year correctly' do
-        expect(student_assessment.school_year).to eq(SchoolYear.find_by_name("2014-2015"))
-      end
-    end
-    context 'does not have date taken' do
-      let(:student_assessment) { FactoryGirl.build(:student_assessment, date_taken: nil) }
-      it 'is invalid' do
-        expect(student_assessment).not_to be_valid
-      end
-    end
-  end
   describe '#risk_level' do
     context 'does not belong to an assessment family' do
       let(:student_assessment) { FactoryGirl.create(:student_assessment) }


### PR DESCRIPTION
# Issue

+ #611 

# QA

+ Tests pass and looks good in production! Looks like all features that call student assessments do so directly through `date_taken` and not `student_school_year`, so the school year association was very useless.