### PR TITLE
Add database records for IEP documents (no actual file storing yet)

### DIFF
--- a/app/assets/javascripts/student_profile/page_container.jsx
+++ b/app/assets/javascripts/student_profile/page_container.jsx
@@ -46,6 +46,7 @@
         attendanceData: serializedData.attendanceData,
         access: serializedData.access,
         dibels: serializedData.dibels,
+        iepDocuments: serializedData.iepDocuments,
 
         // ui
         selectedColumnKey: queryParams.column || 'interventions',
@@ -234,6 +235,7 @@
               'dibels',
               'attendanceData',
               'selectedColumnKey',
+              'iepDocuments',
               'requests'
             ), {
               nowMomentFn: this.props.nowMomentFn,

--- a/app/assets/javascripts/student_profile/profile_details.jsx
+++ b/app/assets/javascripts/student_profile/profile_details.jsx
@@ -16,6 +16,7 @@
       access: React.PropTypes.object,
       dibels: React.PropTypes.array,
       chartData: React.PropTypes.object,
+      iepDocuments: React.PropTypes.array,
       attendanceData: React.PropTypes.object,
       serviceTypesIndex: React.PropTypes.object
     },
@@ -182,13 +183,10 @@
     render: function(){
       return (
         <div>
-          <div>
-            <div style={{float: 'left', display: 'flex', width: '50%'}}>
-              {this.renderAccessDetails()}
-            </div>
-            <div style={{display: 'flex', width: '50%'}}>
-              {this.renderStudentReportFilters()}
-            </div>
+          <div style={{display: 'flex'}}>
+            {this.renderAccessDetails()}
+            {this.renderStudentReportFilters()}
+            {this.renderIepDocuments()}
           </div>
           <div style={{clear: 'both'}}>
             {this.renderFullCaseHistory()}
@@ -215,7 +213,7 @@
       });
 
       return (
-        <div style={styles.column}>
+        <div style={_.merge(styles.column, {display: 'flex', flex: 1})}>
           <h4 style={styles.title}>
             ACCESS
           </h4>
@@ -251,9 +249,28 @@
       );
     },
 
+    renderIepDocuments: function () {
+      const numberOfDocuments = this.props.iepDocuments.length;
+
+      if (numberOfDocuments === 0) return null;
+
+      return (
+        <div style={_.merge(styles.column, {display: 'flex', flex: 1})}>
+          <h4 style={styles.title}>IEPs</h4>
+          <p style={{fontSize: 15}}>
+            This student has {numberOfDocuments} IEP documents.
+          </p>
+          <br/>
+          <p style={{fontSize: 15}}>
+            PDFs of the documents will be available in Insights soon.
+          </p>
+        </div>
+      );
+    },
+
     renderStudentReportFilters: function () {
       return (
-        <div style={styles.column}>
+        <div style={_.merge(styles.column, {display: 'flex', flex: 1})}>
           <h4 style={styles.title}>Student Report</h4>
           <span style={styles.tableHeader}>Select sections to include in report:</span>
           <div>

--- a/app/assets/javascripts/student_profile/student_profile_page.jsx
+++ b/app/assets/javascripts/student_profile/student_profile_page.jsx
@@ -138,6 +138,7 @@
       }),
 
       access: React.PropTypes.object,
+      iepDocuments: React.PropTypes.object,
 
       // flux-y bits
       requests: PropTypes.requests,

--- a/app/assets/javascripts/student_profile/student_profile_page.jsx
+++ b/app/assets/javascripts/student_profile/student_profile_page.jsx
@@ -138,7 +138,7 @@
       }),
 
       access: React.PropTypes.object,
-      iepDocuments: React.PropTypes.object,
+      iepDocuments: React.PropTypes.array,
 
       // flux-y bits
       requests: PropTypes.requests,
@@ -246,6 +246,7 @@
             access={this.props.access}
             dibels={this.props.dibels}
             chartData={this.props.chartData}
+            iepDocuments={this.props.iepDocuments}
             attendanceData={this.props.attendanceData}
             serviceTypesIndex={this.props.serviceTypesIndex} />
       );

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -37,6 +37,7 @@ class StudentsController < ApplicationController
       event_note_types_index: event_note_types_index,
       educators_index: Educator.to_index,
       access: student.latest_access_results,
+      iep_documents: student.iep_documents,
       attendance_data: {
         discipline_incidents: student.discipline_incidents.order(occurred_at: :desc),
         tardies: student.tardies.order(occurred_at: :desc),

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -1,0 +1,126 @@
+require 'zip'
+require 'tempfile'
+
+
+class IepPdfImportJob
+  def initialize(options = {})
+    @time_now = options[:time_now] || Time.now
+  end
+
+  # This imports all the IEP PDFs from a zip that
+  # contains several older documents (ie., for a first-time import).
+  # 
+  # It will fail on any errors, log to the console and won't retry.
+  def bulk_import!
+    remote_filename = 'student-documents_old.zip'
+    
+    # pull down the file to heroku dyno
+    zip_file = download(remote_filename)
+    log "got a zip: #{zip_file.path}"
+
+    log 'making a folder for the unzipped files...'
+    date_zip_folder = Rails.root.join('tmp/iep_pdfs/date_zips')
+    FileUtils.mkdir_p(date_zip_folder)
+
+    log 'unzipping date bundles...'
+    date_zip_filenames = unzip_to_folder(zip_file, date_zip_folder)
+
+    log "got #{date_zip_filenames.size} date zips!"
+    filename_pairs = []
+    date_zip_filenames.each do |date_zip_filename|
+      log "making a folder for #{date_zip_filename}..."
+      folder = File.join(date_zip_folder, date_zip_filename)
+      FileUtils.mkdir_p(folder)
+      date_zip = File.open(date_zip_filename)
+
+      log "  unzipping..."
+      pdf_filenames = unzip_to_folder(date_zip, folder)
+      pdf_filenames.each do |pdf_filename|
+        filename_pairs << {
+          pdf_filename: pdf_filename,
+          date_zip_filename: date_zip_filename
+        }
+      end
+      log "  creating pairs..."
+    end
+
+    log "got #{filename_pairs.size} filename_pairs!"
+    log filename_pairs.inspect
+
+    # translate to records
+    # extract: (date, student lasid, student name)
+    # split on the 0321321_whatever.pdf to get the lasid
+    records = []
+    filename_pairs.map do |pair| 
+      # parse pdf filename
+      log '    parsing pdf...'
+      pdf_filename = pair[:pdf_filename]
+      pdf_basename = Pathname.new(pdf_filename).basename.sub_ext('').to_s
+      local_id, iep_at_a_glance, *student_names = pdf_basename.split('_')
+      if iep_at_a_glance != 'IEPAtAGlance'
+        log 'oh no!'
+        raise 'oh no!'
+      end
+
+      # parse date filename
+      log '    parsing date...'
+      date_zip_filename = pair[:date_zip_filename]
+      date_zip_basename = Pathname.new(date_zip_filename).basename.sub_ext('').to_s
+      date = Date.strptime(date_zip_basename, '%m-%d-%Y')
+      records << {
+        local_id: local_id,
+        pdf_filename: pdf_filename,
+        date: date.to_s
+      }
+    end
+
+    log records.to_json
+
+    # TODO
+    # write to blob store and db
+    #     put the file in blob store key: (date, local_id, filename)
+    #     write a record into postgres (date, local_id, filename)
+
+    # delete all files
+  end
+
+
+
+  def nightly_import!
+    # TODO
+  end
+
+  private
+  def log(str)
+    puts str
+  end
+
+  def download(remote_filename)
+    local_file = Tempfile.new('iep_pdf_zip')
+    # TODO(kr) for shortcutting
+    # local_filename = File.join('tmp/', remote_filename)
+    # return File.open(local_filename, 'r')
+
+    local_file = File.open(local_filename, 'w')
+    log "local zip file: #{local_file.path}"
+    client = SftpClient.for_x2
+    log "have a client!"
+    client.sftp_session.download!(remote_filename, local_file.path)
+    log "downloaded"
+    local_file
+  end
+
+  def unzip_to_folder(zip_file, target_folder)
+    output_filenames = []
+    Zip::File.open(zip_file) do |files_in_zip|
+      files_in_zip.each do |file_in_zip|
+        log "Extracting #{file_in_zip.name}..."
+        output_filename = File.join(target_folder, file_in_zip.name)
+        log output_filename
+        files_in_zip.extract(file_in_zip, output_filename)
+        output_filenames << output_filename
+      end
+    end
+    output_filenames
+  end
+end

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -25,12 +25,10 @@ class IepPdfImportJob
     log "got #{date_zip_filenames.size} date zips!"
     filename_pairs = []
     date_zip_filenames.each do |date_zip_filename|
-      log "making a folder for #{date_zip_filename}..."
       folder = File.join(date_zip_filename + '.unzipped')
       FileUtils.mkdir_p(folder)
       date_zip = File.open(date_zip_filename)
 
-      log "  unzipping..."
       pdf_filenames = unzip_to_folder(date_zip, folder)
       pdf_filenames.each do |pdf_filename|
         filename_pairs << {
@@ -38,7 +36,6 @@ class IepPdfImportJob
           date_zip_filename: date_zip_filename
         }
       end
-      log "  creating pairs..."
     end
 
     # translate to records
@@ -65,11 +62,11 @@ class IepPdfImportJob
     end
 
     records.map do |record|
-      log "storing iep for student ##{record[:local_id]} to db..."
-
       student = Student.find_by_local_id(record[:local_id])
 
-      return unless student
+      log "student not in db! ##{record[:local_id]}" && return unless student
+
+      log "storing iep for student ##{record[:local_id]} to db..."
 
       IepDocument.create!(
         file_date: record[:date],
@@ -109,9 +106,7 @@ class IepPdfImportJob
     output_filenames = []
     Zip::File.open(zip_file) do |files_in_zip|
       files_in_zip.each do |file_in_zip|
-        log "Extracting #{file_in_zip.name}..."
         output_filename = File.join(target_folder, file_in_zip.name)
-        log output_filename
         files_in_zip.extract(file_in_zip, output_filename)
         output_filenames << output_filename
       end

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -27,7 +27,7 @@ class IepPdfImportJob
     filename_pairs = []
     date_zip_filenames.each do |date_zip_filename|
       log "making a folder for #{date_zip_filename}..."
-      folder = File.join(date_zip_folder, date_zip_filename)
+      folder = File.join(date_zip_filename + '.unzipped')
       FileUtils.mkdir_p(folder)
       date_zip = File.open(date_zip_filename)
 

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -41,9 +41,6 @@ class IepPdfImportJob
       log "  creating pairs..."
     end
 
-    log "got #{filename_pairs.size} filename_pairs!"
-    log filename_pairs.inspect
-
     # translate to records
     # extract: (date, student lasid, student name)
     # split on the 0321321_whatever.pdf to get the lasid

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -82,9 +82,8 @@ class IepPdfImportJob
     end
 
     # TODO
-    # write to blob store and db
+    # write to blob store
     #     put the file in blob store key: (date, local_id, filename)
-    #     write a record into postgres (date, local_id, filename)
 
     delete_folder_for_zipped_files
   end

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -1,5 +1,6 @@
 require 'zip'
 require 'tempfile'
+require 'fileutils'
 
 class IepPdfImportJob
   def initialize(options = {})
@@ -37,6 +38,8 @@ class IepPdfImportJob
           date_zip_filename: date_zip_filename
         }
       end
+
+      date_zip.close
     end
 
     # translate to records
@@ -83,7 +86,7 @@ class IepPdfImportJob
     #     put the file in blob store key: (date, local_id, filename)
     #     write a record into postgres (date, local_id, filename)
 
-    # delete all files
+    delete_folder_for_zipped_files
   end
 
   def nightly_import!
@@ -123,6 +126,12 @@ class IepPdfImportJob
       FileUtils.mkdir_p(date_zip_folder)
 
       return date_zip_folder
+    end
+
+    def delete_folder_for_zipped_files
+      date_zip_folder = Rails.root.join('tmp/iep_pdfs')
+
+      FileUtils.rm_rf(date_zip_folder)
     end
 
 end

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -95,17 +95,12 @@ class IepPdfImportJob
 
   def download(remote_filename)
     local_file = Tempfile.new('iep_pdf_zip')
-    # TODO(kr) for shortcutting
-    # local_filename = File.join('tmp/', remote_filename)
-    # return File.open(local_filename, 'r')
-
-    local_file = File.open(local_filename, 'w')
-    log "local zip file: #{local_file.path}"
     client = SftpClient.for_x2
     log "have a client!"
     client.sftp_session.download!(remote_filename, local_file.path)
-    log "downloaded"
-    local_file
+    log "downloaded a file!"
+
+    return local_file
   end
 
   def unzip_to_folder(zip_file, target_folder)

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -7,15 +7,16 @@ class IepPdfImportJob
     @time_now = options[:time_now] || Time.now
   end
 
+  REMOTE_FILENAME = 'student-documents_old.zip'
+
   # This imports all the IEP PDFs from a zip that
   # contains several older documents (ie., for a first-time import).
   #
   # It will fail on any errors, log to the console and won't retry.
   def bulk_import!
-    remote_filename = 'student-documents_old.zip'
 
     # pull down the file to heroku dyno
-    zip_file = download(remote_filename)
+    zip_file = download(REMOTE_FILENAME)
     log "got a zip: #{zip_file.path}"
 
     log 'making a folder for the unzipped files...'

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -13,7 +13,6 @@ class IepPdfImportJob
   #
   # It will fail on any errors, log to the console and won't retry.
   def bulk_import!
-
     # pull down the file to heroku dyno
     zip_file = download(REMOTE_FILENAME)
     log "got a zip: #{zip_file.path}"
@@ -72,7 +71,15 @@ class IepPdfImportJob
       }
     end
 
-    log records.to_json
+    records.map do |record|
+      student = Student.find_by_local_id!(record[:local_id])
+
+      IepDocument.create!(
+        file_date: record[:date],
+        file_name: record[:pdf_filename],
+        student: student
+      )
+    end
 
     # TODO
     # write to blob store and db

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -49,8 +49,6 @@ class IepPdfImportJob
     # split on the 0321321_whatever.pdf to get the lasid
     records = []
     filename_pairs.map do |pair|
-      # parse pdf filename
-      log '    parsing pdf...'
       pdf_filename = pair[:pdf_filename]
       pdf_basename = Pathname.new(pdf_filename).basename.sub_ext('').to_s
       local_id, iep_at_a_glance, *student_names = pdf_basename.split('_')
@@ -59,8 +57,6 @@ class IepPdfImportJob
         raise 'oh no!'
       end
 
-      # parse date filename
-      log '    parsing date...'
       date_zip_filename = pair[:date_zip_filename]
       date_zip_basename = Pathname.new(date_zip_filename).basename.sub_ext('').to_s
       date = Date.strptime(date_zip_basename, '%m-%d-%Y')

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -91,33 +91,32 @@ class IepPdfImportJob
   end
 
   private
-  def log(str)
-    puts str
-  end
 
-  def download(remote_filename)
-    local_file = Tempfile.new('iep_pdf_zip')
-    client = SftpClient.for_x2
-    log "have a client!"
-    client.sftp_session.download!(remote_filename, local_file.path)
-    log "downloaded a file!"
-
-    return local_file
-  end
-
-  def unzip_to_folder(zip_file, target_folder)
-    output_filenames = []
-    Zip::File.open(zip_file) do |files_in_zip|
-      files_in_zip.each do |file_in_zip|
-        output_filename = File.join(target_folder, file_in_zip.name)
-        files_in_zip.extract(file_in_zip, output_filename)
-        output_filenames << output_filename
-      end
+    def log(str)
+      puts str
     end
-    output_filenames
-  end
 
-  private
+    def download(remote_filename)
+      local_file = Tempfile.new('iep_pdf_zip')
+      client = SftpClient.for_x2
+      log "have a client!"
+      client.sftp_session.download!(remote_filename, local_file.path)
+      log "downloaded a file!"
+
+      return local_file
+    end
+
+    def unzip_to_folder(zip_file, target_folder)
+      output_filenames = []
+      Zip::File.open(zip_file) do |files_in_zip|
+        files_in_zip.each do |file_in_zip|
+          output_filename = File.join(target_folder, file_in_zip.name)
+          files_in_zip.extract(file_in_zip, output_filename)
+          output_filenames << output_filename
+        end
+      end
+      output_filenames
+    end
 
     def make_folder_for_zipped_files
       date_zip_folder = Rails.root.join('tmp/iep_pdfs/date_zips')

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -1,7 +1,6 @@
 require 'zip'
 require 'tempfile'
 
-
 class IepPdfImportJob
   def initialize(options = {})
     @time_now = options[:time_now] || Time.now
@@ -84,8 +83,6 @@ class IepPdfImportJob
 
     # delete all files
   end
-
-
 
   def nightly_import!
     # TODO

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -72,6 +72,8 @@ class IepPdfImportJob
     end
 
     records.map do |record|
+      log "storing iep for student ##{record[:local_id]} to db..."
+
       student = Student.find_by_local_id!(record[:local_id])
 
       IepDocument.create!(

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -64,15 +64,17 @@ class IepPdfImportJob
     records.map do |record|
       student = Student.find_by_local_id(record[:local_id])
 
-      log "student not in db! ##{record[:local_id]}" && return unless student
+      if student
+        log "storing iep for student ##{record[:local_id]} to db..."
 
-      log "storing iep for student ##{record[:local_id]} to db..."
-
-      IepDocument.create!(
-        file_date: record[:date],
-        file_name: record[:pdf_filename],
-        student: student
-      )
+        IepDocument.create!(
+          file_date: record[:date],
+          file_name: record[:pdf_filename],
+          student: student
+        )
+      else
+        log "student not in db! ##{record[:local_id]}"
+      end
     end
 
     # TODO

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -18,9 +18,7 @@ class IepPdfImportJob
     zip_file = download(REMOTE_FILENAME)
     log "got a zip: #{zip_file.path}"
 
-    log 'making a folder for the unzipped files...'
-    date_zip_folder = Rails.root.join('tmp/iep_pdfs/date_zips')
-    FileUtils.mkdir_p(date_zip_folder)
+    date_zip_folder = make_folder_for_zipped_files
 
     log 'unzipping date bundles...'
     date_zip_filenames = unzip_to_folder(zip_file, date_zip_folder)
@@ -116,4 +114,14 @@ class IepPdfImportJob
     end
     output_filenames
   end
+
+  private
+
+    def make_folder_for_zipped_files
+      date_zip_folder = Rails.root.join('tmp/iep_pdfs/date_zips')
+      FileUtils.mkdir_p(date_zip_folder)
+
+      return date_zip_folder
+    end
+
 end

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -70,7 +70,9 @@ class IepPdfImportJob
     records.map do |record|
       log "storing iep for student ##{record[:local_id]} to db..."
 
-      student = Student.find_by_local_id!(record[:local_id])
+      student = Student.find_by_local_id(record[:local_id])
+
+      return unless student
 
       IepDocument.create!(
         file_date: record[:date],

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -9,11 +9,11 @@ class IepPdfImportJob
 
   # This imports all the IEP PDFs from a zip that
   # contains several older documents (ie., for a first-time import).
-  # 
+  #
   # It will fail on any errors, log to the console and won't retry.
   def bulk_import!
     remote_filename = 'student-documents_old.zip'
-    
+
     # pull down the file to heroku dyno
     zip_file = download(remote_filename)
     log "got a zip: #{zip_file.path}"
@@ -51,7 +51,7 @@ class IepPdfImportJob
     # extract: (date, student lasid, student name)
     # split on the 0321321_whatever.pdf to get the lasid
     records = []
-    filename_pairs.map do |pair| 
+    filename_pairs.map do |pair|
       # parse pdf filename
       log '    parsing pdf...'
       pdf_filename = pair[:pdf_filename]

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -30,9 +30,10 @@ class IepPdfImportJob
       date_zip = File.open(date_zip_filename)
 
       pdf_filenames = unzip_to_folder(date_zip, folder)
+
       pdf_filenames.each do |pdf_filename|
         filename_pairs << {
-          pdf_filename: pdf_filename,
+          pdf_filename: pdf_filename.split("/").last,
           date_zip_filename: date_zip_filename
         }
       end

--- a/app/models/iep_document.rb
+++ b/app/models/iep_document.rb
@@ -1,2 +1,3 @@
 class IepDocument < ActiveRecord::Base
+  belongs_to :student
 end

--- a/app/models/iep_document.rb
+++ b/app/models/iep_document.rb
@@ -1,0 +1,2 @@
+class IepDocument < ActiveRecord::Base
+end

--- a/app/models/iep_document.rb
+++ b/app/models/iep_document.rb
@@ -1,4 +1,4 @@
 class IepDocument < ActiveRecord::Base
   belongs_to :student
-  validates :file_name, uniqueness: true
+  validates :file_name, uniqueness: { scope: :file_date, message: "one unique file name per date" }
 end

--- a/app/models/iep_document.rb
+++ b/app/models/iep_document.rb
@@ -1,3 +1,4 @@
 class IepDocument < ActiveRecord::Base
   belongs_to :student
+  validates :file_name, uniqueness: true
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -16,6 +16,7 @@ class Student < ActiveRecord::Base
   has_many :tardies, dependent: :destroy
   has_many :absences, dependent: :destroy
   has_many :discipline_incidents, dependent: :destroy
+  has_many :iep_documents, dependent: :destroy
 
   has_one :student_risk_level, dependent: :destroy
 

--- a/db/migrate/20170712184651_create_iep_documents.rb
+++ b/db/migrate/20170712184651_create_iep_documents.rb
@@ -1,0 +1,11 @@
+class CreateIepDocuments < ActiveRecord::Migration[5.0]
+  def change
+    create_table :iep_documents do |t|
+      t.datetime :file_date
+      t.string :file_name
+      t.references :student
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170618234256) do
+ActiveRecord::Schema.define(version: 20170712184651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -167,6 +167,15 @@ ActiveRecord::Schema.define(version: 20170618234256) do
     t.integer  "school_id"
     t.index ["educator_id"], name: "index_homerooms_on_educator_id", using: :btree
     t.index ["slug"], name: "index_homerooms_on_slug", unique: true, using: :btree
+  end
+
+  create_table "iep_documents", force: :cascade do |t|
+    t.datetime "file_date"
+    t.string   "file_name"
+    t.integer  "student_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["student_id"], name: "index_iep_documents_on_student_id", using: :btree
   end
 
   create_table "import_records", force: :cascade do |t|

--- a/lib/tasks/iep_pdfs.rake
+++ b/lib/tasks/iep_pdfs.rake
@@ -1,0 +1,10 @@
+desc 'IEP PDF import'
+namespace :iep_pdfs do
+  task bulk_import: :environment do
+    IepPdfImportJob.new.bulk_import!
+  end
+
+  task nightly_import: :environment do
+    IepPdfImportJob.new.nightly_import!
+  end
+end

--- a/spec/javascripts/student_profile/profile_details_spec.jsx
+++ b/spec/javascripts/student_profile/profile_details_spec.jsx
@@ -22,6 +22,7 @@ describe('ProfileDetails', function() {
           star_series_reading_percentile: [[2016, 1, 18, 83]],
           star_series_math_percentile: [[2012, 11, 18, 43]],
         },
+        iepDocuments: [],
         feed: {
           deprecated: {
             interventions: [{id: 997, start_date_timestamp: "2010-10-1"}],


### PR DESCRIPTION
This is still in progress, just pushing early steps that @alexsoble and I tested manually.

**UPDATE:**

### What's ready in this PR

+ Merge in import process that creates database rows with name, date, and student reference for each IEP (but not the actual PDF itself)
+ Display IEP document count in student profile when IEPs are present with a "coming soon" notice, like this:

![screen shot 2017-07-13 at 4 38 08 pm](https://user-images.githubusercontent.com/3209501/28189824-58343d70-67ed-11e7-93ce-4891d405d8f5.png)

### What's going in the next PR

+ Actually importing IEP PDFs into the blob storage (AWS or Microsoft's version)
+ Allowing educators with access to display or download the PDFs