### PR TITLE
Import High School Students

### DIFF
--- a/app/controllers/educators_controller.rb
+++ b/app/controllers/educators_controller.rb
@@ -8,7 +8,7 @@ class EducatorsController < ApplicationController
   end
 
   def districtwide_admin_homepage
-    @elementary_schools = School.where(school_type: ['ES', 'ESMS'])
+    @schools = School.where(school_type: ['ES', 'ESMS', 'HS'])
   end
 
   def names_for_dropdown

--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -19,24 +19,6 @@ class StudentsImporter < Struct.new :school_scope, :client, :log, :progress_bar
   def import_row(row)
     student = StudentRow.new(row, school_ids_dictionary).build
 
-    if student.grade.in? ['9', '10', '11', '12', 'SP']
-      handle_high_school_student(student)
-    else
-      handle_elementary_student(student, row)
-    end
-  end
-
-  def handle_high_school_student(student)
-    return if student.new_record?  # We don't want to import HS students into the db
-                                   # since this app isn't being used at the high school
-
-    student.enrollment_status = 'High School'
-    student.grade = 'HS'
-    student.school = nil
-    student.save
-  end
-
-  def handle_elementary_student(student, row)
     if student.save
       assign_student_to_homeroom(student, row[:homeroom])
       student.create_student_risk_level!

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -24,7 +24,7 @@ class Student < ActiveRecord::Base
   validate :valid_grade
   validate :registration_date_cannot_be_in_future
 
-  VALID_GRADES = [ 'PK', 'KF', '1', '2', '3', '4', '5', '6', '7', '8', 'HS'].freeze
+  VALID_GRADES = [ 'PK', 'KF', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'].freeze
 
   def valid_grade
     errors.add(:grade, "must be a valid grade") unless grade.in?(VALID_GRADES)

--- a/app/views/educators/districtwide_admin_homepage.html.erb
+++ b/app/views/educators/districtwide_admin_homepage.html.erb
@@ -17,7 +17,7 @@
           School Data Overview
         </h3>
         <ul>
-          <% @elementary_schools.each do |school| %>
+          <% @schools.each do |school| %>
             <li>
               <%= link_to school.name, school_path(school), {
                 class: 'prominent-link'

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -24,7 +24,7 @@ class Import
 
     class_option :school,
       type: :array,
-      default: ['HEA', 'WSNS', 'ESCS', 'BRN', 'KDY', 'AFAS', 'WHCS'],
+      default: ['HEA', 'WSNS', 'ESCS', 'BRN', 'KDY', 'AFAS', 'WHCS', 'SHS'],
       aliases: "-s",
       desc: "Scope by school local IDs; use ELEM to import all elementary schools"
     class_option :first_time,

--- a/spec/importers/file_importers/students_importer_spec.rb
+++ b/spec/importers/file_importers/students_importer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe StudentsImporter do
       context 'no existing students in database' do
 
         it 'imports students' do
-          expect { import }.to change { Student.count }.by 2
+          expect { import }.to change { Student.count }.by 3
         end
 
         it 'imports student data correctly' do
@@ -61,9 +61,9 @@ RSpec.describe StudentsImporter do
         it 'updates the student\'s data correctly' do
           import
 
-          expect(graduating_student.reload.school).to eq nil
-          expect(graduating_student.grade).to eq 'HS'
-          expect(graduating_student.enrollment_status).to eq 'High School'
+          expect(graduating_student.reload.school).to eq high_school
+          expect(graduating_student.grade).to eq '10'
+          expect(graduating_student.enrollment_status).to eq 'Active'
         end
 
       end

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Import do
     it 'invokes all the commands and returns the correct kind of values' do
       expect(commands[1]).to be_a ImportRecord
       expect(commands[2]).to eq nil
-      expect(commands[3]).to eq ['HEA', 'WSNS', 'ESCS', 'BRN', 'KDY', 'AFAS', 'WHCS']
+      expect(commands[3]).to eq ['HEA', 'WSNS', 'ESCS', 'BRN', 'KDY', 'AFAS', 'WHCS', 'SHS']
       expect(commands[4]).to be_a Array
       expect(commands[5]).to eq []
       expect(commands[6]).to eq nil
@@ -25,7 +25,7 @@ RSpec.describe Import do
     let(:log_destination) { LogHelper::Redirect.instance.file }
     let(:expected_file_importer_arguments) {
       [
-        ['HEA', 'WSNS', 'ESCS', 'BRN', 'KDY', 'AFAS', 'WHCS'],
+        ['HEA', 'WSNS', 'ESCS', 'BRN', 'KDY', 'AFAS', 'WHCS', 'SHS'],
         sftp_client_double,
         log_destination,
         false


### PR DESCRIPTION
This PR removes the restriction on importing new high school students. As we progress on the high school project we'll likely redefine concepts like risk level and homeroom. For now just leveraging the existing codebase to bring these students into the database.

The districtwide homepage has also been updated to allow high schools (SHS and Full Circle) so we can see the data imported for high school students.

(Note: I'll be back actively working on Friday [6/23/2017]. I'm submitting this pull request from a 🚅 Shinkansen train 🚄 stopped by heavy rain somewhere between Osaka and Tokyo]