### PR TITLE
Double-write precomputed student hashes to migrate to shorter key

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -74,18 +74,33 @@ class SchoolsController < ApplicationController
       # so keep a buffer that makes sure the import task and precompute job
       # can finish before cutting over to the next day.
       query_time = time_now - 9.hours
-      key = precomputed_student_hashes_key(query_time, authorized_student_ids)
-      doc = PrecomputedQueryDoc.find_by_key(key)
-      return JSON.parse(doc.json).deep_symbolize_keys![:student_hashes] unless doc.nil?
+
+      # There are two keying strategies, and we're double-writing to migrate over.
+      # The older keying strategy concatenated student ids; the newer hashes them
+      # to keep the size down to avoid Postgres size limitations on indexes.
+      # Query new first, fall back to old, and if nothing then fall all the way back.
+      new_key = precomputed_student_hashes_key(query_time, authorized_student_ids, use_hashed_key: true)
+      logger.warn "load_precomputed_student_hashes querying new_key: #{new_key}..."
+      new_doc = PrecomputedQueryDoc.find_by_key(new_key)
+      return parse_hashes_from_doc(new_doc) unless new_doc.nil?
+
+      old_key = precomputed_student_hashes_key(query_time, authorized_student_ids)
+      logger.warn "load_precomputed_student_hashes querying old_key: #{old_key}..."
+      old_doc = PrecomputedQueryDoc.find_by_key(old_key)
+      return parse_hashes_from_doc(old_doc) unless old_doc.nil?
     rescue ActiveRecord::StatementInvalid => err
       logger.error "load_precomputed_student_hashes raised error #{err.inspect}"
     end
 
     # Fallback to performing the full query if something went wrong reading the
     # precomputed value
-    logger.error "falling back to full load_precomputed_student_hashes query for key: #{key}"
+    logger.error "falling back to full load_precomputed_student_hashes query for old_key: #{old_key}, new_key: #{new_key}"
     authorized_students = Student.find(authorized_student_ids)
     authorized_students.map {|student| student_hash_for_slicing(student) }
+  end
+
+  def parse_hashes_from_doc(doc)
+    JSON.parse(doc.json).deep_symbolize_keys![:student_hashes]
   end
 
   def serialized_data_for_star

--- a/app/jobs/precompute_student_hashes_job.rb
+++ b/app/jobs/precompute_student_hashes_job.rb
@@ -43,11 +43,32 @@ class PrecomputeStudentHashesJob < Struct.new :log
     precomputed_time = Time.at(date_timestamp)
     authorized_students = Student.find(authorized_student_ids)
     student_hashes = authorized_students.map {|student| student_hash_for_slicing(student) }
-    key = precomputed_student_hashes_key(precomputed_time, authorized_student_ids)
 
-    # This is a non-atomic upsert
+    # We're going to double-write, since the original key strategy just concatenated all
+    # the student ids, but for the high school this is too large.  So we'll hash that
+    # string and write both.  The write to the old concatenated string will fail, and we'll
+    # catch that, log, and continue on.
+    new_key = precomputed_student_hashes_key(precomputed_time, authorized_student_ids, use_hashed_key: true)
+    old_key = precomputed_student_hashes_key(precomputed_time, authorized_student_ids)
+    write_doc_or_log(new_key, { student_hashes: student_hashes })
+    write_doc_or_log(old_key, { student_hashes: student_hashes })
+
+    nil
+  end
+
+  # This is a non-atomic upsert
+  # This catches errors, emails, logs and returns nil
+  def write_doc_or_log(key, json_hash)
     pre_existing_doc = PrecomputedQueryDoc.find_by_key(key)
     pre_existing_doc.destroy! if pre_existing_doc.present?
-    PrecomputedQueryDoc.create!(key: key, json: { student_hashes: student_hashes }.to_json )
+
+    begin
+      PrecomputedQueryDoc.create!(key: key, json: json_hash.to_json )
+    rescue => error
+      PrecomputeErrorMailer.error_report(error).deliver_now if Rails.env.production?
+      log.puts "write_doc_or_log failed for key: #{key}"
+      log.puts err.inspect
+      nil
+    end
   end
 end

--- a/app/mailers/precompute_error_mailer.rb
+++ b/app/mailers/precompute_error_mailer.rb
@@ -1,0 +1,15 @@
+class PrecomputeErrorMailer < ActionMailer::Base
+
+  def error_report(error)
+    @target_emails = ENV['PRECOMPUTE_ERROR_MAILER_LIST'].split(',')
+    @subject = "ERROR: Student Insights precompute job"
+    @error_message = error.message
+    @error_backtrace = error.backtrace
+
+    mail(
+      to: @target_emails,
+      subject: @subject,
+      from: "Student Insights error report <asoble@gmail.com>"
+    )
+  end
+end

--- a/app/views/precompute_error_mailer/precompute_error_mailer.html.erb
+++ b/app/views/precompute_error_mailer/precompute_error_mailer.html.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1><%= @error_message %></h1>
+    <p>
+      <%= @error_backtrace %>
+    </p>
+  </body>
+</html>

--- a/spec/jobs/precompute_student_hashes_job_spec.rb
+++ b/spec/jobs/precompute_student_hashes_job_spec.rb
@@ -2,8 +2,11 @@ require 'rails_helper'
 
 RSpec.describe PrecomputeStudentHashesJob do
 
+  # set time at 2017-06-22 10:07:42
+  let(:time_now) { Time.at(1498126062) }
   let(:outcome) { PrecomputedQueryDoc.all }
   let(:first_json_blob) { JSON.parse!(outcome.first.json) }
+  let(:last_json_blob) { JSON.parse!(outcome.last.json) }
   let(:log) { LogHelper::Redirect.instance.file }
 
   describe '#school_overview_precompute_jobs' do
@@ -13,15 +16,23 @@ RSpec.describe PrecomputeStudentHashesJob do
       let!(:educator) { FactoryGirl.create(:educator, school: school, schoolwide_access: true) }
       let!(:student) { FactoryGirl.create(:student, school: school) }
 
-      before { PrecomputeStudentHashesJob.new(log).precompute_all!(Time.now) }
+      before { PrecomputeStudentHashesJob.new(log).precompute_all!(time_now) }
 
       let(:first_json_blob_key) { first_json_blob.keys.first }
       let(:first_json_blob_value) { first_json_blob[first_json_blob_key] }
+      let(:last_json_blob_key) { last_json_blob.keys.first }
+      let(:last_json_blob_value) { last_json_blob[first_json_blob_key] }
 
-      it 'returns the correct hash for the job' do
-        expect(outcome.size).to eq 1
+      it 'creates two docs with the correct keys and correct data inside both docs' do
+        expect(outcome.size).to eq 2
+        expect(outcome.map(&:key)).to eq [
+          "short:1498104000:1:b8aed072d29403ece56ae9641638ddd50d420f950bde0eefc092ee8879554141",
+          "precomputed_student_hashes_1498104000_#{student.id}"
+        ]
         expect(first_json_blob_key).to eq "student_hashes"
         expect(first_json_blob_value.first["id"]).to eq student.id
+        expect(last_json_blob_key).to eq "student_hashes"
+        expect(last_json_blob_value.first["id"]).to eq student.id
       end
     end
 


### PR DESCRIPTION
With importing new data for the high school, this led to creating some keys for precomputed data that are longer than Postgres likes.  This led to these precompute jobs failing, and made the new high school overview page timeout on load, and therefore inaccessible to users.

Tracked this down in logentries:
```
ActiveRecord::StatementInvalid: PG::ProgramLimitExceeded: ERROR: index row size 3216 exceeds maximum 2712 for index "index_precomputed_query_docs_on_key"
168 <190>1 2017-06-24T08:02:13.064797+00:00 app scheduler.5296 - - HINT: Values larger than 1/3 of a buffer page cannot be indexed.
184 <190>1 2017-06-24T08:02:13.064800+00:00 app scheduler.5296 - - Consider a function index of an MD5 hash of the value, or use full text indexing
224 <190>1 2017-06-24T08:02:13.064801+00:00 app scheduler.5296 - - : INSERT INTO "precomputed_query_docs" ("key", "json", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"

...

/app/app/jobs/precompute_student_hashes_job.rb:51:in `precompute_and_write_student_hashes!' /app/app/jobs/precompute_student_hashes_job.rb:13:in `block in precompute_all!'
/app/app/jobs/precompute_student_hashes_job.rb:12:in `each' Context
/app/app/jobs/precompute_student_hashes_job.rb:12:in `each_with_index'
/app/app/jobs/precompute_student_hashes_job.rb:12:in `precompute_all!' 
/app/lib/tasks/precompute.rake:4:in `block (2 levels) in <top (required)>'
```

This pull request addresses that by using a new keying strategy that hashes the values (previously it just concatenated the student ids).  It double-writes both key strategies, and then on the read path it reads the new one first, then tries the old one.

This also adds email notifications for when errors occur writing a precomputed doc.