### PR TITLE
Remove old keying strategy for precomputed docs

### DIFF
--- a/app/helpers/students_query_helper.rb
+++ b/app/helpers/students_query_helper.rb
@@ -47,18 +47,21 @@ module StudentsQueryHelper
     }
   end
 
-  # Used to compute key for reading and writing precomputed student_hashes documents
-  # There are two formats to this key: the old one which concatenated all student_ids
-  # and the newer one that hashes the old key so that it's shorter (but more opaque).
+  # Computes a key for reading and writing precomputed student_hashes documents.
+  # 
+  # The original formats to this key concatenated all student_ids but is deprecated and
+  # no longer used (although it's still here since data still exists thats keyed like that).
+  # That can be accessed with `force_deprecated_key`.
+  #
+  # The newer key strategy hashes the values that made up the old key so it's length is
+  # capped.
   def precomputed_student_hashes_key(time_now, authorized_student_ids, options = {})
     timestamp = time_now.beginning_of_day.to_i
     authorized_students_key = authorized_student_ids.sort.join(',')
-    key = ['precomputed_student_hashes', timestamp, authorized_students_key].join('_')
-
-    if options[:use_hashed_key]
-      ['short', timestamp, authorized_student_ids.size, Digest::SHA256.hexdigest(authorized_students_key)].join(':')
+    if options[:force_deprecated_key]
+      ['precomputed_student_hashes', timestamp, authorized_students_key].join('_')
     else
-      key
+      ['short', timestamp, authorized_student_ids.size, Digest::SHA256.hexdigest(authorized_students_key)].join(':')
     end
   end
 end

--- a/app/jobs/precompute_student_hashes_job.rb
+++ b/app/jobs/precompute_student_hashes_job.rb
@@ -44,15 +44,8 @@ class PrecomputeStudentHashesJob < Struct.new :log
     authorized_students = Student.find(authorized_student_ids)
     student_hashes = authorized_students.map {|student| student_hash_for_slicing(student) }
 
-    # We're going to double-write, since the original key strategy just concatenated all
-    # the student ids, but for the high school this is too large.  So we'll hash that
-    # string and write both.  The write to the old concatenated string will fail, and we'll
-    # catch that, log, and continue on.
-    new_key = precomputed_student_hashes_key(precomputed_time, authorized_student_ids, use_hashed_key: true)
-    old_key = precomputed_student_hashes_key(precomputed_time, authorized_student_ids)
-    write_doc_or_log(new_key, { student_hashes: student_hashes })
-    write_doc_or_log(old_key, { student_hashes: student_hashes })
-
+    key = precomputed_student_hashes_key(precomputed_time, authorized_student_ids)
+    write_doc_or_log(key, { student_hashes: student_hashes })
     nil
   end
 

--- a/spec/jobs/precompute_student_hashes_job_spec.rb
+++ b/spec/jobs/precompute_student_hashes_job_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe PrecomputeStudentHashesJob do
   let(:time_now) { Time.at(1498126062) }
   let(:outcome) { PrecomputedQueryDoc.all }
   let(:first_json_blob) { JSON.parse!(outcome.first.json) }
-  let(:last_json_blob) { JSON.parse!(outcome.last.json) }
   let(:log) { LogHelper::Redirect.instance.file }
 
   describe '#school_overview_precompute_jobs' do
@@ -20,19 +19,12 @@ RSpec.describe PrecomputeStudentHashesJob do
 
       let(:first_json_blob_key) { first_json_blob.keys.first }
       let(:first_json_blob_value) { first_json_blob[first_json_blob_key] }
-      let(:last_json_blob_key) { last_json_blob.keys.first }
-      let(:last_json_blob_value) { last_json_blob[first_json_blob_key] }
 
-      it 'creates two docs with the correct keys and correct data inside both docs' do
-        expect(outcome.size).to eq 2
-        expect(outcome.map(&:key)).to eq [
-          "short:1498104000:1:b8aed072d29403ece56ae9641638ddd50d420f950bde0eefc092ee8879554141",
-          "precomputed_student_hashes_1498104000_#{student.id}"
-        ]
+      it 'creates a doc with the correct key and correct data inside' do
+        expect(outcome.size).to eq 1
+        expect(outcome.first.key).to eq "short:1498104000:1:b8aed072d29403ece56ae9641638ddd50d420f950bde0eefc092ee8879554141"
         expect(first_json_blob_key).to eq "student_hashes"
         expect(first_json_blob_value.first["id"]).to eq student.id
-        expect(last_json_blob_key).to eq "student_hashes"
-        expect(last_json_blob_value.first["id"]).to eq student.id
       end
     end
 


### PR DESCRIPTION
This removes the old keying strategy, since we verified that the new one introduced in https://github.com/studentinsights/studentinsights/pull/940 is working.

This can be merged tomorrow (Sunday), after the job runs all the way through double-writing.