### PR TITLE
Throw error if student record doesn't save on import

### DIFF
--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -19,7 +19,7 @@ class StudentsImporter < Struct.new :school_scope, :client, :log, :progress_bar
   def import_row(row)
     student = StudentRow.new(row, school_ids_dictionary).build
 
-    if student.save
+    if student.save!
       assign_student_to_homeroom(student, row[:homeroom])
       student.create_student_risk_level!
     end

--- a/spec/importers/file_importers/students_importer_spec.rb
+++ b/spec/importers/file_importers/students_importer_spec.rb
@@ -71,13 +71,13 @@ RSpec.describe StudentsImporter do
     end
 
     context 'bad data' do
-      context 'missing state id' do
-        let(:row) { { state_id: nil, full_name: 'Hoag, George', home_language: 'English', grade: '1', homeroom: '101' } }
-        it 'raises an error' do
-          expect{ described_class.new.import_row(row) }.not_to raise_error
-
-          # TODO -- expect it to notify us or print something out ...
-        end
+      let(:row) { { state_id: nil, full_name: 'Hoag, George', home_language: 'English', grade: '1', homeroom: '101' } }
+      it 'raises an error' do
+        expect{
+          described_class.new.import_row(row)
+        }.to raise_error(
+          ActiveRecord::RecordInvalid
+        )
       end
     end
 


### PR DESCRIPTION
# Why? 

+ We need all student rows to save successfully to the database ...
+ ... because if they don't then other records won't be able to save because there will be a missing student record
+ Basically if there's an error with a student saving we want to catch it and be alerted to it at the student level instead of having it cascade down to another model that has a relationship with the student model