### PR TITLE
Separate out DEMO_SITE environment variable from QuotaGuard conditional

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: if [ "$DEMO_SITE" = true ]; then bundle exec puma -C config/puma.rb; else bin/qgsocksify bundle exec puma -C config/puma.rb; fi
+web: if [ "$USE_QUOTAGUARD" = true ]; then bundle exec puma -C config/puma.rb; else bin/qgsocksify bundle exec puma -C config/puma.rb; fi
 worker: bundle exec rake jobs:work


### PR DESCRIPTION
# Why?

+ Not sure yet if new districts will need a static QuotaGuard IP yet or not
+ Even if they will need one eventually for LDAP integration, we might want to stand up earlier prototype versions with handrolled logins for admins at other districts
+ Better to default to requiring less config than requiring more config 
+ #950