### PR TITLE
Fix nil homerooms, they are bad

### DIFF
--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -18,17 +18,23 @@ class StudentsImporter < Struct.new :school_scope, :client, :log, :progress_bar
 
   def import_row(row)
     student = StudentRow.new(row, school_ids_dictionary).build
+    student.save!
 
-    if student.save!
-      assign_student_to_homeroom(student, row[:homeroom])
-      student.create_student_risk_level!
+    if row[:homeroom].present?
+      assign_student_to_homeroom!(student, row[:homeroom])
     end
+
+    student.create_student_risk_level!
   end
 
-  def assign_student_to_homeroom(student, homeroom_name)
+  def assign_student_to_homeroom!(student, homeroom_name)
     return unless student.active?
-    name = homeroom_name || (student.school.local_id + ' HOMEROOM')
-    homeroom = Homeroom.where(name: name, school: student.school).first_or_create!
+
+    homeroom = Homeroom.where({
+      name: homeroom_name,
+      school: student.school
+    }).first_or_create!
+
     homeroom.students << student
   end
 

--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -21,13 +21,13 @@ class StudentsImporter < Struct.new :school_scope, :client, :log, :progress_bar
     student.save!
 
     if row[:homeroom].present?
-      assign_student_to_homeroom!(student, row[:homeroom])
+      assign_student_to_homeroom(student, row[:homeroom])
     end
 
     student.create_student_risk_level!
   end
 
-  def assign_student_to_homeroom!(student, homeroom_name)
+  def assign_student_to_homeroom(student, homeroom_name)
     return unless student.active?
 
     homeroom = Homeroom.where({

--- a/db/migrate/20170804204605_remove_homeroom_that_violates_name_constraint.rb
+++ b/db/migrate/20170804204605_remove_homeroom_that_violates_name_constraint.rb
@@ -1,0 +1,13 @@
+class RemoveHomeroomThatViolatesNameConstraint < ActiveRecord::Migration[5.0]
+  def change
+    Homeroom.where(name: nil).each do |homeroom|
+      # unlink all students from homerooms with nil names
+      homeroom.students.each do |student|
+        student.homeroom_id = nil
+        student.save!
+      end
+
+      homeroom.destroy!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170712184651) do
+ActiveRecord::Schema.define(version: 20170804204605) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
# Why?

+ The way the code is currently set up generates "fake" homerooms for students who have a `nil` homeroom assignment in X2
  + This isn't really accurate, we don't want to be going around and adding data that's different from what's in X2
  + It's OK for students not to be assigned to a homeroom. They show up just fine in the Searchbar and appear on the School Overview page... their data is surfaceable

# What's the fix? 

+ This commit skips assigning a homeroom when X2 doesn't supply a homeroom name 
+ It uses .present? to catch both `homeroom name == nil` and `homeroom name == ''`, which was the error that first drew @kevinrobinson's and my attention to the issue