### PR TITLE
Store digest of authorized students on PrecomputedQueryDoc

### DIFF
--- a/app/jobs/precompute_student_hashes_job.rb
+++ b/app/jobs/precompute_student_hashes_job.rb
@@ -54,9 +54,14 @@ class PrecomputeStudentHashesJob < Struct.new :log
   def write_doc_or_log(key, json_hash)
     pre_existing_doc = PrecomputedQueryDoc.find_by_key(key)
     pre_existing_doc.destroy! if pre_existing_doc.present?
+    authorized_students_digest = key.split(':').last
 
     begin
-      PrecomputedQueryDoc.create!(key: key, json: json_hash.to_json )
+      PrecomputedQueryDoc.create!(
+        key: key,
+        json: json_hash.to_json,
+        authorized_students_digest: authorized_students_digest
+      )
     rescue => error
       ErrorMailer.error_report(error).deliver_now if Rails.env.production?
       log.puts "write_doc_or_log failed for key: #{key}"

--- a/db/migrate/20170807214140_add_student_digest_to_query_doc.rb
+++ b/db/migrate/20170807214140_add_student_digest_to_query_doc.rb
@@ -1,0 +1,5 @@
+class AddStudentDigestToQueryDoc < ActiveRecord::Migration[5.0]
+  def change
+    add_column :precomputed_query_docs, :authorized_students_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170807143334) do
+ActiveRecord::Schema.define(version: 20170807214140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -210,6 +210,7 @@ ActiveRecord::Schema.define(version: 20170807143334) do
     t.text     "json"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "authorized_students_digest"
     t.index ["key"], name: "index_precomputed_query_docs_on_key", unique: true, using: :btree
   end
 


### PR DESCRIPTION
# Why?

+ That way we have a way to compare PrecomputedQueryDocs and see if they describe identical groups of students, so that eventually we can delete out-of-date precomputes 

# Issue 

+ #362