### PR TITLE
Allow students to have future registration dates if they are in PK

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -34,9 +34,13 @@ class Student < ActiveRecord::Base
   end
 
   def registration_date_cannot_be_in_future
-    if registration_date && (registration_date > DateTime.now)
-      errors.add(:registration_date, "cannot be in future")
-    end
+    return unless registration_date
+
+    return if DateTime.now > registration_date
+
+    return if grade == 'PK'
+
+    errors.add(:registration_date, "cannot be in future")
   end
 
   def self.with_school

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe Student do
         expect(student).to be_invalid
       end
     end
+    context 'future registration date, PK' do
+      let(:student) {
+        FactoryGirl.build(:student, registration_date: Time.now + 1.year, grade: 'PK')
+      }
+      it 'is valid' do
+        expect(student).to be_valid
+      end
+    end
     context 'past registration date' do
       let(:student) { FactoryGirl.build(:student, :registered_last_year) }
       it 'is valid' do


### PR DESCRIPTION
# Why 

+ Students in PK with future registration dates are triggering the error mailer to send us lots of emails recently 
+ From John Breslin: "That is most likely the date they registered for K this upcoming school year"