### PR TITLE
Check in new Rails 5.1 schema.rb format

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,316 +15,316 @@ ActiveRecord::Schema.define(version: 20170807214140) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "absences", force: :cascade do |t|
+  create_table "absences", id: :serial, force: :cascade do |t|
     t.datetime "occurred_at", null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.integer  "student_id"
-    t.index ["student_id"], name: "index_absences_on_student_id", using: :btree
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "student_id"
+    t.index ["student_id"], name: "index_absences_on_student_id"
   end
 
-  create_table "assessment_families", force: :cascade do |t|
-    t.string   "name"
+  create_table "assessment_families", id: :serial, force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "assessment_subjects", force: :cascade do |t|
-    t.string   "name"
+  create_table "assessment_subjects", id: :serial, force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "assessments", force: :cascade do |t|
-    t.string   "name"
-    t.string   "family"
-    t.string   "subject"
+  create_table "assessments", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "family"
+    t.string "subject"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "delayed_jobs", force: :cascade do |t|
-    t.integer  "priority",   default: 0, null: false
-    t.integer  "attempts",   default: 0, null: false
-    t.text     "handler",                null: false
-    t.text     "last_error"
+  create_table "delayed_jobs", id: :serial, force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
-    t.string   "locked_by"
-    t.string   "queue"
+    t.string "locked_by"
+    t.string "queue"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "discipline_incidents", force: :cascade do |t|
-    t.string   "incident_code"
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
-    t.string   "incident_location"
-    t.text     "incident_description"
-    t.datetime "occurred_at",          null: false
-    t.boolean  "has_exact_time"
-    t.integer  "student_id"
-    t.index ["student_id"], name: "index_discipline_incidents_on_student_id", using: :btree
-  end
-
-  create_table "discontinued_services", force: :cascade do |t|
-    t.integer  "service_id"
-    t.integer  "recorded_by_educator_id"
-    t.datetime "recorded_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "educators", force: :cascade do |t|
-    t.string   "email",                                   default: "",    null: false
-    t.string   "encrypted_password",                      default: "",    null: false
-    t.string   "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                           default: 0,     null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.boolean  "admin",                                   default: false
-    t.string   "phone"
-    t.string   "full_name"
-    t.string   "state_id"
-    t.string   "local_id"
-    t.string   "staff_type"
-    t.integer  "school_id"
-    t.boolean  "schoolwide_access",                       default: false, null: false
-    t.string   "grade_level_access",                      default: [],                 array: true
-    t.boolean  "restricted_to_sped_students",             default: false, null: false
-    t.boolean  "restricted_to_english_language_learners", default: false, null: false
-    t.boolean  "can_view_restricted_notes",               default: false, null: false
-    t.boolean  "districtwide_access",                     default: false, null: false
-    t.boolean  "can_set_districtwide_access",             default: false, null: false
-    t.index ["grade_level_access"], name: "index_educators_on_grade_level_access", using: :gin
-    t.index ["reset_password_token"], name: "index_educators_on_reset_password_token", unique: true, using: :btree
-  end
-
-  create_table "event_note_attachments", force: :cascade do |t|
-    t.string   "url",           null: false
-    t.integer  "event_note_id", null: false
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
-  end
-
-  create_table "event_note_revisions", force: :cascade do |t|
-    t.integer  "student_id"
-    t.integer  "educator_id"
-    t.integer  "event_note_type_id"
-    t.text     "text"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer  "event_note_id"
-    t.integer  "version"
-  end
-
-  create_table "event_note_types", force: :cascade do |t|
-    t.string   "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "event_notes", force: :cascade do |t|
-    t.integer  "student_id"
-    t.integer  "educator_id"
-    t.integer  "event_note_type_id"
-    t.text     "text"
-    t.datetime "recorded_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.boolean  "is_restricted",      default: false
-  end
-
-  create_table "friendly_id_slugs", force: :cascade do |t|
-    t.string   "slug",                      null: false
-    t.integer  "sluggable_id",              null: false
-    t.string   "sluggable_type", limit: 50
-    t.string   "scope"
-    t.datetime "created_at"
-    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true, using: :btree
-    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", using: :btree
-    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id", using: :btree
-    t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type", using: :btree
-  end
-
-  create_table "homerooms", force: :cascade do |t|
-    t.string   "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer  "students_count", default: 0, null: false
-    t.integer  "educator_id"
-    t.string   "slug"
-    t.string   "grade"
-    t.integer  "school_id"
-    t.index ["educator_id"], name: "index_homerooms_on_educator_id", using: :btree
-    t.index ["slug"], name: "index_homerooms_on_slug", unique: true, using: :btree
-  end
-
-  create_table "iep_documents", force: :cascade do |t|
-    t.datetime "file_date"
-    t.string   "file_name"
-    t.integer  "student_id"
+  create_table "discipline_incidents", id: :serial, force: :cascade do |t|
+    t.string "incident_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["student_id"], name: "index_iep_documents_on_student_id", using: :btree
+    t.string "incident_location"
+    t.text "incident_description"
+    t.datetime "occurred_at", null: false
+    t.boolean "has_exact_time"
+    t.integer "student_id"
+    t.index ["student_id"], name: "index_discipline_incidents_on_student_id"
   end
 
-  create_table "import_records", force: :cascade do |t|
+  create_table "discontinued_services", id: :serial, force: :cascade do |t|
+    t.integer "service_id"
+    t.integer "recorded_by_educator_id"
+    t.datetime "recorded_at"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "educators", id: :serial, force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.boolean "admin", default: false
+    t.string "phone"
+    t.string "full_name"
+    t.string "state_id"
+    t.string "local_id"
+    t.string "staff_type"
+    t.integer "school_id"
+    t.boolean "schoolwide_access", default: false, null: false
+    t.string "grade_level_access", default: [], array: true
+    t.boolean "restricted_to_sped_students", default: false, null: false
+    t.boolean "restricted_to_english_language_learners", default: false, null: false
+    t.boolean "can_view_restricted_notes", default: false, null: false
+    t.boolean "districtwide_access", default: false, null: false
+    t.boolean "can_set_districtwide_access", default: false, null: false
+    t.index ["grade_level_access"], name: "index_educators_on_grade_level_access", using: :gin
+    t.index ["reset_password_token"], name: "index_educators_on_reset_password_token", unique: true
+  end
+
+  create_table "event_note_attachments", id: :serial, force: :cascade do |t|
+    t.string "url", null: false
+    t.integer "event_note_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "event_note_revisions", id: :serial, force: :cascade do |t|
+    t.integer "student_id"
+    t.integer "educator_id"
+    t.integer "event_note_type_id"
+    t.text "text"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "event_note_id"
+    t.integer "version"
+  end
+
+  create_table "event_note_types", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "event_notes", id: :serial, force: :cascade do |t|
+    t.integer "student_id"
+    t.integer "educator_id"
+    t.integer "event_note_type_id"
+    t.text "text"
+    t.datetime "recorded_at"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.boolean "is_restricted", default: false
+  end
+
+  create_table "friendly_id_slugs", id: :serial, force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
+    t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
+  end
+
+  create_table "homerooms", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "students_count", default: 0, null: false
+    t.integer "educator_id"
+    t.string "slug"
+    t.string "grade"
+    t.integer "school_id"
+    t.index ["educator_id"], name: "index_homerooms_on_educator_id"
+    t.index ["slug"], name: "index_homerooms_on_slug", unique: true
+  end
+
+  create_table "iep_documents", id: :serial, force: :cascade do |t|
+    t.datetime "file_date"
+    t.string "file_name"
+    t.integer "student_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["student_id"], name: "index_iep_documents_on_student_id"
+  end
+
+  create_table "import_records", id: :serial, force: :cascade do |t|
     t.datetime "time_started"
     t.datetime "time_ended"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "intervention_types", force: :cascade do |t|
-    t.string   "name"
+  create_table "intervention_types", id: :serial, force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "interventions", force: :cascade do |t|
-    t.integer  "student_id"
-    t.integer  "intervention_type_id"
-    t.text     "comment"
-    t.date     "start_date"
-    t.date     "end_date"
+  create_table "interventions", id: :serial, force: :cascade do |t|
+    t.integer "student_id"
+    t.integer "intervention_type_id"
+    t.text "comment"
+    t.date "start_date"
+    t.date "end_date"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "educator_id"
-    t.integer  "number_of_hours"
-    t.text     "goal"
-    t.string   "custom_intervention_name"
+    t.integer "educator_id"
+    t.integer "number_of_hours"
+    t.text "goal"
+    t.string "custom_intervention_name"
   end
 
-  create_table "precomputed_query_docs", force: :cascade do |t|
-    t.text     "key"
-    t.text     "json"
+  create_table "precomputed_query_docs", id: :serial, force: :cascade do |t|
+    t.text "key"
+    t.text "json"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "authorized_students_digest"
-    t.index ["key"], name: "index_precomputed_query_docs_on_key", unique: true, using: :btree
+    t.string "authorized_students_digest"
+    t.index ["key"], name: "index_precomputed_query_docs_on_key", unique: true
   end
 
-  create_table "schools", force: :cascade do |t|
-    t.integer  "state_id"
-    t.string   "school_type"
-    t.string   "name"
+  create_table "schools", id: :serial, force: :cascade do |t|
+    t.integer "state_id"
+    t.string "school_type"
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "local_id"
-    t.string   "slug"
-    t.index ["local_id"], name: "index_schools_on_local_id", using: :btree
-    t.index ["state_id"], name: "index_schools_on_state_id", using: :btree
+    t.string "local_id"
+    t.string "slug"
+    t.index ["local_id"], name: "index_schools_on_local_id"
+    t.index ["state_id"], name: "index_schools_on_state_id"
   end
 
-  create_table "service_types", force: :cascade do |t|
-    t.string   "name"
+  create_table "service_types", id: :serial, force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "summer_program", default: false
+    t.boolean "summer_program", default: false
   end
 
-  create_table "service_uploads", force: :cascade do |t|
-    t.integer  "uploaded_by_educator_id"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-    t.string   "file_name"
+  create_table "service_uploads", id: :serial, force: :cascade do |t|
+    t.integer "uploaded_by_educator_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "file_name"
   end
 
-  create_table "services", force: :cascade do |t|
-    t.integer  "student_id"
-    t.integer  "recorded_by_educator_id"
-    t.integer  "service_type_id"
+  create_table "services", id: :serial, force: :cascade do |t|
+    t.integer "student_id"
+    t.integer "recorded_by_educator_id"
+    t.integer "service_type_id"
     t.datetime "recorded_at"
     t.datetime "date_started"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "provided_by_educator_name"
-    t.integer  "service_upload_id"
+    t.string "provided_by_educator_name"
+    t.integer "service_upload_id"
   end
 
-  create_table "student_assessments", force: :cascade do |t|
-    t.integer  "scale_score"
-    t.integer  "growth_percentile"
-    t.string   "performance_level"
+  create_table "student_assessments", id: :serial, force: :cascade do |t|
+    t.integer "scale_score"
+    t.integer "growth_percentile"
+    t.string "performance_level"
     t.datetime "date_taken"
-    t.integer  "student_id"
+    t.integer "student_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "percentile_rank"
-    t.decimal  "instructional_reading_level"
-    t.integer  "assessment_id"
-    t.string   "grade_equivalent"
-    t.index ["student_id"], name: "index_student_assessments_on_student_id", using: :btree
+    t.integer "percentile_rank"
+    t.decimal "instructional_reading_level"
+    t.integer "assessment_id"
+    t.string "grade_equivalent"
+    t.index ["student_id"], name: "index_student_assessments_on_student_id"
   end
 
-  create_table "student_risk_levels", force: :cascade do |t|
-    t.integer  "student_id"
-    t.integer  "level"
+  create_table "student_risk_levels", id: :serial, force: :cascade do |t|
+    t.integer "student_id"
+    t.integer "level"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "mcas_math_risk_level"
-    t.integer  "star_math_risk_level"
-    t.integer  "mcas_ela_risk_level"
-    t.integer  "star_reading_risk_level"
-    t.integer  "limited_english_proficiency_risk_level"
+    t.integer "mcas_math_risk_level"
+    t.integer "star_math_risk_level"
+    t.integer "mcas_ela_risk_level"
+    t.integer "star_reading_risk_level"
+    t.integer "limited_english_proficiency_risk_level"
   end
 
-  create_table "students", force: :cascade do |t|
-    t.string   "grade"
-    t.boolean  "hispanic_latino"
-    t.string   "race"
-    t.string   "free_reduced_lunch"
+  create_table "students", id: :serial, force: :cascade do |t|
+    t.string "grade"
+    t.boolean "hispanic_latino"
+    t.string "race"
+    t.string "free_reduced_lunch"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "homeroom_id"
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "state_id"
-    t.string   "home_language"
-    t.integer  "school_id"
-    t.string   "student_address"
+    t.integer "homeroom_id"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "state_id"
+    t.string "home_language"
+    t.integer "school_id"
+    t.string "student_address"
     t.datetime "registration_date"
-    t.string   "local_id"
-    t.string   "program_assigned"
-    t.string   "sped_placement"
-    t.string   "disability"
-    t.string   "sped_level_of_need"
-    t.string   "plan_504"
-    t.string   "limited_english_proficiency"
-    t.integer  "most_recent_mcas_math_growth"
-    t.integer  "most_recent_mcas_ela_growth"
-    t.string   "most_recent_mcas_math_performance"
-    t.string   "most_recent_mcas_ela_performance"
-    t.integer  "most_recent_mcas_math_scaled"
-    t.integer  "most_recent_mcas_ela_scaled"
-    t.integer  "most_recent_star_reading_percentile"
-    t.integer  "most_recent_star_math_percentile"
-    t.string   "enrollment_status"
+    t.string "local_id"
+    t.string "program_assigned"
+    t.string "sped_placement"
+    t.string "disability"
+    t.string "sped_level_of_need"
+    t.string "plan_504"
+    t.string "limited_english_proficiency"
+    t.integer "most_recent_mcas_math_growth"
+    t.integer "most_recent_mcas_ela_growth"
+    t.string "most_recent_mcas_math_performance"
+    t.string "most_recent_mcas_ela_performance"
+    t.integer "most_recent_mcas_math_scaled"
+    t.integer "most_recent_mcas_ela_scaled"
+    t.integer "most_recent_star_reading_percentile"
+    t.integer "most_recent_star_math_percentile"
+    t.string "enrollment_status"
     t.datetime "date_of_birth"
-    t.integer  "risk_level"
-    t.string   "gender"
-    t.index ["homeroom_id"], name: "index_students_on_homeroom_id", using: :btree
-    t.index ["local_id"], name: "index_students_on_local_id", using: :btree
-    t.index ["school_id"], name: "index_students_on_school_id", using: :btree
-    t.index ["state_id"], name: "index_students_on_state_id", using: :btree
+    t.integer "risk_level"
+    t.string "gender"
+    t.index ["homeroom_id"], name: "index_students_on_homeroom_id"
+    t.index ["local_id"], name: "index_students_on_local_id"
+    t.index ["school_id"], name: "index_students_on_school_id"
+    t.index ["state_id"], name: "index_students_on_state_id"
   end
 
-  create_table "tardies", force: :cascade do |t|
+  create_table "tardies", id: :serial, force: :cascade do |t|
     t.datetime "occurred_at", null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.integer  "student_id"
-    t.index ["student_id"], name: "index_tardies_on_student_id", using: :btree
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "student_id"
+    t.index ["student_id"], name: "index_tardies_on_student_id"
   end
 
   add_foreign_key "absences", "students"


### PR DESCRIPTION
# Notes 

+ Rails 5.1 changes the format of `schema.rb`, looks like a meaningful change but it's just presentation; checking this in separately so that another PR doesn't look like it's making a bunch of unrelated changes to `schema.rb`.
+ More context on this change: https://github.com/rails/rails/commit/df84e9867219e9311aef6f4efd5dd9ec675bee5c