### PR TITLE
Print student LASID when raising registration date error

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -40,7 +40,9 @@ class Student < ActiveRecord::Base
 
     return if grade == 'PK'
 
-    errors.add(:registration_date, "cannot be in future")
+    message = "cannot be in future for student local id ##{local_id}"
+
+    errors.add(:registration_date, message)
   end
 
   def self.with_school

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -10,9 +10,16 @@ RSpec.describe Student do
       end
     end
     context 'future registration date' do
-      let(:student) { FactoryGirl.build(:student, registration_date: Time.now + 1.year) }
+      let(:student) {
+        FactoryGirl.build(
+          :student, registration_date: Time.now + 1.year, local_id: '2000'
+        )
+      }
       it 'is invalid' do
         expect(student).to be_invalid
+        expect(student.errors.messages).to eq({
+          registration_date: ["cannot be in future for student local id #2000"]
+        })
       end
     end
     context 'future registration date, PK' do


### PR DESCRIPTION
# Why?

+ We're getting a bunch of invalid registration date errors, which I thought I fixed already with #966
+ Need to investigate further, but not getting good info about which students are triggering the error right now
+ This will include the LASID in the debugging emails which should help