### PR TITLE
Fix new EventNoteType migration 

### DIFF
--- a/db/migrate/20170818154033_add_ninth_grade_experience_event_type.rb
+++ b/db/migrate/20170818154033_add_ninth_grade_experience_event_type.rb
@@ -1,6 +1,6 @@
 class AddNinthGradeExperienceEventType < ActiveRecord::Migration[5.1]
   def change
-    return if EventNoteType.find(305).present?
+    return if EventNoteType.where(id: 305).present?
 
     EventNoteType.create({ id: 305, name: '9th Grade Experience' })
   end


### PR DESCRIPTION
# Notes 

+ Was expecting `find(305)` to return `nil`, but it raised an error instead. Wondering if this was a change in Rails 5.1? Because I remember `find` returning `nil` and `find!` raising...

# Update

+ I was wrong, `find` raises an errror but `find_by_id` returns `nil`: https://stackoverflow.com/questions/831347/rails-why-does-findid-raise-an-exception-in-rails