### PR TITLE
Handle case where grade level access is empty

### DIFF
--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -14,7 +14,7 @@ module Admin
     end
 
     def resource_params
-      params["educator"]["grade_level_access"] = params["educator"]["grade_level_access"].keys
+      params["educator"]["grade_level_access"] = params["educator"]["grade_level_access"].try(:keys) || []
 
       params.require("educator").permit(*dashboard.permitted_attributes, grade_level_access: [])
     end

--- a/spec/controllers/admin_educators_controller_spec.rb
+++ b/spec/controllers/admin_educators_controller_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 describe Admin::EducatorsController do
-  def make_request
-    request.env['HTTPS'] = 'on'
-    get :index
-  end
-
   describe '#index' do
+    def make_request
+      request.env['HTTPS'] = 'on'
+      get :index
+    end
+
     context 'not logged in' do
       it 'fails' do
         make_request
@@ -29,6 +29,67 @@ describe Admin::EducatorsController do
         sign_in(educator)
         make_request
         expect(response.status).to eq 200
+      end
+    end
+
+  end
+
+  describe '#update' do
+    let(:admin) { FactoryGirl.create(:educator, :admin) }
+
+    def make_request(params)
+      request.env['HTTPS'] = 'on'
+      post :update, params: params
+    end
+
+    context 'educator data with grade level access data' do
+      let(:educator) { FactoryGirl.create(:educator) }
+
+      let(:params) {
+        {
+          "educator" => {
+            "grade_level_access" => {
+              "1" => "on", "2" => "on"
+            },
+            "schoolwide_access"=>"1",
+            "restricted_to_sped_students"=>"0",
+            "restricted_to_english_language_learners"=>"0",
+            "can_view_restricted_notes"=>"0"
+          },
+          "id" => educator.id
+        }
+      }
+
+      it 'succeeds' do
+        sign_in(admin)
+        make_request(params)
+        educator.reload
+        expect(educator.schoolwide_access).to eq(true)
+        expect(educator.grade_level_access).to match_array(["1", "2"])
+      end
+    end
+
+    context 'educator data no grade level access data' do
+      let(:educator) { FactoryGirl.create(:educator) }
+
+      let(:params) {
+        {
+          "educator" => {
+            "schoolwide_access"=>"1",
+            "restricted_to_sped_students"=>"0",
+            "restricted_to_english_language_learners"=>"0",
+            "can_view_restricted_notes"=>"0"
+          },
+          "id" => educator.id
+        }
+      }
+
+      it 'succeeds' do
+        sign_in(admin)
+        make_request(params)
+        educator.reload
+        expect(educator.schoolwide_access).to eq(true)
+        expect(educator.grade_level_access).to eq([])
       end
     end
 


### PR DESCRIPTION
# Why

+ Updating educators with no grade level access was throwing errors in production
+ Can't access the "keys" of a split string if the string was `nil`; grade level access can't be nil, must be `[]`
+ TODO:
  + Think about a more elegant / less hacky way to do this
  + Write a system test now that we're on Rails 5.1 and that kind of thing is easier? {Added a controller test to exercise the `update` path for now}