### PR TITLE
Tune down max attempts on delayed job

### DIFF
--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -3,4 +3,9 @@ class ImportJob
     load File.expand_path("#{Rails.root}/lib/tasks/import.thor", __FILE__)
     Import::Start.new.invoke_all
   end
+
+  def max_attempts
+    1
+  end
 end
+


### PR DESCRIPTION
# Notes 

+ Default max attempts is 25, we have a bunch of delayed jobs in the queue that are running again and again and again and again . . . tune `max_attempts` all the way down to 1
+ Let's turn it to 1 because this job is going to be re-run automatically every night
  + We don't need to keep trying and trying if a job fails one night, because it could succeed as soon as the next night