### PR TITLE
WIP – Start calling MixpanelUtils with import/export instead of window

### DIFF
--- a/app/assets/javascripts/helpers/mixpanel_utils.jsx
+++ b/app/assets/javascripts/helpers/mixpanel_utils.jsx
@@ -33,4 +33,4 @@ export default {
       console.error(err); // eslint-disable-line no-console
     }
   }
-}
+};

--- a/app/assets/javascripts/helpers/mixpanel_utils.jsx
+++ b/app/assets/javascripts/helpers/mixpanel_utils.jsx
@@ -1,36 +1,36 @@
-(function() {
-  // Define filter operations
-  window.shared || (window.shared = {});
-  const Env = window.shared.Env;
+const Env = window.shared.Env;
 
-  const MixpanelUtils = window.shared.MixpanelUtils = {
-    isMixpanelEnabled: function() {
-      return (window.mixpanel && Env.shouldReportAnalytics);
-    },
-    registerUser: function(currentEducator) {
-      if (!MixpanelUtils.isMixpanelEnabled()) return;
+export default {
 
-      try {
-        window.mixpanel.identify(currentEducator.id);
-        window.mixpanel.register({
-          'deployment_key': Env.deploymentKey,
-          'educator_id': currentEducator.id,
-          'educator_is_admin': currentEducator.admin,
-          'educator_school_id': currentEducator.school_id
-        });
-      }
-      catch (err) {
-        console.error(err); // eslint-disable-line no-console
-      }
-    },
-    track: function(key, attrs) {
-      if (!MixpanelUtils.isMixpanelEnabled()) return;
-      try {
-        return window.mixpanel.track(key, attrs);
-      }
-      catch (err) {
-        console.error(err); // eslint-disable-line no-console
-      }
+  registerUser: function(currentEducator) {
+    const enabled = (window.mixpanel && Env.shouldReportAnalytics);
+
+    if (!enabled) return;
+
+    try {
+      window.mixpanel.identify(currentEducator.id);
+      window.mixpanel.register({
+        'deployment_key': Env.deploymentKey,
+        'educator_id': currentEducator.id,
+        'educator_is_admin': currentEducator.admin,
+        'educator_school_id': currentEducator.school_id
+      });
     }
-  };
-})();
+    catch (err) {
+      console.error(err); // eslint-disable-line no-console
+    }
+  },
+
+  track: function(key, attrs) {
+    const enabled = (window.mixpanel && Env.shouldReportAnalytics);
+
+    if (!enabled) return;
+
+    try {
+      return window.mixpanel.track(key, attrs);
+    }
+    catch (err) {
+      console.error(err); // eslint-disable-line no-console
+    }
+  }
+}

--- a/app/assets/javascripts/homeroom_table/main.jsx
+++ b/app/assets/javascripts/homeroom_table/main.jsx
@@ -1,4 +1,5 @@
 import HomeroomTable from './homeroom_table.jsx';
+import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
 const ReactDOM = window.ReactDOM;
 
 $(function() {
@@ -13,7 +14,6 @@ $(function() {
     // track user for mixpanel
     const currentEducator = $('#current-educator-data').data().currentEducator;
     const homeroom = $('#homeroom-data').data().homeroom;
-    const MixpanelUtils = window.shared.MixpanelUtils;
     MixpanelUtils.registerUser(currentEducator);
     MixpanelUtils.track('PAGE_VISIT', {
       page_key: 'ROSTER_PAGE',

--- a/app/assets/javascripts/school_overview/main.jsx
+++ b/app/assets/javascripts/school_overview/main.jsx
@@ -1,8 +1,8 @@
 //= require ./school_overview_page
+import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
 
 $(function() {
   if ($('body').hasClass('schools') && $('body').hasClass('show')) {
-    const MixpanelUtils = window.shared.MixpanelUtils;
     const SchoolOverviewPage = window.shared.SchoolOverviewPage;
     const Filters = window.shared.Filters;
 

--- a/app/assets/javascripts/school_overview/school_overview_page.jsx
+++ b/app/assets/javascripts/school_overview/school_overview_page.jsx
@@ -1,8 +1,8 @@
 import StudentsTable from '../components/students_table.jsx';
+import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
 
 (function(root) {
   window.shared || (window.shared = {});
-  const MixpanelUtils = window.shared.MixpanelUtils;
   const SlicePanels = window.shared.SlicePanels;
   const SliceButtons = window.shared.SliceButtons;
   const styles = window.shared.styles;

--- a/app/assets/javascripts/service_uploads/main.jsx
+++ b/app/assets/javascripts/service_uploads/main.jsx
@@ -1,11 +1,11 @@
 const ReactDOM = window.ReactDOM;
+import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
 
 $(function() {
   // only run if the correct page
   if (!($('body').hasClass('service_uploads') && $('body').hasClass('index'))) return;
 
   const ServiceUploadsPage = window.shared.ServiceUploadsPage;
-  const MixpanelUtils = window.shared.MixpanelUtils;
 
   const serializedData = $('#serialized-data').data();
   MixpanelUtils.registerUser(serializedData.currentEducator);

--- a/app/assets/javascripts/star_math/main.jsx
+++ b/app/assets/javascripts/star_math/main.jsx
@@ -1,7 +1,8 @@
+import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
+
 $(function() {
 
   if ($('body').hasClass('schools') && $('body').hasClass('star_math')) {
-    const MixpanelUtils = window.shared.MixpanelUtils;
     const StarChartsPage = window.shared.StarChartsPage;
     const Filters = window.shared.Filters;
 

--- a/app/assets/javascripts/star_reading/main.jsx
+++ b/app/assets/javascripts/star_reading/main.jsx
@@ -1,10 +1,11 @@
+import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
+
 $(function() {
 
   if ($('body').hasClass('schools') && $('body').hasClass('star_reading')) {
-    const MixpanelUtils = window.shared.MixpanelUtils;
     const StarChartsPage = window.shared.StarChartsPage;
     const Filters = window.shared.Filters;
-    
+
     const serializedData = $('#serialized-data').data();
     MixpanelUtils.registerUser(serializedData.currentEducator);
     MixpanelUtils.track('PAGE_VISIT', { page_key: 'STAR_READING_PAGE' });

--- a/app/assets/javascripts/student_profile/main.jsx
+++ b/app/assets/javascripts/student_profile/main.jsx
@@ -1,3 +1,4 @@
+import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
 const ReactDOM = window.ReactDOM;
 
 $(function() {
@@ -7,7 +8,6 @@ $(function() {
   // imports
   const PageContainer = window.shared.PageContainer;
   const parseQueryString = window.shared.parseQueryString;
-  const MixpanelUtils = window.shared.MixpanelUtils;
 
   // entry point, reading static bootstrapped data from the page
   const serializedData = $('#serialized-data').data();

--- a/app/assets/javascripts/student_profile/page_container.jsx
+++ b/app/assets/javascripts/student_profile/page_container.jsx
@@ -1,8 +1,9 @@
+import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
+
 (function() {
   window.shared || (window.shared = {});
   const merge = window.shared.ReactHelpers.merge;
 
-  const MixpanelUtils = window.shared.MixpanelUtils;
   const Routes = window.shared.Routes;
   const StudentProfilePage = window.shared.StudentProfilePage;
   const PropTypes = window.shared.PropTypes;

--- a/app/assets/javascripts/student_searchbar.js
+++ b/app/assets/javascripts/student_searchbar.js
@@ -1,10 +1,11 @@
+import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
+
 $(function() {
 
   function setupSearchBarAutocomplete (names) {
     $(".student-searchbar").autocomplete({
       source: names,
       select: function(e, ui) {
-        var MixpanelUtils = window.shared.MixpanelUtils;
         MixpanelUtils.track('SEARCHBAR_SELECTED_STUDENT', {});
         window.location.pathname = '/students/' + ui.item.id;
       },

--- a/app/assets/javascripts/student_searchbar.js
+++ b/app/assets/javascripts/student_searchbar.js
@@ -1,4 +1,4 @@
-import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
+import MixpanelUtils from './helpers/mixpanel_utils.jsx';
 
 $(function() {
 


### PR DESCRIPTION
# Notes 

+ Nothing special about MixpanelUtils in particular, just a very straightforward chunk of code -- a good place to start moving slowly towards using `import` instead of `window.shared` and begin turning that into an easily repeatable task