### PR TITLE
Fix non-deterministic spec around valid registration date

### DIFF
--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe Student do
     context 'future registration date' do
       let(:student) {
         FactoryGirl.build(
-          :student, registration_date: Time.now + 1.year, local_id: '2000'
+          :student,
+          registration_date: Time.now + 1.year,
+          local_id: '2000',
+          grade: '1'
         )
       }
       it 'is invalid' do


### PR DESCRIPTION
# Notes 

+ FactoryGirl is being told to randomly assign grades to student; if FactoryGirl assigns grade == PK, the student's registration date will be valid even if it's in the future
+ Make the grade fixed so that the spec becomes totally deterministic, no randomness from FactoryGirl