### PR TITLE
WIP – Switch to database-level dependent: destroy cascades for three event columns

### DIFF
--- a/db/migrate/20170823184540_use_database_level_destroy_cascades_for_events.rb
+++ b/db/migrate/20170823184540_use_database_level_destroy_cascades_for_events.rb
@@ -1,0 +1,27 @@
+class UseDatabaseLevelDestroyCascadesForEvents < ActiveRecord::Migration[5.1]
+  def change
+    district_name = ENV['DISTRICT_NAME']
+
+    if district_name == 'Somerville'
+      # Delete all absences, tardies, and discipline incidents in Somerville, since removing the foreign keys makes them essentially dead records
+
+      Absences.destroy_all
+      DisciplineIncidents.destroy_all
+      Tardies.destroy_all
+    end
+
+    remove_foreign_key :absences, :students
+    remove_foreign_key :discipline_incidents, :students
+    remove_foreign_key :tardies, :students
+
+    add_foreign_key :absences, :students, on_delete: :cascade
+    add_foreign_key :discipline_incidents, :students, on_delete: :cascade
+    add_foreign_key :tardies, :students, on_delete: :cascade
+
+    if district_name == 'Somerville'
+      # Start new import job for Somerville since we've deleted all the events
+
+      Delayed::Job.enqueue ImportJob.new
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170818154033) do
+ActiveRecord::Schema.define(version: 20170823184540) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -327,7 +327,7 @@ ActiveRecord::Schema.define(version: 20170818154033) do
     t.index ["student_id"], name: "index_tardies_on_student_id"
   end
 
-  add_foreign_key "absences", "students"
-  add_foreign_key "discipline_incidents", "students"
-  add_foreign_key "tardies", "students"
+  add_foreign_key "absences", "students", on_delete: :cascade
+  add_foreign_key "discipline_incidents", "students", on_delete: :cascade
+  add_foreign_key "tardies", "students", on_delete: :cascade
 end


### PR DESCRIPTION
# Issue

+ Fix #246

# Notes 

+ This is a super destructive migration. In order to add the right database-level cascades, we have to remove the foreign key associations. That means we need to delete all the records in question and then re-run the import process. 

+ The right way to do this would be to run the migration at night or when we're confident folks aren't looking at the dashboard, and be ready to do a database backup in case it doesn't go well.