### PR TITLE
Cut N+1 query from school overview page

### DIFF
--- a/app/helpers/serialize_data_helper.rb
+++ b/app/helpers/serialize_data_helper.rb
@@ -37,6 +37,17 @@ module SerializeDataHelper
     ])
   end
 
+  def serialize_event_note_for_school_overview(event_note)
+    event_note.as_json.symbolize_keys.slice(*[
+      :id,
+      :student_id,
+      :educator_id,
+      :event_note_type_id,
+      :recorded_at,
+      :is_restricted,
+    ])
+  end
+
   # deprecated
   def serialize_intervention(intervention)
     {

--- a/app/helpers/students_query_helper.rb
+++ b/app/helpers/students_query_helper.rb
@@ -27,7 +27,7 @@ module StudentsQueryHelper
         interventions: mutable_fields[:all_interventions].select {|intervention| intervention.student_id == student_hash[:id] }
       }
       student_hash.merge({
-        event_notes: for_student[:event_notes].map {|x| serialize_event_note_without_attachments(x) },
+        event_notes: for_student[:event_notes].map {|x| serialize_event_note_for_school_overview(x) },
         active_services: for_student[:active_services].map {|x| serialize_service(x) },
         summer_services: for_student[:summer_services].map {|x| serialize_service(x) },
         interventions: for_student[:interventions].map {|x| serialize_intervention(x) },
@@ -48,7 +48,7 @@ module StudentsQueryHelper
   end
 
   # Computes a key for reading and writing precomputed student_hashes documents.
-  # 
+  #
   # The original formats to this key concatenated all student_ids but is deprecated and
   # no longer used (although it's still here since data still exists thats keyed like that).
   # That can be accessed with `force_deprecated_key`.


### PR DESCRIPTION
# Notes 

+ Make new event note serializer method for school overview
+ New serializer method does not include event note revisions or event note text, since those are not used in the school overview page
+ Trying to cut down on this big ole N+1 query: https://github.com/studentinsights/studentinsights/issues/988#issuecomment-325204636
+ Curious to see if this helps on #988.