### PR TITLE
Make event note serializer class

### DIFF
--- a/app/controllers/event_notes_controller.rb
+++ b/app/controllers/event_notes_controller.rb
@@ -1,5 +1,4 @@
 class EventNotesController < ApplicationController
-  include SerializeDataHelper
 
   rescue_from Exceptions::EducatorNotAuthorized, with: :render_unauthorized_json!
 
@@ -17,8 +16,10 @@ class EventNotesController < ApplicationController
       recorded_at: Time.now
     }))
 
+    serializer = EventNoteSerializer.new(event_note)
+
     if event_note.save
-      render json: serialize_event_note(event_note)
+      render json: serializer.serialize_event_note
     else
       render json: { errors: event_note.errors.full_messages }, status: 422
     end
@@ -28,6 +29,8 @@ class EventNotesController < ApplicationController
     event_note_id = params[:id]
 
     event_note = EventNote.find(event_note_id)
+
+    serializer = EventNoteSerializer.new(event_note)
 
     # Save the state of the existing event note.
     previous_event_note_revision = EventNoteRevision.where(
@@ -56,7 +59,7 @@ class EventNotesController < ApplicationController
     end
 
     if event_note.update!(event_note_params)
-      render json: serialize_event_note(event_note)
+      render json: serializer.serialize_event_note
     else
       render json: { errors: event_note.errors.full_messages }, status: 422
     end

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -97,7 +97,7 @@ class SchoolsController < ApplicationController
   def constant_indexes
     {
       service_types_index: service_types_index,
-      event_note_types_index: event_note_types_index
+      event_note_types_index: EventNoteSerializer.event_note_types_index
     }
   end
 

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -34,7 +34,7 @@ class StudentsController < ApplicationController
       chart_data: chart_data,                                   # STAR, MCAS, discipline, attendance charts
       dibels: student.student_assessments.by_family('DIBELS'),
       service_types_index: service_types_index,
-      event_note_types_index: event_note_types_index,
+      event_note_types_index: EventNoteSerializer.event_note_types_index,
       educators_index: Educator.to_index,
       access: student.latest_access_results,
       iep_documents: student.iep_documents,
@@ -54,7 +54,7 @@ class StudentsController < ApplicationController
       current_educator: current_educator,
       student: serialize_student_for_profile(student),
       feed: student_feed(student, restricted_notes: true),
-      event_note_types_index: event_note_types_index,
+      event_note_types_index: EventNoteSerializer.event_note_types_index,
       educators_index: Educator.to_index,
     }
   end

--- a/app/helpers/serialize_data_helper.rb
+++ b/app/helpers/serialize_data_helper.rb
@@ -15,39 +15,6 @@ module SerializeDataHelper
     })
   end
 
-  def serialize_event_note(event_note)
-    attachments = event_note.event_note_attachments.map do |event_note_attachment|
-      event_note_attachment.as_json.symbolize_keys.slice(:id, :url)
-    end
-    serialize_event_note_without_attachments(event_note).merge({
-      attachments: attachments
-    })
-  end
-
-  def serialize_event_note_without_attachments(event_note)
-    event_note.as_json(include: :event_note_revisions).symbolize_keys.slice(*[
-      :id,
-      :student_id,
-      :educator_id,
-      :event_note_type_id,
-      :text,
-      :recorded_at,
-      :is_restricted,
-      :event_note_revisions
-    ])
-  end
-
-  def serialize_event_note_for_school_overview(event_note)
-    event_note.as_json.symbolize_keys.slice(*[
-      :id,
-      :student_id,
-      :educator_id,
-      :event_note_type_id,
-      :recorded_at,
-      :is_restricted,
-    ])
-  end
-
   # deprecated
   def serialize_intervention(intervention)
     {
@@ -72,11 +39,4 @@ module SerializeDataHelper
     index
   end
 
-  def event_note_types_index
-    index = {}
-    EventNoteType.all.each do |event_note_type|
-      index[event_note_type.id] = event_note_type.as_json.symbolize_keys.slice(:id, :name)
-    end
-    index
-  end
 end

--- a/app/helpers/students_query_helper.rb
+++ b/app/helpers/students_query_helper.rb
@@ -27,7 +27,7 @@ module StudentsQueryHelper
         interventions: mutable_fields[:all_interventions].select {|intervention| intervention.student_id == student_hash[:id] }
       }
       student_hash.merge({
-        event_notes: for_student[:event_notes].map {|x| serialize_event_note_for_school_overview(x) },
+        event_notes: for_student[:event_notes].map {|x| EventNoteSerializer.new(x).serialize_for_school_overview },
         active_services: for_student[:active_services].map {|x| serialize_service(x) },
         summer_services: for_student[:summer_services].map {|x| serialize_service(x) },
         interventions: for_student[:interventions].map {|x| serialize_intervention(x) },

--- a/app/serializers/event_note_serializer.rb
+++ b/app/serializers/event_note_serializer.rb
@@ -1,0 +1,45 @@
+class EventNoteSerializer < Struct.new :event_note
+
+  def serialize_event_note
+    attachments = event_note.event_note_attachments.map do |event_note_attachment|
+      event_note_attachment.as_json.symbolize_keys.slice(:id, :url)
+    end
+
+    serialize_event_without_attachments.merge({
+      attachments: attachments
+    })
+  end
+
+  def serialize_event_without_attachments
+    event_note.as_json(include: :event_note_revisions).symbolize_keys.slice(*[
+      :id,
+      :student_id,
+      :educator_id,
+      :event_note_type_id,
+      :text,
+      :recorded_at,
+      :is_restricted,
+      :event_note_revisions
+    ])
+  end
+
+  def serialize_for_school_overview
+    event_note.as_json.symbolize_keys.slice(*[
+      :id,
+      :student_id,
+      :educator_id,
+      :event_note_type_id,
+      :recorded_at,
+      :is_restricted,
+    ])
+  end
+
+  def self.event_note_types_index
+    index = {}
+    EventNoteType.all.each do |event_note_type|
+      index[event_note_type.id] = event_note_type.as_json.symbolize_keys.slice(:id, :name)
+    end
+    index
+  end
+
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,7 @@ module SomervilleTeacherTool
       class_paths = [
         "#{config.root}/app/models",
         "#{config.root}/app/jobs",
+        "#{config.root}/app/serializers",
         "#{config.root}/app/importers/clients",
         "#{config.root}/app/importers/data_transformers",
         "#{config.root}/app/importers/file_importers",


### PR DESCRIPTION
# Notes 

+ After fixing up N+1 query #992, refactoring the relevant code (event note serialization) to be a bit more object-oriented: one class that handles event note serialization, different methods within the class for different event note serialization needs 
+ In the same spirit/rationale as #989
+ Also aiming to follow the spirit of the Sandi Metz Rules — https://robots.thoughtbot.com/sandi-metz-rules-for-developers — shorter classes/files