### PR TITLE
All specs should be run with Time Zone ==> Eastern Time

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,8 @@ SimpleCov.start
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
+ENV['TZ'] ||= 'America/New_York'
+
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?


### PR DESCRIPTION
# Notes 

+ My local machine is usually on Central Time, but our specs expect `Time.now` to equal results in Eastern Time
+ Make sure test environment always thinks it's Eastern Time to keep everything consistent