### PR TITLE
Exercise event note creation in StudentsController; fix bug

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -135,7 +135,7 @@ class StudentsController < ApplicationController
     {
       event_notes: student.event_notes
         .select {|note| note.is_restricted == restricted_notes}
-        .map {|event_note| serialize_event_note(event_note) },
+        .map {|event_note| EventNoteSerializer.new(event_note).serialize_event_note },
       services: {
         active: student.services.active.map {|service| serialize_service(service) },
         discontinued: student.services.discontinued.map {|service| serialize_service(service) }

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -8,6 +8,13 @@ def create_service(student, educator)
   })
 end
 
+def create_event_note(student, educator)
+  FactoryGirl.create(:event_note, {
+    student: student,
+    educator: educator,
+  })
+end
+
 describe StudentsController, :type => :controller do
 
   describe '#show' do
@@ -55,7 +62,6 @@ describe StudentsController, :type => :controller do
             services: {active: [], discontinued: []},
             deprecated: {interventions: []}
           })
-
 
           expect(serialized_data[:service_types_index]).to eq({
             502 => {:id=>502, :name=>"Attendance Officer"},
@@ -383,12 +389,18 @@ describe StudentsController, :type => :controller do
     let(:student) { FactoryGirl.create(:student) }
     let(:educator) { FactoryGirl.create(:educator, :admin) }
     let!(:service) { create_service(student, educator) }
+    let!(:event_note) { create_event_note(student, educator) }
 
     it 'returns services' do
       feed = controller.send(:student_feed, student)
       expect(feed.keys).to eq([:event_notes, :services, :deprecated])
       expect(feed[:services].keys).to eq [:active, :discontinued]
       expect(feed[:services][:active].first[:id]).to eq service.id
+    end
+
+    it 'returns event notes' do
+      feed = controller.send(:student_feed, student)
+      expect(feed[:event_notes]).to eq 'okay'
     end
 
     context 'after service is discontinued' do

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -400,7 +400,11 @@ describe StudentsController, :type => :controller do
 
     it 'returns event notes' do
       feed = controller.send(:student_feed, student)
-      expect(feed[:event_notes]).to eq 'okay'
+      event_notes = feed[:event_notes]
+
+      expect(event_notes.size).to eq 1
+      expect(event_notes.first[:student_id]).to eq(student.id)
+      expect(event_notes.first[:educator_id]).to eq(educator.id)
     end
 
     context 'after service is discontinued' do


### PR DESCRIPTION
# Notes 

+ My last PR refactoring event notes serialization broke the Student Profile view, but the `StudentsController` spec doesn't exercise event notes so I didn't notice 
+ Turning the `StudentsController` spec red and then green again once the bug is fixed