### PR TITLE
Disallow Object.assign via .estlintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,11 @@
     "plugin:react/recommended"
   ],
   "rules": {
+    "no-restricted-properties": [2, {
+      "object": "Object",
+      "property": "assign",
+      "message": "Not supported by IE 11, try _.clone."
+    }],
     "indent": ["error", 2],
     "semi": ["error", "always"],
     "comma-dangle": ["error", "only-multiline"],


### PR DESCRIPTION
# Notes 

+ `Object.assign` not supported in IE10 or IE11, our target browsers
+ See #1000 (fix to bug caused by Object.assign not working in IE)
+ See also #999, eslint-plugin-compat didn't catch the incompatibility