### PR TITLE
change recorded_at to discontinued_at for discontinuedservice model

### DIFF
--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -47,7 +47,7 @@ class ServiceUploadsController < ApplicationController
 
         discontinued_service = DiscontinuedService.new(
           service: service,
-          recorded_at: date_ended,
+          discontinued_at: date_ended,
           recorded_by_educator: current_educator,
         )
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,6 +1,6 @@
 class ServicesController < ApplicationController
   include SerializeDataHelper
-  
+
   rescue_from Exceptions::EducatorNotAuthorized, with: :redirect_unauthorized!
   before_action :authorize!
 
@@ -15,7 +15,7 @@ class ServicesController < ApplicationController
     discontinued_service = DiscontinuedService.new({
       service_id: service_id,
       recorded_by_educator_id: current_educator.id,
-      recorded_at: Time.now
+      discontinued_at: Time.now
     })
     if discontinued_service.save
       render json: serialize_service(Service.find(service_id))

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -175,7 +175,7 @@ class StudentsController < ApplicationController
     @event_notes = @student.event_notes.where(:is_restricted => false).where(recorded_at: @filter_from_date..@filter_to_date)
 
     # Load services for the student for the filtered dates
-    @services = @student.services.includes(:discontinued_services).where("date_started <= ? AND (discontinued_services.recorded_at >= ? OR discontinued_services.recorded_at IS NULL)", @filter_to_date, @filter_from_date).order('date_started, discontinued_services.recorded_at').references(:discontinued_services)
+    @services = @student.services.includes(:discontinued_services).where("date_started <= ? AND (discontinued_services.discontinued_at >= ? OR discontinued_services.discontinued_at IS NULL)", @filter_to_date, @filter_from_date).order('date_started, discontinued_services.discontinued_at').references(:discontinued_services)
 
     # Load student school years for the filtered dates
     @student_school_years = @student.events_by_student_school_years(@filter_from_date, @filter_to_date)

--- a/app/helpers/serialize_data_helper.rb
+++ b/app/helpers/serialize_data_helper.rb
@@ -1,6 +1,6 @@
 module SerializeDataHelper
   def serialize_service(service)
-    discontinued_service = service.discontinued_services.order(:recorded_at).last
+    discontinued_service = service.discontinued_services.order(:discontinued_at).last
     service.as_json.symbolize_keys.slice(*[
       :id,
       :student_id,
@@ -11,7 +11,7 @@ module SerializeDataHelper
       :recorded_at
     ]).merge({
       discontinued_by_educator_id: discontinued_service.try(:recorded_by_educator_id),
-      discontinued_recorded_at: discontinued_service.try(:recorded_at)
+      discontinued_recorded_at: discontinued_service.try(:discontinued_at)
     })
   end
 

--- a/app/importers/student_services/student_services_file.rb
+++ b/app/importers/student_services/student_services_file.rb
@@ -78,7 +78,7 @@ class StudentServicesFile < Struct.new :file_name, :sftp_client, :log
 
     DiscontinuedService.create!(
       service: service,
-      recorded_at: date_ended,
+      discontinued_at: date_ended,
       recorded_by_educator: recorded_by_educator,
     )
   end

--- a/app/models/discontinued_service.rb
+++ b/app/models/discontinued_service.rb
@@ -2,12 +2,12 @@ class DiscontinuedService < ActiveRecord::Base
   belongs_to :service
   belongs_to :recorded_by_educator, class_name: 'Educator'
 
-  validates_presence_of :service_id, :recorded_by_educator_id, :recorded_at
-  validate :must_be_recorded_after_service_start_date
+  validates_presence_of :service_id, :recorded_by_educator_id, :discontinued_at
+  validate :must_be_discontinued_after_service_start_date
 
-  def must_be_recorded_after_service_start_date
-    if service.date_started > recorded_at
-      errors.add(:recorded_at, "must be after service start date")
+  def must_be_discontinued_after_service_start_date
+    if service.date_started > discontinued_at
+      errors.add(:discontinued_at, "must be after service start date")
     end
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -20,7 +20,7 @@ class Service < ActiveRecord::Base
     #
     # This attribute name isn't accurate
     # anymore, we should change it to "date_ended"
-    discontinued_services.order(recorded_at: :desc).first.try(:recorded_at)
+    discontinued_services.order(discontinued_at: :desc).first.try(:discontinued_at)
   end
 
   def has_scheduled_end_date?
@@ -40,12 +40,12 @@ class Service < ActiveRecord::Base
   end
 
   def self.future_discontinue
-    includes(:discontinued_services).where('discontinued_services.recorded_at > ?', DateTime.current)
+    includes(:discontinued_services).where('discontinued_services.discontinued_at > ?', DateTime.current)
                                     .references(:discontinued_services)
   end
 
   def self.discontinued
-    includes(:discontinued_services).where('discontinued_services.recorded_at < ?', DateTime.current)
+    includes(:discontinued_services).where('discontinued_services.discontinued_at < ?', DateTime.current)
                                     .references(:discontinued_services)
   end
 

--- a/db/migrate/20170905171916_rename_recorded_at_to_discontinued_at.rb
+++ b/db/migrate/20170905171916_rename_recorded_at_to_discontinued_at.rb
@@ -1,0 +1,5 @@
+class RenameRecordedAtToDiscontinuedAt < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :discontinued_services, :recorded_at, :discontinued_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170818154033) do
+ActiveRecord::Schema.define(version: 20170905171916) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,7 +81,7 @@ ActiveRecord::Schema.define(version: 20170818154033) do
   create_table "discontinued_services", id: :serial, force: :cascade do |t|
     t.integer "service_id"
     t.integer "recorded_by_educator_id"
-    t.datetime "recorded_at"
+    t.datetime "discontinued_at"
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -412,7 +412,7 @@ describe StudentsController, :type => :controller do
         DiscontinuedService.create!({
           service_id: service.id,
           recorded_by_educator_id: educator.id,
-          recorded_at: Time.now
+          discontinued_at: Time.now
         })
       end
       it 'filters it' do
@@ -545,7 +545,7 @@ describe StudentsController, :type => :controller do
 
         it 'assigns the student\'s services correctly with full history' do
           old_service = FactoryGirl.create(:service, date_started: '2012-02-22', student: student)
-          FactoryGirl.create(:discontinued_service, service: old_service, recorded_at: '2012-05-21')
+          FactoryGirl.create(:discontinued_service, service: old_service, discontinued_at: '2012-05-21')
           recent_service = FactoryGirl.create(:service, date_started: '2016-01-13', student: student)
           expect(assigns(:services)).not_to include(old_service)
           expect(assigns(:services)).to include(recent_service)

--- a/spec/factories/discontinued_services.rb
+++ b/spec/factories/discontinued_services.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :discontinued_service do
     association :service
-    recorded_at Date.new(2014, 11, 2)
+    discontinued_at Date.new(2014, 11, 2)
     association :recorded_by_educator, factory: :educator
   end
 end

--- a/spec/models/discontinued_service_spec.rb
+++ b/spec/models/discontinued_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe DiscontinuedService do
 
-  describe '#must_be_recorded_after_service_start_date' do
+  describe '#must_be_discontinued_after_service_start_date' do
     let(:educator) { FactoryGirl.create(:educator) }
 
     context 'recorded before service start date' do
@@ -11,7 +11,7 @@ RSpec.describe DiscontinuedService do
         DiscontinuedService.new(
           service: service,
           recorded_by_educator: educator,
-          recorded_at: service.date_started - 1.day,
+          discontinued_at: service.date_started - 1.day,
         )
       }
       it 'is invalid' do
@@ -25,7 +25,7 @@ RSpec.describe DiscontinuedService do
         DiscontinuedService.new(
           service: service,
           recorded_by_educator: educator,
-          recorded_at: service.date_started + 1.day,
+          discontinued_at: service.date_started + 1.day,
         )
       }
       it 'valid' do

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -9,25 +9,25 @@ RSpec.describe Service do
 
   let!(:discontinued_now) {
     service = FactoryGirl.create(:service, id: 70003)
-    DiscontinuedService.create(service: service, recorded_by_educator: educator, recorded_at: Time.now)
+    DiscontinuedService.create(service: service, recorded_by_educator: educator, discontinued_at: Time.now)
     service
   }
 
   let!(:past_discontinued) {
     service = FactoryGirl.create(:service, id: 70004)
-    DiscontinuedService.create(service: service, recorded_by_educator: educator, recorded_at: Time.now - 1.day)
+    DiscontinuedService.create(service: service, recorded_by_educator: educator, discontinued_at: Time.now - 1.day)
     service
   }
 
   let!(:future_discontinued) {
     service = FactoryGirl.create(:service, id: 70005)
-    DiscontinuedService.create(service: service, recorded_by_educator: educator, recorded_at: Time.now + 1.day)
+    DiscontinuedService.create(service: service, recorded_by_educator: educator, discontinued_at: Time.now + 1.day)
     service
   }
 
   let!(:another_future_discontinued) {
     service = FactoryGirl.create(:service, id: 70006)
-    DiscontinuedService.create(service: service, recorded_by_educator: educator, recorded_at: Time.now + 2.days)
+    DiscontinuedService.create(service: service, recorded_by_educator: educator, discontinued_at: Time.now + 2.days)
     service
   }
 


### PR DESCRIPTION
#839 
@alexsoble Basically I made a migration to change the name, then change `recorded_at` to `discontinued_at` wherever I can find for `discontinuedservice` model. The tests went down to red. I made each test green again. Its good for a review. 