### PR TITLE
Add deploy script to run auto-migrations and keep demo site up-to-date

### DIFF
--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -1,0 +1,28 @@
+SOMERVILLE_PROD_HEROKU_APP_NAME=$1
+DEMO_HEROKU_APP_NAME=$2
+
+if [ -z "$SOMERVILLE_PROD_HEROKU_APP_NAME" ]; then
+  echo "🚨  🚨  🚨  Please supply a Somerville production Heorku app name."; exit 0;
+fi
+
+if [ -z "$DEMO_HEROKU_APP_NAME" ]; then
+  echo "🚨  🚨  🚨  Please supply a demo Heorku app name."; exit 0;
+fi
+
+# Deploy to Somerville production app and migrate
+echo "🚢  🚢  🚢  Deploying code to the Somerville production app.";
+git push heroku master
+echo;
+
+echo "⚙  ⚙  ⚙  Migrating the database.";
+heroku run rake db:migrate --app "$SOMERVILLE_PROD_HEROKU_APP_NAME"
+echo;
+
+# Deploy to demo app and migrate
+echo "🚢  🚢  🚢  Deploying code to the demo Heroku app.";
+git push heroku-demo master
+echo;
+
+echo "⚙  ⚙  ⚙  Migrating the database.";
+heroku run rake db:migrate --app "$DEMO_HEROKU_APP_NAME"
+echo;


### PR DESCRIPTION
# Why? 

+ Using the script removes the possibility of forgetting to run migrations after deploying them, which would be bad. 
+ It also will keep our demo site up-to-date and migrated, which is nice because it shouldn't be randomly down when we show it to strangers. 

