### PR TITLE
Make precomputed_student_hashes_key a class method on PrecomputedQueryDoc

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -53,7 +53,7 @@ class SchoolsController < ApplicationController
       # so keep a buffer that makes sure the import task and precompute job
       # can finish before cutting over to the next day.
       query_time = time_now - 9.hours
-      key = precomputed_student_hashes_key(query_time, authorized_student_ids)
+      key = PrecomputedQueryDoc.precomputed_student_hashes_key(query_time, authorized_student_ids)
       logger.warn "load_precomputed_student_hashes querying key: #{key}..."
       doc = PrecomputedQueryDoc.find_by_key(key)
       return parse_hashes_from_doc(doc) unless doc.nil?

--- a/app/helpers/students_query_helper.rb
+++ b/app/helpers/students_query_helper.rb
@@ -47,21 +47,4 @@ module StudentsQueryHelper
     }
   end
 
-  # Computes a key for reading and writing precomputed student_hashes documents.
-  #
-  # The original formats to this key concatenated all student_ids but is deprecated and
-  # no longer used (although it's still here since data still exists thats keyed like that).
-  # That can be accessed with `force_deprecated_key`.
-  #
-  # The newer key strategy hashes the values that made up the old key so it's length is
-  # capped.
-  def precomputed_student_hashes_key(time_now, authorized_student_ids, options = {})
-    timestamp = time_now.beginning_of_day.to_i
-    authorized_students_key = authorized_student_ids.sort.join(',')
-    if options[:force_deprecated_key]
-      ['precomputed_student_hashes', timestamp, authorized_students_key].join('_')
-    else
-      ['short', timestamp, authorized_student_ids.size, Digest::SHA256.hexdigest(authorized_students_key)].join(':')
-    end
-  end
 end

--- a/app/jobs/precompute_student_hashes_job.rb
+++ b/app/jobs/precompute_student_hashes_job.rb
@@ -44,7 +44,7 @@ class PrecomputeStudentHashesJob < Struct.new :log
     authorized_students = Student.find(authorized_student_ids)
     student_hashes = authorized_students.map {|student| student_hash_for_slicing(student) }
 
-    key = precomputed_student_hashes_key(precomputed_time, authorized_student_ids)
+    key = PrecomputedQueryDoc.precomputed_student_hashes_key(precomputed_time, authorized_student_ids)
     write_doc_or_log(key, { student_hashes: student_hashes })
     nil
   end

--- a/app/models/precomputed_query_doc.rb
+++ b/app/models/precomputed_query_doc.rb
@@ -3,4 +3,19 @@ class PrecomputedQueryDoc < ActiveRecord::Base
   # and not a read-through cache.
   # The primary key means nothing, and reads and writes should be done on the `key` column, which
   # has an index and uniqueness constraint.
+
+  # The original formats to this key concatenated all student_ids but is deprecated and
+  # no longer used (although it's still here since data still exists thats keyed like that).
+  # That can be accessed with `force_deprecated_key`.
+
+  def self.precomputed_student_hashes_key(time_now, authorized_student_ids, options = {})
+    timestamp = time_now.beginning_of_day.to_i
+    authorized_students_key = authorized_student_ids.sort.join(',')
+    if options[:force_deprecated_key]
+      ['precomputed_student_hashes', timestamp, authorized_students_key].join('_')
+    else
+      ['short', timestamp, authorized_student_ids.size, Digest::SHA256.hexdigest(authorized_students_key)].join(':')
+    end
+  end
+
 end


### PR DESCRIPTION
# Notes 

+ Pulling logic out of the `StudentsQueryHelper` module and into classes in the spirit of #989
+ `#precompute_student_hashes_key` fits really naturally in the `PrecomputedQueryDoc` -- it's the key used to read and write these docs so it feels very logical there rather than in a module