### PR TITLE
Add task for caching student searchbar data in a more targeted way 

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -145,7 +145,7 @@ class Educator < ActiveRecord::Base
     if districtwide_access?
       Section.all
     elsif schoolwide_access?
-      Section.joins(:course).where('courses.school_id = ?', school.id) 
+      Section.joins(:course).where('courses.school_id = ?', school.id)
     else
       sections
     end
@@ -176,6 +176,12 @@ class Educator < ActiveRecord::Base
 
   def self.save_student_searchbar_json
     find_each { |educator| educator.save_student_searchbar_json }
+  end
+
+  def self.save_student_searchbar_json_for_folks_who_log_in
+    educators_who_log_in = Educator.where("sign_in_count > ?", 0)
+
+    educators_who_log_in.find_each { |e| e.save_student_searchbar_json }
   end
 
   def save_student_searchbar_json

--- a/lib/tasks/chores.rake
+++ b/lib/tasks/chores.rake
@@ -16,8 +16,13 @@ namespace :chores do
   end
 
   desc 'Update educator student searchbar cached data'
-  task update_educator_student_searchbars: :environment do
+  task update_searchbar_data_for_all_educators: :environment do
     Educator.save_student_searchbar_json
+  end
+
+  desc 'Update educator student searchbar data for those who have logged in'
+  task update_searchbar_data_for_educators_who_log_in: :environment do
+    Educator.save_student_searchbar_json_for_folks_who_log_in
   end
 
   desc 'Kick off background worker for data import'


### PR DESCRIPTION
# Note 

+ The `rake chores:update_searchbar_data_for_all_educators` task takes a long time to run and doesn't precompute searchbar data for all educators quickly. 
+ Of the 778 educators in the system, only 235 have logged into Insights.
+ This PR adds a task to precompute student searchbar data only for the educators who have logged in to Insights, so we can quickly get the most precomputing value for our buck -- don't precompute for educators who haven't logged in and may never. 