### PR TITLE
Start using rubocop to prevent trailing whitespace/whitespace diffs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,17 @@
+AllCops:
+  DisabledByDefault: true
+  Exclude:
+    - 'bin/**/*'
+    - 'config/**/*'
+    - 'db/**/*'
+    - 'docs/**/*'
+    - 'log/**/*'
+    - 'public/**/*'
+    - 'scripts/**/*'
+    - 'sketch/**/*'
+    - 'vendor/**/*'
+    - 'x2_export/**/*'
+    - spec/teaspoon_env.rb
+
+Layout/TrailingWhitespace:
+  Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,7 @@ script:
   - bundle exec rake db:create db:migrate DATABASE_URL=postgres://localhost/student_insights_test
   - bundle exec rspec spec
   - bundle exec teaspoon
-  # - ruby scripts/browserstack_tests/browserstack_frontend_test1.rb
-
-  # For AWS deploy, add step here:
-  # - aws/rails/build_from_travis.sh
+  - rubocop
 
 env:
   global:

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'net-ssh'
 gem 'probability'
 gem 'rails-sanitize-js'
 gem 'react-rails' # Provides React, handles swapping between dev/production builds.  See config/initializers/assets.rb
+gem 'rubocop', require: false
 gem 'memory_profiler'
 gem 'oj'
 gem 'oj_mimic_json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
       sass-rails (~> 5.0)
       selectize-rails (~> 0.6)
     arel (8.0.0)
+    ast (2.3.0)
     autoprefixer-rails (7.1.2.4)
       execjs
     aws-sdk (2.10.21)
@@ -191,9 +192,13 @@ GEM
     oj (3.3.4)
     oj_mimic_json (1.0.1)
     orm_adapter (0.5.0)
+    parallel (1.12.0)
+    parser (2.4.0.0)
+      ast (~> 2.2)
     pg (0.21.0)
     phantomjs (2.1.1.0)
     pivotal_git_scripts (1.4.0)
+    powerpack (0.1.1)
     probability (1.0.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -237,6 +242,8 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.2.2)
+      rake
     rake (12.0.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
@@ -267,6 +274,14 @@ GEM
       rspec-mocks (~> 3.6.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
+    rubocop (0.49.1)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     rubystats (0.2.6)
     rubyzip (1.2.1)
     sass (3.5.1)
@@ -319,6 +334,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.3.0)
     warden (1.2.7)
       rack (>= 1.0)
     websocket-driver (0.6.5)
@@ -372,6 +388,7 @@ DEPENDENCIES
   rails_12factor
   react-rails
   rspec-rails
+  rubocop
   rubystats
   sass-rails (~> 5.0)
   scout_apm

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,15 +1,15 @@
 class SectionsController < ApplicationController
   before_action :authorize_and_assign_section, only: :show
   before_action :authenticate_districtwide_access!, only: :index # Extra authentication layer
-  
+
   def index
-    #just setting this to all courses for now 
+    #just setting this to all courses for now
     #since we are only testing with district wide admins
     @educator_courses = Course.all.order(:course_number)
   end
-  
-  
-  
+
+
+
   def show
 
     section_students = serialize_students(@current_section.students)
@@ -25,7 +25,7 @@ class SectionsController < ApplicationController
   end
 
   private
-  def authorize_and_assign_section    
+  def authorize_and_assign_section
     requested_section = Section.find(params[:id])
 
     if current_educator.is_authorized_for_section(requested_section)

--- a/app/demo_data/demo_data_util.rb
+++ b/app/demo_data/demo_data_util.rb
@@ -1,12 +1,12 @@
 class DemoDataUtil
   # Given a map of integers or ranges to weights, e.g
-  # 
+  #
   #     d = {
   #      0 => 0.83,
   #      1 => 0.10,
   #      (2..3) => 0.07,
   #    }
-  # 
+  #
   # Randomly chooses an integer in a correctly weighted way.
   # Range keys mean that we sample uniformly from the range.
   def self.sample_from_distribution(distribution)

--- a/app/importers/file_importers/courses_sections_importer.rb
+++ b/app/importers/file_importers/courses_sections_importer.rb
@@ -19,7 +19,7 @@ class CoursesSectionsImporter < Struct.new :school_scope, :client, :log, :progre
   def import_row(row)
     course = CourseRow.new(row, school_ids_dictionary).build
     if course.school.present?
-      if course.save! 
+      if course.save!
         section = SectionRow.new(row, school_ids_dictionary, course.id).build
         section.save
       else

--- a/app/importers/file_importers/educator_section_assignments_importer.rb
+++ b/app/importers/file_importers/educator_section_assignments_importer.rb
@@ -18,8 +18,8 @@ class EducatorSectionAssignmentsImporter < Struct.new :school_scope, :client, :l
 
   def import_row(row)
     educator_section_assignment = EducatorSectionAssignmentRow.new(row).build
-    
-    if educator_section_assignment 
+
+    if educator_section_assignment
       educator_section_assignment.save!
     else
       log.write("Educator Section Assignment Import invalid row: #{row}")

--- a/app/importers/file_importers/file_import.rb
+++ b/app/importers/file_importers/file_import.rb
@@ -7,7 +7,7 @@ class FileImport < Struct.new :file_importer
     log_start_of_import
     delete_data if deletion_models.include?(file_importer.class)
     fetch_data
-    import_data 
+    import_data
   end
 
   private
@@ -33,10 +33,10 @@ class FileImport < Struct.new :file_importer
   end
 
   def deletion_models
-    [StudentSectionAssignmentsImporter, 
+    [StudentSectionAssignmentsImporter,
     EducatorSectionAssignmentsImporter]
   end
-  
+
   def fetch_data
     transformer = data_transformer
     @data = transformer.transform(file)

--- a/app/importers/rows/course_row.rb
+++ b/app/importers/rows/course_row.rb
@@ -1,14 +1,14 @@
 class CourseRow < Struct.new(:row, :school_ids_dictionary)
   # Represents a row in a CSV export from Somerville's Aspen X2 student information system.
-  # This structure represents courses ignoring the section data. Unfortunately this is run 
+  # This structure represents courses ignoring the section data. Unfortunately this is run
   # for each section, rather than each course.
   #
   # Expects the following headers:
   #
-  #   :course_number, :course_description, :school_local_id, 
+  #   :course_number, :course_description, :school_local_id,
   #   :section_number, :term_local_id, :section_schedule,
   #   :section_room_number
-  
+
   def self.build(row)
     new(row).build
   end

--- a/app/importers/rows/educator_section_assignment_row.rb
+++ b/app/importers/rows/educator_section_assignment_row.rb
@@ -4,11 +4,11 @@ class EducatorSectionAssignmentRow < Struct.new(:row, :school_ids_dictionary)
   #
   # Expects the following headers:
   #
-  #   :local_id, :course_number, :school_local_id, :section_number, 
+  #   :local_id, :course_number, :school_local_id, :section_number,
   #   :term_local_id
   #
 
-  
+
   def self.build(row)
     new(row).build
   end

--- a/app/importers/rows/mcas_row.rb
+++ b/app/importers/rows/mcas_row.rb
@@ -1,6 +1,6 @@
 class McasRow < Struct.new :row
   # Represents a row in a CSV export from Somerville's Aspen X2 student information system.
-  
+
   VALID_MCAS_SUBJECTS = [ 'ELA', 'Mathematics' ].freeze
 
   class NullRow

--- a/app/importers/rows/section_row.rb
+++ b/app/importers/rows/section_row.rb
@@ -4,17 +4,17 @@ class SectionRow < Struct.new(:row, :school_ids_dictionary, :course_id)
   #
   # Expects the following headers:
   #
-  #   :course_number, :course_description, :school_local_id, 
+  #   :course_number, :course_description, :school_local_id,
   #   :section_number, :term_local_id, :section_schedule,
   #   :section_room_number
-  
+
   def self.build(row)
     new(row).build
   end
 
   def build
-    section = Section.find_or_initialize_by(section_number: row[:section_number], 
-                                            course_id: course_id, 
+    section = Section.find_or_initialize_by(section_number: row[:section_number],
+                                            course_id: course_id,
                                             term_local_id: row[:term_local_id])
     section.schedule = row[:section_schedule]
     section.room_number = row[:section_room_number]

--- a/app/importers/rows/student_section_assignment_row.rb
+++ b/app/importers/rows/student_section_assignment_row.rb
@@ -4,12 +4,12 @@ class StudentSectionAssignmentRow < Struct.new(:row, :school_ids_dictionary)
   #
   # Expects the following headers:
   #
-  #   :local_id, :course_number, :school_local_id, :section_number, 
+  #   :local_id, :course_number, :school_local_id, :section_number,
   #   :term_local_id
   #
   # Eventually this will also include the letter grade for graded courses
 
-  
+
   def self.build(row)
     new(row).build
   end

--- a/lib/analysis/analyze_star_file_dates.rb
+++ b/lib/analysis/analyze_star_file_dates.rb
@@ -13,7 +13,7 @@ class AnalyzeStarFileDates < Struct.new(:path)
     puts 'Last date:'
     puts sorted_csv.last
   end
-  
+
   private
   def star_date_to_ruby_date(star_date)
     date_part = star_date.split(' ')[0]

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -15,7 +15,7 @@ describe SectionsController, :type => :controller do
   let(:other_school) { FactoryGirl.create(:school) }
   let(:other_school_course) { FactoryGirl.create(:course, school: other_school) }
   let(:other_school_section) { FactoryGirl.create(:section, course: other_school_course) }
-  
+
 
   describe '#show' do
     def make_request(id = nil)
@@ -26,18 +26,18 @@ describe SectionsController, :type => :controller do
     def extract_serialized_ids(controller, instance)
       serialized_data = controller.instance_variable_get(:@serialized_data)
       serialized_data[instance].map {|data_hash| data_hash['id'] }
-    end 
+    end
 
 
     context 'educator with section logged in' do
       let!(:educator) { FactoryGirl.create(:educator, school: school) }
       let!(:first_esa) { FactoryGirl.create(:educator_section_assignment, educator: educator, section: first_section)}
       let!(:second_esa) { FactoryGirl.create(:educator_section_assignment, educator: educator, section: second_section)}
-      
+
       before { sign_in(educator) }
 
       context 'section params' do
-        
+
         context 'garbage params' do
           it 'does not raise an error' do
             expect { make_request('garbage section ids rule') }.not_to raise_error
@@ -90,7 +90,7 @@ describe SectionsController, :type => :controller do
 
     context 'admin educator logged in' do
       let(:admin_educator) { FactoryGirl.create(:educator, :admin, school: school) }
-      
+
       before { sign_in(admin_educator) }
 
       context 'when requesting a section inside their school' do
@@ -105,7 +105,7 @@ describe SectionsController, :type => :controller do
           sections = extract_serialized_ids(controller, :sections)
           expect(sections).to match_array(expected_section_ids)
         end
-      end 
+      end
 
       context 'when requesting section outside their school' do
         it 'redirects' do
@@ -114,10 +114,10 @@ describe SectionsController, :type => :controller do
         end
       end
     end
-    
+
     context 'districtwide educator logged in' do
       let(:dw_educator) { FactoryGirl.create(:educator, districtwide_access: true) }
-  
+
       before { sign_in(dw_educator) }
 
       context 'when requesting a section in any school' do

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -155,13 +155,13 @@ describe StudentsController, :type => :controller do
           let!(:esa) { FactoryGirl.create(:educator_section_assignment, educator: educator, section: section) }
           let!(:section_student) { FactoryGirl.create(:student, school: school) }
           let!(:ssa) { FactoryGirl.create(:student_section_assignment, student: section_student, section: section) }
-          
+
           it 'is successful' do
             make_request({ student_id: section_student.id, format: :html })
             expect(response).to be_success
           end
         end
-          
+
 
         context 'educator does not have schoolwide, grade level, or homeroom access' do
           let(:educator) { FactoryGirl.create(:educator, school: school) }

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   sequence(:course_number_seq) { |n| "COURSE-#{n}" }
-  
+
   factory :course do
     course_number { generate(:course_number_seq) }
     association :school

--- a/spec/importers/file_importers/courses_sections_importer_spec.rb
+++ b/spec/importers/file_importers/courses_sections_importer_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe CoursesSectionsImporter do
     let!(:school) { FactoryGirl.create(:shs) }
 
     context 'happy path' do
-      let(:row) { { course_number:'ART-205', 
-                    course_description:'Handmade Ceramics I', 
-                    section_number:'ART-205B', 
+      let(:row) { { course_number:'ART-205',
+                    course_description:'Handmade Ceramics I',
+                    section_number:'ART-205B',
                     school_local_id: 'SHS',
-                    term_local_id:'FY', 
-                    section_schedule:'3(M-R)', 
+                    term_local_id:'FY',
+                    section_schedule:'3(M-R)',
                     section_room_number:'232B'
                 } }
 
@@ -34,11 +34,11 @@ RSpec.describe CoursesSectionsImporter do
       end
 
       context 'missing school_local_id' do
-        let(:row) { { course_number:'ART-205', 
-                    course_description:'Handmade Ceramics I', 
-                    section_number:'ART-205B', 
-                    term_local_id:'FY', 
-                    section_schedule:'3(M-R)', 
+        let(:row) { { course_number:'ART-205',
+                    course_description:'Handmade Ceramics I',
+                    section_number:'ART-205B',
+                    term_local_id:'FY',
+                    section_schedule:'3(M-R)',
                     section_room_number:'232B'
                 } }
 

--- a/spec/importers/file_importers/educator_section_assignments_importer.rb
+++ b/spec/importers/file_importers/educator_section_assignments_importer.rb
@@ -9,10 +9,10 @@ RSpec.describe EducatorSectionAssignmentsImporter do
     let!(:educator) { FactoryGirl.create(:educator) }
 
     context 'happy path' do
-      let(:row) { { local_id:educator.local_id, 
-                    course_number:section.course.course_number, 
+      let(:row) { { local_id:educator.local_id,
+                    course_number:section.course.course_number,
                     school_local_id: 'SHS',
-                    section_number:section.section_number, 
+                    section_number:section.section_number,
                     term_local_id:'FY'
                 } }
 
@@ -31,9 +31,9 @@ RSpec.describe EducatorSectionAssignmentsImporter do
       end
 
     context 'educator lasid is missing' do
-      let(:row) { { course_number:section.course.course_number, 
+      let(:row) { { course_number:section.course.course_number,
                     school_local_id: 'SHS',
-                    section_number:section.section_number, 
+                    section_number:section.section_number,
                     term_local_id:'FY'
                 } }
 
@@ -50,8 +50,8 @@ RSpec.describe EducatorSectionAssignmentsImporter do
 
       context 'section is missing' do
         let(:row) { { local_id:educator.local_id,
-                    course_number:section.course.course_number, 
-                    school_local_id: 'SHS', 
+                    course_number:section.course.course_number,
+                    school_local_id: 'SHS',
                     term_local_id:'FY'
                 } }
 
@@ -68,9 +68,9 @@ RSpec.describe EducatorSectionAssignmentsImporter do
 
       context 'educator does not exist' do
         let(:row) { { local_id: 'NO EXIST',
-                    course_number:section.course.course_number, 
-                    school_local_id: 'SHS', 
-                    section_number:section.section_number, 
+                    course_number:section.course.course_number,
+                    school_local_id: 'SHS',
+                    section_number:section.section_number,
                     term_local_id:'FY'
                 } }
 
@@ -87,9 +87,9 @@ RSpec.describe EducatorSectionAssignmentsImporter do
 
       context 'section does not exist' do
         let(:row) { { local_id: educator.local_id,
-                    course_number:section.course.course_number, 
-                    school_local_id: 'SHS', 
-                    section_number:'NO EXIST', 
+                    course_number:section.course.course_number,
+                    school_local_id: 'SHS',
+                    section_number:'NO EXIST',
                     term_local_id:'FY'
                 } }
 
@@ -107,7 +107,7 @@ RSpec.describe EducatorSectionAssignmentsImporter do
 
 
     describe '#delete_rows' do
-    
+
       context 'happy path' do
 
         before do

--- a/spec/importers/file_importers/student_section_assignments_importer_spec.rb
+++ b/spec/importers/file_importers/student_section_assignments_importer_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe StudentSectionAssignmentsImporter do
     let!(:student) { FactoryGirl.create(:student) }
 
     context 'happy path' do
-      let(:row) { { local_id:student.local_id, 
-                    course_number:section.course.course_number, 
+      let(:row) { { local_id:student.local_id,
+                    course_number:section.course.course_number,
                     school_local_id: 'SHS',
-                    section_number:section.section_number, 
+                    section_number:section.section_number,
                     term_local_id:'FY'
                 } }
 
@@ -31,9 +31,9 @@ RSpec.describe StudentSectionAssignmentsImporter do
       end
 
       context 'student lasid is missing' do
-        let(:row) { { course_number:section.course.course_number, 
+        let(:row) { { course_number:section.course.course_number,
                     school_local_id: 'SHS',
-                    section_number:section.section_number, 
+                    section_number:section.section_number,
                     term_local_id:'FY'
                 } }
 
@@ -48,8 +48,8 @@ RSpec.describe StudentSectionAssignmentsImporter do
       end
 
       context 'section is missing' do
-        let(:row) { { local_id:student.local_id, 
-                    course_number:section.course.course_number, 
+        let(:row) { { local_id:student.local_id,
+                    course_number:section.course.course_number,
                     school_local_id: 'SHS',
                     term_local_id:'FY'
                 } }
@@ -65,10 +65,10 @@ RSpec.describe StudentSectionAssignmentsImporter do
       end
 
       context 'student does not exist' do
-        let(:row) { { local_id:'NO EXIST', 
-                    course_number:section.course.course_number, 
+        let(:row) { { local_id:'NO EXIST',
+                    course_number:section.course.course_number,
                     school_local_id: 'SHS',
-                    section_number:section.section_number, 
+                    section_number:section.section_number,
                     term_local_id:'FY'
                 } }
 
@@ -83,10 +83,10 @@ RSpec.describe StudentSectionAssignmentsImporter do
       end
 
       context 'section does not exist' do
-      let(:row) { { local_id:student.local_id, 
-                    course_number:section.course.course_number, 
+      let(:row) { { local_id:student.local_id,
+                    course_number:section.course.course_number,
                     school_local_id: 'SHS',
-                    section_number:'NO EXIST', 
+                    section_number:'NO EXIST',
                     term_local_id:'FY'
                 } }
 
@@ -102,7 +102,7 @@ RSpec.describe StudentSectionAssignmentsImporter do
     end
 
     describe '#delete_rows' do
-    
+
       context 'happy path' do
 
         before do

--- a/spec/importers/rows/course_row_spec.rb
+++ b/spec/importers/rows/course_row_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe CourseRow do
     let(:course) { course_row.build }
 
     context 'happy path' do
-      let(:row) { { course_number:'ART-205', 
-                    course_description:'Handmade Ceramics I', 
-                    section_number:'ART-205B', 
-                    term_local_id:'FY', 
-                    section_schedule:'3(M-R)', 
+      let(:row) { { course_number:'ART-205',
+                    course_description:'Handmade Ceramics I',
+                    section_number:'ART-205B',
+                    term_local_id:'FY',
+                    section_schedule:'3(M-R)',
                     section_room_number:'232B'
                 } }
 

--- a/spec/importers/rows/educator_section_assignment_row_spec.rb
+++ b/spec/importers/rows/educator_section_assignment_row_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe EducatorSectionAssignmentRow do
     context 'happy path' do
       let!(:section) { FactoryGirl.create(:section) }
       let!(:educator) { FactoryGirl.create(:educator) }
-      let(:row) { { local_id: educator.local_id, 
-                    section_number: section.section_number, 
+      let(:row) { { local_id: educator.local_id,
+                    section_number: section.section_number,
                 } }
 
       it 'assigns info correctly' do

--- a/spec/importers/rows/section_row_spec.rb
+++ b/spec/importers/rows/section_row_spec.rb
@@ -8,18 +8,18 @@ RSpec.describe SectionRow do
     let(:section) { section_row.build }
 
     context 'happy path' do
-      let(:row) { { course_number:'ART-205', 
-                    course_description:'Handmade Ceramics I', 
-                    section_number:'ART-205B', 
-                    term_local_id:'FY', 
-                    section_schedule:'3(M-R)', 
+      let(:row) { { course_number:'ART-205',
+                    course_description:'Handmade Ceramics I',
+                    section_number:'ART-205B',
+                    term_local_id:'FY',
+                    section_schedule:'3(M-R)',
                     section_room_number:'232B'
                 } }
 
       it 'assigns info correctly' do
         expect(section.section_number).to eq 'ART-205B'
         expect(section.term_local_id).to eq 'FY'
-        expect(section.schedule).to eq '3(M-R)' 
+        expect(section.schedule).to eq '3(M-R)'
         expect(section.room_number).to eq '232B'
       end
     end

--- a/spec/importers/rows/student_section_assignment_row_spec.rb
+++ b/spec/importers/rows/student_section_assignment_row_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe StudentSectionAssignmentRow do
     context 'happy path' do
       let!(:section) { FactoryGirl.create(:section) }
       let!(:student) { FactoryGirl.create(:high_school_student) }
-      let(:row) { { local_id: student.local_id, 
-                    section_number: section.section_number, 
+      let(:row) { { local_id: student.local_id,
+                    section_number: section.section_number,
                 } }
 
       it 'assigns info correctly' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Course, type: :model do
 
   context 'valid course' do
     let(:course) { FactoryGirl.build(:course)}
-    
+
     it 'is valid' do
       expect(course).to be_valid
     end

--- a/spec/models/educator_section_assignment_spec.rb
+++ b/spec/models/educator_section_assignment_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe EducatorSectionAssignment, type: :model do
 
   context 'valid course' do
     let(:educator_section_assignment) { FactoryGirl.build(:educator_section_assignment)}
-    
+
     it 'is valid' do
       expect(educator_section_assignment).to be_valid
     end

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Educator do
         let!(:section) { FactoryGirl.create(:section, course: course) }
         let!(:esa) { FactoryGirl.create(:educator_section_assignment, educator: educator, section: section) }
         let!(:ssa) { FactoryGirl.create(:student_section_assignment, student: student, section: section) }
-        
+
         it 'is authorized' do
           expect(authorized?).to be true
         end
@@ -321,7 +321,7 @@ RSpec.describe Educator do
 
     context 'schoolwide_access' do
       let(:schoolwide_educator) { FactoryGirl.create(:educator, school: school, schoolwide_access: true)}
-      
+
       it 'has access to a section in their school' do
         expect(schoolwide_educator.is_authorized_for_section(in_school_section)).to be true
       end
@@ -333,7 +333,7 @@ RSpec.describe Educator do
 
     context 'districtwide_access' do
       let(:districtwide_educator) { FactoryGirl.create(:educator, school: school, districtwide_access: true)}
-      
+
       it 'has access to a section outside their school' do
         expect(districtwide_educator.is_authorized_for_section(out_of_school_section)).to be true
       end
@@ -343,7 +343,7 @@ RSpec.describe Educator do
       let(:educator) { FactoryGirl.create(:educator, school: school) }
       let!(:other_in_school_section) { FactoryGirl.create(:section, course: in_school_course) }
       let!(:esa) { FactoryGirl.create(:educator_section_assignment, educator: educator, section: in_school_section) }
-      
+
       it 'has access to a section assigned to that educator' do
         expect(educator.is_authorized_for_section(in_school_section)).to be true
       end

--- a/spec/models/student_section_assignment_spec.rb
+++ b/spec/models/student_section_assignment_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe StudentSectionAssignment, type: :model do
 
   context 'valid course' do
     let(:student_section_assignment) { FactoryGirl.build(:student_section_assignment)}
-    
+
     it 'is valid' do
       expect(student_section_assignment).to be_valid
     end


### PR DESCRIPTION
# Notes 

+ Now that the team is growing and more folks are working on the Ruby/Rails side of the code, it's time to start linting that part of the codebase 
+ Preferred strategy: add `rubocop` and turn on cops one by one, starting with easy fixes that can be autocorrected 
+ This PR starts with a single cop, `Layout/TrailingWhitespace`, that checks for trailing whitespace and can autocorrect
+ Checking in all the autocorrected files so that we start from a clean/passing state