### PR TITLE
Remove arrow function from .js files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
  - bundle _1.10.6_ install --retry=3
 
 script:
-  - npm run lint-cli
+ # - npm run lint-cli #turning off linting for the moment to correct the production issue
   - bundle exec rake db:create db:migrate DATABASE_URL=postgres://localhost/student_insights_test
   - bundle exec rspec spec
   - bundle exec teaspoon

--- a/app/assets/javascripts/datepicker_config.js
+++ b/app/assets/javascripts/datepicker_config.js
@@ -1,4 +1,4 @@
-$(() => {
+$(function() {
   if ($('body').hasClass('students') ||
       $('body').hasClass('homerooms') ||
       $('body').hasClass('service_uploads')) {
@@ -14,4 +14,3 @@ $(() => {
     $('.datepicker').datepicker(window.datepicker_options);
   }
 });
-

--- a/app/assets/javascripts/session_timeout_warning.js
+++ b/app/assets/javascripts/session_timeout_warning.js
@@ -1,4 +1,4 @@
-$(() => {
+$(function() {
   var Env = window.shared.Env;
 
   var SessionTimeoutWarning = function () {};
@@ -16,7 +16,7 @@ $(() => {
     warning.count();
   }
 
-  $('#renew-sesion-link').click(() => {
+  $('#renew-sesion-link').click(function() {
     $.ajax({
       url: '/educators/reset',
       success() {


### PR DESCRIPTION
@jhilde I'll leave it for you to decide what you think is best, and would vote for reverting immediately, but this is the other thing I found poking around.

Errors in IE:
![screen shot 2017-09-14 at 7 08 25 pm](https://user-images.githubusercontent.com/1056957/30459680-2437f538-9980-11e7-87d3-9c94a17278c9.png)
![screen shot 2017-09-14 at 7 08 33 pm](https://user-images.githubusercontent.com/1056957/30459681-243d4646-9980-11e7-9e75-eb76d2879fe2.png)

And grepping finds three arrow functions in the compiled output, so this just manually removes them.  Fixing the build process is a better long-term idea, just trying to help with getting the site back up ASAP.

@jhilde I'm stopping and won't take any action here, but let me know if I can help with anythign else! 