### PR TITLE
Update HTML rendering to force closing HTML tags

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -20,6 +20,7 @@ class SectionsController < ApplicationController
       sections: current_educator.allowed_sections,
       current_educator: current_educator,
     }
+    render 'shared/serialized_data'
   end
 
   private

--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -98,6 +98,7 @@ class ServiceUploadsController < ApplicationController
       ),
       service_type_names: ServiceType.pluck(:name)
     }
+    render 'shared/serialized_data'
   end
 
   def destroy

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -43,6 +43,7 @@ class StudentsController < ApplicationController
         absences: student.absences.order(occurred_at: :desc)
       }
     }
+    render 'shared/serialized_data'
   end
 
   def restricted_notes
@@ -56,6 +57,7 @@ class StudentsController < ApplicationController
       event_note_types_index: EventNoteSerializer.event_note_types_index,
       educators_index: Educator.to_index,
     }
+    render 'shared/serialized_data'
   end
 
   def student_report

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,4 +22,10 @@ module ApplicationHelper
     @devise_mapping ||= Devise.mappings[:user]
   end
 
+  # IE11 reports HTML1500 warnings on the console if tags are not explicitly
+  # closed (like happens if you used `tag`).  Here we're rendering tags with
+  # attributes and no content to be able to parse the JSON in JS.
+  def json_div(options = nil)
+    content_tag('div', '', options)
+  end
 end

--- a/app/views/homerooms/show.html.erb
+++ b/app/views/homerooms/show.html.erb
@@ -24,7 +24,7 @@
 
 <div id="homeroom-table"></div>
 
-<%= tag("div", id: "chart-data", data: @risk_levels) %>
-<%= tag("div", id: "homeroom-data", data: { homeroom: @homeroom}) %>
-<%= tag("div", id: "current-educator-data", data: { current_educator: current_educator}) %>
-<%= tag("div", id: "serialized-data", data: @serialized_data) %>
+<%= json_div(id: "chart-data", data: @risk_levels) %>
+<%= json_div(id: "homeroom-data", data: { homeroom: @homeroom}) %>
+<%= json_div(id: "current-educator-data", data: { current_educator: current_educator}) %>
+<%= json_div(id: "serialized-data", data: @serialized_data) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,11 +57,11 @@
       </div>
     </div>
     <%= yield %>
-    <%= tag("div", id: "calendar-icon-path", data: { path: asset_path('calendar-icon.svg') }) %>
+    <%= json_div(id: "calendar-icon-path", data: { path: asset_path('calendar-icon.svg') }) %>
     <%= # Gives the front-end clues about what UI elements to render or not.
         # All functionality meant for admins only should be restricted on the server side.
         # This tag is a helper for the UI, not a security feature.
 
-        tag("div", id: "educator-is-admin") if current_educator.try(:admin) %>
+        json_div(id: "educator-is-admin") if current_educator.try(:admin) %>
   </body>
 </html>

--- a/app/views/sections/show.html.erb
+++ b/app/views/sections/show.html.erb
@@ -1,3 +1,0 @@
-<div id="main"></div>
-<%= tag("div", id: "serialized-data", data: @serialized_data) %>
-

--- a/app/views/service_uploads/index.html.erb
+++ b/app/views/service_uploads/index.html.erb
@@ -1,5 +1,0 @@
-<div id="main"></div>
-<%= tag("div", id: "serialized-data", data: @serialized_data) %>
-
-
-

--- a/app/views/shared/serialized_data.html.erb
+++ b/app/views/shared/serialized_data.html.erb
@@ -1,3 +1,3 @@
 <div id="main"></div>
 
-<%= tag("div", id: "serialized-data", data: @serialized_data) %>
+<%= json_div(id: "serialized-data", data: @serialized_data) %>

--- a/app/views/students/restricted_notes.html.erb
+++ b/app/views/students/restricted_notes.html.erb
@@ -1,4 +1,0 @@
-<div id="main">
-  <a href="#" onclick="window.history.back();">Go back</a>
-</div>
-<%= tag("div", id: "serialized-data", data: @serialized_data) %>

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -1,2 +1,0 @@
-<div id="main"></div>
-<%= tag("div", id: "serialized-data", data: @serialized_data) %>

--- a/app/views/students/student_report.pdf.erb
+++ b/app/views/students/student_report.pdf.erb
@@ -208,7 +208,7 @@ ul, li {
 <br style="clear: left;" /><br/>
 <% end %>
 
-<%= tag("div", id: "serialized-data", data: @serialized_data) %>
+<%= json_div(id: "serialized-data", data: @serialized_data) %>
 
 <div class="scripts">
   <%= wicked_pdf_javascript_include_tag 'application' %>


### PR DESCRIPTION
Addressing console warnings on Windows 7 IE11:
<img width="806" alt="screen shot 2017-09-16 at 12 01 01 pm" src="https://user-images.githubusercontent.com/1056957/30514020-d0dec936-9adb-11e7-891d-792f1ed6f06e.png">

This also removes some templates that were redundant with `shared/serialized_data` and makes a small changes to remove rendering a "back" link in the restricted notes page (there's a back button in the browser, so unless there's a particular reason to keep it seems redundant).