### PR TITLE
Fix bug with date state when recording services

### DIFF
--- a/app/assets/javascripts/student_profile/record_service.jsx
+++ b/app/assets/javascripts/student_profile/record_service.jsx
@@ -209,8 +209,8 @@
     },
 
     renderButtons: function() {
-      const {serviceTypeId} = this.state;
-      const isFormComplete = (serviceTypeId && this.dateStartedMoment().isValid());
+      const {serviceTypeId, providedByEducatorName} = this.state;
+      const isFormComplete = (serviceTypeId && providedByEducatorName !== '' && this.dateStartedMoment().isValid());
 
       return (
         <div style={{ marginTop: 15 }}>

--- a/spec/javascripts/student_profile/record_service_spec.jsx
+++ b/spec/javascripts/student_profile/record_service_spec.jsx
@@ -10,6 +10,7 @@ describe('RecordService', function() {
   const merge = window.shared.ReactHelpers.merge;
   const ReactDOM = window.ReactDOM;
   const RecordService = window.shared.RecordService;
+  const {Simulate} = React.addons.TestUtils;
   
   const helpers = {
     renderInto: function(el, props) {
@@ -35,6 +36,19 @@ describe('RecordService', function() {
 
     findSaveButton: function(el) {
       return $(el).find('.btn.save');
+    },
+
+    findDateInput: function(el) {
+      return $(el).find('.Datepicker .datepicker.hasDatepicker');
+    },
+
+    isSaveButtonEnabled: function(el) {
+      return helpers.findSaveButton(el).attr('disabled') !== 'disabled';
+    },
+
+    simulateDateChange: function(el, text) {
+      const inputEl = helpers.findDateInput(el).get(0);
+      return Simulate.change(inputEl, {target: {value: text}});
     }
   };
 
@@ -57,10 +71,33 @@ describe('RecordService', function() {
       expect(el).toContainText('Who is working with Tamyra?');
       // TODO (as): test staff dropdown autocomplete async
       expect(el).toContainText('When did they start?');
-      expect($(el).find('.Datepicker .datepicker.hasDatepicker').length).toEqual(1);
+      expect(helpers.findDateInput(el).length).toEqual(1);
+      expect(el).not.toContainText('Invalid date');
       expect(helpers.findSaveButton(el).length).toEqual(1);
-      expect(helpers.findSaveButton(el).attr('disabled')).toEqual('disabled');
+      expect(helpers.isSaveButtonEnabled(el)).toEqual(false);
       expect($(el).find('.btn.cancel').length).toEqual(1);
+    });
+
+    it('shows warning on invalid date', function() {
+      const el = this.testEl;
+      helpers.renderInto(el);
+      helpers.simulateDateChange(el, 'fds 1/2/2/22 not a valid date');
+      expect(el).toContainText('Choose a valid date');
+    });
+
+    it('does not allow save on invalid date', function() {
+      const el = this.testEl;
+      helpers.renderInto(el);
+      helpers.simulateDateChange(el, '1/2/2/22 not a valid date');
+      expect(helpers.isSaveButtonEnabled(el)).toEqual(false);
+    });
+
+    it('allow saving when service and valid date set (teacher optional)', function() {
+      const el = this.testEl;
+      helpers.renderInto(el);
+      $(el).find('.btn:first').click();
+      helpers.simulateDateChange(el, '12/19/2018');
+      expect(helpers.isSaveButtonEnabled(el)).toEqual(true);
     });
   });
 });

--- a/spec/javascripts/student_profile/record_service_spec.jsx
+++ b/spec/javascripts/student_profile/record_service_spec.jsx
@@ -49,6 +49,11 @@ describe('RecordService', function() {
     simulateDateChange: function(el, text) {
       const inputEl = helpers.findDateInput(el).get(0);
       return Simulate.change(inputEl, {target: {value: text}});
+    },
+
+    simulateEducatorChange: function(el, text) {
+      const inputEl = $(el).find('.ProvidedByEducatorDropdown').get(0);
+      Simulate.change(inputEl, {target: {value: text}});
     }
   };
 
@@ -92,10 +97,20 @@ describe('RecordService', function() {
       expect(helpers.isSaveButtonEnabled(el)).toEqual(false);
     });
 
-    it('allow saving when service and valid date set (teacher optional)', function() {
+    it('does not allow without educator', function() {
       const el = this.testEl;
       helpers.renderInto(el);
       $(el).find('.btn:first').click();
+      helpers.simulateEducatorChange(el, '');
+      helpers.simulateDateChange(el, '12/19/2018');
+      expect(helpers.isSaveButtonEnabled(el)).toEqual(false);
+    });
+
+    it('requires service, educator and valid date set in order to save', function() {
+      const el = this.testEl;
+      helpers.renderInto(el);
+      $(el).find('.btn:first').click();
+      helpers.simulateEducatorChange(el, 'kevin');
       helpers.simulateDateChange(el, '12/19/2018');
       expect(helpers.isSaveButtonEnabled(el)).toEqual(true);
     });


### PR DESCRIPTION
Addressing https://rollbar.com/somerville-teacher-tool/somerville-teacher-tool/items/41/ and usability issues with the date picker.  If users tried to edit the text manually (ie, not using the datepicker with the mouse), on changes it would change the date to unexpected values (as the component parsed the text into a moment and then rendered it back out to text).

This updates the `RecordService` component to track the raw text as state, and then parses that as needed into a moment or particular format.  If it fails to parse into a valid date (just the format, not looking at when the date is in time), then the UI shows a message and the user is prevented from saving.  This also adds some tests and refactors some test helpers.

Screenshot showing input allowing arbitrary text, but warning on invalid date and disabling save:
<img width="455" alt="screen shot 2017-09-16 at 2 57 00 pm" src="https://user-images.githubusercontent.com/1056957/30515105-fb83be9e-9aef-11e7-94e0-70a9477f0a5b.png">
