### PR TITLE
Relax propType check for RiskBubble risk level

### DIFF
--- a/app/assets/javascripts/student_profile/risk_bubble.jsx
+++ b/app/assets/javascripts/student_profile/risk_bubble.jsx
@@ -28,15 +28,15 @@
     displayName: 'RiskBubble',
 
     propTypes: {
-      riskLevel: React.PropTypes.number.isRequired
+      riskLevel: React.PropTypes.number
     },
 
     bubbleColor: function() {
-      if (this.props.riskLevel === null) return '#555555';
       if (this.props.riskLevel === 0) return '#bbd86b';
       if (this.props.riskLevel === 1) return '#62c186';
       if (this.props.riskLevel === 2) return '#ffcb08';
       if (this.props.riskLevel === 3) return '#f15a3d';
+      return '#555555';
     },
 
     render: function() {


### PR DESCRIPTION
Warning in development mode:
<img width="983" alt="screen shot 2017-09-16 at 3 20 46 pm" src="https://user-images.githubusercontent.com/1056957/30515292-d158ac62-9af2-11e7-9136-64f9f690c581.png">

`null` is a valid value according to the component code and what's in the database, so making this prop required doesn't make sense.  What we really want is "you must pass the prop as a key, even if the value is null or undefined," but that's not what `.isRequired` means.