### PR TITLE
Remove student searchbar caching from educator import job

### DIFF
--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -21,7 +21,6 @@ class EducatorsImporter < Struct.new :school_scope, :client, :log, :progress_bar
 
     if educator.present?
       educator.save!
-      educator.save_student_searchbar_json
 
       homeroom = Homeroom.find_by_name(row[:homeroom]) if row[:homeroom]
       homeroom.update(educator: educator) if homeroom.present?


### PR DESCRIPTION
# Notes 

+ Good catch from @jhilde: this isn't needed on every import since all the main educator users of the platform have had this data precomputed for them with a background job.
+ https://github.com/studentinsights/studentinsights/issues/993#issuecomment-329496753