### PR TITLE
Patch bug with updating student risk level when no school

### DIFF
--- a/app/models/student_risk_level.rb
+++ b/app/models/student_risk_level.rb
@@ -55,7 +55,7 @@ class StudentRiskLevel < ActiveRecord::Base
   def calculate_level
     # As defined by Somerville Public Schools
 
-    if student.school.school_type == "HS"
+    if student.school.try(:school_type) == "HS"
       #High School risk levels have not been defined
       level = nil
     elsif mcas_or_star_at_level(3) || limited_english_proficiency_risk_level == 3

--- a/spec/models/student_risk_level_spec.rb
+++ b/spec/models/student_risk_level_spec.rb
@@ -2,6 +2,15 @@ require 'rails_helper'
 
 RSpec.describe StudentRiskLevel, type: :model do
 
+  describe '#update_risk_level!' do
+    context 'when no school' do
+      let(:student) { FactoryGirl.create(:student, school: nil) }
+      it 'does not raise' do
+        expect { student_risk_level.update_risk_level! }.to_not raise_error
+      end
+    end
+  end
+
   describe '#risk_level' do
 
     context 'missing MCAS and STAR results' do


### PR DESCRIPTION
Fixing this issue from ErrorEmailer on 9/17/17 at 11:37am ET.

```
undefined method `school_type' for nil:NilClass
["/app/app/models/student_risk_level.rb:58:in `calculate_level'", "/app/app/models/student_risk_level.rb:52:in `update_risk_level!'", "/app/app/models/student.rb:203:in `update_risk_level'", "/app/app/models/student.rb:198:in `block in update_risk_levels'", "/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.3/lib/active_record/relation/batches.rb:63:in `block (2 levels) in find_each'", "/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.3/lib/active_record/relation/batches.rb:63:in `each'", "/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.3/lib/active_record/relation/batches.rb:63:in `block in find_each'", "/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.3/lib/active_record/relation/batches.rb:129:in `block in find_in_batches'", "/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.3/lib/active_record/relation/batches.rb:230:in `block in in_batches'", "/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.3/lib/active_record/relation/batches.rb:214:in `loop'", "/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.3/lib/active_record/relation/batches.rb:214:in `in_batches'", "/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.3/lib/active_record/relation/batches.rb:128:in `find_in_batches'", "/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.3/lib/active_record/relation/batches.rb:62:in `find_each'", "/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.3/lib/active_record/querying.rb:9:in `find_each'", "/app/app/models/student.rb:198:in `update_risk_levels'", "/app/lib/tasks/import.thor:112:in `run_update_tasks'", "/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'", "/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'", "/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `block in invoke_all'", "/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `each'", "/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `map'", "/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `invoke_all'", "/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.4/lib/thor/group.rb:232:in `dispatch'", "/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'", "/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.4/lib/thor/runner.rb:44:in `method_missing'", "/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.4/lib/thor/command.rb:29:in `run'", "/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.4/lib/thor/command.rb:126:in `run'", "/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'", "/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'", "/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'", "/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.4/bin/thor:6:in `<top (required)>'", "/app/vendor/bundle/bin/thor:17:in `load'", "/app/vendor/bundle/bin/thor:17:in `<main>'"]
```

