### PR TITLE
Add ImportRecord when emailing about failed import job

### DIFF
--- a/app/views/error_mailer/error_report.erb
+++ b/app/views/error_mailer/error_report.erb
@@ -4,13 +4,13 @@
   </head>
   <body>
     <h1><%= @error_message %></h1>
-    <p>
+    <pre>
       <%= @error_backtrace %>
-    </p>
+    </pre>
     <% if @extra_info %>
-      <p>
-        <%= @extra_info %>
-      </p>
+      <pre>
+        <%= JSON.pretty_generate(@extra_info) %>
+      </pre>
     <% end %>
   </body>
 </html>

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -102,7 +102,11 @@ class Import
           timing_log << timing_data
         end
       rescue => error
-        ErrorMailer.error_report(error, timing_log).deliver_now if Rails.env.production?
+        extra_info =  {
+          timing_log: timing_log,
+          import_record: record.as_json
+        }
+        ErrorMailer.error_report(error, extra_info).deliver_now if Rails.env.production?
         raise error
       end
     end

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -103,7 +103,6 @@ class Import
         end
       rescue => error
         extra_info =  {
-          timing_log: timing_log,
           import_record: record.as_json
         }
         ErrorMailer.error_report(error, extra_info).deliver_now if Rails.env.production?


### PR DESCRIPTION
So we can see it right in the email, and also use `<pre>` to format stack traces.