### PR TITLE
Only parse/save recent attendance events

### DIFF
--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -13,9 +13,7 @@ class AttendanceImporter < Struct.new :school_scope, :client, :log, :progress_ba
   end
 
   def import_row(row)
-    occurred_at = DateTime.parse(row[:event_date])
-
-    return if Time.current - 90.days > occurred_at
+    return if Time.current - 90.days > row[:event_date]
 
     AttendanceRow.build(row).save!
   end

--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -15,7 +15,7 @@ class AttendanceImporter < Struct.new :school_scope, :client, :log, :progress_ba
   def import_row(row)
     occurred_at = DateTime.parse(row[:event_date])
 
-    return if Time.current - 4.days > occurred_at
+    return if Time.current - 90.days > occurred_at
 
     AttendanceRow.build(row).save!
   end

--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -13,6 +13,10 @@ class AttendanceImporter < Struct.new :school_scope, :client, :log, :progress_ba
   end
 
   def import_row(row)
+    occurred_at = DateTime.parse(row[:event_date])
+
+    return if Time.current - 4.days > occurred_at
+
     AttendanceRow.build(row).save!
   end
 end

--- a/spec/importers/file_importers/attendance_importer_spec.rb
+++ b/spec/importers/file_importers/attendance_importer_spec.rb
@@ -6,101 +6,109 @@ RSpec.describe AttendanceImporter do
 
   describe '#import_row' do
 
-    context 'one row for one student on one date' do
-      let!(:student) { FactoryGirl.create(:student, local_id: '1') }
-      let(:date) { DateTime.parse('2005-09-16') }
+    context 'recent attendance events' do
+      before do
+        Timecop.freeze('2005-09-16')
+      end
 
-      context 'row with absence' do
-        let(:row) {
-          { event_date: date, local_id: '1', absence: '1', tardy: '0' }
-        }
+      after do
+        Timecop.return
+      end
+
+      context 'one row for one student on one date' do
+        let!(:student) { FactoryGirl.create(:student, local_id: '1') }
+        let(:date) { '2005-09-16' }
+
+        context 'row with absence' do
+          let(:row) {
+            { event_date: date, local_id: '1', absence: '1', tardy: '0' }
+          }
+
+          it 'creates an absence' do
+            expect {
+              described_class.new.import_row(row)
+            }.to change {
+              Absence.count
+            }.by 1
+          end
+
+          it 'creates only 1 absence if run twice' do
+            expect {
+              described_class.new.import_row(row)
+              described_class.new.import_row(row)
+            }.to change { Absence.count }.by 1
+          end
+
+          it 'increments student absences by 1' do
+            expect {
+              described_class.new.import_row(row)
+            }.to change {
+              student.reload.absences.size
+            }.by 1
+          end
+
+          it 'does not increment student tardies' do
+            expect {
+              described_class.new.import_row(row)
+            }.to change {
+              student.tardies.size
+            }.by 0
+          end
+        end
+      end
+
+      context 'multiple rows for different students on the same date' do
+
+        let!(:edwin) { FactoryGirl.create(:student, local_id: '1', first_name: 'Edwin') }
+        let!(:kristen) { FactoryGirl.create(:student, local_id: '2', first_name: 'Kristen') }
+        let(:date) { '2005-09-16' }
+
+        let(:row_for_edwin) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
+        let(:row_for_kristen) { { event_date: date, local_id: '2', absence: '1', tardy: '0' } }
+
+        it 'creates an absence for each student' do
+          expect {
+            described_class.new.import_row(row_for_edwin)
+            described_class.new.import_row(row_for_kristen)
+          }.to change { Absence.count }.by 2
+        end
+      end
+
+      context 'multiple rows for same student on same date' do
+        let!(:student) { FactoryGirl.create(:student, local_id: '1') }
+        let(:date) { '2005-09-16' }
+
+        let(:first_row) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
+        let(:second_row) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
 
         it 'creates an absence' do
           expect {
-            described_class.new.import_row(row)
-          }.to change {
-            Absence.count
-          }.by 1
-        end
-
-        it 'creates only 1 absence if run twice' do
-          expect {
-            described_class.new.import_row(row)
-            described_class.new.import_row(row)
+            described_class.new.import_row(first_row)
+            described_class.new.import_row(second_row)
           }.to change { Absence.count }.by 1
         end
+      end
 
-        it 'increments the student school year absences by 1' do
+      context 'multiple rows for same student on different dates' do
+        let!(:student) { FactoryGirl.create(:student, local_id: '1') }
+        let(:date) { '2005-09-16' }
+
+        let(:first_row) { { event_date: '2005-09-16', local_id: '1', absence: '1', tardy: '0' } }
+        let(:second_row) { { event_date: '2005-09-17', local_id: '1', absence: '1', tardy: '0' } }
+        let(:third_row) { { event_date: '2005-09-18', local_id: '1', absence: '1', tardy: '0' } }
+        let(:fourth_row) { { event_date: '2005-09-19', local_id: '1', absence: '1', tardy: '0' } }
+
+        it 'creates multiple absences' do
+          importer = described_class.new
           expect {
-            described_class.new.import_row(row)
-          }.to change {
-            student.reload.absences.size
-          }.by 1
-        end
-
-        it 'does not increment the student school year tardies' do
-          expect {
-            described_class.new.import_row(row)
-          }.to change {
-            student.tardies.size
-          }.by 0
+            importer.import_row(first_row)
+            importer.import_row(second_row)
+            importer.import_row(third_row)
+            importer.import_row(fourth_row)
+          }.to change { Absence.count }.by 4
         end
       end
-    end
-
-    context 'multiple rows for different students on the same date' do
-
-      let!(:edwin) { FactoryGirl.create(:student, local_id: '1', first_name: 'Edwin') }
-      let!(:kristen) { FactoryGirl.create(:student, local_id: '2', first_name: 'Kristen') }
-      let(:date) { DateTime.parse('2005-09-16') }
-
-      let(:row_for_edwin) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
-      let(:row_for_kristen) { { event_date: date, local_id: '2', absence: '1', tardy: '0' } }
-
-      it 'creates an absence for each student' do
-        expect {
-          described_class.new.import_row(row_for_edwin)
-          described_class.new.import_row(row_for_kristen)
-        }.to change { Absence.count }.by 2
-      end
 
     end
-
-    context 'multiple rows for same student on same date' do
-      let!(:student) { FactoryGirl.create(:student, local_id: '1') }
-      let(:date) { DateTime.parse('2005-09-16') }
-
-      let(:first_row) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
-      let(:second_row) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
-
-      it 'creates an absence' do
-        expect {
-          described_class.new.import_row(first_row)
-          described_class.new.import_row(second_row)
-        }.to change { Absence.count }.by 1
-      end
-
-    end
-
-    context 'multiple rows for same student on different dates' do
-      let!(:student) { FactoryGirl.create(:student, local_id: '1') }
-      let(:date) { DateTime.parse('2005-09-16') }
-      let(:first_row) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
-      let(:second_row) { { event_date: date + 1.day, local_id: '1', absence: '1', tardy: '0' } }
-      let(:third_row) { { event_date: date + 2.days, local_id: '1', absence: '1', tardy: '0' } }
-      let(:fourth_row) { { event_date: date + 3.days, local_id: '1', absence: '1', tardy: '0' } }
-
-      it 'creates multiple absences' do
-        importer = described_class.new
-        expect {
-          importer.import_row(first_row)
-          importer.import_row(second_row)
-          importer.import_row(third_row)
-          importer.import_row(fourth_row)
-        }.to change { Absence.count }.by 4
-      end
-
-    end
-
   end
 end

--- a/spec/importers/file_importers/attendance_importer_spec.rb
+++ b/spec/importers/file_importers/attendance_importer_spec.rb
@@ -108,7 +108,27 @@ RSpec.describe AttendanceImporter do
           }.to change { Absence.count }.by 4
         end
       end
+    end
 
+    context 'old attendance events' do
+      context 'one row for one student on one date' do
+        let!(:student) { FactoryGirl.create(:student, local_id: '1') }
+        let(:date) { '2005-09-16' }
+
+        context 'row with absence' do
+          let(:row) {
+            { event_date: date, local_id: '1', absence: '1', tardy: '0' }
+          }
+
+          it 'does not create an absence' do
+            expect {
+              described_class.new.import_row(row)
+            }.to change {
+              Absence.count
+            }.by 0
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Notes

+ We're spending a lot of time and energy in the attendance import doing lookups on attendance events that happened far in the past, are already in the database, and haven't changed
+ Skip attendance rows that are more than four days in the past
+ Technically we could set it to 1 or 2 days since the import task runs nightly, but I'm thinking that if the import task fails one or two nights we don't want to risk skipping any event rows