### PR TITLE
Increase Delayed::Worker runtime

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,0 +1,1 @@
+Delayed::Worker.max_run_time = 8.hours


### PR DESCRIPTION
Follow on to https://github.com/studentinsights/studentinsights/pull/1052

The job-level `max_run_time` can only override the global value to be smaller. docs: https://github.com/collectiveidea/delayed_job#custom-jobs
>To set a per-job max run time that overrides the Delayed::Worker.max_run_time you can define a max_run_time method on the job

> NOTE: this can ONLY be used to set a max_run_time that is lower than Delayed::Worker.max_run_time. Otherwise the lock on the job would expire and another worker would start the working on the in progress job.

Not sure I entirely understand that explanation as to why it's like this, but tests enforce this too:
https://github.com/collectiveidea/delayed_job/blob/bd07783f27acc6fa84ae95db28033eceac82284a/lib/delayed/backend/shared_spec.rb#L466

Confirmed the existing behavior and that this change works locally:
on master:
```
> job = Delayed::Job.enqueue ImportJob.new
> job.max_run_time
=> 4 hours
```

this branch:
```
> job = Delayed::Job.enqueue ImportJob.new
> job.max_run_time
=> 6 hours
```