### PR TITLE
Make SftpClient not expose secrets when printed

### DIFF
--- a/app/importers/student_services/student_service_importer.rb
+++ b/app/importers/student_services/student_service_importer.rb
@@ -29,17 +29,13 @@ class StudentServiceImporter
   end
 
   def files_in_remote_server
-    sftp.dir.entries("services_upload").select do |entry|
+    @sftp_client.dir_entries("services_upload").select do |entry|
       (entry.name != '.') && (entry.name != '..')
     end
   end
 
   def files_names_already_uploaded
     ServiceUpload.pluck(:file_name)
-  end
-
-  def sftp
-    @sftp_session ||= sftp_client.sftp_session
   end
 
   def sftp_client


### PR DESCRIPTION
Addressing https://github.com/studentinsights/studentinsights/issues/1062

This prevents us from accidentally printing out secrets by logging objects.  This also changes the interface to not expose the `Net::SFTP` session directly, since it has the same problem of printing out secrets if you `puts` it.

after:
```
irb(main):017:0> a = SftpClient.for_x2()
=> #<struct SftpClient override_env=nil, user="SIS_SFTP_USER", host="SIS_SFTP_HOST", password=nil, key_data="SIS_SFTP_KEY">
irb(main):018:0> b = SftpClient.for_star()
=> #<struct SftpClient override_env=nil, user="STAR_SFTP_USER", host="STAR_SFTP_HOST", password="STAR_SFTP_PASSWORD", key_data=nil>
```