### PR TITLE
Add grades to section view (districtwide access only)

### DIFF
--- a/app/assets/javascripts/section/main.jsx
+++ b/app/assets/javascripts/section/main.jsx
@@ -12,6 +12,7 @@ $(function() {
           students={serializedData.students}
           section={serializedData.section}
           educators={serializedData.educators}
-          sections={serializedData.sections}/>, document.getElementById('main'));
+          sections={serializedData.sections}
+          currentEducator={serializedData.currentEducator}/>, document.getElementById('main'));
   }
 });

--- a/app/assets/javascripts/section/section_page.jsx
+++ b/app/assets/javascripts/section/section_page.jsx
@@ -13,7 +13,8 @@ import SortHelpers from '../helpers/sort_helpers.jsx';
       students: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
       educators: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
       sections: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-      section: React.PropTypes.object.isRequired
+      section: React.PropTypes.object.isRequired,
+      currentEducator: React.PropTypes.object.isRequired
     },
 
     styleStudentName: function(student, column) {
@@ -44,6 +45,41 @@ import SortHelpers from '../helpers/sort_helpers.jsx';
     },
 
     render: function() {
+      // Grades are being rolled out ONLY to educators with districtwide access
+      // for data validation purposes 
+      const columnsDistrictwide = [
+        {label: 'Name', key: 'first_name', cell:this.styleStudentName, sortFunc: this.nameSorter},
+        {label: 'Program Assigned', key: 'program_assigned', sortFunc: this.programSorter},
+        
+        // SPED & Disability
+        {label: 'Disability', group: 'SPED & Disability', key: 'disability'},
+        {label: '504 Plan', group: 'SPED & Disability', key: 'plan_504'},
+        
+        // Language
+        {label: 'Fluency', group: 'Language', key: 'limited_english_proficiency', sortFunc: this.languageProficiencySorter},
+        {label: 'Home Language', group: 'Language', key: 'home_language'},
+
+        {label: 'Free / Reduced Lunch', key: 'free_reduced_lunch'},
+        {label: 'Grade', key: 'grade_numeric'},
+        {label: 'Absences', key: 'most_recent_school_year_absences_count', sortFunc: SortHelpers.sortByNumber},
+        {label: 'Tardies', key: 'most_recent_school_year_tardies_count', sortFunc: SortHelpers.sortByNumber},
+        {label: 'Discipline Incidents', key: 'most_recent_school_year_discipline_incidents_count', sortFunc: SortHelpers.sortByNumber},
+        
+        // STAR: Math
+        {label: 'Percentile', group: 'STAR: Math', key:'most_recent_star_math_percentile', sortFunc: SortHelpers.sortByNumber},
+
+        // STAR: Reading
+        {label: 'Percentile', group: 'STAR: Reading', key:'most_recent_star_reading_percentile', sortFunc: SortHelpers.sortByNumber},
+        
+        // MCAS: Math
+        {label: 'Performance', group: 'MCAS: Math', key:'most_recent_mcas_math_performance', sortFunc: this.mcasPerformanceSorter},
+        {label: 'Score', group: 'MCAS: Math', key:'most_recent_mcas_math_scaled', sortFunc: SortHelpers.sortByNumber},
+        
+        // MCAS: ELA
+        {label: 'Performance', group: 'MCAS: ELA', key:'most_recent_mcas_ela_performance', sortFunc: this.mcasPerformanceSorter},
+        {label: 'Score', group: 'MCAS: ELA', key:'most_recent_mcas_ela_scaled', sortFunc: SortHelpers.sortByNumber}
+      ];
+      
       const columns = [
         {label: 'Name', key: 'first_name', cell:this.styleStudentName, sortFunc: this.nameSorter},
         {label: 'Program Assigned', key: 'program_assigned', sortFunc: this.programSorter},
@@ -87,7 +123,7 @@ import SortHelpers from '../helpers/sort_helpers.jsx';
           <div className="roster">
             <FlexibleRoster
               rows={this.props.students}
-              columns={columns}
+              columns={this.props.currentEducator.districtwide_access ? columnsDistrictwide : columns}
               initialSortIndex={0}/>
           </div>
         </div>

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -43,7 +43,8 @@ class SectionsController < ApplicationController
   end
 
   def serialize_students(students)
-    students.as_json(methods: [:most_recent_school_year_discipline_incidents_count, :most_recent_school_year_absences_count, :most_recent_school_year_tardies_count])
+    students.select('students.*, student_section_assignments.grade_numeric')
+            .as_json(methods: [:most_recent_school_year_discipline_incidents_count, :most_recent_school_year_absences_count, :most_recent_school_year_tardies_count])
   end
 
   def serialize_section(section)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,7 +10,6 @@ end
 
 require "#{Rails.root}/db/seeds/database_constants"
 
-
 puts "Creating demo schools, homerooms, interventions..."
 raise "empty yer db" if School.count > 0 ||
                         Student.count > 0 ||
@@ -101,7 +100,6 @@ sections = [
   Section.create(section_number: "SCI-201B", term_local_id: "S1", schedule: "4(M,W,F)", room_number: "306W", course: science_course),
 ]
 
-
 ServiceUpload.create([
   { file_name: "ReadingIntervention-2016.csv" },
   { file_name: "ATP-2016.csv" },
@@ -139,8 +137,25 @@ sections.each do |section|
   puts "Creating students for section #{section.section_number}..."
   school = section.course.school
   15.times do
-    fake_student = FakeStudent.new(school, shs_homeroom)
-    StudentSectionAssignment.create(student: fake_student.student, section: section)
+    grade_letter = ['A','B','C','D','F'].sample
+    case grade_letter
+      when "A"
+        grade_numeric = rand(90..100)
+      when "B"
+        grade_numeric = rand(80..89)
+      when "C"
+        grade_numeric = rand(70..79)
+      when "D"
+        grade_numeric = rand(60..69)
+      when "F"
+        grade_numeric = rand(50..59)
+    end
+
+      fake_student = FakeStudent.new(school, shs_homeroom)
+      StudentSectionAssignment.create(student: fake_student.student,
+                                      section: section,
+                                      grade_numeric: grade_numeric,
+                                      grade_letter: grade_letter)
   end
 end
 

--- a/spec/javascripts/section/section_page_spec.jsx
+++ b/spec/javascripts/section/section_page_spec.jsx
@@ -24,7 +24,8 @@ describe('SectionPage', function() {
       { id: 2, section_number: 'Art-2'},
       { id: 3, section_number: 'Art-3'}
     ],
-    section: { id: 1, section_number: 'Art-1', course_number: 'Art', course_description: 'Awesome Art Class', term_local_id: '9', schedule: '3(M-R)', room_number: '304' }
+    section: { id: 1, section_number: 'Art-1', course_number: 'Art', course_description: 'Awesome Art Class', term_local_id: '9', schedule: '3(M-R)', room_number: '304' },
+    currentEducator: { districtwide_access: false }
   };
 
   SpecSugar.withTestEl('', function() {


### PR DESCRIPTION
This PR adds a grade (numeric, not letter) column in the student roster for sections. 

Currently this column is only enabled for educators with the districtwide_access flag set. Essentially we wanted to validate the data in place before rolling out to teachers. (Grades are still going to the browser for others, just not displayed. So not a security mechanism, just hidden from view. Educators can only see sections they are assigned to / have permissions. That's where the security is.)

Tested on IE11!

![sectionviewgrades](https://user-images.githubusercontent.com/2595259/30605272-73bf7536-9d3b-11e7-8fcc-dac01a7dafde.PNG)
