### PR TITLE
Turn on grades in section view for all educators

### DIFF
--- a/app/assets/javascripts/section/section_page.jsx
+++ b/app/assets/javascripts/section/section_page.jsx
@@ -47,7 +47,7 @@ import SortHelpers from '../helpers/sort_helpers.jsx';
     render: function() {
       // Grades are being rolled out ONLY to educators with districtwide access
       // for data validation purposes 
-      const columnsDistrictwide = [
+      const columns = [
         {label: 'Name', key: 'first_name', cell:this.styleStudentName, sortFunc: this.nameSorter},
         {label: 'Program Assigned', key: 'program_assigned', sortFunc: this.programSorter},
         
@@ -80,38 +80,6 @@ import SortHelpers from '../helpers/sort_helpers.jsx';
         {label: 'Score', group: 'MCAS: ELA', key:'most_recent_mcas_ela_scaled', sortFunc: SortHelpers.sortByNumber}
       ];
       
-      const columns = [
-        {label: 'Name', key: 'first_name', cell:this.styleStudentName, sortFunc: this.nameSorter},
-        {label: 'Program Assigned', key: 'program_assigned', sortFunc: this.programSorter},
-        
-        // SPED & Disability
-        {label: 'Disability', group: 'SPED & Disability', key: 'disability'},
-        {label: '504 Plan', group: 'SPED & Disability', key: 'plan_504'},
-        
-        // Language
-        {label: 'Fluency', group: 'Language', key: 'limited_english_proficiency', sortFunc: this.languageProficiencySorter},
-        {label: 'Home Language', group: 'Language', key: 'home_language'},
-
-        {label: 'Free / Reduced Lunch', key: 'free_reduced_lunch'},
-        {label: 'Absences', key: 'most_recent_school_year_absences_count', sortFunc: SortHelpers.sortByNumber},
-        {label: 'Tardies', key: 'most_recent_school_year_tardies_count', sortFunc: SortHelpers.sortByNumber},
-        {label: 'Discipline Incidents', key: 'most_recent_school_year_discipline_incidents_count', sortFunc: SortHelpers.sortByNumber},
-        
-        // STAR: Math
-        {label: 'Percentile', group: 'STAR: Math', key:'most_recent_star_math_percentile', sortFunc: SortHelpers.sortByNumber},
-
-        // STAR: Reading
-        {label: 'Percentile', group: 'STAR: Reading', key:'most_recent_star_reading_percentile', sortFunc: SortHelpers.sortByNumber},
-        
-        // MCAS: Math
-        {label: 'Performance', group: 'MCAS: Math', key:'most_recent_mcas_math_performance', sortFunc: this.mcasPerformanceSorter},
-        {label: 'Score', group: 'MCAS: Math', key:'most_recent_mcas_math_scaled', sortFunc: SortHelpers.sortByNumber},
-        
-        // MCAS: ELA
-        {label: 'Performance', group: 'MCAS: ELA', key:'most_recent_mcas_ela_performance', sortFunc: this.mcasPerformanceSorter},
-        {label: 'Score', group: 'MCAS: ELA', key:'most_recent_mcas_ela_scaled', sortFunc: SortHelpers.sortByNumber}
-      ];
-      
       return (
         <div className="section">
           <div className="header">
@@ -123,7 +91,7 @@ import SortHelpers from '../helpers/sort_helpers.jsx';
           <div className="roster">
             <FlexibleRoster
               rows={this.props.students}
-              columns={this.props.currentEducator.districtwide_access ? columnsDistrictwide : columns}
+              columns={columns}
               initialSortIndex={0}/>
           </div>
         </div>

--- a/spec/javascripts/section/section_page_spec.jsx
+++ b/spec/javascripts/section/section_page_spec.jsx
@@ -64,7 +64,7 @@ describe('SectionPage', function() {
       
       const headers = $(el).find('#roster-header th');
 
-      expect(headers.length).toEqual(16);
+      expect(headers.length).toEqual(17);
       expect(headers[0].innerHTML).toEqual('Name');
     });
 


### PR DESCRIPTION
This is a continuation of #1070 which added the grade column for section view. Initially this was only turned on for educators with districtwide_access set to true for data validation. With validation complete, I'm now turning the column on for all educators (with permissions to the section of course). 