### PR TITLE
Fix bug with student importer creating more risk level records

### DIFF
--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -18,14 +18,14 @@ class StudentsImporter < Struct.new :school_scope, :client, :log, :progress_bar
 
   def import_row(row)
     student = StudentRow.new(row, school_ids_dictionary).build
+    return if student.registration_date_in_future
 
-    student.save! unless student.registration_date_in_future
+    student.save!
+    student.create_student_risk_level!
 
     if row[:homeroom].present?
       assign_student_to_homeroom(student, row[:homeroom])
     end
-
-    student.create_student_risk_level!
   end
 
   def assign_student_to_homeroom(student, homeroom_name)

--- a/spec/importers/file_importers/students_importer_spec.rb
+++ b/spec/importers/file_importers/students_importer_spec.rb
@@ -22,12 +22,18 @@ RSpec.describe StudentsImporter do
 
       context 'no existing students in database' do
 
-        it 'imports students' do
-          expect { import }.to change { Student.count }.by 4
+        it 'creates Student and StudentRiskLevel records' do
+          expect { import }.to change { [Student.count, StudentRiskLevel.count] }.by([4, 4])
+        end
+
+        it 'does not import students with far future registration dates' do
+          import
+          expect(Student.count).to eq 4
+          expect(Student.where(state_id: '1000000003').size).to eq 0
         end
 
         it 'imports student data correctly' do
-          import
+          expect { import }.to change { [Student.count, StudentRiskLevel.count] }.by([4, 4])
 
           first_student = Student.find_by_state_id('1000000000')
           expect(first_student.reload.school).to eq healey
@@ -40,11 +46,13 @@ RSpec.describe StudentsImporter do
           expect(first_student.race).to eq 'Black'
           expect(first_student.hispanic_latino).to eq false
           expect(first_student.gender).to eq 'F'
+          expect(first_student.student_risk_level).to_not eq nil
 
           second_student = Student.find_by_state_id('1000000002')
           expect(second_student.race).to eq 'White'
           expect(second_student.hispanic_latino).to eq true
           expect(second_student.gender).to eq 'F'
+          expect(second_student.student_risk_level).to_not eq nil
         end
 
       end

--- a/spec/importers/file_importers/students_importer_spec.rb
+++ b/spec/importers/file_importers/students_importer_spec.rb
@@ -57,6 +57,19 @@ RSpec.describe StudentsImporter do
 
       end
 
+      context 'with an existing student in the database' do
+        before do
+          student = Student.new(local_id: '100', school: healey, grade: '7')
+          student.save!
+          student.create_student_risk_level!
+        end
+        it 'does not create records for updates' do
+          expect([Student.count, StudentRiskLevel.count]).to eq([1, 1])
+          import
+          expect([Student.count, StudentRiskLevel.count]).to eq([4, 4])
+        end
+      end
+
       context 'student in database who has since graduated on to high school' do
         let!(:graduating_student) {
           Student.create!(local_id: '101', school: healey, grade: '8')   # Old data

--- a/spec/importers/file_importers/students_importer_spec.rb
+++ b/spec/importers/file_importers/students_importer_spec.rb
@@ -57,14 +57,25 @@ RSpec.describe StudentsImporter do
 
       end
 
-      context 'with an existing student in the database' do
+      context 'when an existing student in the database' do
         before do
           student = Student.new(local_id: '100', school: healey, grade: '7')
           student.save!
           student.create_student_risk_level!
         end
-        it 'does not create records for updates' do
+        it 'does not create new records for existing students' do
           expect([Student.count, StudentRiskLevel.count]).to eq([1, 1])
+          import
+          expect([Student.count, StudentRiskLevel.count]).to eq([4, 4])
+        end
+      end
+
+      context 'when students already imported' do
+        before do
+          import
+        end
+        it 'does not create new records for existing students' do
+          expect([Student.count, StudentRiskLevel.count]).to eq([4, 4])
           import
           expect([Student.count, StudentRiskLevel.count]).to eq([4, 4])
         end


### PR DESCRIPTION
Addressing part of https://github.com/studentinsights/studentinsights/issues/1074.

I think there are two bugs here.  One is that the importer calls `create_risk_level!` for every row that's processed during import, even for `Student` records that already exist and are just being updated (or haven't changed at all).  The other is that the check for registration dates in the future only applies to the `student.save!` call, and so other actions like assigning a homeroom or creating a risk level would still run.  I don't think this is what we want based on my read of https://github.com/studentinsights/studentinsights/pull/987.