### PR TITLE
Remove risk level chart computation from homeroom

### DIFF
--- a/app/controllers/homerooms_controller.rb
+++ b/app/controllers/homerooms_controller.rb
@@ -10,10 +10,6 @@ class HomeroomsController < ApplicationController
 
     @rows = eager_students().map {|student| fat_student_hash(student) }
 
-    # Risk level chart
-    @risk_levels = @homeroom.student_risk_levels.group(:level).count
-    @risk_levels['null'] = if @risk_levels.has_key? nil then @risk_levels[nil] else 0 end
-
     # Dropdown for homeroom navigation
     @homerooms_by_name = current_educator.allowed_homerooms_by_name
 

--- a/app/views/homerooms/show.html.erb
+++ b/app/views/homerooms/show.html.erb
@@ -24,7 +24,6 @@
 
 <div id="homeroom-table"></div>
 
-<%= json_div(id: "chart-data", data: @risk_levels) %>
 <%= json_div(id: "homeroom-data", data: { homeroom: @homeroom}) %>
 <%= json_div(id: "current-educator-data", data: { current_educator: current_educator}) %>
 <%= json_div(id: "serialized-data", data: @serialized_data) %>


### PR DESCRIPTION
This came up from the same line of inquiry in https://github.com/studentinsights/studentinsights/issues/1074.  Looking at index usage by table with `heroku pg:index-usage`, it looks like `student_risk_levels` is only using an index 68% of times.  I grepped around and found this usage in the homerooms page.

This isn't used anywhere in the product so this removes it.  The bug in https://github.com/studentinsights/studentinsights/issues/1074 means this was also doing a table scan on ~500k records.