### PR TITLE
Add ops notes for heroku-pg-extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ The project is configured to use LDAP as its authentication strategy in producti
 
 One way to accomplish this is to set a `QUOTAGUARDSTATIC_MASK` environment variable that routes only outbound traffic to certain IP subnets using the static IPs. [Read Quotaguard Static's documentation for more information.](https://devcenter.heroku.com/articles/quotaguardstatic#socks-proxy-setup)
 
+# Ops
+Here are some notes on maintaining, troubleshooting and performance.
+
+## Response latency
+Look in the Heroku metrics panel.  If you need to understand further, use Scout.
+
+## Postgres
+You can use [heroku-pg-extras](https://github.com/heroku/heroku-pg-extras) to get helpful diagnostic information about slow queries, index usage, and table scans.
 
 # Other Tools
 


### PR DESCRIPTION
I added the [heroku-pg-extras](https://github.com/heroku/heroku-pg-extras) Heroku addon as well as enabled the `CREATE EXTENSION pg_stat_statements;` Postgres extension.

This has useful bits like: what queries have the most aggregate time? (this answer isn't meaningful here since I just turned on tracking)
```
 total_exec_time | prop_exec_time |   ncalls    |  sync_io_time   |                                                                                                                                                           query
-----------------+----------------+-------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 04:08:13.865255 | 58.8%          | 4,604,806   | 00:00:00        | SELECT  "student_risk_levels".* FROM "student_risk_levels" WHERE "student_risk_levels"."student_id" = $1 LIMIT $2
 01:13:19.206881 | 17.4%          | 128,097,887 | 00:00:00.015469 | SELECT  "students".* FROM "students" WHERE "students"."local_id" = $1 LIMIT $2
 00:16:17.323373 | 3.9%           | 38,478,165  | 00:00:00        | SELECT  "students".* FROM "students" WHERE "students"."id" = $1 LIMIT $2
 00:10:32.979696 | 2.5%           | 46,293,031  | 00:00:00        | SELECT  "assessments".* FROM "assessments" WHERE "assessments"."id" = $1 LIMIT $2
 00:08:52.020486 | 2.1%           | 13,039,367  | 00:00:00.048519 | SELECT  "student_assessments".* FROM "student_assessments" INNER JOIN "assessments" ON "assessments"."id" = "student_assessments"."assessment_id" WHERE "student_assessments"."student_id" = $1 AND "assessments"."family" = $2 AND "assessments"."subject" = $3 ORDER BY "student_assessments"."date_taken" DESC LIMIT $4
 00:05:31.55398  | 1.3%           | 23,609,755  | 00:00:00        | SELECT  "schools".* FROM "schools" WHERE "schools"."id" = $1 LIMIT $2
 00:05:24.764564 | 1.3%           | 4,306       | 00:00:00        | SELECT "students".* FROM "students" WHERE ("students"."school_id" IS NOT NULL)
 00:05:06.902865 | 1.2%           | 1,766       | 00:00:00        | SELECT "educators".* FROM "educators"
 00:03:47.824322 | 0.9%           | 3,323,388   | 00:00:00        | SELECT  "homerooms".* FROM "homerooms" WHERE "homerooms"."name" = $1 AND "homerooms"."school_id" = ? ORDER BY "homerooms"."id" ASC LIMIT $2
 00:03:33.69733  | 0.8%           | 6,691,299   | 00:00:00.18259  | INSERT INTO "student_risk_levels" ("student_id", "created_at", "updated_at") VALUES ($1, $2, $3) RETURNING "id"
(10 rows)
```

and: what's index usage like?
```
$ heroku pg:index-usage
           relname            | percent_of_times_index_used | rows_in_table
------------------------------+-----------------------------+---------------
 student_risk_levels          | 68                          |        570799
 absences                     | 99                          |        216988
```

