### PR TITLE
Add validation and tests on StudentRiskLevel, migrate to destroy extra records

### DIFF
--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -21,7 +21,7 @@ class StudentsImporter < Struct.new :school_scope, :client, :log, :progress_bar
     return if student.registration_date_in_future
 
     student.save!
-    student.create_student_risk_level!
+    student.update_risk_level!
 
     if row[:homeroom].present?
       assign_student_to_homeroom(student, row[:homeroom])

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -192,25 +192,27 @@ class Student < ActiveRecord::Base
 
   ## RISK LEVELS ##
 
-  def self.update_risk_levels
+  def self.update_risk_levels!
     # This method is meant to be called daily to
     # check for updates to all student's risk levels
     # and save the results to the db (too expensive
     # to calculate on the fly with each page load).
-    find_each { |s| s.update_risk_level }
+    find_each { |s| s.update_risk_level! }
   end
 
-  def update_risk_level
+  # Update or create, and cache
+  def update_risk_level!
     if student_risk_level.present?
       student_risk_level.update_risk_level!
     else
-      create_student_risk_level!
+      self.student_risk_level = StudentRiskLevel.new(student_id: id)
+      self.student_risk_level.save!
     end
 
     # Cache risk level to the student table
     if self.risk_level != student_risk_level.level
       self.risk_level = student_risk_level.level
-      self.save
+      self.save!
     end
   end
 

--- a/app/models/student_risk_level.rb
+++ b/app/models/student_risk_level.rb
@@ -1,5 +1,6 @@
 class StudentRiskLevel < ActiveRecord::Base
   belongs_to :student
+  validates :student, presence: true, uniqueness: true
   delegate :student_assessments, :limited_english_proficiency, to: :student
   after_create :update_risk_level!
 

--- a/db/migrate/20170924173046_remove_student_risk_level_records.rb
+++ b/db/migrate/20170924173046_remove_student_risk_level_records.rb
@@ -1,0 +1,31 @@
+class RemoveStudentRiskLevelRecords < ActiveRecord::Migration[5.1]
+  # See https://github.com/studentinsights/studentinsights/issues/1071
+  def change
+    students = Student.all
+    good_student_risk_level_ids = students.map(&:student_risk_level).map(&:id)
+    bad_student_risk_level_ids = StudentRiskLevel.all.where.not(id: good_student_risk_level_ids)
+    puts "Found: #{students.size} students"
+    puts "Found: #{good_student_risk_level_ids.size} StudentRiskLevel records through Student associations"
+    puts "Found: #{bad_student_risk_level_ids.size} other StudentRiskLevel records"
+
+    puts "Checking some conditions..."
+    if good_student_risk_level_ids.size <= 0
+      raise "no good records"
+    elsif bad_student_risk_level_ids.size >= StudentRiskLevel.all.size
+      raise "more bad records than expected"
+    elsif bad_student_risk_level_ids.size + good_student_risk_level_ids.size != StudentRiskLevel.all.size
+      raise "bad and good records don't equal total"
+    end
+
+    puts "Destroying..."
+    StudentRiskLevel.where(id: bad_student_risk_level_ids).destroy!
+    puts "Done."
+
+    puts "Confirming..."
+    remaining_good_count = Student.all.map(&:student_risk_level).map(&:id).size
+    puts "Found #{remaining_good_count} StudentRiskLevel records through Student associations"
+    all_count = StudentRiskLevel.all.size
+    puts "Found #{all_count} StudentRiskLevel records total"
+  end
+
+end

--- a/db/migrate/20170924173046_remove_student_risk_level_records.rb
+++ b/db/migrate/20170924173046_remove_student_risk_level_records.rb
@@ -9,9 +9,9 @@ class RemoveStudentRiskLevelRecords < ActiveRecord::Migration[5.1]
     puts "Found: #{bad_student_risk_level_ids.size} other StudentRiskLevel records"
 
     puts "Checking some conditions..."
-    if good_student_risk_level_ids.size <= 0
+    if Rails.env.production? && good_student_risk_level_ids.size <= 0
       raise "no good records"
-    elsif bad_student_risk_level_ids.size >= StudentRiskLevel.all.size
+    elsif StudentRiskLevel.all.size != 0 && bad_student_risk_level_ids.size >= StudentRiskLevel.all.size
       raise "more bad records than expected"
     elsif bad_student_risk_level_ids.size + good_student_risk_level_ids.size != StudentRiskLevel.all.size
       raise "bad and good records don't equal total"

--- a/db/migrate/20170924173046_remove_student_risk_level_records.rb
+++ b/db/migrate/20170924173046_remove_student_risk_level_records.rb
@@ -2,7 +2,7 @@ class RemoveStudentRiskLevelRecords < ActiveRecord::Migration[5.1]
   # See https://github.com/studentinsights/studentinsights/issues/1071
   def change
     students = Student.all
-    good_student_risk_level_ids = students.map(&:student_risk_level).map(&:id)
+    good_student_risk_level_ids = student_risk_level_ids_for(students)
     bad_student_risk_level_ids = StudentRiskLevel.all.where.not(id: good_student_risk_level_ids)
     puts "Found: #{students.size} students"
     puts "Found: #{good_student_risk_level_ids.size} StudentRiskLevel records through Student associations"
@@ -17,15 +17,19 @@ class RemoveStudentRiskLevelRecords < ActiveRecord::Migration[5.1]
       raise "bad and good records don't equal total"
     end
 
-    puts "Destroying..."
-    StudentRiskLevel.where(id: bad_student_risk_level_ids).destroy!
+    puts "Deleting records..."
+    deleted_record_count = StudentRiskLevel.where(id: bad_student_risk_level_ids).delete_all
+    puts "Deleted #{deleted_record_count} StudentRiskLevel records."
     puts "Done."
 
     puts "Confirming..."
-    remaining_good_count = Student.all.map(&:student_risk_level).map(&:id).size
+    remaining_good_count = student_risk_level_ids_for(students).size
     puts "Found #{remaining_good_count} StudentRiskLevel records through Student associations"
     all_count = StudentRiskLevel.all.size
     puts "Found #{all_count} StudentRiskLevel records total"
   end
 
+  def student_risk_level_ids_for(students)
+    students.map {|student| student.try(:student_risk_level).try(:id) }.compact
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -163,7 +163,7 @@ end
   FakeStudent.new(healey, nil)
 end
 
-Student.update_risk_levels
+Student.update_risk_levels!
 Student.update_recent_student_assessments
 
 IepDocument.create!(

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -113,7 +113,7 @@ class Import
 
     def run_update_tasks
       begin
-        Student.update_risk_levels
+        Student.update_risk_levels!
         Student.update_recent_student_assessments
         Homeroom.destroy_empty_homerooms
       rescue => error

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -48,7 +48,7 @@ describe HomeroomsController, :type => :controller do
             let!(:second_student) { FactoryGirl.create(:student, :registered_last_year, homeroom: educator.homeroom) }
             let!(:third_student) { FactoryGirl.create(:student, :registered_last_year) }
 
-            before { Student.update_risk_levels }
+            before { Student.update_risk_levels! }
 
             it 'assigns rows to a non-empty array' do
               make_request(educator.homeroom.slug)

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -216,15 +216,28 @@ RSpec.describe Student do
     end
   end
 
-  describe '#update_risk_level' do
+  describe '#update_risk_level!' do
+    context 'when risk level record already exists' do
+      let(:student) { FactoryGirl.create(:student) }
+      let(:student_risk_level) { StudentRiskLevel.create!(student: student) }
+      before do
+        student.student_risk_level = student_risk_level
+        student.save!
+      end
+      it 'updates existing record and does not create a new one' do
+        expect { student.update_risk_level! }.to change(StudentRiskLevel, :count).by 0
+        expect(student.student_risk_level).to eq student_risk_level
+      end
+    end
+
     context 'no pre-existing risk level' do
       context 'non-ELL student with no test results' do
         let(:student) { FactoryGirl.create(:student) }
         it 'creates a risk level' do
-          expect { student.update_risk_level }.to change(StudentRiskLevel, :count).by 1
+          expect { student.update_risk_level! }.to change(StudentRiskLevel, :count).by 1
         end
         it 'assigns correct level' do
-          student.update_risk_level
+          student.update_risk_level!
           student_risk_level = student.student_risk_level
           expect(student_risk_level.level).to eq nil
           expect(student.risk_level).to eq nil
@@ -233,10 +246,10 @@ RSpec.describe Student do
       context 'ELL student with no test results' do
         let(:student) { FactoryGirl.build(:limited_english_student) }
         it 'creates a risk level' do
-          expect { student.update_risk_level }.to change(StudentRiskLevel, :count).by 1
+          expect { student.update_risk_level! }.to change(StudentRiskLevel, :count).by 1
         end
         it 'assigns correct level' do
-          student.update_risk_level
+          student.update_risk_level!
           student_risk_level = student.student_risk_level
           expect(student_risk_level.level).to eq 3
           expect(student.risk_level).to eq 3

--- a/spec/reports/students_spreadsheet_spec.rb
+++ b/spec/reports/students_spreadsheet_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe StudentsSpreadsheet do
       # the test data is not deterministic (setting a seed in srand only worked on
       # a single-file test run), so we only test for the output shape
       3.times { FakeStudent.new(school, homeroom) }
-      Student.update_risk_levels
+      Student.update_risk_levels!
       Student.update_recent_student_assessments
     end
 


### PR DESCRIPTION
Trying to close out https://github.com/studentinsights/studentinsights/issues/1071

The primary changes are to:
- add a validation on `StudentRiskLevel` to enforce that it's unique on `student_id`
- add a migration to delete stray `StudentRiskLevel` records

Incidentally, this updates `Student#update_risk_level` is two ways.  One is to make the `self.save` call raise on an error so that validation errors bubble up, and to replace `create_student_risk_level!` with more explicit calls since that method had unexpected behavior.

