### PR TITLE
Fix bug in StudentServiceImporter

### DIFF
--- a/app/importers/student_services/student_service_importer.rb
+++ b/app/importers/student_services/student_service_importer.rb
@@ -29,7 +29,7 @@ class StudentServiceImporter
   end
 
   def files_in_remote_server
-    @sftp_client.dir_entries("services_upload").select do |entry|
+    sftp_client.dir_entries("services_upload").select do |entry|
       (entry.name != '.') && (entry.name != '..')
     end
   end


### PR DESCRIPTION
This was introduced in https://github.com/studentinsights/studentinsights/pull/1066/files and came up in manually testing that those changes worked as expected.

@alexsoble it looks to me like this job doesn't run and it's intended to be run as a one-off.  The folder doesn't exist on the box either.  I figure those are both as expected, but FYI in case not :)