### PR TITLE
Increase delayed_job max run time again

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,1 +1,1 @@
-Delayed::Worker.max_run_time = 8.hours
+Delayed::Worker.max_run_time = 12.hours


### PR DESCRIPTION
+ Since it's timing out at 28800 seconds/8 hours