### PR TITLE
Add section data to Student Profile for high school students

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -76,6 +76,7 @@
   //= require ./student_profile/profile_chart
   //= require ./student_profile/profile_bar_chart
   //= require ./student_profile/student_profile_header
+  //= require ./student_profile/student_sections_roster
   //= require ./student_profile/pdf/student_profile_pdf
 // details:
   //= require ./student_profile/services_details

--- a/app/assets/javascripts/helpers/profile_details_style.jsx
+++ b/app/assets/javascripts/helpers/profile_details_style.jsx
@@ -19,6 +19,14 @@
       marginBottom: 10,
       width: '100%',
     },
+    roundedBox: {
+      border: '1px solid #ccc',
+      padding: 15,
+      marginTop: 10,
+      marginBottom: 10,
+      width: '100%',
+      borderRadius: '5px 5px 5px 5px',
+    },
     header: {
       display: 'flex',
       flexFlow: 'row',
@@ -59,6 +67,11 @@
       marginBottom: 20
     },
     fullCaseHistoryTitle: {
+      color: 'black',
+      display: 'inline-block',
+      flex: 'auto',
+    },
+    sectionsRosterTitle: {
       color: 'black',
       display: 'inline-block',
       flex: 'auto',

--- a/app/assets/javascripts/helpers/profile_details_style.jsx
+++ b/app/assets/javascripts/helpers/profile_details_style.jsx
@@ -25,7 +25,7 @@
       marginTop: 10,
       marginBottom: 10,
       width: '100%',
-      borderRadius: '5px 5px 5px 5px',
+      borderRadius: 5,
     },
     header: {
       display: 'flex',

--- a/app/assets/javascripts/student_profile/page_container.jsx
+++ b/app/assets/javascripts/student_profile/page_container.jsx
@@ -50,6 +50,7 @@ import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
         dibels: serializedData.dibels,
         iepDocuments: serializedData.iepDocuments,
         sections: serializedData.sections,
+        currentEducatorAllowedSections: serializedData.currentEducatorAllowedSections,
 
         // ui
         selectedColumnKey: queryParams.column || 'interventions',
@@ -240,6 +241,7 @@ import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
               'selectedColumnKey',
               'iepDocuments',
               'sections',
+              'currentEducatorAllowedSections',
               'requests'
             ), {
               nowMomentFn: this.props.nowMomentFn,

--- a/app/assets/javascripts/student_profile/page_container.jsx
+++ b/app/assets/javascripts/student_profile/page_container.jsx
@@ -49,6 +49,7 @@ import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
         access: serializedData.access,
         dibels: serializedData.dibels,
         iepDocuments: serializedData.iepDocuments,
+        sections: serializedData.sections,
 
         // ui
         selectedColumnKey: queryParams.column || 'interventions',
@@ -238,6 +239,7 @@ import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
               'attendanceData',
               'selectedColumnKey',
               'iepDocuments',
+              'sections',
               'requests'
             ), {
               nowMomentFn: this.props.nowMomentFn,

--- a/app/assets/javascripts/student_profile/profile_details.jsx
+++ b/app/assets/javascripts/student_profile/profile_details.jsx
@@ -1,4 +1,5 @@
 import FlexibleRoster from '../components/flexible_roster.jsx';
+import SortHelpers from '../helpers/sort_helpers.jsx';
 import _ from 'lodash';
 
 (function() {
@@ -22,6 +23,7 @@ import _ from 'lodash';
       chartData: React.PropTypes.object,
       iepDocuments: React.PropTypes.array,
       sections: React.PropTypes.array,
+      currentEducatorAllowedSections: React.PropTypes.array,
       attendanceData: React.PropTypes.object,
       serviceTypesIndex: React.PropTypes.object,
       currentEducator: React.PropTypes.object,
@@ -193,7 +195,7 @@ import _ from 'lodash';
     },
 
     styleSectionNumber: function(section, column) {
-      const educatorHasAccessToSection = _.includes(this.props.currentEducator.allowed_sections_index, section.id);
+      const educatorHasAccessToSection = _.includes(this.props.currentEducatorAllowedSections, section.id);
       
       return educatorHasAccessToSection ? 
              this.styleSectionNumberLink(section) :
@@ -248,7 +250,7 @@ import _ from 'lodash';
       const columns = [
         {label: 'Section Number', key: 'section_number', cell:this.styleSectionNumber},
         {label: 'Course Description', key: 'course_description'},
-        {label: 'Grade', key: 'grade_numeric'},
+        {label: 'Grade', key: 'grade_numeric', sortFunc: SortHelpers.sortByNumber},
         {label: 'Schedule', key: 'schedule'},
         {label: 'Educators', key: 'educators', cell:this.styleEducators},
         {label: 'Room', key: 'room_number'},

--- a/app/assets/javascripts/student_profile/profile_details.jsx
+++ b/app/assets/javascripts/student_profile/profile_details.jsx
@@ -1,5 +1,3 @@
-import FlexibleRoster from '../components/flexible_roster.jsx';
-import SortHelpers from '../helpers/sort_helpers.jsx';
 import _ from 'lodash';
 
 (function() {
@@ -7,8 +5,8 @@ import _ from 'lodash';
   const merge = window.shared.ReactHelpers.merge;
   const QuadConverter = window.shared.QuadConverter;
   const styles = window.shared.ProfileDetailsStyle;
+  const StudentSectionsRoster = window.shared.StudentSectionsRoster;
   const Datepicker = window.shared.Datepicker;
-  const Routes = window.shared.Routes;
   const filterFromDate = QuadConverter.firstDayOfSchool(QuadConverter.toSchoolYear(moment())-1);
   const filterToDate = moment();
 
@@ -170,38 +168,6 @@ import _ from 'lodash';
       return _.sortBy(events, 'date').reverse();
     },
 
-    styleEducators: function(section, column) {
-      const educatorNames = section.educators.map(educator => {
-        return educator['full_name'];
-      },this);
-    
-      return (
-        <p>{educatorNames.join(' / ')}</p>
-      );
-    },
-
-    styleSectionNumberLink(section) {
-      return (
-        <a href={Routes.section(section.id)}>
-          {section.section_number}
-        </a>
-      );
-    },
-
-    styleSectionNumberNoLink(section) {
-      return (
-        <p>{section.section_number}</p>
-      );
-    },
-
-    styleSectionNumber: function(section, column) {
-      const educatorHasAccessToSection = _.includes(this.props.currentEducatorAllowedSections, section.id);
-      
-      return educatorHasAccessToSection ? 
-             this.styleSectionNumberLink(section) :
-             this.styleSectionNumberNoLink(section);
-    },
-
     onFilterFromDateChanged: function(dateText) {
       const textMoment = moment.utc(dateText, 'MM/DD/YYYY');
       const updatedMoment = (textMoment.isValid()) ? textMoment : null;
@@ -241,31 +207,21 @@ import _ from 'lodash';
     renderSectionDetails: function() {
       const sections = this.props.sections;
       
-      // If there are no sections, don't generate the section
+      // If there are no sections, don't generate the student sections roster
       if (!sections || sections.length == 0) return null;
 
-      // If this student is not a high school student, don't generate the section
+      // If this student is not a high school student, don't generate the student sections roster
       if (this.props.student.school_type != 'HS') return null;
-      
-      const columns = [
-        {label: 'Section Number', key: 'section_number', cell:this.styleSectionNumber},
-        {label: 'Course Description', key: 'course_description'},
-        {label: 'Grade', key: 'grade_numeric', sortFunc: SortHelpers.sortByNumber},
-        {label: 'Schedule', key: 'schedule'},
-        {label: 'Educators', key: 'educators', cell:this.styleEducators},
-        {label: 'Room', key: 'room_number'},
-        {label: 'Term', key: 'term_local_id'}
-      ];
       
       return (
         <div id="sections-roster" className="roster" style={styles.roundedBox}>
           <h4 style={styles.sectionsRosterTitle}>
             Sections
           </h4>
-          <FlexibleRoster
-            rows={sections}
-            columns={columns}
-            initialSortIndex={0}/>
+          <StudentSectionsRoster
+            sections={this.props.sections}
+            linkableSections={this.props.currentEducatorAllowedSections}
+            />
         </div>
         
       );

--- a/app/assets/javascripts/student_profile/profile_details.jsx
+++ b/app/assets/javascripts/student_profile/profile_details.jsx
@@ -21,6 +21,7 @@ import _ from 'lodash';
       dibels: React.PropTypes.array,
       chartData: React.PropTypes.object,
       iepDocuments: React.PropTypes.array,
+      sections: React.PropTypes.array,
       attendanceData: React.PropTypes.object,
       serviceTypesIndex: React.PropTypes.object,
       currentEducator: React.PropTypes.object,
@@ -236,6 +237,14 @@ import _ from 'lodash';
     },
 
     renderSectionDetails: function() {
+      const sections = this.props.sections;
+      
+      // If there are no sections, don't generate the section
+      if (!sections || sections.length == 0) return null;
+
+      // If this student is not a high school student, don't generate the section
+      if (this.props.student.school_type != 'HS') return null;
+      
       const columns = [
         {label: 'Section Number', key: 'section_number', cell:this.styleSectionNumber},
         {label: 'Course Description', key: 'course_description'},
@@ -252,7 +261,7 @@ import _ from 'lodash';
             Sections
           </h4>
           <FlexibleRoster
-            rows={this.props.student.sections}
+            rows={sections}
             columns={columns}
             initialSortIndex={0}/>
         </div>

--- a/app/assets/javascripts/student_profile/profile_details.jsx
+++ b/app/assets/javascripts/student_profile/profile_details.jsx
@@ -1,3 +1,4 @@
+import FlexibleRoster from '../components/flexible_roster.jsx';
 import _ from 'lodash';
 
 (function() {
@@ -6,6 +7,7 @@ import _ from 'lodash';
   const QuadConverter = window.shared.QuadConverter;
   const styles = window.shared.ProfileDetailsStyle;
   const Datepicker = window.shared.Datepicker;
+  const Routes = window.shared.Routes;
   const filterFromDate = QuadConverter.firstDayOfSchool(QuadConverter.toSchoolYear(moment())-1);
   const filterToDate = moment();
 
@@ -20,7 +22,8 @@ import _ from 'lodash';
       chartData: React.PropTypes.object,
       iepDocuments: React.PropTypes.array,
       attendanceData: React.PropTypes.object,
-      serviceTypesIndex: React.PropTypes.object
+      serviceTypesIndex: React.PropTypes.object,
+      currentEducator: React.PropTypes.object,
     },
 
     getInitialState: function() {
@@ -164,6 +167,38 @@ import _ from 'lodash';
       return _.sortBy(events, 'date').reverse();
     },
 
+    styleEducators: function(section, column) {
+      const educatorNames = section.educators.map(educator => {
+        return educator['full_name'];
+      },this);
+    
+      return (
+        <p>{educatorNames.join(' / ')}</p>
+      );
+    },
+
+    styleSectionNumberLink(section) {
+      return (
+        <a href={Routes.section(section.id)}>
+          {section.section_number}
+        </a>
+      );
+    },
+
+    styleSectionNumberNoLink(section) {
+      return (
+        <p>{section.section_number}</p>
+      );
+    },
+
+    styleSectionNumber: function(section, column) {
+      const educatorHasAccessToSection = _.includes(this.props.currentEducator.allowed_sections_index, section.id);
+      
+      return educatorHasAccessToSection ? 
+             this.styleSectionNumberLink(section) :
+             this.styleSectionNumberNoLink(section);
+    },
+
     onFilterFromDateChanged: function(dateText) {
       const textMoment = moment.utc(dateText, 'MM/DD/YYYY');
       const updatedMoment = (textMoment.isValid()) ? textMoment : null;
@@ -185,6 +220,9 @@ import _ from 'lodash';
     render: function(){
       return (
         <div>
+          <div style={{clear: 'both'}}>
+            {this.renderSectionDetails()}
+          </div>
           <div style={{display: 'flex'}}>
             {this.renderAccessDetails()}
             {this.renderStudentReportFilters()}
@@ -194,6 +232,31 @@ import _ from 'lodash';
             {this.renderFullCaseHistory()}
           </div>
         </div>
+      );
+    },
+
+    renderSectionDetails: function() {
+      const columns = [
+        {label: 'Section Number', key: 'section_number', cell:this.styleSectionNumber},
+        {label: 'Course Description', key: 'course_description'},
+        {label: 'Grade', key: 'grade_numeric'},
+        {label: 'Schedule', key: 'schedule'},
+        {label: 'Educators', key: 'educators', cell:this.styleEducators},
+        {label: 'Room', key: 'room_number'},
+        {label: 'Term', key: 'term_local_id'}
+      ];
+      
+      return (
+        <div id="sections-roster" className="roster" style={styles.roundedBox}>
+          <h4 style={styles.sectionsRosterTitle}>
+            Sections
+          </h4>
+          <FlexibleRoster
+            rows={this.props.student.sections}
+            columns={columns}
+            initialSortIndex={0}/>
+        </div>
+        
       );
     },
 

--- a/app/assets/javascripts/student_profile/student_profile_page.jsx
+++ b/app/assets/javascripts/student_profile/student_profile_page.jsx
@@ -142,6 +142,7 @@ import _ from 'lodash';
       access: React.PropTypes.object,
       iepDocuments: React.PropTypes.array,
       sections: React.PropTypes.array,
+      currentEducatorAllowedSections: React.PropTypes.array,
 
       // flux-y bits
       requests: PropTypes.requests,
@@ -251,6 +252,7 @@ import _ from 'lodash';
             chartData={this.props.chartData}
             iepDocuments={this.props.iepDocuments}
             sections={this.props.sections}
+            currentEducatorAllowedSections={this.props.currentEducatorAllowedSections}
             attendanceData={this.props.attendanceData}
             serviceTypesIndex={this.props.serviceTypesIndex} 
             currentEducator={this.props.currentEducator}/>

--- a/app/assets/javascripts/student_profile/student_profile_page.jsx
+++ b/app/assets/javascripts/student_profile/student_profile_page.jsx
@@ -141,6 +141,7 @@ import _ from 'lodash';
 
       access: React.PropTypes.object,
       iepDocuments: React.PropTypes.array,
+      sections: React.PropTypes.array,
 
       // flux-y bits
       requests: PropTypes.requests,
@@ -249,6 +250,7 @@ import _ from 'lodash';
             dibels={this.props.dibels}
             chartData={this.props.chartData}
             iepDocuments={this.props.iepDocuments}
+            sections={this.props.sections}
             attendanceData={this.props.attendanceData}
             serviceTypesIndex={this.props.serviceTypesIndex} 
             currentEducator={this.props.currentEducator}/>
@@ -298,12 +300,13 @@ import _ from 'lodash';
     renderProfileColumn: function() {
       const student = this.props.student;
       const access = this.props.access;
+      const sections = this.props.sections;
       const columnKey = 'profile';
 
       const profileElements = [this.renderDemographics(student, access)];
       
       if(student.school_type == 'HS') {
-        profileElements.push(this.renderSections(student));
+        profileElements.push(this.renderSections(sections));
       }
       
 
@@ -365,8 +368,8 @@ import _ from 'lodash';
 
     },
 
-    renderSections: function(student) {
-      const sectionCount = student.sections.length;
+    renderSections: function(sections) {
+      const sectionCount = sections.length;
       const sectionText = sectionCount == 1 ? `${sectionCount} section` : `${sectionCount} sections`;
     
       return (

--- a/app/assets/javascripts/student_profile/student_profile_page.jsx
+++ b/app/assets/javascripts/student_profile/student_profile_page.jsx
@@ -250,7 +250,8 @@ import _ from 'lodash';
             chartData={this.props.chartData}
             iepDocuments={this.props.iepDocuments}
             attendanceData={this.props.attendanceData}
-            serviceTypesIndex={this.props.serviceTypesIndex} />
+            serviceTypesIndex={this.props.serviceTypesIndex} 
+            currentEducator={this.props.currentEducator}/>
       );
       case 'ela': return <ELADetails chartData={this.props.chartData} student={this.props.student} />;
       case 'math': return <MathDetails chartData={this.props.chartData} student={this.props.student} />;
@@ -296,16 +297,15 @@ import _ from 'lodash';
 
     renderProfileColumn: function() {
       const student = this.props.student;
+      const access = this.props.access;
       const columnKey = 'profile';
-      const demographicsElements = [
-        'Disability: ' + (student.sped_level_of_need || 'None'),
-        'Low income: ' + student.free_reduced_lunch,
-        'Language: ' + student.limited_english_proficiency
-      ];
 
-      if (this.props.access) {
-        demographicsElements.push('ACCESS Composite score: ' + this.props.access.composite);
+      const profileElements = [this.renderDemographics(student, access)];
+      
+      if(student.school_type == 'HS') {
+        profileElements.push(this.renderSections(student));
       }
+      
 
       return (
         <div
@@ -316,7 +316,7 @@ import _ from 'lodash';
           </div>
           <div
             style={merge(styles.column, styles.academicColumn, this.selectedColumnStyles(columnKey), styles.profileColumn)}>
-            <SummaryList title="Demographics" elements={demographicsElements} />
+            {this.renderPaddedElements(styles.summaryWrapper, profileElements)}
           </div>
         </div>
       );
@@ -347,6 +347,33 @@ import _ from 'lodash';
       );
     },
 
+    renderDemographics: function(student, access) {
+      const demographicsElements = [
+        'Disability: ' + (student.sped_level_of_need || 'None'),
+        'Low income: ' + student.free_reduced_lunch,
+        'Language: ' + student.limited_english_proficiency
+      ];
+
+      if (access) {
+        demographicsElements.push('ACCESS Composite score: ' + access.composite);
+      }
+
+      return (
+        <SummaryList title="Demographics" elements={demographicsElements} />
+      );
+
+
+    },
+
+    renderSections: function(student) {
+      const sectionCount = student.sections.length;
+      const sectionText = sectionCount == 1 ? `${sectionCount} section` : `${sectionCount} sections`;
+    
+      return (
+        <SummaryList title="Sections" elements={[sectionText]} />  
+      );
+    },
+    
     renderPlacement: function(student) {
       const placement = (student.sped_placement !== null)
         ? student.program_assigned + ', ' + student.sped_placement

--- a/app/assets/javascripts/student_profile/student_sections_roster.jsx
+++ b/app/assets/javascripts/student_profile/student_sections_roster.jsx
@@ -1,0 +1,73 @@
+import _ from 'lodash';
+import SortHelpers from '../helpers/sort_helpers.jsx';
+import FlexibleRoster from '../components/flexible_roster.jsx';
+
+
+(function() {
+  window.shared || (window.shared = {});
+
+  const Routes = window.shared.Routes;
+
+  /*
+  Renders the table of sections.
+  */
+  
+  window.shared.StudentSectionsRoster = React.createClass({
+    displayName: 'StudentSectionsRoster',
+
+    propTypes: {
+      sections: React.PropTypes.array,            // Array of sections to display
+      linkableSections: React.PropTypes.array     // Array of section ids to render as links
+    },
+
+    styleEducators: function(section, column) {
+      const educatorNames = _.map(section.educators, 'full_name');
+      return (
+        <p>{educatorNames.join(' / ')}</p>
+      );
+    },
+
+    styleSectionNumberLink(section) {
+      return (
+        <a href={Routes.section(section.id)}>
+          {section.section_number}
+        </a>
+      );
+    },
+
+    styleSectionNumberNoLink(section) {
+      return (
+        <p>{section.section_number}</p>
+      );
+    },
+
+    styleSectionNumber: function(section, column) {
+      const linkableSection = _.includes(this.props.linkableSections, section.id);
+      
+      return linkableSection ? 
+             this.styleSectionNumberLink(section) :
+             this.styleSectionNumberNoLink(section);
+    },
+
+    render: function() {
+      const sections = this.props.sections;
+      
+      const columns = [
+        {label: 'Section Number', key: 'section_number', cell:this.styleSectionNumber},
+        {label: 'Course Description', key: 'course_description'},
+        {label: 'Grade', key: 'grade_numeric', sortFunc: SortHelpers.sortByNumber},
+        {label: 'Schedule', key: 'schedule'},
+        {label: 'Educators', key: 'educators', cell:this.styleEducators},
+        {label: 'Room', key: 'room_number'},
+        {label: 'Term', key: 'term_local_id'}
+      ];
+      
+      return (
+        <FlexibleRoster
+          rows={sections}
+          columns={columns}
+          initialSortIndex={0}/>
+      );
+    },
+  });
+})();

--- a/app/assets/javascripts/student_profile/student_sections_roster.jsx
+++ b/app/assets/javascripts/student_profile/student_sections_roster.jsx
@@ -20,10 +20,14 @@ import FlexibleRoster from '../components/flexible_roster.jsx';
       linkableSections: React.PropTypes.array     // Array of section ids to render as links
     },
 
+    formatEducatorNames: function(educators) {
+      const educatorNames = _.map(educators, 'full_name');
+      return educatorNames.join(' / ');
+    },
+
     styleEducators: function(section, column) {
-      const educatorNames = _.map(section.educators, 'full_name');
       return (
-        <p>{educatorNames.join(' / ')}</p>
+        <p>{this.formatEducatorNames(section.educators)}</p>
       );
     },
 
@@ -49,6 +53,12 @@ import FlexibleRoster from '../components/flexible_roster.jsx';
              this.styleSectionNumberNoLink(section);
     },
 
+    sortEducatorNames: function(a, b, sortBy) {
+      const educatorNamesA = this.formatEducatorNames(a.educators);
+      const educatorNamesB = this.formatEducatorNames(b.educators);
+      return SortHelpers.baseSortByString(educatorNamesA, educatorNamesB);
+    },
+
     render: function() {
       const sections = this.props.sections;
       
@@ -57,7 +67,7 @@ import FlexibleRoster from '../components/flexible_roster.jsx';
         {label: 'Course Description', key: 'course_description'},
         {label: 'Grade', key: 'grade_numeric', sortFunc: SortHelpers.sortByNumber},
         {label: 'Schedule', key: 'schedule'},
-        {label: 'Educators', key: 'educators', cell:this.styleEducators},
+        {label: 'Educators', key: 'educators', cell:this.styleEducators, sortFunc: this.sortEducatorNames},
         {label: 'Room', key: 'room_number'},
         {label: 'Term', key: 'term_local_id'}
       ];

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -37,9 +37,8 @@ class StudentsController < ApplicationController
       educators_index: Educator.to_index,
       access: student.latest_access_results,
       iep_documents: student.iep_documents,
-      sections: student.sections.select('sections.*, student_section_assignments.grade_numeric')
-                                .as_json({:include => { :educators => {:only => :full_name}}, :methods => :course_description}),
-      current_educator_allowed_sections: current_educator.allowed_sections_index,
+      sections: serialize_student_sections_for_profile(student),
+      current_educator_allowed_sections: current_educator.allowed_sections.map(&:id),
       attendance_data: {
         discipline_incidents: student.discipline_incidents.order(occurred_at: :desc),
         tardies: student.tardies.order(occurred_at: :desc),
@@ -140,6 +139,10 @@ class StudentsController < ApplicationController
       discipline_incidents_count: student.most_recent_school_year_discipline_incidents_count,
       restricted_notes_count: student.event_notes.where(is_restricted: true).count,
     }).stringify_keys
+  end
+
+  def serialize_student_sections_for_profile(student)
+    student.sections_with_grades.as_json({:include => { :educators => {:only => :full_name}}, :methods => :course_description})
   end
 
   # The feed of mutable data that changes most frequently and is owned by Student Insights.

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -27,7 +27,7 @@ class StudentsController < ApplicationController
     chart_data = StudentProfileChart.new(student).chart_data
 
     @serialized_data = {
-      current_educator: current_educator,
+      current_educator: current_educator.to_json(:methods => :allowed_sections_index),
       student: serialize_student_for_profile(student),          # Risk level, school homeroom, most recent school year attendance/discipline counts
       feed: student_feed(student, restricted_notes: false),     # Notes, services
       chart_data: chart_data,                                   # STAR, MCAS, discipline, attendance charts
@@ -132,10 +132,12 @@ class StudentsController < ApplicationController
       absences_count: student.most_recent_school_year_absences_count,
       tardies_count: student.most_recent_school_year_tardies_count,
       school_name: student.try(:school).try(:name),
+      school_type: student.try(:school).try(:school_type),
       homeroom_name: student.try(:homeroom).try(:name),
       discipline_incidents_count: student.most_recent_school_year_discipline_incidents_count,
-      restricted_notes_count: student.event_notes.where(is_restricted: true).count
-    }).stringify_keys
+      restricted_notes_count: student.event_notes.where(is_restricted: true).count,
+      sections: student.sections.select('sections.*, student_section_assignments.grade_numeric').as_json(:include =>  :educators, :methods => :course_description)
+      }).stringify_keys
   end
 
   # The feed of mutable data that changes most frequently and is owned by Student Insights.

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -151,10 +151,6 @@ class Educator < ActiveRecord::Base
     end
   end
 
-  def allowed_sections_index
-    allowed_sections.map { |section| section.id }
-  end
-
   def allowed_homerooms_by_name
     allowed_homerooms.order(:name)
   end

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -151,6 +151,10 @@ class Educator < ActiveRecord::Base
     end
   end
 
+  def allowed_sections_index
+    allowed_sections.map { |section| section.id }
+  end
+
   def allowed_homerooms_by_name
     allowed_homerooms.order(:name)
   end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -17,7 +17,9 @@ class Student < ActiveRecord::Base
   has_many :absences, dependent: :destroy
   has_many :discipline_incidents, dependent: :destroy
   has_many :iep_documents, dependent: :destroy
-
+  has_many :student_section_assignments
+  has_many :sections, through: :student_section_assignments
+  
   has_one :student_risk_level, dependent: :destroy
 
   validates_presence_of :local_id

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -19,7 +19,7 @@ class Student < ActiveRecord::Base
   has_many :iep_documents, dependent: :destroy
   has_many :student_section_assignments
   has_many :sections, through: :student_section_assignments
-  
+
   has_one :student_risk_level, dependent: :destroy
 
   validates_presence_of :local_id

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -263,6 +263,11 @@ class Student < ActiveRecord::Base
     end
   end
 
+  # Sections
+  def sections_with_grades
+    sections.select("sections.*, student_section_assignments.grade_numeric")
+  end
+
   private
 
     def this_year

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -20,7 +20,12 @@ describe StudentsController, :type => :controller do
   describe '#show' do
     let!(:school) { FactoryGirl.create(:school) }
     let(:educator) { FactoryGirl.create(:educator_with_homeroom) }
+    let(:other_educator) { FactoryGirl.create(:educator, full_name: "Teacher, Louis") }
     let(:student) { FactoryGirl.create(:student, :with_risk_level, school: school) }
+    let(:course) { FactoryGirl.create(:course, school: school) }
+    let(:section) { FactoryGirl.create(:section, course: course) }
+    let!(:ssa) { FactoryGirl.create(:student_section_assignment, student: student, section: section) }
+    let!(:esa) { FactoryGirl.create(:educator_section_assignment, educator: other_educator, section: section)}
     let(:homeroom) { student.homeroom }
 
     def make_request(options = { student_id: nil, format: :html })
@@ -92,13 +97,19 @@ describe StudentsController, :type => :controller do
             {:id=>306, :name=>"10th Grade Experience"},
           ])
 
-          expect(serialized_data[:educators_index]).to eq({
+          expect(serialized_data[:educators_index]).to include({
             educator.id => {:id=>educator.id, :email=>educator.email, :full_name=>nil}
           })
 
           expect(serialized_data[:attendance_data].keys).to eq [
             :discipline_incidents, :tardies, :absences
           ]
+
+          expect(serialized_data[:sections].length).to equal(1)
+          expect(serialized_data[:sections][0]["id"]).to eq(section.id)
+          expect(serialized_data[:sections][0]["grade_numeric"]).to eq(ssa.grade_numeric)
+          expect(serialized_data[:sections][0]["educators"][0]["full_name"]).to eq(other_educator.full_name)
+          expect(serialized_data[:current_educator_allowed_sections]).to include(section.id)
         end
 
         context 'student has multiple discipline incidents' do
@@ -129,9 +140,74 @@ describe StudentsController, :type => :controller do
             expect(discipline_incidents).to eq [more_recent_incident, less_recent_incident]
           end
         end
+      end
 
-        context 'educator has grade level access' do
-          let(:educator) { FactoryGirl.create(:educator, grade_level_access: [student.grade], school: school )}
+      context 'educator has grade level access' do
+        let(:educator) { FactoryGirl.create(:educator, grade_level_access: [student.grade], school: school )}
+
+        it 'is successful' do
+          make_request({ student_id: student.id, format: :html })
+          expect(response).to be_success
+        end
+      end
+
+      context 'educator has homeroom access' do
+        let(:educator) { FactoryGirl.create(:educator, school: school) }
+        before { homeroom.update(educator: educator) }
+
+        it 'is successful' do
+          make_request({ student_id: student.id, format: :html })
+          expect(response).to be_success
+        end
+      end
+
+      context 'educator has section access' do
+        let!(:educator) { FactoryGirl.create(:educator, school: school)}
+        let!(:course) { FactoryGirl.create(:course, school: school)}
+        let!(:section) { FactoryGirl.create(:section) }
+        let!(:esa) { FactoryGirl.create(:educator_section_assignment, educator: educator, section: section) }
+        let!(:section_student) { FactoryGirl.create(:student, school: school) }
+        let!(:ssa) { FactoryGirl.create(:student_section_assignment, student: section_student, section: section) }
+
+        it 'is successful' do
+          make_request({ student_id: section_student.id, format: :html })
+          expect(response).to be_success
+        end
+      end
+
+      context 'educator does not have schoolwide, grade level, or homeroom access' do
+        let(:educator) { FactoryGirl.create(:educator, school: school) }
+
+        it 'fails' do
+          make_request({ student_id: student.id, format: :html })
+          expect(response).to redirect_to(not_authorized_path)
+        end
+      end
+
+      context 'educator has some grade level access but for the wrong grade' do
+        let(:student) { FactoryGirl.create(:student, :with_risk_level, grade: '1', school: school) }
+        let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['KF'], school: school) }
+
+        it 'fails' do
+          make_request({ student_id: student.id, format: :html })
+          expect(response).to redirect_to(not_authorized_path)
+        end
+      end
+
+      context 'educator access restricted to SPED students' do
+        let(:educator) { FactoryGirl.create(:educator,
+                                            grade_level_access: ['1'],
+                                            restricted_to_sped_students: true,
+                                            school: school )
+        }
+
+        context 'student in SPED' do
+          let(:student) { FactoryGirl.create(:student,
+                                              :with_risk_level,
+                                              grade: '1',
+                                              program_assigned: 'Sp Ed',
+                                              school: school)
+          }
 
           it 'is successful' do
             make_request({ student_id: student.id, format: :html })
@@ -139,125 +215,56 @@ describe StudentsController, :type => :controller do
           end
         end
 
-        context 'educator has homeroom access' do
-          let(:educator) { FactoryGirl.create(:educator, school: school) }
-          before { homeroom.update(educator: educator) }
-
-          it 'is successful' do
-            make_request({ student_id: student.id, format: :html })
-            expect(response).to be_success
-          end
-        end
-
-        context 'educator has section access' do
-          let!(:educator) { FactoryGirl.create(:educator, school: school)}
-          let!(:course) { FactoryGirl.create(:course, school: school)}
-          let!(:section) { FactoryGirl.create(:section) }
-          let!(:esa) { FactoryGirl.create(:educator_section_assignment, educator: educator, section: section) }
-          let!(:section_student) { FactoryGirl.create(:student, school: school) }
-          let!(:ssa) { FactoryGirl.create(:student_section_assignment, student: section_student, section: section) }
-
-          it 'is successful' do
-            make_request({ student_id: section_student.id, format: :html })
-            expect(response).to be_success
-          end
-        end
-
-        context 'educator does not have schoolwide, grade level, or homeroom access' do
-          let(:educator) { FactoryGirl.create(:educator, school: school) }
+        context 'student in Reg Ed' do
+          let(:student) { FactoryGirl.create(:student,
+                                              :with_risk_level,
+                                              grade: '1',
+                                              program_assigned: 'Reg Ed')
+          }
 
           it 'fails' do
             make_request({ student_id: student.id, format: :html })
             expect(response).to redirect_to(not_authorized_path)
           end
-        end
-
-        context 'educator has some grade level access but for the wrong grade' do
-          let(:student) { FactoryGirl.create(:student, :with_risk_level, grade: '1', school: school) }
-          let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['KF'], school: school) }
-
-          it 'fails' do
-            make_request({ student_id: student.id, format: :html })
-            expect(response).to redirect_to(not_authorized_path)
-          end
-        end
-
-        context 'educator access restricted to SPED students' do
-          let(:educator) { FactoryGirl.create(:educator,
-                                              grade_level_access: ['1'],
-                                              restricted_to_sped_students: true,
-                                              school: school )
-          }
-
-          context 'student in SPED' do
-            let(:student) { FactoryGirl.create(:student,
-                                               :with_risk_level,
-                                               grade: '1',
-                                               program_assigned: 'Sp Ed',
-                                               school: school)
-            }
-
-            it 'is successful' do
-              make_request({ student_id: student.id, format: :html })
-              expect(response).to be_success
-            end
-          end
-
-          context 'student in Reg Ed' do
-            let(:student) { FactoryGirl.create(:student,
-                                               :with_risk_level,
-                                               grade: '1',
-                                               program_assigned: 'Reg Ed')
-            }
-
-            it 'fails' do
-              make_request({ student_id: student.id, format: :html })
-              expect(response).to redirect_to(not_authorized_path)
-            end
-          end
-
-        end
-
-        context 'educator access restricted to ELL students' do
-          let(:educator) { FactoryGirl.create(:educator,
-                                              grade_level_access: ['1'],
-                                              restricted_to_english_language_learners: true,
-                                              school: school )
-          }
-
-          context 'limited English proficiency' do
-            let(:student) { FactoryGirl.create(:student,
-                                               :with_risk_level,
-                                               grade: '1',
-                                               limited_english_proficiency: 'FLEP',
-                                               school: school)
-            }
-
-            it 'is successful' do
-              make_request({ student_id: student.id, format: :html })
-              expect(response).to be_success
-            end
-          end
-
-          context 'fluent in English' do
-            let(:student) { FactoryGirl.create(:student,
-                                               :with_risk_level,
-                                               grade: '1',
-                                               limited_english_proficiency: 'Fluent')
-            }
-
-            it 'fails' do
-              make_request({ student_id: student.id, format: :html })
-              expect(response).to redirect_to(not_authorized_path)
-            end
-          end
-
         end
 
       end
 
-    end
+      context 'educator access restricted to ELL students' do
+        let(:educator) { FactoryGirl.create(:educator,
+                                            grade_level_access: ['1'],
+                                            restricted_to_english_language_learners: true,
+                                            school: school )
+        }
 
+        context 'limited English proficiency' do
+          let(:student) { FactoryGirl.create(:student,
+                                              :with_risk_level,
+                                              grade: '1',
+                                              limited_english_proficiency: 'FLEP',
+                                              school: school)
+          }
+
+          it 'is successful' do
+            make_request({ student_id: student.id, format: :html })
+            expect(response).to be_success
+          end
+        end
+
+        context 'fluent in English' do
+          let(:student) { FactoryGirl.create(:student,
+                                              :with_risk_level,
+                                              grade: '1',
+                                              limited_english_proficiency: 'Fluent')
+          }
+
+          it 'fails' do
+            make_request({ student_id: student.id, format: :html })
+            expect(response).to redirect_to(not_authorized_path)
+          end
+        end
+      end
+    end
   end
 
   describe '#service' do

--- a/spec/factories/student_section_assignments.rb
+++ b/spec/factories/student_section_assignments.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :student_section_assignment do
     association :student
     association :section
+    grade_numeric { rand(500..1000) / 10 }
   end
 end

--- a/spec/javascripts/student_profile/profile_details_spec.jsx
+++ b/spec/javascripts/student_profile/profile_details_spec.jsx
@@ -176,9 +176,7 @@ describe('ProfileDetails', function() {
     it('renders the correct roster headers', function() {
       const el = this.testEl;
       const props = {
-        currentEducator: {
-          allowed_sections_index: [1,2,3,4]
-        }
+        currentEducatorAllowedSections: [1,2,3,4]
       };
   
       helpers.renderHSInto(el, props);
@@ -192,9 +190,7 @@ describe('ProfileDetails', function() {
     it('renders the correct roster data', function() {
       const el = this.testEl;
       const props = {
-        currentEducator: {
-          allowed_sections_index: [1,2,3,4]
-        }
+        currentEducatorAllowedSections: [1,2,3,4]
       };
   
       helpers.renderHSInto(el, props);
@@ -211,9 +207,7 @@ describe('ProfileDetails', function() {
     it('renders section number based on educator access', function() {
       const el = this.testEl;
       const props = {
-        currentEducator: {
-          allowed_sections_index: [2,3,4]
-        }
+        currentEducatorAllowedSections: [2,3,4]
       };
   
       helpers.renderHSInto(el, props);

--- a/spec/javascripts/student_profile/profile_details_spec.jsx
+++ b/spec/javascripts/student_profile/profile_details_spec.jsx
@@ -24,6 +24,63 @@ describe('ProfileDetails', function() {
           star_series_math_percentile: [[2012, 11, 18, 43]],
         },
         iepDocuments: [],
+        services: [],
+        feed: {
+          deprecated: {
+            interventions: [{id: 997, start_date_timestamp: "2010-10-1"}],
+            notes: [{id: 945, created_at_timestamp: "2013-02-11T14:41:52.857Z"}]
+          },
+          event_notes: [{id: 992, recorded_at: "2010-10-17T00:00:00.000Z"}],
+          services: {
+            active: [{id: 996, date_started: "2010-02-09", service_type_id: 508}],
+            discontinued: [{id: 945, date_started: "2010-10-08"}]
+          }
+        },
+        dibels: [{id: 901, date_taken: "2012-05-15Z", performance_level: "Strategic"}],
+        serviceTypesIndex: {
+          "508": {name: "Math intervention", id: 508}
+        }
+      }, props || {});
+      ReactDOM.render(<ProfileDetails {...mergedProps} />, el);
+    },
+    renderHSInto: function(el, props) {
+      const mergedProps = merge({
+        student: {
+          first_name: 'Test',
+          last_name: 'HighSchool',
+          school_type: 'HS'
+        },
+        attendanceData: {
+          absences: [{id: 991, occurred_at: "2016-02-21T18:35:03.757Z"}],
+          tardies: [{id: 998, occurred_at: "2014-01-01T14:35:03.750Z"}],
+          discipline_incidents: [{id: 9912, occurred_at: "2012-01-10T14:35Z"}]
+        },
+        chartData: {
+          mcas_series_ela_scaled: [[2015, 2, 18, 63]],
+          mcas_series_math_scaled: [[2014, 9, 18, 23]],
+          star_series_reading_percentile: [[2016, 1, 18, 83]],
+          star_series_math_percentile: [[2012, 11, 18, 43]],
+        },
+        iepDocuments: [],
+        school_type: "HS",
+        sections: [
+          {
+            course_description: "Some Course",
+            grade_numeric: 75.8,
+            id: 1,
+            room_number: "201",
+            schedule: "2(M,R)",
+            section_number: "SOM-A",
+            term_local_id: "FY",
+            educators: [
+              {
+                full_name: "Educator, HighSchool",
+                id: 1
+              }
+            ]
+
+          }
+        ],
         feed: {
           deprecated: {
             interventions: [{id: 997, start_date_timestamp: "2010-10-1"}],
@@ -108,6 +165,65 @@ describe('ProfileDetails', function() {
         'May 15th, 2012:DIBELSTest scored STRATEGIC in DIBELS.'
       );
 
+      // This is not a high school so sections should not be shown
+      expect($("#sections-roster",el).length).toEqual(0);
+
+    });
+  });
+  
+  SpecSugar.withTestEl('Sections', function() {
+
+    it('renders the correct roster headers', function() {
+      const el = this.testEl;
+      const props = {
+        currentEducator: {
+          allowed_sections_index: [1,2,3,4]
+        }
+      };
+  
+      helpers.renderHSInto(el, props);
+
+      const headers = $(el).find('#roster-header th');
+
+      expect(headers.length).toEqual(7);
+      expect(headers[0].innerHTML).toEqual('Section Number');
+    });
+
+    it('renders the correct roster data', function() {
+      const el = this.testEl;
+      const props = {
+        currentEducator: {
+          allowed_sections_index: [1,2,3,4]
+        }
+      };
+  
+      helpers.renderHSInto(el, props);
+
+      const dataElements = $(el).find('#roster-data tr');
+
+      expect(dataElements.length).toEqual(1);
+
+      const firstDataRows = dataElements.eq(0).find('td');
+      expect(firstDataRows[0].innerHTML).toEqual('<a href="/sections/1">SOM-A</a>');
+      expect(firstDataRows[2].innerHTML).toEqual('75.8');
+    });
+
+    it('renders section number based on educator access', function() {
+      const el = this.testEl;
+      const props = {
+        currentEducator: {
+          allowed_sections_index: [2,3,4]
+        }
+      };
+  
+      helpers.renderHSInto(el, props);
+
+      const dataElements = $(el).find('#roster-data tr');
+
+      expect(dataElements.length).toEqual(1);
+
+      const firstDataRows = dataElements.eq(0).find('td');
+      expect(firstDataRows[0].innerHTML).toEqual('<p>SOM-A</p>');
     });
   });
 });

--- a/spec/javascripts/student_profile/student_profile_page_spec.jsx
+++ b/spec/javascripts/student_profile/student_profile_page_spec.jsx
@@ -7,7 +7,7 @@ describe('StudentProfilePage integration test', function() {
   const PageContainer = window.shared.PageContainer;
 
   const helpers = {
-    renderStudentProfilePage: function(el, grade, dibels, absencesCount) {
+    renderStudentProfilePage: function(el, grade, dibels, absencesCount, sectionsCount, schoolType) {
       const serializedData = _.cloneDeep(studentProfile);
       if (grade !== undefined) {
         serializedData["student"]["grade"] = grade;
@@ -19,6 +19,17 @@ describe('StudentProfilePage integration test', function() {
 
       if (absencesCount !== undefined) {
         serializedData["student"]["absences_count"] = absencesCount;
+      }
+
+      if (sectionsCount !== undefined) {
+        const sections = _.times(sectionsCount, function(n) {
+          return {id: n+1};
+        });
+        serializedData["sections"] = sections;
+      }
+
+      if (schoolType !== undefined) {
+        serializedData["student"]["school_type"] = schoolType;
       }
 
 
@@ -95,8 +106,27 @@ describe('StudentProfilePage integration test', function() {
         });
       });
 
+      describe('student with sections', function() {
+        it('does not have sections count', function() {
+          const el = this.testEl;
+          helpers.renderStudentProfilePage(el, '5', [], 0, 3, 'ES');
+          expect(el).not.toContainText('Sections');
+        });
+      });
     });
 
-  });
+    describe('student in high school', function() {
+      it('renders student with 1 section', function() {
+        const el = this.testEl;
+        helpers.renderStudentProfilePage(el, '10', [], 0, 1, 'HS');
+        expect(el).toContainText('1 section');
+      });
 
+      it('renders student with 5 sections', function() {
+        const el = this.testEl;
+        helpers.renderStudentProfilePage(el, '10', [], 0, 5, 'HS');
+        expect(el).toContainText('5 sections');
+      });
+    });
+  });
 });


### PR DESCRIPTION
This PR adds sections to the overview area of the Student Profile implementing #1078.

**Who does it affect?** All high school students. Any student in a school type other than "HS" remains as is.

**What does it look like?**
![capture](https://user-images.githubusercontent.com/2595259/30946917-afc8ac7e-a3d4-11e7-8c00-b8beec9ee4ff.PNG)

**What do I need to know?**
If an educator has permission to view a student's profile (via districtwide, schoolwide, homeroom, grade level, section, etc), they can see the student's current sections with current average grade. 

If an educator has access to a section in which the student is currently enrolled, they will see the section number as a link (goes to section view). Otherwise, the section number will be plain text.
