### PR TITLE
Revert "Remove student searchbar caching from educator import job"

### DIFF
--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -21,6 +21,7 @@ class EducatorsImporter < Struct.new :school_scope, :client, :log, :progress_bar
 
     if educator.present?
       educator.save!
+      educator.save_student_searchbar_json
 
       homeroom = Homeroom.find_by_name(row[:homeroom]) if row[:homeroom]
       homeroom.update(educator: educator) if homeroom.present?


### PR DESCRIPTION
Reverts studentinsights/studentinsights#1051.

Should address #1104.

This will make the nightly import job run longer, but as we've discussed on the team, we don't really care how long it runs as long as it gets the job done. And we've already bumped up the max length of the job a few times. 

I'd rather have this as part of the main import job instead of yet another background job because that way we can reuse useful tooling (like the ErrorMailer) from the import job. And having data import/update occurring in as few separate jobs as possible seems simpler to manage. 