### PR TITLE
Fix numeric sorting

### DIFF
--- a/app/assets/javascripts/helpers/sort_helpers.jsx
+++ b/app/assets/javascripts/helpers/sort_helpers.jsx
@@ -22,15 +22,14 @@ export default {
   },
 
   sortByNumber: function (a, b, sortBy) {
-    const numA = parseInt(a[sortBy]);
-    const numB = parseInt(b[sortBy]);
+    // Parsing all numbers by floats to retain the decimal in sorting
+    const numA = parseFloat(a[sortBy]);
+    const numB = parseFloat(b[sortBy]);
 
-    if (!_.isNumber(numA) && !_.isNumber(numB)) return 0;
-
-    if (!_.isNumber(numA) || numA < numB) return 1;
-    if (!_.isNumber(numB) || numA > numB) return -1;
-
-    return 0;
+    if(numA === numB) return 0;
+    if(_.isNaN(numA)) return 1;
+    if(_.isNaN(numB)) return -1;
+    return numA > numB ? -1 : 1;
   },
 
   sortByCustomEnum: function (a, b, sortBy, customEnum) {

--- a/spec/javascripts/helpers/sort_helpers_spec.jsx
+++ b/spec/javascripts/helpers/sort_helpers_spec.jsx
@@ -41,9 +41,14 @@ describe('SortHelpers', function() {
     const preSortData = [
       {testElement: 5},
       {testElement: 4},
+      {testElement: null},
       {testElement: 5},
       {testElement: 1},
-      {testElement: 0}
+      {testElement: null},
+      {testElement: 0},
+      {testElement: 5},
+      {testElement: 1},
+      {testElement: null}
     ];
     
     it('correctly sorts', function() {
@@ -52,9 +57,14 @@ describe('SortHelpers', function() {
       let targetData = [
         {testElement: 5},
         {testElement: 5},
+        {testElement: 5},
         {testElement: 4},
         {testElement: 1},
-        {testElement: 0}
+        {testElement: 1},
+        {testElement: 0},
+        {testElement: null},
+        {testElement: null},
+        {testElement: null},
       ];
       
       sortData.sort((a, b) => SortHelpers.sortByNumber(a, b, 'testElement'));


### PR DESCRIPTION
PR for #1108 

It looks like a combination between some faulty logic and a change from isInteger to isNumber so we could use lodash 3.10.1 caused numbers not to be properly sorted.

Modified the test to include nulls so we could exercise this case in the tests.

Plan on batching this with other little PRs for deploy to production.