### PR TITLE
Remove free / reduced lunch (income status) from all views except school

### DIFF
--- a/app/assets/javascripts/homeroom_table/homeroom_table.jsx
+++ b/app/assets/javascripts/homeroom_table/homeroom_table.jsx
@@ -95,7 +95,6 @@ export default React.createClass({
       'program': 'Program',
       'sped': 'SPED & Disability',
       'language': 'Language',
-      'free-reduced': 'Free/Reduced Lunch',
       'star': 'STAR',
       'mcas': 'MCAS',
     };
@@ -360,9 +359,6 @@ export default React.createClass({
         {this.renderSubHeader(
           'language', 'Home Language', 'home_language', 'string'
         )}
-        {this.renderSubHeader(
-          'free-reduced', 'Free/Reduced Lunch', 'free_reduced_lunch', 'string'
-        )}
         {(this.showStar()) ? this.renderStarSubHeaders() : null}
         {(this.showMcas()) ? this.renderMcasSubHeaders() : null}
       </tr>
@@ -460,7 +456,6 @@ export default React.createClass({
         {this.renderDataCell('sped', row['plan_504'])}
         {this.renderDataCell('language', row['limited_english_proficiency'])}
         {this.renderDataCell('language', row['home_language'])}
-        {this.renderDataCell('free-reduced', row['free_reduced_lunch'])}
         {this.renderStarData(row)}
         {this.renderMcasData(row)}
       </tr>

--- a/app/assets/javascripts/section/section_page.jsx
+++ b/app/assets/javascripts/section/section_page.jsx
@@ -59,7 +59,6 @@ import SortHelpers from '../helpers/sort_helpers.jsx';
         {label: 'Fluency', group: 'Language', key: 'limited_english_proficiency', sortFunc: this.languageProficiencySorter},
         {label: 'Home Language', group: 'Language', key: 'home_language'},
 
-        {label: 'Free / Reduced Lunch', key: 'free_reduced_lunch'},
         {label: 'Grade', key: 'grade_numeric', sortFunc: SortHelpers.sortByNumber},
         {label: 'Absences', key: 'most_recent_school_year_absences_count', sortFunc: SortHelpers.sortByNumber},
         {label: 'Tardies', key: 'most_recent_school_year_tardies_count', sortFunc: SortHelpers.sortByNumber},

--- a/app/assets/javascripts/student_profile/student_profile_page.jsx
+++ b/app/assets/javascripts/student_profile/student_profile_page.jsx
@@ -355,7 +355,6 @@ import _ from 'lodash';
     renderDemographics: function(student, access) {
       const demographicsElements = [
         'Disability: ' + (student.sped_level_of_need || 'None'),
-        'Low income: ' + student.free_reduced_lunch,
         'Language: ' + student.limited_english_proficiency
       ];
 

--- a/app/views/students/student_report.pdf.erb
+++ b/app/views/students/student_report.pdf.erb
@@ -41,7 +41,6 @@ ul, li {
   </div>
   <div style="float: left; width: 312px;">
     <ul>
-      <li>Low Income: <%= @student.free_reduced_lunch %></li>
       <li>Language: <%= @student.home_language %></li>
       <li>Disability: <%= @student.disability || "None"%></li>
       <li>504 plan: <%= @student.plan_504 %></li>

--- a/spec/javascripts/section/section_page_spec.jsx
+++ b/spec/javascripts/section/section_page_spec.jsx
@@ -64,7 +64,7 @@ describe('SectionPage', function() {
       
       const headers = $(el).find('#roster-header th');
 
-      expect(headers.length).toEqual(17);
+      expect(headers.length).toEqual(16);
       expect(headers[0].innerHTML).toEqual('Name');
     });
 


### PR DESCRIPTION
This PR implements #1099.

Removed column from:
Homeroom view
Section View

Removed demographic attribute from:
Student Profile
Student Report (pdf)