### PR TITLE
Pump up Delayed::Worker max run time all the way up to 24 hours

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,1 +1,1 @@
-Delayed::Worker.max_run_time = 16.hours
+Delayed::Worker.max_run_time = 24.hours


### PR DESCRIPTION
# Notes 

+ This seems to me like the highest sensible limit for a nightly job :)
+ Most important thing is that the job completes!