### PR TITLE
Quick & ugly, save more info about nightly data import timing to database

### DIFF
--- a/app/reports/import_task_report.rb
+++ b/app/reports/import_task_report.rb
@@ -2,9 +2,10 @@ class ImportTaskReport
 
   attr_accessor :models_for_report
 
-  def initialize(models_for_report, log)
-    @log = log
+  def initialize(models_for_report:, record:, log:)
     @models_for_report = models_for_report
+    @record = record
+    @log = log
     @initial_counts_hash = compute_initial_counts
   end
 
@@ -44,6 +45,8 @@ class ImportTaskReport
     newline; puts end_of_task_report
     newline; newline; puts "=== BY SCHOOL ==="
     puts by_school_report
+    newline; newline; puts "=== IMPORT TIMING ==="
+    puts @record.importer_timing_json
     newline; AssessmentsReport.new(@log).print_report
   end
 

--- a/db/migrate/20170917110110_add_importer_timing_to_importer_record.rb
+++ b/db/migrate/20170917110110_add_importer_timing_to_importer_record.rb
@@ -1,0 +1,5 @@
+class AddImporterTimingToImporterRecord < ActiveRecord::Migration[5.1]
+  def change
+    add_column :import_records, :importer_timing_json, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -199,6 +199,7 @@ ActiveRecord::Schema.define(version: 20170928210614) do
     t.datetime "time_ended"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "importer_timing_json"
   end
 
   create_table "intervention_types", id: :serial, force: :cascade do |t|

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -54,8 +54,14 @@ class Import
     no_commands do
       def report
         models = [ Student, StudentAssessment, DisciplineIncident, Absence, Tardy, Educator, School, Course, Section, StudentSectionAssignment, EducatorSectionAssignment ]
+
         log = options["test_mode"] ? LogHelper::Redirect.instance.file : STDOUT
-        @report ||= ImportTaskReport.new(models, log)
+
+        @report ||= ImportTaskReport.new(
+          models_for_report: models,
+          record: record,
+          log: log,
+        )
       end
 
       def record
@@ -101,6 +107,9 @@ class Import
 
           timing_data[:end_time] = Time.current
           timing_log << timing_data
+          record.importer_timing_json = timing_log.to_json
+
+          record.save!
         end
       rescue => error
         extra_info =  {


### PR DESCRIPTION
# Notes 

+ Add column to store importer timing data as free-text JSON so that we can have a database record for which importers are taking the most time
+ Print at the end of each import process and add to error mailer