### PR TITLE
Remove file_date field from IepDocuments

### DIFF
--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -254,7 +254,6 @@ class FakeStudent
     15.in(100) do
       IepDocument.create(
         file_name: 'Fake IEP',
-        file_date: DateTime.current,
         student: @student
       )
     end

--- a/app/importers/iep_import/iep_file_name_parser.rb
+++ b/app/importers/iep_import/iep_file_name_parser.rb
@@ -8,10 +8,6 @@ class IepFileNameParser < Struct.new :path, :zip_filename
     path.split("/").last
   end
 
-  def file_date
-    Date.strptime(date_zip_basename, '%m-%d-%Y').to_s
-  end
-
   def check_iep_at_a_glance
     raise 'oh no!' if pdf_basename.split('_')[1] != 'IEPAtAGlance'
   end
@@ -20,10 +16,6 @@ class IepFileNameParser < Struct.new :path, :zip_filename
 
     def pdf_basename
       Pathname.new(path).basename.sub_ext('').to_s
-    end
-
-    def date_zip_basename
-      Pathname.new(zip_filename).basename.sub_ext('').to_s
     end
 
 end

--- a/app/importers/iep_import/iep_storer.rb
+++ b/app/importers/iep_import/iep_storer.rb
@@ -1,13 +1,11 @@
 class IepStorer
   def initialize(file_name:,
                  path_to_file:,
-                 file_date:,
                  local_id:,
                  client:,
                  logger:)
     @file_name = file_name
     @path_to_file = path_to_file
-    @file_date = file_date
     @local_id = local_id
     @client = client
     @logger = logger
@@ -48,7 +46,6 @@ class IepStorer
     @logger.info("storing iep for student to db.")
 
     IepDocument.create!(
-      file_date: @file_date,
       file_name: @file_name,
       student: @student
     )

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -59,7 +59,6 @@ class IepPdfImportJob
       IepStorer.new(
         path_to_file: path_to_file,
         file_name: file_info.file_name,
-        file_date: file_info.file_date,
         local_id: file_info.local_id,
         client: s3,
         logger: logger

--- a/app/models/iep_document.rb
+++ b/app/models/iep_document.rb
@@ -1,4 +1,4 @@
 class IepDocument < ActiveRecord::Base
   belongs_to :student
-  validates :file_name, uniqueness: { scope: :file_date, message: "one unique file name per date" }
+  validates :file_name, presence: true, uniqueness: true
 end

--- a/db/migrate/20171001205522_remove_file_date_field_from_iep_documents.rb
+++ b/db/migrate/20171001205522_remove_file_date_field_from_iep_documents.rb
@@ -1,0 +1,5 @@
+class RemoveFileDateFieldFromIepDocuments < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :iep_documents, :file_date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170929173803) do
+ActiveRecord::Schema.define(version: 20171001205522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -186,7 +186,6 @@ ActiveRecord::Schema.define(version: 20170929173803) do
   end
 
   create_table "iep_documents", id: :serial, force: :cascade do |t|
-    t.datetime "file_date"
     t.string "file_name"
     t.integer "student_id"
     t.datetime "created_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -166,10 +166,4 @@ end
 Student.update_risk_levels!
 Student.update_recent_student_assessments
 
-IepDocument.create!(
-  file_name: 'fake-iep-document.pdf',
-  file_date: DateTime.current,
-  student: Student.first
-)
-
 PrecomputeStudentHashesJob.new(STDOUT).precompute_all!(Time.now)

--- a/spec/controllers/iep_documents_controller_spec.rb
+++ b/spec/controllers/iep_documents_controller_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe IepDocumentsController, type: :controller do
 
     subject {
       IepDocument.create(
-        file_date: DateTime.current,
         file_name: 'IEP Document',
         student: student,
       )

--- a/spec/models/iep_storer_spec.rb
+++ b/spec/models/iep_storer_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe IepStorer, type: :model do
     IepStorer.new(
       file_name: 'IEP Document',
       path_to_file: '/path/to/file',
-      file_date: DateTime.current,
       local_id: 'abc_student_local_id',
       client: FakeAwsClient,
       logger: QuietLogger


### PR DESCRIPTION
# Notes 

+ We won't get this from the documents downloaded via the nightly import; they don't have an associated date and are just considered the most recent IEP