### PR TITLE
Update students_export.sql

### DIFF
--- a/x2_export/students_export.sql
+++ b/x2_export/students_export.sql
@@ -21,6 +21,8 @@ SELECT
   'gender',
   'race',
   'hispanic_latino'
+  'primary_phone'
+  'primary_email'
 UNION ALL
 SELECT
   STD_ID_STATE,
@@ -44,6 +46,8 @@ SELECT
   PSN_GENDER_CODE,
   PSN_RACE_VIEW,
   PSN_HISPANIC_LATINO_IND
+  PSN_PHONE_01
+  PSN_EMAIL_01
 FROM student
 INNER JOIN school
   ON student.STD_SKL_OID=school.SKL_OID

--- a/x2_export/students_export.sql
+++ b/x2_export/students_export.sql
@@ -49,7 +49,6 @@ INNER JOIN school
   ON student.STD_SKL_OID=school.SKL_OID
 INNER JOIN person
   ON student.STD_PSN_OID = person.PSN_OID
-AND STD_ID_STATE IS NOT NULL
 AND STD_OID IS NOT NULL
   INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/students_export.txt"
   FIELDS TERMINATED BY ','


### PR DESCRIPTION
# Notes 

+ Allow import of students with null `state_id`. See conversation here: https://github.com/studentinsights/studentinsights/issues/1056
  + This PR just changes our copy of the `.sql` file in the repo; the data flow won't change until John Breslin uses the updated `.sql` file
+ Add `primary_phone` and `primary_email` fields to the Students exporter