### PR TITLE
Improve performance of student searchbar JSON computing

### DIFF
--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -15,7 +15,7 @@ module Admin
 
     def update
       super
-      PrecomputeSearchbarJson.for(requested_resource)
+      PrecomputeSearchbarJson.new.for(requested_resource)
     end
 
     def resource_params

--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -15,7 +15,7 @@ module Admin
 
     def update
       super
-      requested_resource.save_student_searchbar_json
+      PrecomputeSearchbarJson.for(educator)
     end
 
     def resource_params

--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -15,7 +15,7 @@ module Admin
 
     def update
       super
-      PrecomputeSearchbarJson.for(educator)
+      PrecomputeSearchbarJson.for(requested_resource)
     end
 
     def resource_params

--- a/app/helpers/searchbar_helper.rb
+++ b/app/helpers/searchbar_helper.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 module SearchbarHelper
   def self.names_for(educator)
-    authorized_students = Student.with_school.select do |student|
+    authorized_students = educator.school.students.select do |student|
       educator.is_authorized_for_student(student)
     end
+
     authorized_students.map do |student|
       {
         label: "#{student.first_name} #{student.last_name} - #{student.school.local_id} - #{student.grade}",

--- a/app/helpers/searchbar_helper.rb
+++ b/app/helpers/searchbar_helper.rb
@@ -11,4 +11,13 @@ module SearchbarHelper
       }
     end
   end
+
+  def self.names_for_all_students
+    Student.with_school.map do |student|
+      {
+        label: "#{student.first_name} #{student.last_name} - #{student.school.local_id} - #{student.grade}",
+        id: student.id
+      }
+    end
+  end
 end

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -18,10 +18,11 @@ class EducatorsImporter < Struct.new :school_scope, :client, :log, :progress_bar
 
   def import_row(row)
     educator = EducatorRow.new(row, school_ids_dictionary).build
+    searchbar = PrecomputeSearchbarJson.new
 
     if educator.present?
       educator.save!
-      PrecomputeSearchbarJson.for(educator)
+      searchbar.for(educator)
 
       homeroom = Homeroom.find_by_name(row[:homeroom]) if row[:homeroom]
       homeroom.update(educator: educator) if homeroom.present?

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -21,7 +21,7 @@ class EducatorsImporter < Struct.new :school_scope, :client, :log, :progress_bar
 
     if educator.present?
       educator.save!
-      educator.save_student_searchbar_json
+      PrecomputeSearchbarJson.for(educator)
 
       homeroom = Homeroom.find_by_name(row[:homeroom]) if row[:homeroom]
       homeroom.update(educator: educator) if homeroom.present?

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -174,21 +174,6 @@ class Educator < ActiveRecord::Base
     }
   end
 
-  def self.save_student_searchbar_json
-    find_each { |educator| educator.save_student_searchbar_json }
-  end
-
-  def self.save_student_searchbar_json_for_folks_who_log_in
-    educators_who_log_in = Educator.where("sign_in_count > ?", 0)
-
-    educators_who_log_in.find_each { |e| e.save_student_searchbar_json }
-  end
-
-  def save_student_searchbar_json
-    self.student_searchbar_json = SearchbarHelper.names_for(self).to_json
-    save!
-  end
-
   private
 
   def has_access_to_no_students?

--- a/app/models/precompute_searchbar_json.rb
+++ b/app/models/precompute_searchbar_json.rb
@@ -10,7 +10,7 @@ class PrecomputeSearchbarJson
 
   def self.for(educator)
     if educator.districtwide_access
-      educator.student_searchbar_json = districtwide_access_json
+      educator.student_searchbar_json = districtwide_access_json.to_json
     else
       educator.student_searchbar_json = SearchbarHelper.names_for(educator).to_json
     end

--- a/app/models/precompute_searchbar_json.rb
+++ b/app/models/precompute_searchbar_json.rb
@@ -1,11 +1,11 @@
 module PrecomputeSearchbarJson
 
   def self.for_all_educators
-    Educator.find_each { |educator| save_student_searchbar_json(educator) }
+    Educator.find_each { |educator| self.for(educator) }
   end
 
   def self.for_educators_who_log_in
-    educators_who_log_in.find_each { |educator| save_student_searchbar_json(educator) }
+    educators_who_log_in.find_each { |educator| self.for(educator) }
   end
 
   def self.for(educator)

--- a/app/models/precompute_searchbar_json.rb
+++ b/app/models/precompute_searchbar_json.rb
@@ -1,5 +1,9 @@
 class PrecomputeSearchbarJson
 
+  def initialize
+    @json_for_all_students = nil
+  end
+
   def for_all_educators
     Educator.find_each { |educator| self.for(educator) }
   end
@@ -10,7 +14,7 @@ class PrecomputeSearchbarJson
 
   def for(educator)
     if educator.districtwide_access
-      educator.student_searchbar_json = districtwide_access_json.to_json
+      educator.student_searchbar_json = self.districtwide_access_json
     else
       educator.student_searchbar_json = SearchbarHelper.names_for(educator).to_json
     end
@@ -23,7 +27,7 @@ class PrecomputeSearchbarJson
   end
 
   def districtwide_access_json
-    @json_for_all ||= SearchbarHelper.names_for_all_students
+    @json_for_all_students ||= SearchbarHelper.names_for_all_students.to_json
   end
 
 end

--- a/app/models/precompute_searchbar_json.rb
+++ b/app/models/precompute_searchbar_json.rb
@@ -1,4 +1,4 @@
-class PrecomputeSearchbarJson
+module PrecomputeSearchbarJson
 
   def self.for_all_educators
     Educator.find_each { |educator| save_student_searchbar_json(educator) }

--- a/app/models/precompute_searchbar_json.rb
+++ b/app/models/precompute_searchbar_json.rb
@@ -1,14 +1,14 @@
-module PrecomputeSearchbarJson
+class PrecomputeSearchbarJson
 
-  def self.for_all_educators
+  def for_all_educators
     Educator.find_each { |educator| self.for(educator) }
   end
 
-  def self.for_educators_who_log_in
+  def for_educators_who_log_in
     educators_who_log_in.find_each { |educator| self.for(educator) }
   end
 
-  def self.for(educator)
+  def for(educator)
     if educator.districtwide_access
       educator.student_searchbar_json = districtwide_access_json.to_json
     else
@@ -18,11 +18,11 @@ module PrecomputeSearchbarJson
     educator.save!
   end
 
-  def self.educators_who_log_in
+  def educators_who_log_in
     Educator.where("sign_in_count > ?", 0)
   end
 
-  def self.districtwide_access_json
+  def districtwide_access_json
     @json_for_all ||= SearchbarHelper.names_for_all_students
   end
 

--- a/app/models/precompute_searchbar_json.rb
+++ b/app/models/precompute_searchbar_json.rb
@@ -9,18 +9,6 @@ class PrecomputeSearchbarJson
   end
 
   def self.for(educator)
-    new.save_student_searchbar_json(educator)
-  end
-
-  def educators_who_log_in
-    Educator.where("sign_in_count > ?", 0)
-  end
-
-  def districtwide_access_json
-    @json_for_all ||= SearchbarHelper.names_for_all_students
-  end
-
-  def save_student_searchbar_json(educator)
     if educator.districtwide_access
       educator.student_searchbar_json = districtwide_access_json
     else
@@ -28,6 +16,14 @@ class PrecomputeSearchbarJson
     end
 
     educator.save!
+  end
+
+  def self.educators_who_log_in
+    Educator.where("sign_in_count > ?", 0)
+  end
+
+  def self.districtwide_access_json
+    @json_for_all ||= SearchbarHelper.names_for_all_students
   end
 
 end

--- a/app/models/precompute_searchbar_json.rb
+++ b/app/models/precompute_searchbar_json.rb
@@ -1,0 +1,29 @@
+class PrecomputeSearchbarJson
+
+  def self.for_all_educators
+    Educator.find_each { |educator| save_student_searchbar_json(educator) }
+  end
+
+  def self.for_educators_who_log_in
+    educators_who_log_in.find_each { |educator| save_student_searchbar_json(educator) }
+  end
+
+  def educators_who_log_in
+    Educator.where("sign_in_count > ?", 0)
+  end
+
+  def districtwide_access_json
+    @json_for_all ||= SearchbarHelper.names_for_all_students
+  end
+
+  def save_student_searchbar_json(educator)
+    if educator.districtwide_access
+      educator.student_searchbar_json = districtwide_access_json
+    else
+      educator.student_searchbar_json = SearchbarHelper.names_for(educator).to_json
+    end
+
+    educator.save!
+  end
+
+end

--- a/app/models/precompute_searchbar_json.rb
+++ b/app/models/precompute_searchbar_json.rb
@@ -8,6 +8,10 @@ class PrecomputeSearchbarJson
     educators_who_log_in.find_each { |educator| save_student_searchbar_json(educator) }
   end
 
+  def self.for(educator)
+    new.save_student_searchbar_json(educator)
+  end
+
   def educators_who_log_in
     Educator.where("sign_in_count > ?", 0)
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -167,4 +167,4 @@ Student.update_risk_levels!
 Student.update_recent_student_assessments
 
 PrecomputeStudentHashesJob.new(STDOUT).precompute_all!(Time.now)
-PrecomputeSearchbarJson.for_all_educators
+PrecomputeSearchbarJson.new.for_all_educators

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -167,3 +167,4 @@ Student.update_risk_levels!
 Student.update_recent_student_assessments
 
 PrecomputeStudentHashesJob.new(STDOUT).precompute_all!(Time.now)
+PrecomputeSearchbarJson.for_all_educators

--- a/lib/tasks/chores.rake
+++ b/lib/tasks/chores.rake
@@ -17,12 +17,12 @@ namespace :chores do
 
   desc 'Update educator student searchbar cached data'
   task update_searchbar_data_for_all_educators: :environment do
-    PrecomputeSearchbarJson.for_all_educators
+    PrecomputeSearchbarJson.new.for_all_educators
   end
 
   desc 'Update educator student searchbar data for those who have logged in'
   task update_searchbar_data_for_educators_who_log_in: :environment do
-    PrecomputeSearchbarJson.for_educators_who_log_in
+    PrecomputeSearchbarJson.new.for_educators_who_log_in
   end
 
   desc 'Kick off background worker for data import'

--- a/lib/tasks/chores.rake
+++ b/lib/tasks/chores.rake
@@ -17,12 +17,12 @@ namespace :chores do
 
   desc 'Update educator student searchbar cached data'
   task update_searchbar_data_for_all_educators: :environment do
-    Educator.save_student_searchbar_json
+    PrecomputeSearchbarJson.for_all_educators
   end
 
   desc 'Update educator student searchbar data for those who have logged in'
   task update_searchbar_data_for_educators_who_log_in: :environment do
-    Educator.save_student_searchbar_json_for_folks_who_log_in
+    PrecomputeSearchbarJson.for_educators_who_log_in
   end
 
   desc 'Kick off background worker for data import'

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -249,29 +249,6 @@ RSpec.describe Educator do
     end
   end
 
-  describe '#save_student_searchbar_json' do
-    context 'educator has permissions for a few students' do
-      let(:school) { FactoryGirl.create(:school, local_id: 'Big River High') }
-      let!(:betsy) { FactoryGirl.create(:student, first_name: 'Betsy', last_name: 'Ramirez', school: school, grade: '3') }
-      let!(:bettina) { FactoryGirl.create(:student, first_name: 'Bettina', last_name: 'Abbas', school: school, grade: '3') }
-      let(:educator) { FactoryGirl.create(:educator, districtwide_access: true) }
-
-      it 'saves the correct JSON' do
-        educator.save_student_searchbar_json
-        expect(educator.student_searchbar_json).to eq(
-          "[{\"label\":\"Betsy Ramirez - Big River High - 3\",\"id\":#{betsy.id}},{\"label\":\"Bettina Abbas - Big River High - 3\",\"id\":#{bettina.id}}]"
-        )
-      end
-    end
-    context 'educator has permissions for no students' do
-      let(:educator) { FactoryGirl.create(:educator) }
-
-      it 'saves the correct JSON' do
-        educator.save_student_searchbar_json
-        expect(educator.student_searchbar_json).to eq("[]")
-      end
-    end
-  end
   describe '#allowed_sections' do
     let!(:school) { FactoryGirl.create(:healey) }
     let!(:other_school) { FactoryGirl.create(:brown) }

--- a/spec/models/precompute_searchbar_json_spec.rb
+++ b/spec/models/precompute_searchbar_json_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe PrecomputeSearchbarJson do
       let!(:another_educator) { FactoryGirl.create(:educator, districtwide_access: true) }
 
       it 'only calculates districtwide JSON once' do
-
+        expect(SearchbarHelper).to receive(:names_for_all_students).once
+        PrecomputeSearchbarJson.new.for_all_educators
       end
 
     end

--- a/spec/models/precompute_searchbar_json_spec.rb
+++ b/spec/models/precompute_searchbar_json_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe PrecomputeSearchbarJson do
 
   describe '.for' do
+
     context 'educator has permissions for a few students' do
       let(:school) { FactoryGirl.create(:school, local_id: 'Big River High') }
       let!(:betsy) { FactoryGirl.create(:student, first_name: 'Betsy', last_name: 'Ramirez', school: school, grade: '3') }
@@ -10,20 +11,36 @@ RSpec.describe PrecomputeSearchbarJson do
       let(:educator) { FactoryGirl.create(:educator, districtwide_access: true) }
 
       it 'saves the correct JSON' do
-        PrecomputeSearchbarJson.for(educator)
+        PrecomputeSearchbarJson.new.for(educator)
         expect(educator.student_searchbar_json).to eq(
           "[{\"label\":\"Betsy Ramirez - Big River High - 3\",\"id\":#{betsy.id}},{\"label\":\"Bettina Abbas - Big River High - 3\",\"id\":#{bettina.id}}]"
         )
       end
     end
+
     context 'educator has permissions for no students' do
       let(:educator) { FactoryGirl.create(:educator) }
 
       it 'saves the correct JSON' do
-        PrecomputeSearchbarJson.for(educator)
+        PrecomputeSearchbarJson.new.for(educator)
         expect(educator.student_searchbar_json).to eq("[]")
       end
     end
+
+    context 'multiple districtwide_access educators' do
+      let(:school) { FactoryGirl.create(:school, local_id: 'Big River High') }
+      let!(:betsy) { FactoryGirl.create(:student, first_name: 'Betsy', last_name: 'Ramirez', school: school, grade: '3') }
+      let!(:bettina) { FactoryGirl.create(:student, first_name: 'Bettina', last_name: 'Abbas', school: school, grade: '3') }
+
+      let!(:educator) { FactoryGirl.create(:educator, districtwide_access: true) }
+      let!(:another_educator) { FactoryGirl.create(:educator, districtwide_access: true) }
+
+      it 'only calculates districtwide JSON once' do
+
+      end
+
+    end
+
   end
 
 end

--- a/spec/models/precompute_searchbar_json_spec.rb
+++ b/spec/models/precompute_searchbar_json_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe PrecomputeSearchbarJson do
+
+  describe '.for' do
+    context 'educator has permissions for a few students' do
+      let(:school) { FactoryGirl.create(:school, local_id: 'Big River High') }
+      let!(:betsy) { FactoryGirl.create(:student, first_name: 'Betsy', last_name: 'Ramirez', school: school, grade: '3') }
+      let!(:bettina) { FactoryGirl.create(:student, first_name: 'Bettina', last_name: 'Abbas', school: school, grade: '3') }
+      let(:educator) { FactoryGirl.create(:educator, districtwide_access: true) }
+
+      it 'saves the correct JSON' do
+        PrecomputeSearchbarJson.for(educator)
+        expect(educator.student_searchbar_json).to eq(
+          "[{\"label\":\"Betsy Ramirez - Big River High - 3\",\"id\":#{betsy.id}},{\"label\":\"Bettina Abbas - Big River High - 3\",\"id\":#{bettina.id}}]"
+        )
+      end
+    end
+    context 'educator has permissions for no students' do
+      let(:educator) { FactoryGirl.create(:educator) }
+
+      it 'saves the correct JSON' do
+        PrecomputeSearchbarJson.for(educator)
+        expect(educator.student_searchbar_json).to eq("[]")
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
# What does this do?

+ When precomputing searcbar JSON, if educator is school-based, only query students at their school. (Very good catch by @jhilde.)
+ When precomputing searcbar JSON, if educator is districtwide, use an instance variable cached to the job so that we don't precompute JSON for all students more than once per job.
+ Pull all this logic into a `PrecomputeSearchbarJson` service object. 

# Issue 

+ Fix #1120.