### PR TITLE
Modify the way we handle stale assignments for students and educators

### DIFF
--- a/app/importers/file_importers/educator_section_assignments_importer.rb
+++ b/app/importers/file_importers/educator_section_assignments_importer.rb
@@ -1,4 +1,8 @@
 class EducatorSectionAssignmentsImporter < Struct.new :school_scope, :client, :log, :progress_bar
+  def initialize(*)
+    super
+    @imported_assignments = []
+  end
 
   def remote_file_name
     'educator_section_assignment_export.txt'
@@ -13,7 +17,8 @@ class EducatorSectionAssignmentsImporter < Struct.new :school_scope, :client, :l
   end
 
   def delete_rows
-    EducatorSectionAssignment.delete_all
+    #Delete all stale rows no longer included in the import
+    EducatorSectionAssignment.where.not(id: @imported_assignments).delete_all
   end
 
   def import_row(row)
@@ -21,6 +26,7 @@ class EducatorSectionAssignmentsImporter < Struct.new :school_scope, :client, :l
 
     if educator_section_assignment
       educator_section_assignment.save!
+      @imported_assignments.push(educator_section_assignment.id)
     else
       log.write("Educator Section Assignment Import invalid row: #{row}")
     end

--- a/app/importers/file_importers/file_import.rb
+++ b/app/importers/file_importers/file_import.rb
@@ -5,9 +5,9 @@ class FileImport < Struct.new :file_importer
 
   def import
     log_start_of_import
-    delete_data if deletion_models.include?(file_importer.class)
     fetch_data
     import_data
+    delete_data if deletion_models.include?(file_importer.class)
   end
 
   private

--- a/app/importers/file_importers/student_section_assignments_importer.rb
+++ b/app/importers/file_importers/student_section_assignments_importer.rb
@@ -1,4 +1,9 @@
 class StudentSectionAssignmentsImporter < Struct.new :school_scope, :client, :log, :progress_bar
+  def initialize(*)
+    super
+    @imported_assignments = []
+  end
+
   def remote_file_name
     'student_section_assignment_export.txt'
   end
@@ -12,13 +17,15 @@ class StudentSectionAssignmentsImporter < Struct.new :school_scope, :client, :lo
   end
 
   def delete_rows
-    StudentSectionAssignment.delete_all
+    #Delete all stale rows no longer included in the import
+    StudentSectionAssignment.where.not(id: @imported_assignments).delete_all
   end
 
   def import_row(row)
     student_section_assignment = StudentSectionAssignmentRow.new(row).build
     if student_section_assignment
       student_section_assignment.save!
+      @imported_assignments.push(student_section_assignment.id)
     else
       log.write("Student Section Assignment Import invalid row: #{row}")
     end

--- a/db/migrate/20171002212324_add_id_to_educator_section_assignments.rb
+++ b/db/migrate/20171002212324_add_id_to_educator_section_assignments.rb
@@ -1,0 +1,5 @@
+class AddIdToEducatorSectionAssignments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :educator_section_assignments, :id, :primary_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171001205522) do
+ActiveRecord::Schema.define(version: 20171002212324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,7 +86,7 @@ ActiveRecord::Schema.define(version: 20171001205522) do
     t.datetime "updated_at"
   end
 
-  create_table "educator_section_assignments", id: false, force: :cascade do |t|
+  create_table "educator_section_assignments", force: :cascade do |t|
     t.integer "section_id"
     t.integer "educator_id"
     t.index ["educator_id"], name: "index_educator_section_assignments_on_educator_id"

--- a/spec/importers/file_importers/educator_section_assignments_importer.rb
+++ b/spec/importers/file_importers/educator_section_assignments_importer.rb
@@ -106,16 +106,31 @@ RSpec.describe EducatorSectionAssignmentsImporter do
     end
 
     describe '#delete_rows' do
+      let(:log) { LogHelper::Redirect.instance.file }
+      let!(:school) { FactoryGirl.create(:shs) }
+      let!(:section) { FactoryGirl.create(:section) }
+      let!(:educator) { FactoryGirl.create(:educator) }
+      let(:row) { {
+        local_id:educator.local_id,
+        course_number:section.course.course_number,
+        school_local_id: section.course.school.local_id,
+        section_number:section.section_number,
+        term_local_id:section.term_local_id
+      } }
 
       context 'happy path' do
 
         before do
           FactoryGirl.create_list(:educator_section_assignment,20)
-          described_class.new.delete_rows
+          FactoryGirl.create(:educator_section_assignment, educator_id: educator.id, section_id: section.id)
+
+          esa_importer = described_class.new
+          esa_importer.import_row(row)
+          esa_importer.delete_rows
         end
 
-        it 'deletes all student section assignments' do
-          expect(EducatorSectionAssignment.count).to eq(0)
+        it 'deletes all student section assignments except the recently imported one' do
+          expect(EducatorSectionAssignment.count).to eq(1)
         end
       end
     end

--- a/spec/importers/file_importers/student_section_assignments_importer_spec.rb
+++ b/spec/importers/file_importers/student_section_assignments_importer_spec.rb
@@ -101,14 +101,29 @@ RSpec.describe StudentSectionAssignmentsImporter do
   end
 
   describe '#delete_rows' do
+    let(:log) { LogHelper::Redirect.instance.file }
+    let!(:school) { FactoryGirl.create(:shs) }
+    let!(:section) { FactoryGirl.create(:section) }
+    let!(:student) { FactoryGirl.create(:student) }
+    let(:row) { { local_id:student.local_id,
+      course_number:section.course.course_number,
+      school_local_id: section.course.school.local_id,
+      section_number:section.section_number,
+      term_local_id: section.term_local_id
+    } }
+
     context 'happy path' do
       before do
         FactoryGirl.create_list(:student_section_assignment, 20)
-        described_class.new.delete_rows
+        FactoryGirl.create(:student_section_assignment, student_id: student.id, section_id: section.id)
+
+        ssa_importer = described_class.new
+        ssa_importer.import_row(row)
+        ssa_importer.delete_rows
       end
 
-      it 'deletes all student section assignments' do
-        expect(StudentSectionAssignment.count).to eq(0)
+      it 'deletes all student section assignments except the recently imported one' do
+        expect(StudentSectionAssignment.count).to eq(1)
       end
     end
   end


### PR DESCRIPTION
Background:
The files we import to create the assignments of students and educators to sections includes the full import every time rather than providing us with deltas. That makes it difficult to determine which assignment have been deleted in Aspen. (Think student drops a course). 

Previous Strategy:
Initially I simply deleted all rows in the student_section_assignments and educator_section_assignments tables then imported all the fresh data. While that works, it is very sensitive to importer failure (as was seen in production today because of a timeout) and educators won't see data while each importer is running.

New Strategy:
As each of the two assignment importer imports rows, the id is added to an array. This becomes the list of fresh data. After all the importing is done for the importer, delete_rows is called. This deletes all rows from the table whose ids are not in the array (i.e. the stale rows).