### PR TITLE
Optimize school check in Educator#is_authorized_for_student

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -65,7 +65,7 @@ class Educator < ActiveRecord::Base
 
     return false if self.restricted_to_sped_students && !(student.program_assigned.in? ['Sp Ed', 'SEIP'])
     return false if self.restricted_to_english_language_learners && student.limited_english_proficiency == 'Fluent'
-    return false if self.school.present? && self.school != student.school
+    return false if self.school_id.present? && self.school_id != student.school_id
 
     return true if self.schoolwide_access? || self.admin? # Schoolwide admin
     return true if self.has_access_to_grade_levels? && student.grade.in?(self.grade_level_access) # Grade level access


### PR DESCRIPTION
Testing on the console in production, this cuts 10-20 seconds off the time to execute this method across all students for each educator in a sample.

The average of the "before" sample below is 30589ms per educator and the average of the "after" sample is 4688ms per educator (although note there's quite a bit of variability, which is related to the data for the educator).  But for 800 educators, that's a difference of ~7 hours down to ~1 hour.  Even if this sample isn't completely representative, that should give us a good several hours leftover in a nightly job (eg., to serialize into a list of names, put into whatever format we need to 
for product features).

More details:
I measured the time to run across all students for an educator:
```
def simulate(educator)
  start = Time.now
  vals = Student.all.map {|s| educator.is_authorized_for_student(s) }
  output = ["id: #{educator.id}", "students: [#{[vals.select {|val| val }.size, vals.select {|val| !val }.size]}]", "#{((Time.now - start) * 1000).to_i}ms"].join(", ")
  output
end
es = Educator.all.sample(50);nil
puts es.map(&:id)
runs = es.map {|e| simulate(e) };nil
puts runs
puts es.map(&:id)
```

### Smoke test
Before:
```
21050ms
```

After:
```
3802ms
```

### Sampling of 30 educators, time to run across all students with the patch:
Before:
```
18011ms   students: 0
27378ms   students: 23
36131ms   students: 94
28371ms   students: 0
34840ms   students: 17
61104ms   students: 161
25314ms   students: 112
57015ms   students: 34
40148ms   students: 25
62256ms   students: 70
  519ms   students: 5868
34404ms   students: 233
25491ms   students: 32
30693ms   students: 19
23040ms   students: 21
29449ms   students: 0
18313ms   students: 0
37670ms   students: 117
47624ms   students: 0
37404ms   students: 0
32414ms   students: 27
17429ms   students: 0
24459ms   students: 23
38630ms   students: 0
35354ms   students: 0
33643ms   students: 0
32090ms   students: 25
21922ms   students: 485
29364ms   students: 0
17395ms   students: 1755
26354ms   students: 22
35058ms   students: 0
24489ms   students: 0
37427ms   students: 81
29345ms   students: 0
24976ms   students: 0
51393ms   students: 124
42699ms   students: 140
37561ms   students: 64
44781ms   students: 0
16528ms   students: 1755
33556ms   students: 0
17775ms   students: 27
23467ms   students: 68
20123ms   students: 628
18323ms   students: 880
 4175ms   students: 0
24488ms   students: 6
33117ms   students: 0
25957ms   students: 34
```

```
Time          Authorized students
 2316ms    students: 0
 3916ms    students: 23
11936ms    students: 94
 3707ms    students: 0
 3349ms    students: 17
 6778ms    students: 161
 2510ms    students: 112
 7811ms    students: 34
 5655ms    students: 25
 8590ms    students: 70
  356ms    students: 5868
 8259ms    students: 233
 3190ms    students: 32
 1686ms    students: 19
 3386ms    students: 21
 8874ms    students: 0
 2993ms    students: 0
 8124ms    students: 117
12333ms    students: 0
 9094ms    students: 0
 5936ms    students: 27
 1669ms    students: 0
 4495ms    students: 23
 2902ms    students: 0
 8684ms    students: 0
 3168ms    students: 0
 4253ms    students: 25
  442ms    students: 485
 3362ms    students: 0
  498ms    students: 1755
 4316ms    students: 22
10622ms    students: 0
 1880ms    students: 0
 5308ms    students: 81
 4066ms    students: 0
 5011ms    students: 0
10152ms    students: 124
 8996ms    students: 140
 7572ms    students: 64
 2918ms    students: 0
  369ms    students: 1755
 7549ms    students: 0
 2245ms    students: 27
 3165ms    students: 68
  633ms    students: 628
  499ms    students: 880
  366ms    students: 0
 2633ms    students: 6
 3029ms    students: 0
 2807ms    students: 34
```
