### PR TITLE
Fix PropTypes error

### DIFF
--- a/app/assets/javascripts/student_profile/sparkline.jsx
+++ b/app/assets/javascripts/student_profile/sparkline.jsx
@@ -14,7 +14,9 @@ import _ from 'lodash';
     propTypes: {
       height: React.PropTypes.number.isRequired,
       width: React.PropTypes.number.isRequired,
-      quads: React.PropTypes.arrayOf(React.PropTypes.arrayOf(React.PropTypes.number)).isRequired,
+      quads: React.PropTypes.arrayOf(React.PropTypes.arrayOf(
+        React.PropTypes.oneOfType([ React.PropTypes.string, React.PropTypes.number ])
+      )).isRequired,
       dateRange: React.PropTypes.array.isRequired,
       valueRange: React.PropTypes.array.isRequired,
       thresholdValue: React.PropTypes.number.isRequired,


### PR DESCRIPTION
# Notes 

+ @edavidsonsawyer noticed that there's an unaddressed PropTypes error in the app
+ On the student profile, the Sparkline component throws an error in development
+ Props needed to be updated to allow for the fifth optional "grade_equivalent" string value in the quads prop