### PR TITLE
Idea/WIP – Data Sanity Check page

### DIFF
--- a/app/controllers/educators_controller.rb
+++ b/app/controllers/educators_controller.rb
@@ -1,7 +1,10 @@
 class EducatorsController < ApplicationController
   # Authentication by default inherited from ApplicationController.
 
-  before_action :authenticate_districtwide_access!, only: [:districtwide_admin_homepage] # Extra authentication layer
+  # Extra authentication layer:
+  before_action :authenticate_districtwide_access!, only: [
+    :districtwide_admin_homepage, :sanity_check
+  ]
 
   def homepage
     redirect_to homepage_path_for_role(current_educator)
@@ -9,6 +12,31 @@ class EducatorsController < ApplicationController
 
   def districtwide_admin_homepage
     @schools = School.where(school_type: ['ES', 'ESMS', 'HS'])
+  end
+
+  def sanity_check
+    @models = [
+      Absence,
+      Course,
+      DisciplineIncident,
+      DiscontinuedService,
+      EducatorSectionAssignment,
+      Educator,
+      EventNoteAttachment,
+      EventNoteRevision,
+      EventNote,
+      Homeroom,
+      IepDocument,
+      Intervention,
+      School,
+      Section,
+      Service,
+      StudentAssessment,
+      StudentRiskLevel,
+      StudentSectionAssignment,
+      Student,
+      Tardy
+    ].freeze
   end
 
   def names_for_dropdown

--- a/app/views/educators/districtwide_admin_homepage.html.erb
+++ b/app/views/educators/districtwide_admin_homepage.html.erb
@@ -53,6 +53,12 @@
                 class: 'prominent-link'
               } %>
             </li>
+            <li>
+              <%= link_to 'Data sanity check',
+                sanity_check_url, {
+                class: 'prominent-link'
+              } %>
+            </li>
           </ul>
         </div>
       </div>

--- a/app/views/educators/sanity_check.html.erb
+++ b/app/views/educators/sanity_check.html.erb
@@ -1,0 +1,14 @@
+<table style="margin: 40px auto; border-collapse: collapse;">
+  <tbody>
+    <% @models.each do |record_type| %>
+      <tr>
+        <td style="font-size: 16px; border: 1px solid #ccc; padding: 4px;">
+          <%= record_type.to_s.pluralize %>
+        </td>
+        <td style="font-size: 16px; border: 1px solid #ccc; padding: 4px;">
+          <%= number_with_delimiter(record_type.count) %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   end
   get '/educators/reset'=> 'educators#reset_session_clock'
   get '/educators/services_dropdown/:id' => 'educators#names_for_dropdown'
-  get '/educators/districtwide' => 'educators#districtwide_admin_homepage'
+  get '/educators/districtwide' => 'educators#sanity_check'
 
   devise_scope :educator do
     root to: "devise/sessions#new"


### PR DESCRIPTION
Was thinking about how to address #1071. I'm not sure whether the data sanity check would have caught the superfluous Student Risk Level records we found in the database, since those were technically valid (as in they passed the Rails validations we set for them). 

One thing that would have caught that would have been a page with the number of counts for each model in our database, so I mocked up what a page like that could look like. 

We could also surface the results of data sanity checks on this page too. That would give more transparency to district administrators about data quality and any issues, and let them check data quality themselves through the UI.

What do folks think?

# Screenshot (with demo data)

![screen shot 2017-10-05 at 1 17 47 pm](https://user-images.githubusercontent.com/3209501/31245123-9c567800-a9cf-11e7-9f6d-f4385c1c570f.png)
