### PR TITLE
Fix school filters on two importers

### DIFF
--- a/app/importers/file_importers/courses_sections_importer.rb
+++ b/app/importers/file_importers/courses_sections_importer.rb
@@ -20,7 +20,7 @@ class CoursesSectionsImporter < Struct.new :school_scope, :client, :log, :progre
   end
 
   def filter
-    SchoolFilter.new(['HEA', 'WSNS', 'ESCS', 'BRN', 'KDY', 'AFAS', 'WHCS', 'SHS'])
+    SchoolFilter.new(school_scope)
   end
 
   def school_ids_dictionary

--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -20,7 +20,7 @@ class StudentsImporter < Struct.new :school_scope, :client, :log, :progress_bar
   end
 
   def filter
-    SchoolFilter.new(['HEA', 'WSNS', 'ESCS', 'BRN', 'KDY', 'AFAS', 'WHCS', 'SHS'])
+    SchoolFilter.new(school_scope)
   end
 
   def school_ids_dictionary


### PR DESCRIPTION
# Notes 

+ Two of the importers aren't properly accepting school filters and always defaulting to import data from every school
+ Not a big deal since we're not using filters right now, but we may want to use them when starting to import data for our second school district
+ I hardcoded this in a few months ago during the SHS import process and forgot to revert it: https://github.com/studentinsights/studentinsights/commit/f427901c660e76cb249c5dcad830918b80e15b1a