### PR TITLE
Adding counselor and house to x2 query.

### DIFF
--- a/x2_export/students_export.sql
+++ b/x2_export/students_export.sql
@@ -22,7 +22,9 @@ SELECT
   'race',
   'hispanic_latino',
   'primary_phone',
-  'primary_email'
+  'primary_email',
+  'house',
+  'counselor'
 UNION ALL
 SELECT
   STD_ID_STATE,
@@ -47,7 +49,9 @@ SELECT
   PSN_RACE_VIEW,
   PSN_HISPANIC_LATINO_IND,
   PSN_PHONE_01,
-  PSN_EMAIL_01
+  PSN_EMAIL_01,
+  STD_FIELDB_008, -- House - SHS
+  STD_FIELDB_027 -- Counselor - SHS
 FROM student
 INNER JOIN school
   ON student.STD_SKL_OID=school.SKL_OID


### PR DESCRIPTION
This adds the new house and counselor fields to the nightly students export.

Switched in production by John Breslin after the importers ran this morning.

The house field is text, one of the 4 houses for SHS students, "" for other school students.
The counselor field is text, format of <LAST_NAME>, <FIRST INITIAL> X-<EXTENSION>. For SHS students, this is populated (all SHS students have an assigned counselor). For other school students, this is \N. 