### PR TITLE
Remove educator searchbar precomputing from nightly task

### DIFF
--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -121,7 +121,6 @@ class Import
 
     def run_update_tasks
       begin
-        Educator.save_student_searchbar_json
         Student.update_risk_levels!
         Student.update_recent_student_assessments
         Homeroom.destroy_empty_homerooms


### PR DESCRIPTION
# Notes 

+ @jhilde had the right idea about this from the beginning; this should run as its own nightly task
+ The educator searchbar precomputing sometimes takes more than 20 hours to run for reasons we don't fully understand yet
+ That throws an import error email which is high-urgency; put precomputing this JSON to optimize the searchbar endpoint is not high-urgency because it doesn't block educator login. So this should get its own, less urgent error report.