### PR TITLE
Add "avoid ===" rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,3 +60,6 @@ Lint/Loop:
 
 Lint/UnreachableCode:
   Enabled: true
+
+Style/CaseEquality:
+  Enabled: true


### PR DESCRIPTION
# Notes 

+ Based on chat with @jhilde in #1158
+ Ruby style guide notes: https://github.com/bbatsov/ruby-style-guide#no-case-equality