### PR TITLE
WIP – Remove old assessment-related tables

### DIFF
--- a/db/migrate/20171019183422_remove_assessment_subject_and_family_tables.rb
+++ b/db/migrate/20171019183422_remove_assessment_subject_and_family_tables.rb
@@ -1,0 +1,6 @@
+class RemoveAssessmentSubjectAndFamilyTables < ActiveRecord::Migration[5.1]
+  def change
+    drop_table :assessment_families
+    drop_table :assessment_subjects
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171012173106) do
+ActiveRecord::Schema.define(version: 20171019183422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,18 +21,6 @@ ActiveRecord::Schema.define(version: 20171012173106) do
     t.datetime "updated_at", null: false
     t.integer "student_id"
     t.index ["student_id"], name: "index_absences_on_student_id"
-  end
-
-  create_table "assessment_families", id: :serial, force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "assessment_subjects", id: :serial, force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
   end
 
   create_table "assessments", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
# Notes 

+ Checked to see if the Assessments table was normalized by assessment family and subject or not to start work on #1171; found that Assessments are not normalized, but those old tables are still hanging around the schema/database
+ This PR removes the cruft tables to clean things up for #1171