### PR TITLE
Handle Next Gen MCAS as a separate assessment

### DIFF
--- a/app/assets/javascripts/components/slice_panels.jsx
+++ b/app/assets/javascripts/components/slice_panels.jsx
@@ -108,10 +108,10 @@ import _ from 'lodash';
         this.createItem('Advanced', Filters.Range(key, [260, 281])),
       ];
 
-      const mcasScaledScores = _.compact(_.map(this.props.students, key));
-      const meanScaledScore = _.sum(mcasScaledScores) / mcasScaledScores.length;
+      const sortedScores = _.map(this.props.students, key).sort();
+      const medianScore = sortedScores[Math.floor(sortedScores.length / 2)];
 
-      if (meanScaledScore > 280) return nullItem.concat(nextGenMCASFilters, oldMCASFilters);
+      if (medianScore > 280) return nullItem.concat(nextGenMCASFilters, oldMCASFilters);
 
       return nullItem.concat(oldMCASFilters, nextGenMCASFilters);
     },

--- a/app/assets/javascripts/components/slice_panels.jsx
+++ b/app/assets/javascripts/components/slice_panels.jsx
@@ -93,6 +93,29 @@ import _ from 'lodash';
       return [this.createItem('None', Filters.EventNoteType(null))].concat(sortedItems);
     },
 
+    MCASFilterItems(key) {
+      const nullItem = [this.createItem('None', Filters.Null(key))];
+      const nextGenMCASFilters = [
+        this.createItem('Not Meeting Expectations', Filters.Range(key, [400, 450])),
+        this.createItem('Partially Meeting', Filters.Range(key, [450, 500])),
+        this.createItem('Meeting Expectations', Filters.Range(key, [500, 550])),
+        this.createItem('Exceeding Expectations', Filters.Range(key, [260, 281]))
+      ];
+      const oldMCASFilters = [
+        this.createItem('Warning', Filters.Range(key, [200, 220])),
+        this.createItem('Needs Improvement', Filters.Range(key, [220, 240])),
+        this.createItem('Proficient', Filters.Range(key, [240, 260])),
+        this.createItem('Advanced', Filters.Range(key, [260, 281])),
+      ];
+
+      const mcasScaledScores = _.compact(_.map(this.props.allStudents, key));
+      const meanScaledScore = _.sum(mcasScaledScores) / mcasScaledScores.length;
+
+      if (meanScaledScore > 280) return nullItem.concat(nextGenMCASFilters, oldMCASFilters);
+
+      return nullItem.concat(oldMCASFilters, nextGenMCASFilters);
+    },
+
     render: function() {
       return (
         <div
@@ -178,14 +201,12 @@ import _ from 'lodash';
     },
 
     renderMCASTable: function(title, key, props) {
+      const filterItems = this.MCASFilterItems(key);
+
       return this.renderTable(merge(props || {}, {
         title: title,
-        items: [this.createItem('None', Filters.Null(key))].concat([
-          this.createItem('Warning', Filters.Range(key, [200, 220])),
-          this.createItem('Needs Improvement', Filters.Range(key, [220, 240])),
-          this.createItem('Proficient', Filters.Range(key, [240, 260])),
-          this.createItem('Advanced', Filters.Range(key, [260, 281]))
-        ])
+        items: filterItems,
+        limit: 5
       }));
     },
 

--- a/app/assets/javascripts/components/slice_panels.jsx
+++ b/app/assets/javascripts/components/slice_panels.jsx
@@ -108,7 +108,7 @@ import _ from 'lodash';
         this.createItem('Advanced', Filters.Range(key, [260, 281])),
       ];
 
-      const mcasScaledScores = _.compact(_.map(this.props.allStudents, key));
+      const mcasScaledScores = _.compact(_.map(this.props.students, key));
       const meanScaledScore = _.sum(mcasScaledScores) / mcasScaledScores.length;
 
       if (meanScaledScore > 280) return nullItem.concat(nextGenMCASFilters, oldMCASFilters);

--- a/app/assets/javascripts/student_profile/ela_details.jsx
+++ b/app/assets/javascripts/student_profile/ela_details.jsx
@@ -51,6 +51,7 @@
       chartData: React.PropTypes.shape({
         star_series_reading_percentile: React.PropTypes.array.isRequired,
         mcas_series_ela_scaled: React.PropTypes.array.isRequired,
+        next_gen_mcas_ela_scaled: React.PropTypes.array.isRequired,
         mcas_series_ela_growth: React.PropTypes.array.isRequired
       }).isRequired,
       student: React.PropTypes.object.isRequired

--- a/app/assets/javascripts/student_profile/ela_details.jsx
+++ b/app/assets/javascripts/student_profile/ela_details.jsx
@@ -80,9 +80,40 @@
         <div className="ELADetails">
           {this.renderNavBar()}
           {this.renderStarReading()}
+          {this.renderMCASELANextGenScores()}
           {this.renderMCASELAScores()}
           {this.renderMCASELAGrowth()}
         </div>
+      );
+    },
+
+    renderMCASNextGenLink() {
+      const data = this.props.chartData.next_gen_mcas_ela_scaled;
+
+      if (!data || data.length === 0) return null;
+      return (
+        <span>
+          <a style={styles.navBar} href="#NextGenScores">
+            MCAS Next Gen ELA Scores Chart
+          </a>
+          {' | '}
+        </span>
+      );
+
+    },
+
+    renderMCASLink() {
+      const data = this.props.chartData.mcas_series_ela_scaled;
+
+      if (!data || data.length === 0) return null;
+
+      return (
+        <span>
+          <a style={styles.navBar} href="#Scores">
+            MCAS ELA Scores Chart
+          </a>
+          {' | '}
+        </span>
       );
     },
 
@@ -93,10 +124,8 @@
             STAR Reading Chart
           </a>
           {' | '}
-          <a style={styles.navBar} href="#Scores">
-            MCAS ELA Scores Chart
-          </a>
-          {' | '}
+          {this.renderMCASNextGenLink()}
+          {this.renderMCASLink()}
           <a style={styles.navBar} href="#SGPs">
             MCAS ELA SGPs Chart
           </a>
@@ -138,14 +167,44 @@
       );
     },
 
+    renderMCASELANextGenScores() {
+      const data = this.props.chartData.next_gen_mcas_ela_scaled;
+
+      if (!data || data.length === 0) return null;
+
+      return (
+        <div id="NextGenScores" style={styles.container}>
+          {this.renderHeader('MCAS Next Gen ELA Scores, last 4 years')}
+          <ProfileChart
+            quadSeries={[{
+              name: 'Scaled score',
+              data: data
+            }]}
+            titleText=""
+            student={this.props.student}
+            yAxis={merge(ProfileChartSettings.default_mcas_score_yaxis,{
+              min: 400,
+              max: 600,
+              plotLines: ProfileChartSettings.mcas_next_gen_level_bands,
+              title: { text: 'Scaled score' }
+            })} />
+
+        </div>
+      );
+    },
+
     renderMCASELAScores () {
+      const data = this.props.chartData.mcas_series_ela_scaled;
+
+      if (!data || data.length === 0) return null;
+
       return (
         <div id="Scores" style={styles.container}>
           {this.renderHeader('MCAS ELA Scores, last 4 years')}
           <ProfileChart
             quadSeries={[{
               name: 'Scaled score',
-              data: this.props.chartData.mcas_series_ela_scaled
+              data: data
             }]}
             titleText=""
             student={this.props.student}

--- a/app/assets/javascripts/student_profile/ela_details.jsx
+++ b/app/assets/javascripts/student_profile/ela_details.jsx
@@ -80,8 +80,8 @@
         <div className="ELADetails">
           {this.renderNavBar()}
           {this.renderStarReading()}
-          {this.renderMCASELANextGenScores()}
           {this.renderMCASELAScores()}
+          {this.renderMCASELANextGenScores()}
           {this.renderMCASELAGrowth()}
         </div>
       );

--- a/app/assets/javascripts/student_profile/math_details.jsx
+++ b/app/assets/javascripts/student_profile/math_details.jsx
@@ -80,8 +80,8 @@
         <div className="MathDetails">
           {this.renderNavBar()}
           {this.renderStarMath()}
-          {this.renderMCASMathNextGenScores()}
           {this.renderMCASMathScores()}
+          {this.renderMCASMathNextGenScores()}
           {this.renderMCASMathGrowth()}
         </div>
       );

--- a/app/assets/javascripts/student_profile/math_details.jsx
+++ b/app/assets/javascripts/student_profile/math_details.jsx
@@ -51,6 +51,7 @@
       chartData: React.PropTypes.shape({
         star_series_math_percentile: React.PropTypes.array.isRequired,
         mcas_series_math_scaled: React.PropTypes.array.isRequired,
+        next_gen_mcas_mathematics_scaled: React.PropTypes.array.isRequired,
         mcas_series_math_growth: React.PropTypes.array.isRequired
       }).isRequired,
       student: React.PropTypes.object.isRequired

--- a/app/assets/javascripts/student_profile/math_details.jsx
+++ b/app/assets/javascripts/student_profile/math_details.jsx
@@ -80,9 +80,40 @@
         <div className="MathDetails">
           {this.renderNavBar()}
           {this.renderStarMath()}
-          {this.renderMCASMathScore()}
+          {this.renderMCASMathNextGenScores()}
+          {this.renderMCASMathScores()}
           {this.renderMCASMathGrowth()}
         </div>
+      );
+    },
+
+    renderMCASNextGenLink() {
+      const data = this.props.chartData.next_gen_mcas_mathematics_scaled;
+
+      if (!data || data.length === 0) return null;
+
+      return (
+        <span>
+          <a style={styles.navBar} href="#MCASMathNextGen">
+            MCAS Next Gen Math Chart
+          </a>
+          {' | '}
+        </span>
+      );
+    },
+
+    renderMCASLink() {
+      const data = this.props.chartData.mcas_series_math_scaled;
+
+      if (!data || data.length === 0) return null;
+
+      return (
+        <span>
+          <a style={styles.navBar} href="#MCASMath">
+            MCAS Math Chart
+          </a>
+          {' | '}
+        </span>
       );
     },
 
@@ -93,10 +124,8 @@
             STAR Math Chart
           </a>
           {' | '}
-          <a style={styles.navBar} href="#MCASMath">
-            MCAS Math Chart
-          </a>
-          {' | '}
+          {this.renderMCASNextGenLink()}
+          {this.renderMCASLink()}
           <a style={styles.navBar} href="#MCASMathGrowth">
             MCAS Math SGPs
           </a>
@@ -138,14 +167,43 @@
       );
     },
 
-    renderMCASMathScore () {
+    renderMCASMathNextGenScores () {
+      const data = this.props.chartData.next_gen_mcas_mathematics_scaled;
+
+      if (!data || data.length === 0) return null;
+
+      return (
+        <div id="MCASMathNextGen" style={styles.container}>
+          {this.renderHeader('MCAS Next Gen Math Scores')}
+          <ProfileChart
+            quadSeries={[{
+              name: 'Scaled score',
+              data: data
+            }]}
+            titleText='"Next Generation" MCAS Math Scores'
+            student={this.props.student}
+            yAxis={merge(ProfileChartSettings.default_mcas_score_yaxis,{
+              min: 400,
+              max: 600,
+              plotLines: ProfileChartSettings.mcas_next_gen_level_bands,
+              title: { text: 'Scaled score' }
+            })} />
+        </div>
+      );
+    },
+
+    renderMCASMathScores () {
+      const data = this.props.chartData.mcas_series_math_scaled;
+
+      if (!data || data.length === 0) return null;
+
       return (
         <div id="MCASMath" style={styles.container}>
           {this.renderHeader('MCAS Math Scores, last 4 years')}
           <ProfileChart
             quadSeries={[{
               name: 'Scaled score',
-              data: this.props.chartData.mcas_series_math_scaled
+              data: data
             }]}
             titleText="MCAS Math Scores, last 4 years"
             student={this.props.student}

--- a/app/assets/javascripts/student_profile/profile_chart_settings.jsx
+++ b/app/assets/javascripts/student_profile/profile_chart_settings.jsx
@@ -174,6 +174,52 @@
     }
   }];
 
+  ProfileChartSettings.mcas_next_gen_level_bands = [{
+    color: '#E7EBED',
+    from: 400,
+    to: 450,
+    label: {
+      text: 'Not Meeting Expectations',
+      align: 'left',
+      style: {
+        color: '#999999'
+      }
+    }
+  }, {
+    color: '#F6F7F8',
+    from: 450,
+    to: 500,
+    label: {
+      text: 'Partially Meeting',
+      align: 'left',
+      style: {
+        color: '#999999'
+      }
+    }
+  }, {
+    color: '#E7EBED',
+    from: 500,
+    to: 550,
+    label: {
+      text: 'Meeting Expectations',
+      align: 'left',
+      style: {
+        color: '#999999'
+      }
+    }
+  }, {
+    color: '#F6F7F8',
+    from: 550,
+    to: 600,
+    label: {
+      text: 'Exceeding Expectations',
+      align: 'left',
+      style: {
+        color: '#999999'
+      }
+    }
+  }];
+
   ProfileChartSettings.default_mcas_score_yaxis = {
     allowDecimals: false,
     title: {

--- a/app/charts/student_profile_chart.rb
+++ b/app/charts/student_profile_chart.rb
@@ -47,6 +47,8 @@ class StudentProfileChart < Struct.new :student
     {
       star_series_math_percentile: percentile_ranks_to_highcharts(data[:star_math_results]),
       star_series_reading_percentile: percentile_ranks_to_highcharts(data[:star_reading_results]),
+      next_gen_mcas_mathematics_scaled: scale_scores_to_highcharts(data[:next_gen_mcas_mathematics_results]),
+      next_gen_mcas_ela_scaled: scale_scores_to_highcharts(data[:next_gen_mcas_ela_results]),
       mcas_series_math_scaled: scale_scores_to_highcharts(data[:mcas_mathematics_results]),
       mcas_series_ela_scaled: scale_scores_to_highcharts(data[:mcas_ela_results]),
       mcas_series_math_growth: growth_percentiles_to_highcharts(data[:mcas_mathematics_results]),
@@ -63,6 +65,8 @@ class StudentProfileChart < Struct.new :student
       star_reading_results: student.star_reading_results,
       mcas_mathematics_results: student.mcas_mathematics_results,
       mcas_ela_results: student.mcas_ela_results,
+      next_gen_mcas_mathematics_results: student.next_gen_mcas_mathematics_results,
+      next_gen_mcas_ela_results: student.next_gen_mcas_ela_results,
       interventions: student.interventions
     }
   end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -227,6 +227,7 @@ class StudentsController < ApplicationController
 
       result = case test.family
         when "MCAS" then student_assessment.scale_score
+        when "Next Gen MCAS" then student_assessment.scale_score
         when "STAR" then student_assessment.percentile_rank
         when "DIBELS" then student_assessment.performance_level
         else student_assessment.scale_score

--- a/app/demo_data/fake_next_gen_mcas_ela_result_generator.rb
+++ b/app/demo_data/fake_next_gen_mcas_ela_result_generator.rb
@@ -1,0 +1,33 @@
+class FakeNextGenMcasElaResultGenerator
+
+  def initialize(student)
+    @dates = (2010..2015).to_a.shuffle
+    @student = student
+  end
+
+  def mcas_ela_assessment_id
+    @assessment_id ||= Assessment.find_by_family_and_subject(
+      'Next Gen MCAS', 'ELA'
+    ).id
+  end
+
+  def performance_levels
+    [
+      'Not Meeting Expectations',
+      'Partially Meeting',
+      'Meeting Expectations',
+      'Exceeding Expectations',
+    ]
+  end
+
+  def next
+    {
+      assessment_id: mcas_ela_assessment_id,
+      date_taken: DateTime.new(@dates.pop, 5, 15),
+      scale_score: rand(400..600),
+      performance_level: performance_levels.sample,
+      growth_percentile: rand(100),
+      student_id: @student.id
+    }
+  end
+end

--- a/app/demo_data/fake_next_gen_mcas_math_result_generator.rb
+++ b/app/demo_data/fake_next_gen_mcas_math_result_generator.rb
@@ -1,0 +1,33 @@
+class FakeNextGenMcasMathResultGenerator
+
+  def initialize(student)
+    @dates = (2010..2015).to_a.shuffle
+    @student = student
+  end
+
+  def mcas_mathematics_assessment_id
+    @assessment_id ||= Assessment.find_by_family_and_subject(
+      'Next Gen MCAS', 'Mathematics'
+    ).id
+  end
+
+  def performance_levels
+    [
+      'Not Meeting Expectations',
+      'Partially Meeting',
+      'Meeting Expectations',
+      'Exceeding Expectations',
+    ]
+  end
+
+  def next
+    {
+      assessment_id: mcas_mathematics_assessment_id,
+      date_taken: DateTime.new(@dates.pop, 5, 15),
+      scale_score: rand(400..600),
+      performance_level: performance_levels.sample,
+      growth_percentile: rand(100),
+      student_id: @student.id
+    }
+  end
+end

--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -150,6 +150,8 @@ class FakeStudent
     [
       FakeMcasMathResultGenerator.new(student),
       FakeMcasElaResultGenerator.new(student),
+      FakeNextGenMcasMathResultGenerator.new(student),
+      FakeNextGenMcasElaResultGenerator.new(student),
       FakeDibelsResultGenerator.new(student),
       FakeAccessResultGenerator.new(student)
     ]

--- a/app/importers/rows/mcas_row.rb
+++ b/app/importers/rows/mcas_row.rb
@@ -43,8 +43,16 @@ class McasRow < Struct.new :row
     end
   end
 
+  def family
+    if row[:assessment_scale_score] && row[:assessment_scale_score] > 399
+      'Next Gen MCAS'
+    else
+      'MCAS'
+    end
+  end
+
   def assessment
-    Assessment.find_or_create_by!(subject: subject, family: 'MCAS')
+    Assessment.find_or_create_by!(subject: subject, family: family)
   end
 
 end

--- a/app/importers/rows/mcas_row.rb
+++ b/app/importers/rows/mcas_row.rb
@@ -21,7 +21,7 @@ class McasRow < Struct.new :row
     )
 
     student_assessment.assign_attributes(
-      scale_score: row[:assessment_scale_score],
+      scale_score: scale_score,
       performance_level: row[:assessment_performance_level],
       growth_percentile: row[:assessment_growth]
     )
@@ -35,6 +35,10 @@ class McasRow < Struct.new :row
     Student.find_by_local_id!(row[:local_id])
   end
 
+  def scale_score
+    (row[:assessment_scale_score]).to_i
+  end
+
   def subject
     if "English Language Arts".in?(row[:assessment_name])
       'ELA'
@@ -44,7 +48,7 @@ class McasRow < Struct.new :row
   end
 
   def family
-    if row[:assessment_scale_score] && row[:assessment_scale_score] > 399
+    if scale_score.present? && scale_score > 399
       'Next Gen MCAS'
     else
       'MCAS'

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -28,6 +28,8 @@ class Assessment < ActiveRecord::Base
     Assessment.create!([
       { family: "MCAS", subject: "Mathematics" },
       { family: "MCAS", subject: "ELA" },
+      { family: "Next Gen MCAS", subject: "Mathematics" },
+      { family: "Next Gen MCAS", subject: "ELA" },
       { family: "STAR", subject: "Mathematics" },
       { family: "STAR", subject: "Reading" },
       { family: "ACCESS", subject: "Composite" },

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -116,6 +116,14 @@ class Student < ActiveRecord::Base
     ordered_results_by_family_and_subject("MCAS", "ELA")
   end
 
+  def next_gen_mcas_mathematics_results
+    ordered_results_by_family_and_subject("Next Gen MCAS", "ELA")
+  end
+
+  def next_gen_mcas_ela_results
+    ordered_results_by_family_and_subject("Next Gen MCAS", "ELA")
+  end
+
   def star_reading_results
     ordered_results_by_family_and_subject("STAR", "Reading")
   end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -148,11 +148,11 @@ class Student < ActiveRecord::Base
   end
 
   def latest_mcas_mathematics
-    latest_result_by_family_and_subject("MCAS", "Mathematics") || MissingStudentAssessment.new
+    latest_result_by_family_and_subject(["Next Gen MCAS", "MCAS"], "Mathematics") || MissingStudentAssessment.new
   end
 
   def latest_mcas_ela
-    latest_result_by_family_and_subject("MCAS", "ELA") || MissingStudentAssessment.new
+    latest_result_by_family_and_subject(["Next Gen MCAS", "MCAS"], "ELA") || MissingStudentAssessment.new
   end
 
   def latest_star_mathematics

--- a/db/migrate/20171020155409_migrate_next_gen_mcas.rb
+++ b/db/migrate/20171020155409_migrate_next_gen_mcas.rb
@@ -1,0 +1,33 @@
+class MigrateNextGenMcas < ActiveRecord::Migration[5.1]
+  def change
+    return if Assessment.find_by(family: 'Next Gen MCAS')
+
+    puts "⚙  ⚙  ⚙  Making new assessment models for Next Gen..."
+    next_gen_mcas_math = Assessment.create!(family: 'Next Gen MCAS', subject: 'Mathematics')
+    next_gen_mcas_ela = Assessment.create!(family: 'Next Gen MCAS', subject: 'ELA')
+
+    return if StudentAssessment.count == 0  # Nothing to migrate here!
+
+    puts "⚙  ⚙  ⚙  Looking up old assessment models for MCAS..."
+    mcas_math = Assessment.find_by(family: 'MCAS', subject: 'Mathematics')
+    mcas_ela = Assessment.find_by(family: 'MCAS', subject: 'ELA')
+
+    [mcas_math, mcas_ela].each do |assessment|
+      subject = assessment.subject
+      new_assessment_id = Assessment.find_by(family: 'Next Gen MCAS', subject: subject).id
+
+      puts "detecting and migrating Next Gen MCAS for #{subject}..."; puts;
+
+      student_assessments = assessment.student_assessments
+
+      student_assessments.map do |student_assessment|
+        if student_assessment.scale_score && student_assessment.scale_score > 399
+          student_assessment.assessment_id = new_assessment_id
+          student_assessment.save
+        end
+      end
+
+      puts "checked #{student_assessments.size} student_assessments..."; puts;
+    end
+  end
+end

--- a/db/migrate/20171020155409_migrate_next_gen_mcas.rb
+++ b/db/migrate/20171020155409_migrate_next_gen_mcas.rb
@@ -2,23 +2,29 @@ class MigrateNextGenMcas < ActiveRecord::Migration[5.1]
   def change
     return if Assessment.find_by(family: 'Next Gen MCAS')
 
-    puts "⚙  ⚙  ⚙  Making new assessment models for Next Gen..."
+    puts "⚙  ⚙  ⚙  Making new assessment models for Next Gen..."; puts;
+
     next_gen_mcas_math = Assessment.create!(family: 'Next Gen MCAS', subject: 'Mathematics')
+
     next_gen_mcas_ela = Assessment.create!(family: 'Next Gen MCAS', subject: 'ELA')
 
     return if StudentAssessment.count == 0  # Nothing to migrate here!
 
-    puts "⚙  ⚙  ⚙  Looking up old assessment models for MCAS..."
+    puts "⚙  ⚙  ⚙  Looking up old assessment models for MCAS..."; puts;
+
     mcas_math = Assessment.find_by(family: 'MCAS', subject: 'Mathematics')
+
     mcas_ela = Assessment.find_by(family: 'MCAS', subject: 'ELA')
 
     [mcas_math, mcas_ela].each do |assessment|
       subject = assessment.subject
       new_assessment_id = Assessment.find_by(family: 'Next Gen MCAS', subject: subject).id
 
-      puts "detecting and migrating Next Gen MCAS for #{subject}..."; puts;
+      puts "Detecting and migrating Next Gen MCAS for #{subject}..."; puts;
 
       student_assessments = assessment.student_assessments
+
+      puts "Found #{student_assessments.size} student assessments..."; puts;
 
       student_assessments.map do |student_assessment|
         if student_assessment.scale_score && student_assessment.scale_score > 399
@@ -27,7 +33,9 @@ class MigrateNextGenMcas < ActiveRecord::Migration[5.1]
         end
       end
 
-      puts "checked #{student_assessments.size} student_assessments..."; puts;
+      migrated_student_assessments = StudentAssessment.where(assessment_id: new_assessment_id)
+
+      puts "Migrated #{migrated_student_assessments.size} student assessments..."; puts;
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171019183422) do
+ActiveRecord::Schema.define(version: 20171020155409) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/charts/student_profile_chart_spec.rb
+++ b/spec/charts/student_profile_chart_spec.rb
@@ -14,9 +14,11 @@ RSpec.describe StudentProfileChart do
     let(:student) { FactoryGirl.create(:student) }
     it 'has the expected keys' do
       chart_data = StudentProfileChart.new(student).chart_data
-      expect(chart_data.keys).to eq([
+      expect(chart_data.keys).to match_array([
         :star_series_math_percentile,
         :star_series_reading_percentile,
+        :next_gen_mcas_mathematics_scaled,
+        :next_gen_mcas_ela_scaled,
         :mcas_series_math_scaled,
         :mcas_series_ela_scaled,
         :mcas_series_math_growth,

--- a/spec/importers/rows/mcas_row_spec.rb
+++ b/spec/importers/rows/mcas_row_spec.rb
@@ -82,8 +82,31 @@ RSpec.describe McasRow do
       it 'creates a new Assessment as a side-effect' do
         expect(Assessment.count).to eq 1
         expect(Assessment.last.subject).to eq 'ELA'
-
       end
     end
+
+    context 'Next Gen MCAS' do
+      let(:row) {
+        {
+          assessment_test: 'MCAS',
+          assessment_subject: 'Arts',
+          assessment_name: 'MCAS 2016 English Language Arts',
+          local_id: student.local_id,
+          assessment_date: Date.today,
+          assessment_scale_score: "550.0"
+        }
+      }
+
+      before { McasRow.build(row).save! }
+
+      let(:student_assessment) { StudentAssessment.last }
+
+      let(:assessment_family) { student_assessment.assessment.family }
+
+      it 'assigns the correct "Next Gen" assessment family' do
+        expect(assessment_family).to eq 'Next Gen MCAS'
+      end
+    end
+
   end
 end


### PR DESCRIPTION
# What does this do? 

+ Handles new "Next Gen" MCAS data. This new format has a new range for scaled scores (400 to 600) and new performance levels.
+ This PR includes a migration to detect and update "Next Gen" MCAS records by checking which range their scaled scores fall into.
+ It also updates the `McasRow` importer class to detect future "Next Gen" MCAS records that come through from X2.

# How does the UI change?

## School Overview 

+ If the majority of students in the filters have most recent "Next Gen" MCAS scores, the School Overview shows the "Next Gen" performance levels as filters. For example, 9th graders will have "Next Gen" scores as their most recent since the last time they took MCAS was at the end of 8th grade, and "Next Gen" was administered in grades 3-8.

![screen shot 2017-10-24 at 12 57 56 pm](https://user-images.githubusercontent.com/3209501/31959837-76ea236e-b8bb-11e7-9429-16210c416907.png)

+ If the majority of students in the filters have most recent old MCAS scores, the School Overview shows the old performance levels as filters.

![screen shot 2017-10-24 at 12 58 07 pm](https://user-images.githubusercontent.com/3209501/31959798-5279f7e8-b8bb-11e7-8201-416b8ace8fe7.png)

## Student Profile 

+ New charts to show "Next Gen" scores, scales, and categories when a student has "Next Gen" results. (Since there's only one Next Gen score per student in the database these graphs show points right now instead of lines.)

![screen shot 2017-10-24 at 1 03 33 pm](https://user-images.githubusercontent.com/3209501/31959947-ce68abc4-b8bb-11e7-86fd-8490fbcc4fae.png)

## Homeroom

+ The homeroom view doesn't change. 

# Issue 

+ Fix  #1171.

# Change list 

+ [x] Add new model for "Next Generation" MCAS
+ [x] Add fake data generator with new "Next Generation" scaled scores
+ [x] Add new chart to Student Profile if relevant data is present 
+ [x] Update School Overview page 
+ [x] Update Homeroom Roster page 
+ [x] Update Student Report
+ [x] Update X2AssessmentImporter code to correctly classify incoming MCAS data from X2
+ [x] Write migration to re-assign "Next Generation" student assessments 
+ [x] Fix spec
+ [x] Add more spec coverage for areas that need it
+ [x] QA against real data locally
+ [x] Add screenshots of UI and explanations about changes to PR
+ [ ] Deploy, run migrations, and triple-check in IE