### PR TITLE
Unblock webpack Heroku deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,24 +28,24 @@
     "react": "15.4.2",
     "react-addons-test-utils": "15.4.2",
     "react-dom": "15.4.2",
-    "react-modal": "^3.0.4"
+    "react-modal": "^3.0.4",
+    "webpack": "^3.8.1",
+    "webpack-manifest-plugin": "^1.3.2",
+    "webpack-merge": "^4.1.0",
+    "clean-webpack-plugin": "^0.1.17",
+    "compression-webpack-plugin": "^1.0.1"
   },
   "devDependencies": {
     "babel-jest": "^21.2.0",
     "babel-loader": "^7.1.2",
     "babel-preset-react": "^6.24.1",
     "babel-preset-react-app": "^3.0.3",
-    "clean-webpack-plugin": "^0.1.17",
-    "compression-webpack-plugin": "^1.0.1",
     "concurrently": "^3.5.0",
     "eslint": "^3.3.1",
     "eslint-plugin-react": "^6.1.2",
     "jest": "^21.2.1",
     "lodash": "3.10.1",
     "react-test-renderer": "^16.0.0",
-    "script-loader": "^0.7.2",
-    "webpack": "^3.8.1",
-    "webpack-manifest-plugin": "^1.3.2",
-    "webpack-merge": "^4.1.0"
+    "script-loader": "^0.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "webpack-merge": "^4.1.0",
     "clean-webpack-plugin": "^0.1.17",
     "compression-webpack-plugin": "^1.0.1",
-    "babel-loader": "^7.1.2"
-  },
-  "devDependencies": {
+    "babel-loader": "^7.1.2",
     "babel-jest": "^21.2.0",
     "babel-preset-react": "^6.24.1",
-    "babel-preset-react-app": "^3.0.3",
+    "babel-preset-react-app": "^3.0.3"
+  },
+  "devDependencies": {
     "concurrently": "^3.5.0",
     "eslint": "^3.3.1",
     "eslint-plugin-react": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     "webpack-manifest-plugin": "^1.3.2",
     "webpack-merge": "^4.1.0",
     "clean-webpack-plugin": "^0.1.17",
-    "compression-webpack-plugin": "^1.0.1"
+    "compression-webpack-plugin": "^1.0.1",
+    "babel-loader": "^7.1.2"
   },
   "devDependencies": {
     "babel-jest": "^21.2.0",
-    "babel-loader": "^7.1.2",
     "babel-preset-react": "^6.24.1",
     "babel-preset-react-app": "^3.0.3",
     "concurrently": "^3.5.0",


### PR DESCRIPTION
# Notes 

+ Unblock webpack Heroku deploys by moving webpack-required dependencies out of  `devDependencies`
+ From the Heroku/nodejs docs: "...since you usually don’t want all development dependencies in your production builds, it’s preferable to move only the dependencies you actually need for production builds (bower, grunt, gulp, etc) into dependencies." (https://devcenter.heroku.com/articles/nodejs-support)
