### PR TITLE
Remove student_searchbar_json from Educator#as_json

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -26,6 +26,14 @@ class Educator < ActiveRecord::Base
 
   VALID_GRADES = [ 'PK', 'KF', '1', '2', '3', '4', '5', '6', '7', '8' ].freeze
 
+  # override
+  # The `student_searchbar_json` field can be really heavy (~500kb), and
+  # there's no circumstances where we want to include it when serializing
+  # an educator model.  So override `as_json to omit it by default.
+  def as_json(options = {})
+    super(options.merge({ except: [:student_searchbar_json] }))
+  end
+
   def has_school_unless_districtwide
     if school.blank?
       errors.add(:school_id, "must be assigned a school") unless districtwide_access?

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 
 RSpec.describe Educator do
 
+  describe '#as_json' do
+    it 'does not include student_searchbar_json' do
+      educator = FactoryGirl.build(:educator)
+      expect(educator.as_json.has_key?('student_searchbar_json')).to be false
+    end
+  end
   describe '#has_school_unless_districtwide' do
     context 'no school assigned' do
       context 'has districtwide_access' do


### PR DESCRIPTION
In looking at the production bundle sizes for https://github.com/studentinsights/studentinsights/pull/1182, I noticed that there was a ~600kb difference between the HTML files in production and the demo site.  It looks like this is from serializing `current_educator`, which includes the `student_searchbar_json` field introduced in https://github.com/studentinsights/studentinsights/pull/1001.  This is inadvertently adding 200-400kb of data to most HTML pages (student profile, school overview, homeroom).

This overrides `as_json` for now, since this will reduce load times immediately, and there's no case I can think of where we'd want this to be serialized with an educator.

Alternately, we could move this to a different table, since it's really an index or derived view of something we compute (who the educator is authorized to see), rather than a source of truth about the educator.  That would let us remove the `as_json` override.