### PR TITLE
Fix most sorting on educator permissions dashboard

### DIFF
--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -2,10 +2,11 @@ module Admin
   class EducatorsController < Admin::ApplicationController
     # To customize the behavior of this controller,
     # simply overwrite any of the RESTful actions.
+    before_action :default_params
 
-    def index
-      @_order = Administrate::Order.new(:full_name)
-      super
+    def default_params
+      params[:order] ||= "full_name"
+      params[:direction] ||= "desc"
     end
 
     def edit

--- a/app/dashboards/educator_dashboard.rb
+++ b/app/dashboards/educator_dashboard.rb
@@ -8,7 +8,7 @@ class EducatorDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    school: SchoolNameField.with_options(searchable: false),
+    school_id: SchoolNameField.with_options(searchable: false),
     homeroom: HomeroomNameField.with_options(searchable: false),
     students: Field::HasMany.with_options(searchable: false),
     interventions: Field::HasMany.with_options(searchable: false),
@@ -46,7 +46,7 @@ class EducatorDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
     :full_name,
-    :school,
+    :school_id,
     :homeroom,
     :schoolwide_access,
     :can_view_restricted_notes,
@@ -55,7 +55,7 @@ class EducatorDashboard < Administrate::BaseDashboard
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = [
-    :school,
+    :school_id,
     :homeroom,
     :email,
     :sign_in_count,

--- a/app/fields/school_name_field.rb
+++ b/app/fields/school_name_field.rb
@@ -2,6 +2,10 @@ require "administrate/field/base"
 
 class SchoolNameField < Administrate::Field::Base
   def to_s
-    data.try(:name) || data.try(:local_id)
+    return 'None' unless data
+
+    school = School.find(data)
+
+    school.try(:name) || school.try(:local_id)
   end
 end


### PR DESCRIPTION
# Notes 

+ Unbreak sorting for string/numeric/boolean columns by removing outdated override
+ Re-set default sort order using better code path
+ Write custom code to make sorting by school work

# GIF (demo data) 

![sort-sort](https://user-images.githubusercontent.com/3209501/32027016-58af9da6-b9ac-11e7-9382-df50cd086d66.gif)

# Issue 

+ #1194

# What's left? 

+ Sorting is still broken on the Homeroom column. That's because the `administrate` project doesn't include an out-of-the-box way to enable sorting for a `HasOne` relationship. I wasn't able to figure out how to solve this in a custom way during the time I had to work on this today. I'll take another look tomorrow. If I don't fix it we could ship this as-is since it unbreaks most columns and tackle Homeroom sorting as a separate piece of work. Any suggestions or ideas for Homeroom are welcome!