### PR TITLE
Demo Site Seed Reduction

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -21,14 +21,11 @@ class School < ActiveRecord::Base
     School.create([
       { state_id: 15, local_id: "BRN", name: "Benjamin G Brown", school_type: "ES" },
       { state_id: 75, local_id: "HEA", name: "Arthur D Healey", school_type: "ESMS" },
-      { state_id: 83, local_id: "KDY", name: "John F Kennedy", school_type: "ESMS" },
       { state_id: 87, local_id: "AFAS", name: "Albert F. Argenziano School", school_type: "ESMS" },
       { state_id: 111, local_id: "ESCS", name: "E Somerville Community", school_type: "ESMS" },
       { state_id: 115, local_id: "WSNS", name: "West Somerville Neighborhood", school_type: "ESMS" },
       { state_id: 120, local_id: "WHCS", name: "Winter Hill Community", school_type: "ESMS" },
-      { state_id: 410, local_id: "NW", name: "Next Wave Junior High", school_type: "MS" },
       { state_id: 505, local_id: "SHS", name: "Somerville High", school_type: "HS" },
-      { state_id: 510, local_id: "FC", name: "Full Circle High School", school_type: "HS" }
     ])
   end
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -21,11 +21,14 @@ class School < ActiveRecord::Base
     School.create([
       { state_id: 15, local_id: "BRN", name: "Benjamin G Brown", school_type: "ES" },
       { state_id: 75, local_id: "HEA", name: "Arthur D Healey", school_type: "ESMS" },
+      { state_id: 83, local_id: "KDY", name: "John F Kennedy", school_type: "ESMS" },
       { state_id: 87, local_id: "AFAS", name: "Albert F. Argenziano School", school_type: "ESMS" },
       { state_id: 111, local_id: "ESCS", name: "E Somerville Community", school_type: "ESMS" },
       { state_id: 115, local_id: "WSNS", name: "West Somerville Neighborhood", school_type: "ESMS" },
       { state_id: 120, local_id: "WHCS", name: "Winter Hill Community", school_type: "ESMS" },
+      { state_id: 410, local_id: "NW", name: "Next Wave Junior High", school_type: "MS" },
       { state_id: 505, local_id: "SHS", name: "Somerville High", school_type: "HS" },
+      { state_id: 510, local_id: "FC", name: "Full Circle High School", school_type: "HS" }
     ])
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,10 +11,10 @@ end
 require "#{Rails.root}/db/seeds/database_constants"
 
 puts "Creating demo schools, homerooms, interventions..."
-raise "empty yer db" if School.count > 0 ||
-                        Student.count > 0 ||
-                        InterventionType.count > 0 ||
-                        Assessment.count > 0
+# raise "empty yer db" if School.count > 0 ||
+#                         Student.count > 0 ||
+#                         InterventionType.count > 0 ||
+#                         Assessment.count > 0
 
 # The local demo data setup uses the Somerville database constants
 # (eg., the set of `ServiceType`s) for generating local demo data and
@@ -82,8 +82,6 @@ Educator.create!([{
 puts 'Creating homerooms..'
 
 homerooms = [
-  Homeroom.create(name: "HEA 300", grade: "3", school: healey),
-  Homeroom.create(name: "HEA 400", grade: "4", school: healey),
   Homeroom.create(name: "HEA 500", grade: "5", school: healey),
   Homeroom.create(name: "WSNS 500", grade: "5", school: wsns),
 ]
@@ -126,7 +124,7 @@ end
 homerooms.each do |homeroom|
   puts "Creating students for homeroom #{homeroom.name}..."
   school = homeroom.school
-  15.times do
+  10.times do
     FakeStudent.new(school, homeroom)
   end
 end
@@ -136,7 +134,7 @@ shs_homeroom = Homeroom.create(name: "SHS ALL", grade: "10", school: shs)
 sections.each do |section|
   puts "Creating students for section #{section.section_number}..."
   school = section.course.school
-  15.times do
+  10.times do
     grade_letter = ['A','B','C','D','F'].sample
     case grade_letter
       when "A"
@@ -159,7 +157,7 @@ sections.each do |section|
   end
 end
 
-15.times do
+10.times do
   FakeStudent.new(healey, nil)
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,10 +11,11 @@ end
 require "#{Rails.root}/db/seeds/database_constants"
 
 puts "Creating demo schools, homerooms, interventions..."
-# raise "empty yer db" if School.count > 0 ||
-#                         Student.count > 0 ||
-#                         InterventionType.count > 0 ||
-#                         Assessment.count > 0
+
+raise "empty yer db" if School.count > 0 ||
+                        Student.count > 0 ||
+                        EventNote.count > 0 ||
+                        Service.count > 0
 
 # The local demo data setup uses the Somerville database constants
 # (eg., the set of `ServiceType`s) for generating local demo data and
@@ -149,11 +150,11 @@ sections.each do |section|
         grade_numeric = rand(50..59)
     end
 
-      fake_student = FakeStudent.new(school, shs_homeroom)
-      StudentSectionAssignment.create(student: fake_student.student,
-                                      section: section,
-                                      grade_numeric: grade_numeric,
-                                      grade_letter: grade_letter)
+    fake_student = FakeStudent.new(school, shs_homeroom)
+    StudentSectionAssignment.create(student: fake_student.student,
+                                    section: section,
+                                    grade_numeric: grade_numeric,
+                                    grade_letter: grade_letter)
   end
 end
 


### PR DESCRIPTION
## What does this PR do?

Responding to Issue #1198 , This PR will reduce the Seed generations in half! 
This PR also displays the need to resolve the conflict between accepted pr #1178 and the raise check for an empty DB in `seeds.rb` on line 14:
```rb
raise "empty yer db" if School.count > 0 ||
                        Student.count > 0 ||
                        InterventionType.count > 0 ||
                        Assessment.count > 0
```

## Change Details:

### Research:
I started by researching the error, and came upon a post to review the database directly in psql, to find out the tables that are creating the largest rows. Upon DB migrate, the development database was showing the following info: 
```pg
student_insights_development=# SELECT schemaname,relname,n_live_tup
FROM pg_stat_user_tables
ORDER BY n_live_tup DESC;
 schemaname |           relname            | n_live_tup 
------------+------------------------------+------------
 public     | schema_migrations            |        117
 public     | service_types                |         13
 public     | event_note_types             |          6
 public     | assessments                  |          2
 public     | ar_internal_metadata         |          1
 public     | courses                      |          0
 public     | homerooms                    |          0
 public     | interventions                |          0
 public     | event_note_attachments       |          0
 public     | students                     |          0
 public     | intervention_types           |          0
```
a total of 31 tables, and 139 records.

After investigating this, I went on to better understand the seed file, and run it, but came upon the aforementioned error, due to the 2 Assessments already seeded in the DB from the last migration.

To move forward, I commented out this evaluation happening, and proceeded to seed the database successfully. Upon a fresh seed, the database was showing the following info:
```pg
 schemaname |           relname            | n_live_tup 
------------+------------------------------+------------
 public     | student_assessments          |      11633
 public     | tardies                      |       1033
 public     | absences                     |       1008
 public     | event_notes                  |        596
 public     | students                     |        135
 public     | student_risk_levels          |        135
 public     | interventions                |        128
 public     | schema_migrations            |        117
 public     | student_section_assignments  |         60
 public     | services                     |         55
 public     | discipline_incidents         |         54
 public     | intervention_types           |         26
 public     | assessments                  |         15
 public     | service_types                |         13
 public     | schools                      |         10
 public     | educators                    |          6
 public     | event_note_types             |          6
 public     | homerooms                    |          5
 public     | sections                     |          4
 public     | service_uploads              |          4
 public     | precomputed_query_docs       |          4
 public     | educator_section_assignments |          4
 public     | courses                      |          2
 public     | iep_documents                |          1
 public     | ar_internal_metadata         |          1
 public     | friendly_id_slugs            |          0
 public     | event_note_revisions         |          0
 public     | event_note_attachments       |          0
 public     | import_records               |          0
 public     | delayed_jobs                 |          0
 public     | discontinued_services        |          0
(31 rows) (15055 records)
```

### Approach:
My immediate reaction was to investigate reducing the `school_assessments` and to figure out how there were 10 schools, when there were only 3 being referenced in `seeds.rb`. 

I found that schools were being created in the `School` model with `seed_somerville_schools` method. 

From there, I did a search for where the schools were being referred elsewhere, and chose 3 schools that seemed safe to remove. 

That database returned the following:
```pg
 schemaname |           relname            | n_live_tup 
------------+------------------------------+------------
 public     | student_assessments          |      11456
 public     | absences                     |       1058
 public     | tardies                      |       1057
 public     | event_notes                  |        603
 public     | student_risk_levels          |        135
 public     | students                     |        135
 public     | schema_migrations            |        117
 public     | interventions                |        106
 public     | services                     |         86
 public     | student_section_assignments  |         60
 public     | discipline_incidents         |         46
 public     | intervention_types           |         26
 public     | assessments                  |         15
 public     | service_types                |         13
 public     | schools                      |          7
 public     | event_note_types             |          6
 public     | educators                    |          6
 public     | homerooms                    |          5
 public     | precomputed_query_docs       |          4
 public     | service_uploads              |          4
 public     | educator_section_assignments |          4
 public     | sections                     |          4
 public     | courses                      |          2
 public     | iep_documents                |          1
 public     | ar_internal_metadata         |          1
 public     | event_note_attachments       |          0
 public     | friendly_id_slugs            |          0
 public     | import_records               |          0
 public     | delayed_jobs                 |          0
 public     | discontinued_services        |          0
 public     | event_note_revisions         |          0
(31 rows) (14957 records)
```
Only a 95 record difference 😞 . 
I noticed the longest time spent while seeding was on creating students per section and homeroom, so I removed a few homerooms and sections, then reduced the student generating loops to `10.times` from 15, which resulted in the following:

```pg
 schemaname |           relname            | n_live_tup 
------------+------------------------------+------------
 public     | student_assessments          |       5994
 public     | absences                     |        517
 public     | tardies                      |        484
 public     | event_notes                  |        288
 public     | schema_migrations            |        117
 public     | students                     |         70
 public     | student_risk_levels          |         70
 public     | discipline_incidents         |         50
 public     | student_section_assignments  |         40
 public     | services                     |         32
 public     | interventions                |         32
 public     | intervention_types           |         26
 public     | assessments                  |         15
 public     | service_types                |         13
 public     | schools                      |          7
 public     | event_note_types             |          6
 public     | educators                    |          6
 public     | service_uploads              |          4
 public     | sections                     |          4
 public     | precomputed_query_docs       |          4
 public     | educator_section_assignments |          4
 public     | homerooms                    |          3
 public     | courses                      |          2
 public     | iep_documents                |          1
 public     | ar_internal_metadata         |          1
 public     | delayed_jobs                 |          0
 public     | import_records               |          0
 public     | friendly_id_slugs            |          0
 public     | event_note_revisions         |          0
 public     | discontinued_services        |          0
 public     | event_note_attachments       |          0
(31 rows) ( 7790 records)
```
🎉 

### Things To Consider for Merge:

- I removed 3 and 4th grade homerooms, kept sections because they seemed unique, and didn't get into the area where assessments are being created, but the resulting total was reduced quite a bit from the reduction of students. 
- I commented out the DB check in order to do this, and I'd like to confirm whether that should stay that way or not. 
- The seed file was a bit difficult to understand, and things are being generated outside the seeds file, which seems like it could be causing extra generation being done but not easy to track. 
- are 10 students in a group enough for demoing? I hope so! 
