### PR TITLE
Allow Webpack to clean build target folders

### DIFF
--- a/ui/config/webpack.dev.js
+++ b/ui/config/webpack.dev.js
@@ -15,7 +15,7 @@ module.exports = merge(common, {
   },
 
   plugins: [
-    new CleanWebpackPlugin(['../../public/dev'], { verbose: false })
+    new CleanWebpackPlugin(['../../public/dev'], { verbose: false, allowExternal: true })
   ]
 });
 /* eslint-disable no-undef */

--- a/ui/config/webpack.prod.js
+++ b/ui/config/webpack.prod.js
@@ -19,7 +19,7 @@ module.exports = merge(common, {
   },
 
   plugins: [
-    new CleanWebpackPlugin(['../../public/build']),
+    new CleanWebpackPlugin(['../../public/build'], { allowExternal: true }),
     new UglifyJSPlugin({sourceMap: true}),
     new webpack.DefinePlugin({
       'process.env': {


### PR DESCRIPTION
Small fix to a warning in https://github.com/studentinsights/studentinsights/pull/1182, no real impact.  It just removes:
```
clean-webpack-plugin: /tmp/build_c3ba56210a14900ce00a73ebede49ebf/studentinsights-studentinsights-adedc3b/public/build is outside of the project root. Skipping...
```

This happens since the clean plugin has to reach outside of its folder and into the `public/build` or `public/dev` folder, and the plugin helpfully warns that that might not be a good idea.