### PR TITLE
WIP – Backfill missing IEPs

### DIFF
--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -90,7 +90,7 @@ class IepPdfImportJob
     end
 
     def s3
-      @client ||= Aws::S3::Client.new
+      @client ||= Aws::S3::Client.new(region: 'us-west-2')
     end
 
     def download(remote_filename)

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -125,12 +125,13 @@ class IepPdfImportJob
     def clean_up
       FileUtils.rm_rf(Rails.root.join('tmp/data_download/unzipped_ieps'))
       FileUtils.rm_rf([
-        Rails.root.join('tmp/data_download/student-documents-6.zip'),
-        Rails.root.join('tmp/data_download/student-documents-5.zip'),
-        Rails.root.join('tmp/data_download/student-documents-4.zip'),
-        Rails.root.join('tmp/data_download/student-documents-3.zip'),
-        Rails.root.join('tmp/data_download/student-documents-2.zip'),
-        Rails.root.join('tmp/data_download/student-documents-1.zip'),
+        Rails.root.join("tmp/data_download/#{ENV['BULK_IEP_IMPORT_TARGET']}"),
+        Rails.root.join("tmp/data_download/student-documents-6.zip"),
+        Rails.root.join("tmp/data_download/student-documents-5.zip"),
+        Rails.root.join("tmp/data_download/student-documents-4.zip"),
+        Rails.root.join("tmp/data_download/student-documents-3.zip"),
+        Rails.root.join("tmp/data_download/student-documents-2.zip"),
+        Rails.root.join("tmp/data_download/student-documents-1.zip"),
       ])
     end
 

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -3,7 +3,16 @@ require 'tempfile'
 require 'fileutils'
 
 class IepPdfImportJob
+
+  REQUIRED_KEYS = [
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_S3_IEP_BUCKET',
+  ]
+
   def initialize(options = {})
+    raise "missing AWS keys!" if REQUIRED_KEYS.any? { |aws_key| (ENV[aws_key]).nil? }
+
     @time_now = options[:time_now] || Time.now
   end
 

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -11,7 +11,7 @@ class IepPdfImportJob
   # contains several older documents (ie., for a first-time import).
   # It will fail on any errors, log to the console and won't retry.
   def bulk_import!
-    remote_filenames = ['student-documents_old.zip']
+    remote_filenames = [ENV['BULK_IEP_IMPORT_TARGET']]
 
     import_ieps!(remote_filenames)
   end


### PR DESCRIPTION
# What's this PR about?

This PR is about closing a gap in the IEP data we've imported to Insights (fix #1167).

# What's changed? 

Not too much! Turns out the nightly import script was written flexibly enough to handle the bulk import as well. 

This PR changes around a few things as I learn what variables are going to stay the same across different imports (moved AWS region from `ENV` to hard-coded) and what variables are going to change (moved target bulk import ZIP from hard-coded to `ENV`).

It also adds some credential checks up front so that the job won't run if it doesn't have the proper AWS credentials. This is meant to improve the local development experience.

# I have a comment/contribution! 

Awesome, please add your comment! Keep in mind that this time-sensitive and the job needs to run successfully by Monday 10/30 or we'll have another IEP backfill. (See https://github.com/studentinsights/studentinsights/issues/1167#issuecomment-340001878 for more information.) So this may end up being a selfie.

# Progress 

+ [x] Verify that the job handles the bulk import ZIP without any issues
+ [x] Get names/LASIDs of a couple of students whose IEP docs are missing because of the gap from @snoopyuri 
+ [ ] Deploy, run the bulk import job, and manually check the students @snoopyuri flagged