### PR TITLE
Experimenting with Jest's snapshot feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-react": "^6.1.2",
     "jest": "^21.2.1",
     "react-addons-test-utils": "15.4.2",
-    "react-test-renderer": "^16.0.0",
+    "react-test-renderer": "15.4.2",
     "script-loader": "^0.7.2",
     "webpack": "^3.8.1",
     "webpack-manifest-plugin": "^1.3.2",

--- a/spec/javascripts/components/__snapshots__/roster_spec.jsx.snap
+++ b/spec/javascripts/components/__snapshots__/roster_spec.jsx.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Roster renders correctly 1`] = `
+<div
+  className="FlexibleRoster"
+>
+  <table
+    className="roster-table"
+    id="roster-table"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
+  >
+    <thead>
+      <tr
+        className="column-groups"
+      />
+      <tr
+        id="roster-header"
+      >
+        <th
+          className="sort-header sort-down"
+          onClick={[Function]}
+        >
+          Test Label 1
+        </th>
+        <th
+          className="sort-header"
+          onClick={[Function]}
+        >
+          Test Label 2
+        </th>
+        <th
+          className="sort-header"
+          onClick={[Function]}
+        >
+          Test Label 3
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      id="roster-data"
+    >
+      <tr
+        style={
+          Object {
+            "backgroundColor": "#FFFFFF",
+          }
+        }
+      >
+        <td>
+          Data 1-1
+        </td>
+        <td>
+          Data 1-2
+        </td>
+        <td>
+          Data 1-3
+        </td>
+      </tr>
+      <tr
+        style={
+          Object {
+            "backgroundColor": "#F7F7F7",
+          }
+        }
+      >
+        <td>
+          Data 2-1
+        </td>
+        <td>
+          Data 2-2
+        </td>
+        <td>
+          Data 2-3
+        </td>
+      </tr>
+      <tr
+        style={
+          Object {
+            "backgroundColor": "#FFFFFF",
+          }
+        }
+      >
+        <td>
+          Data 3-1
+        </td>
+        <td>
+          Data 3-2
+        </td>
+        <td>
+          Data 3-3
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/spec/javascripts/components/roster_spec.jsx
+++ b/spec/javascripts/components/roster_spec.jsx
@@ -1,5 +1,6 @@
 import SpecSugar from '../support/spec_sugar.jsx';
 import Roster from '../../../app/assets/javascripts/components/flexible_roster.jsx';
+import renderer from 'react-test-renderer';
 
 describe('Roster', function() {
   
@@ -48,4 +49,28 @@ describe('Roster', function() {
       expect(firstDataRows[0].innerHTML).toEqual('Data 1-1');
     });
   });
+  
+  
+  it('renders correctly', () => {
+    const props = {
+      columns: [
+        { label: 'Test Label 1', key: 'element1'},
+        { label: 'Test Label 2', key: 'element2'},
+        { label: 'Test Label 3', key: 'element3'}
+      ],
+      rows: [
+        { id: 1, element1: 'Data 1-1', element2: 'Data 1-2', element3: 'Data 1-3'},
+        { id: 2, element1: 'Data 2-1', element2: 'Data 2-2', element3: 'Data 2-3'},
+        { id: 3, element1: 'Data 3-1', element2: 'Data 3-2', element3: 'Data 3-3'}
+      ],
+      initialSortIndex: 0
+    };
+    
+    const tree = renderer.create(
+      <Roster {...props} />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+
 });

--- a/spec/javascripts/section/__snapshots__/section_header_spec.jsx.snap
+++ b/spec/javascripts/section/__snapshots__/section_header_spec.jsx.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SectionHeader renders correctly 1`] = `
+<div
+  className="SectionHeader"
+>
+  <div
+    id="section-header-info"
+  >
+    <h1>
+      Art-1
+    </h1>
+    <p
+      id="course-info"
+    >
+      Awesome Art Class
+       
+      (Art)
+    </p>
+    <p
+      id="section-detail"
+    >
+      Room 
+      304
+       
+      <span>
+        •
+      </span>
+       Schedule: 
+      3(M-R)
+       
+      <span>
+        •
+      </span>
+       Term: 
+      9
+    </p>
+  </div>
+  <div>
+    <p>
+      Section: 
+      <span>
+        <select
+          id="section-select"
+          onChange={[Function]}
+          value={1}
+        >
+          <option
+            value={1}
+          >
+            Art-1
+          </option>
+          <option
+            value={2}
+          >
+            Art-2
+          </option>
+          <option
+            value={3}
+          >
+            Art-3
+          </option>
+        </select>
+      </span>
+    </p>
+  </div>
+</div>
+`;

--- a/spec/javascripts/section/__snapshots__/section_page_spec.jsx.snap
+++ b/spec/javascripts/section/__snapshots__/section_page_spec.jsx.snap
@@ -1,0 +1,340 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SectionPage renders correctly 1`] = `
+<div
+  className="section"
+>
+  <div
+    className="header"
+  >
+    <div
+      className="SectionHeader"
+    >
+      <div
+        id="section-header-info"
+      >
+        <h1>
+          Art-1
+        </h1>
+        <p
+          id="course-info"
+        >
+          Awesome Art Class
+           
+          (Art)
+        </p>
+        <p
+          id="section-detail"
+        >
+          Room 
+          304
+           
+          <span>
+            •
+          </span>
+           Schedule: 
+          3(M-R)
+           
+          <span>
+            •
+          </span>
+           Term: 
+          9
+        </p>
+      </div>
+      <div>
+        <p>
+          Section: 
+          <span>
+            <select
+              id="section-select"
+              onChange={[Function]}
+              value={1}
+            >
+              <option
+                value={1}
+              >
+                Art-1
+              </option>
+              <option
+                value={2}
+              >
+                Art-2
+              </option>
+              <option
+                value={3}
+              >
+                Art-3
+              </option>
+            </select>
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
+    className="roster"
+  >
+    <div
+      className="FlexibleRoster"
+    >
+      <table
+        className="roster-table"
+        id="roster-table"
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
+      >
+        <thead>
+          <tr
+            className="column-groups"
+          >
+            <th
+              className=""
+              colSpan={2}
+            />
+            <th
+              className="column-group"
+              colSpan={2}
+            >
+              SPED & Disability
+            </th>
+            <th
+              className="column-group"
+              colSpan={2}
+            >
+              Language
+            </th>
+            <th
+              className=""
+              colSpan={4}
+            />
+            <th
+              className="column-group"
+              colSpan={1}
+            >
+              STAR: Math
+            </th>
+            <th
+              className="column-group"
+              colSpan={1}
+            >
+              STAR: Reading
+            </th>
+            <th
+              className="column-group"
+              colSpan={2}
+            >
+              MCAS: Math
+            </th>
+            <th
+              className="column-group"
+              colSpan={2}
+            >
+              MCAS: ELA
+            </th>
+          </tr>
+          <tr
+            id="roster-header"
+          >
+            <th
+              className="sort-header sort-down"
+              onClick={[Function]}
+            >
+              Name
+            </th>
+            <th
+              className="sort-header"
+              onClick={[Function]}
+            >
+              Program Assigned
+            </th>
+            <th
+              className="sort-header"
+              onClick={[Function]}
+            >
+              Disability
+            </th>
+            <th
+              className="sort-header"
+              onClick={[Function]}
+            >
+              504 Plan
+            </th>
+            <th
+              className="sort-header"
+              onClick={[Function]}
+            >
+              Fluency
+            </th>
+            <th
+              className="sort-header"
+              onClick={[Function]}
+            >
+              Home Language
+            </th>
+            <th
+              className="sort-header"
+              onClick={[Function]}
+            >
+              Grade
+            </th>
+            <th
+              className="sort-header"
+              onClick={[Function]}
+            >
+              Absences
+            </th>
+            <th
+              className="sort-header"
+              onClick={[Function]}
+            >
+              Tardies
+            </th>
+            <th
+              className="sort-header"
+              onClick={[Function]}
+            >
+              Discipline Incidents
+            </th>
+            <th
+              className="sort-header"
+              onClick={[Function]}
+            >
+              Percentile
+            </th>
+            <th
+              className="sort-header"
+              onClick={[Function]}
+            >
+              Percentile
+            </th>
+            <th
+              className="sort-header"
+              onClick={[Function]}
+            >
+              Performance
+            </th>
+            <th
+              className="sort-header"
+              onClick={[Function]}
+            >
+              Score
+            </th>
+            <th
+              className="sort-header"
+              onClick={[Function]}
+            >
+              Performance
+            </th>
+            <th
+              className="sort-header"
+              onClick={[Function]}
+            >
+              Score
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          id="roster-data"
+        >
+          <tr
+            style={
+              Object {
+                "backgroundColor": "#FFFFFF",
+              }
+            }
+          >
+            <td>
+              <a
+                href="/students/2"
+              >
+                Duck, Donald
+              </a>
+            </td>
+            <td>
+              Special Ed
+            </td>
+            <td>
+              Motor
+            </td>
+            <td>
+              504 Plan
+            </td>
+            <td>
+              ELL
+            </td>
+            <td>
+              English
+            </td>
+            <td />
+            <td>
+              1
+            </td>
+            <td>
+              0
+            </td>
+            <td>
+              0
+            </td>
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
+          </tr>
+          <tr
+            style={
+              Object {
+                "backgroundColor": "#F7F7F7",
+              }
+            }
+          >
+            <td>
+              <a
+                href="/students/1"
+              >
+                Mouse, Minnie
+              </a>
+            </td>
+            <td>
+              Regular Ed
+            </td>
+            <td>
+              
+            </td>
+            <td>
+              
+            </td>
+            <td>
+              FLEP
+            </td>
+            <td>
+              Spanish
+            </td>
+            <td />
+            <td>
+              3
+            </td>
+            <td>
+              5
+            </td>
+            <td>
+              0
+            </td>
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;

--- a/spec/javascripts/section/section_header_spec.jsx
+++ b/spec/javascripts/section/section_header_spec.jsx
@@ -1,0 +1,34 @@
+import renderer from 'react-test-renderer';
+import SectionHeader from '../../../app/assets/javascripts/section/section_header.jsx';
+
+describe('SectionHeader', function() {
+  
+  it('renders correctly', () => {
+    const props = {
+      educators: [
+        { }
+      ],
+      sections: [
+        { id: 1, section_number: 'Art-1'},
+        { id: 2, section_number: 'Art-2'},
+        { id: 3, section_number: 'Art-3'}
+      ],
+      section: { id: 1, section_number: 'Art-1', course_number: 'Art', course_description: 'Awesome Art Class', term_local_id: '9', schedule: '3(M-R)', room_number: '304' },
+    };
+    
+    const tree = renderer.create(
+      <SectionHeader {...props} />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+/*
+
+propTypes: {
+    section: React.PropTypes.object.isRequired,
+    sections: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+    educators: React.PropTypes.arrayOf(React.PropTypes.object).isRequired
+  },
+
+*/

--- a/spec/javascripts/section/section_page_spec.jsx
+++ b/spec/javascripts/section/section_page_spec.jsx
@@ -1,4 +1,5 @@
 import SpecSugar from '../support/spec_sugar.jsx';
+import renderer from 'react-test-renderer';
 
 describe('SectionPage', function() {
   const ReactDOM = window.ReactDOM;
@@ -79,5 +80,29 @@ describe('SectionPage', function() {
       const firstDataRows = dataElements.eq(0).find('td');
       expect(firstDataRows[0].innerHTML).toEqual('<a href="/students/2">Duck, Donald</a>');
     });
+  });
+
+  it('renders correctly', () => {
+    const props = {
+      students: [
+        { id: 1, first_name: 'Minnie', last_name: 'Mouse', program_assigned: 'Regular Ed', disability:'', plan_504: '', limited_english_proficiency: 'FLEP', home_language: 'Spanish', free_reduced_lunch: 'Free Lunch', most_recent_school_year_absences_count: 3, most_recent_school_year_tardies_count: 5, most_recent_school_year_discipline_incidents_count: 0},
+        { id: 2, first_name: 'Donald', last_name: 'Duck', program_assigned: 'Special Ed', disability:'Motor', plan_504: '504 Plan', limited_english_proficiency: 'ELL', home_language: 'English', free_reduced_lunch: 'Reduced Lunch', most_recent_school_year_absences_count: 1, most_recent_school_year_tardies_count: 0, most_recent_school_year_discipline_incidents_count: 0},
+      ],
+      educators: [
+        { }
+      ],
+      sections: [
+        { id: 1, section_number: 'Art-1'},
+        { id: 2, section_number: 'Art-2'},
+        { id: 3, section_number: 'Art-3'}
+      ],
+      section: { id: 1, section_number: 'Art-1', course_number: 'Art', course_description: 'Awesome Art Class', term_local_id: '9', schedule: '3(M-R)', room_number: '304' },
+      currentEducator: { districtwide_access: false }
+    };
+    
+    const tree = renderer.create(
+      <SectionPage {...props} />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3513,12 +3513,12 @@ react-modal@^3.0.4:
     exenv "^1.2.0"
     prop-types "^15.5.10"
 
-react-test-renderer@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.0.0.tgz#9fe7b8308f2f71f29fc356d4102086f131c9cb15"
+react-test-renderer@15.4.2:
+  version "15.4.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.4.2.tgz#27e1dff5d26d0e830f99614c487622bc831416f3"
   dependencies:
-    fbjs "^0.8.16"
-    object-assign "^4.1.1"
+    fbjs "^0.8.4"
+    object-assign "^4.1.0"
 
 react@15.4.2:
   version "15.4.2"


### PR DESCRIPTION
The bug I introduced described in #1192 has been annoying me. Essentially, I added a mandatory prop to a component. I didn't realize it was being used by another page, so I didn't change it. Tests were clear because that page isn't well tested. 

As Kevin pointed out, perhaps Flow or Typescript would alleviate my craving of some sort of type safety that's compiler enforced. _We won't be using Flow or Typescript anytime soon._

So I started to think about how we can ensure that each of the React components are tested. 

I'm thinking using Jest snapshots for very basic testing of React components could go a long way. Essentially, Jest takes a snapshot the first time the tests are run. Those snapshots are committed alongside jest test js.

So I wanted to test a couple of components. Two with existing tests `SectionPage` and `FlexibleRoster` and one without `SectionHeader`.

Would love your thoughts @kevinrobinson and @alexsoble. Note I had to downgrade react-test-renderer to the version of react we're using. Doesn't look like that was used anywhere else.