### PR TITLE
Enable gzip for JSON, move school overview to JSON endpoint

### DIFF
--- a/app/assets/javascripts/school_overview/main.jsx
+++ b/app/assets/javascripts/school_overview/main.jsx
@@ -4,14 +4,17 @@ export default function renderSchoolOverviewMain(el) {
   const SchoolOverviewPage = window.shared.SchoolOverviewPage;
   const Filters = window.shared.Filters;
 
-  const serializedData = $('#serialized-data').data();
-  MixpanelUtils.registerUser(serializedData.currentEducator);
-  MixpanelUtils.track('PAGE_VISIT', { page_key: 'SCHOOL_OVERVIEW_DASHBOARD' });
-
-  window.ReactDOM.render(<SchoolOverviewPage
-    allStudents={serializedData.students}
-    school={serializedData.school}
-    serviceTypesIndex={serializedData.constantIndexes.service_types_index}
-    eventNoteTypesIndex={serializedData.constantIndexes.event_note_types_index}
-    initialFilters={Filters.parseFiltersHash(window.location.hash)} />, el);
+  const {schoolSlug} = $('#serialized-data').data();
+  fetch(`/schools/${schoolSlug}/overview.json`, { credentials: 'include' })
+    .then(r => r.json())
+    .then(serializedData => {
+      MixpanelUtils.registerUser(serializedData.currentEducator);
+      MixpanelUtils.track('PAGE_VISIT', { page_key: 'SCHOOL_OVERVIEW_DASHBOARD' });
+      window.ReactDOM.render(<SchoolOverviewPage
+        allStudents={serializedData.students}
+        school={serializedData.school}
+        serviceTypesIndex={serializedData.constant_indexes.service_types_index}
+        eventNoteTypesIndex={serializedData.constant_indexes.event_note_types_index}
+        initialFilters={Filters.parseFiltersHash(window.location.hash)} />, el);
+    });
 }

--- a/app/assets/javascripts/school_overview/main.jsx
+++ b/app/assets/javascripts/school_overview/main.jsx
@@ -1,20 +1,34 @@
 import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
 
-export default function renderSchoolOverviewMain(el) {
+// Load data from inline on the page or with another request
+export default function renderSchoolOverviewMain(el, options = {}) {
+  if (options.json) {
+    const {schoolSlug} = $('#serialized-data').data();
+    fetch(`/schools/${schoolSlug}/overview_json`, { credentials: 'include' })
+      .then(r => r.json())
+      .then(json => render(el, json));
+  } else {
+    const serializedData = $('#serialized-data').data();
+    const {students, school} = serializedData; // undo outer camelcase
+    render(el, {
+      students,
+      school,
+      current_educator: serializedData.currentEducator,
+      constant_indexes: serializedData.constantIndexes
+    });
+  }
+}
+
+function render(el, json) {
   const SchoolOverviewPage = window.shared.SchoolOverviewPage;
   const Filters = window.shared.Filters;
 
-  const {schoolSlug} = $('#serialized-data').data();
-  fetch(`/schools/${schoolSlug}/overview.json`, { credentials: 'include' })
-    .then(r => r.json())
-    .then(serializedData => {
-      MixpanelUtils.registerUser(serializedData.currentEducator);
-      MixpanelUtils.track('PAGE_VISIT', { page_key: 'SCHOOL_OVERVIEW_DASHBOARD' });
-      window.ReactDOM.render(<SchoolOverviewPage
-        allStudents={serializedData.students}
-        school={serializedData.school}
-        serviceTypesIndex={serializedData.constant_indexes.service_types_index}
-        eventNoteTypesIndex={serializedData.constant_indexes.event_note_types_index}
-        initialFilters={Filters.parseFiltersHash(window.location.hash)} />, el);
-    });
+  MixpanelUtils.registerUser(json.current_educator);
+  MixpanelUtils.track('PAGE_VISIT', { page_key: 'SCHOOL_OVERVIEW_DASHBOARD' });
+  window.ReactDOM.render(<SchoolOverviewPage
+    allStudents={json.students}
+    school={json.school}
+    serviceTypesIndex={json.constant_indexes.service_types_index}
+    eventNoteTypesIndex={json.constant_indexes.event_note_types_index}
+    initialFilters={Filters.parseFiltersHash(window.location.hash)} />, el);
 }

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -4,12 +4,17 @@ class SchoolsController < ApplicationController
   before_action :set_school, :authorize_for_school
 
   def show
-    @serialized_data = { school_slug: @school.slug }
+    @serialized_data = json_for_overview(@school)
     render 'shared/serialized_data'
   end
 
   def overview
-    render json: overview_json(@school)
+    @serialized_data = { school_slug: @school.slug }
+    render 'shared/serialized_data'
+  end
+
+  def overview_json
+    render json: json_for_overview(@school)
   end
 
   def star_math
@@ -33,7 +38,7 @@ class SchoolsController < ApplicationController
   end
 
   private
-  def overview_json(school)
+  def json_for_overview(school)
     authorized_students = authorized_students_for_overview(school)
 
     student_hashes = log_timing('schools#show student_hashes') do

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -4,23 +4,12 @@ class SchoolsController < ApplicationController
   before_action :set_school, :authorize_for_school
 
   def show
-    authorized_students = authorized_students_for_overview(@school)
-
-    student_hashes = log_timing('schools#show student_hashes') do
-      load_precomputed_student_hashes(Time.now, authorized_students.map(&:id))
-    end
-
-    merged_student_hashes = log_timing('schools#show merge_mutable_fields_for_slicing') do
-      merge_mutable_fields_for_slicing(student_hashes)
-    end
-
-    @serialized_data = {
-      students: merged_student_hashes,
-      school: @school,
-      current_educator: current_educator,
-      constant_indexes: constant_indexes
-    }
+    @serialized_data = { school_slug: @school.slug }
     render 'shared/serialized_data'
+  end
+
+  def overview
+    render json: overview_json(@school)
   end
 
   def star_math
@@ -44,6 +33,24 @@ class SchoolsController < ApplicationController
   end
 
   private
+  def overview_json(school)
+    authorized_students = authorized_students_for_overview(school)
+
+    student_hashes = log_timing('schools#show student_hashes') do
+      load_precomputed_student_hashes(Time.now, authorized_students.map(&:id))
+    end
+
+    merged_student_hashes = log_timing('schools#show merge_mutable_fields_for_slicing') do
+      merge_mutable_fields_for_slicing(student_hashes)
+    end
+
+    {
+      students: merged_student_hashes,
+      school: school,
+      current_educator: current_educator,
+      constant_indexes: constant_indexes
+    }
+  end
 
   # This should always find a record, but if it doesn't we fall back to the
   # raw query.

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,15 @@ module SomervilleTeacherTool
         "#{config.root}/lib"
       ]
 
-      config.middleware.use Rack::Deflater
+      # The intention here is that we compress server responses
+      # (eg, HTML and JSON) but not doubly-gzip static assets which
+      # are already compressed on disk.
+      config.middleware.use Rack::Deflater, include: [
+        'text/html',
+        'text/csv',
+        'application/json',
+        'application/pdf'
+      ]
 
       config.eager_load_paths = (config.eager_load_paths + class_paths).uniq
       class_paths.each do |class_path|

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,8 @@ module SomervilleTeacherTool
         "#{config.root}/lib"
       ]
 
+      config.middleware.use Rack::Deflater
+
       config.eager_load_paths = (config.eager_load_paths + class_paths).uniq
       class_paths.each do |class_path|
         config.autoload_paths << class_path

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module SomervilleTeacherTool
       # (eg, HTML and JSON) but not doubly-gzip static assets which
       # are already compressed on disk.
       config.middleware.use Rack::Deflater, include: [
-        'text/html',
+        #'text/html', This doesn't seem to reduce byte site, see https://github.com/studentinsights/studentinsights/issues/1196#issuecomment-340269968
         'text/csv',
         'application/json',
         'application/pdf'

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,11 +32,13 @@ module SomervilleTeacherTool
       # The intention here is that we compress server responses
       # (eg, HTML and JSON) but not doubly-gzip static assets which
       # are already compressed on disk.
+      #
+      # However, when the middleware runs for mime types other than
+      # application/json, it runs through the deflate code path but
+      # doesn't seem to actually reduce the byte site.
+      # See https://github.com/studentinsights/studentinsights/issues/1196#issuecomment-340269968
       config.middleware.use Rack::Deflater, include: [
-        #'text/html', This doesn't seem to reduce byte site, see https://github.com/studentinsights/studentinsights/issues/1196#issuecomment-340269968
-        'text/csv',
-        'application/json',
-        'application/pdf'
+        'application/json'
       ]
 
       config.eager_load_paths = (config.eager_load_paths + class_paths).uniq

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   resources :students, only: [:show] do
     resources :event_notes, only: [:create, :update]
     member do
+      get :profile
       get :student_report
       get :restricted_notes
       post :service
@@ -49,8 +50,11 @@ Rails.application.routes.draw do
   resources :iep_documents, only: [:show]
 
   resources :schools, only: [:show] do
-    get :star_reading, on: :member
-    get :star_math, on: :member
-    get :csv, on: :member
+    member do
+      get :overview
+      get :star_reading
+      get :star_math
+      get :csv
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,6 @@ Rails.application.routes.draw do
   resources :students, only: [:show] do
     resources :event_notes, only: [:create, :update]
     member do
-      get :profile
       get :student_report
       get :restricted_notes
       post :service

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
   resources :schools, only: [:show] do
     member do
       get :overview
+      get :overview_json
       get :star_reading
       get :star_math
       get :csv

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -5,7 +5,7 @@ describe SchoolsController, :type => :controller do
   describe '#show' do
     before { School.seed_somerville_schools }
     let!(:districtwide_educator) { FactoryGirl.create(:educator, districtwide_access: true) }
-    
+
     def show_request(school_id)
       request.env['HTTPS'] = 'on'
       get :show, params: { id: school_id }

--- a/ui/route.js
+++ b/ui/route.js
@@ -20,6 +20,10 @@ export default function route() {
     renderSchoolOverviewMain(el); 
   }
 
+  if ($('body').hasClass('schools') && $('body').hasClass('overview')) {
+    renderSchoolOverviewMain(el, { json: true }); 
+  }
+
   if ($('body').hasClass('homerooms') && $('body').hasClass('show')) {
     homeroomMain(); // different HTML
   }


### PR DESCRIPTION
This enables a Rails middleware to gzip responses for JSON endpoints and update the school overview page to request JSON.  See https://github.com/studentinsights/studentinsights/issues/1196 for more background.  This PR aims to work around not being able to get compression in HTML responses, and also to avoid making large changes to drive routing from JS.

edit: I updated this to leave the current #show endpoint as is, and to ship another #overview endpoint so we can more safely compare directly in production.

Here are some numbers.  Since this is dependent on environment because of the actual data payload sizes and interaction with other loading behaviors like fetching scripts.  It also may be different across browsers, and this testing is only with Chrome.  We won't be able to exactly measure the actual impact on load time until it's deployed.  So here's some data from development and the demo site, and then estimates about impact in production.

## names endpoint
In production, for developer user (which is an outlier in terms of the size of this response), there's no compression (although this is cached in the browser):
<img width="827" alt="screen shot 2017-10-29 at 9 07 30 am" src="https://user-images.githubusercontent.com/1056957/32144025-0d43ce0c-bc89-11e7-98f2-3f61fe2c637d.png">

In the demo site, for the demo user, compression cuts the size to 67% of what it was.
<img width="823" alt="screen shot 2017-10-29 at 9 07 50 am" src="https://user-images.githubusercontent.com/1056957/32144023-08f44fca-bc89-11e7-8304-43cab9177965.png">

If we get a similar compression rate in production, that'd reduce the size to 190kb.

## School overview
The main tradeoff here is by moving the JSON out of the HTML response, we get better compression and reduce the network transfer size, but we add another network request to get the data.

### development
Here's local development, the HTML is 61kb and takes ~1000ms to finish loading everything.
<img width="827" alt="screen shot 2017-10-29 at 9 00 51 am" src="https://user-images.githubusercontent.com/1056957/32144027-0d614428-bc89-11e7-83b0-0ffc3ad1c2e9.png">

With this PR, it becomes:
<img width="484" alt="screen shot 2017-10-29 at 9 20 19 am" src="https://user-images.githubusercontent.com/1056957/32144132-723eb67c-bc8a-11e7-95b6-7fba8f5d7fb8.png">

And so we're sending 48% of the bytes we used to send.

### demo
On the demo site, this looks like:
<img width="627" alt="screen shot 2017-10-29 at 11 30 48 am" src="https://user-images.githubusercontent.com/1056957/32145318-bc4eb1b0-bc9c-11e7-85ef-aad644099d1d.png">

And the page takes roughly ~1100ms to "finish" the requests with a warm cache, just based on reloading the page a few times.

After on the demo site:
<img width="791" alt="screen shot 2017-10-29 at 11 24 25 am" src="https://user-images.githubusercontent.com/1056957/32145273-eaf84f36-bc9b-11e7-9d90-c810825620bc.png">

So that reduces the overall bytes transferred to 25% of what it was previously, with the tradeoff that it's now split across two serial requests.  Time to "finish" loading is ~900ms, similarly roughly estimated.


### production
In production, this is the current size of the HTML page:
<img width="825" alt="screen shot 2017-10-29 at 9 17 49 am" src="https://user-images.githubusercontent.com/1056957/32144108-282b9b5e-bc8a-11e7-8e09-cb0edbc0c442.png">

If we get a similar compression rate, this would reduce the total bytes transferred from 1.1MB to ~275kb.  With the larger data payloads, the compression should be more meaningful (for this page in particular) than having to make the second request.  That may not be true for other pages.