### PR TITLE
Use Rollbar for server-side error tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'jquery-ui-rails', '~> 5.0.3'
 gem 'net-sftp'
 gem 'net-ssh'
 gem 'probability'
+gem 'rollbar'
 gem 'rubocop', require: false
 gem 'memory_profiler'
 gem 'oj'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,7 @@ GEM
     minitest (5.10.3)
     momentjs-rails (2.17.1)
       railties (>= 3.1)
+    multi_json (1.12.1)
     net-ldap (0.11)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
@@ -233,6 +234,8 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rollbar (2.14.0)
+      multi_json
     rspec-core (3.6.0)
       rspec-support (~> 3.6.0)
     rspec-expectations (3.6.0)
@@ -354,6 +357,7 @@ DEPENDENCIES
   rails (~> 5.1.1)
   rails-controller-testing
   rails_12factor
+  rollbar
   rspec-rails
   rubocop
   rubystats

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,0 +1,57 @@
+Rollbar.configure do |config|
+  # Without configuration, Rollbar is enabled in all environments.
+  # To disable in specific environments, set config.enabled=false.
+
+  config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
+
+  # Here we'll disable in 'test':
+  if Rails.env.test?
+    config.enabled = false
+  end
+
+  # By default, Rollbar will try to call the `current_user` controller method
+  # to fetch the logged-in user object, and then call that object's `id`,
+  # `username`, and `email` methods to fetch those properties. To customize:
+  # config.person_method = "my_current_user"
+  # config.person_id_method = "my_id"
+  # config.person_username_method = "my_username"
+  # config.person_email_method = "my_email"
+
+  # If you want to attach custom data to all exception and message reports,
+  # provide a lambda like the following. It should return a hash.
+  # config.custom_data_method = lambda { {:some_key => "some_value" } }
+
+  # Add exception class names to the exception_level_filters hash to
+  # change the level that exception is reported at. Note that if an exception
+  # has already been reported and logged the level will need to be changed
+  # via the rollbar interface.
+  # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
+  # 'ignore' will cause the exception to not be reported at all.
+  # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
+  #
+  # You can also specify a callable, which will be called with the exception instance.
+  # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
+
+  # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
+  # is not installed)
+  # config.use_async = true
+  # Supply your own async handler:
+  # config.async_handler = Proc.new { |payload|
+  #  Thread.new { Rollbar.process_from_async_handler(payload) }
+  # }
+
+  # Enable asynchronous reporting (using sucker_punch)
+  # config.use_sucker_punch
+
+  # Enable delayed reporting (using Sidekiq)
+  # config.use_sidekiq
+  # You can supply custom Sidekiq options:
+  # config.use_sidekiq 'queue' => 'default'
+
+  # If you run your staging application instance in production environment then
+  # you'll want to override the environment reported by `Rails.env` with an
+  # environment variable like this: `ROLLBAR_ENV=staging`. This is a recommended
+  # setup for Heroku. See:
+  # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
+  config.environment = ENV['ROLLBAR_ENV'] || Rails.env
+end

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -5,7 +5,7 @@ Rollbar.configure do |config|
   config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
 
   # Here we'll disable in 'test':
-  if Rails.env.test?
+  if Rails.env.test? || Rails.env.development?
     config.enabled = false
   end
 

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -4,8 +4,7 @@ Rollbar.configure do |config|
 
   config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
 
-  # Here we'll disable in 'test':
-  if Rails.env.test? || Rails.env.development?
+  if Rails.env.test? || Rails.env.development? || (ENV["SHOULD_REPORT_ERRORS"] == false)
     config.enabled = false
   end
 

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -19,7 +19,7 @@ Rollbar.configure do |config|
 
   # If you want to attach custom data to all exception and message reports,
   # provide a lambda like the following. It should return a hash.
-  # config.custom_data_method = lambda { {:some_key => "some_value" } }
+  config.custom_data_method = lambda { { deployment_key: ENV["DEPLOYMENT_KEY"] } }
 
   # Add exception class names to the exception_level_filters hash to
   # change the level that exception is reported at. Note that if an exception


### PR DESCRIPTION
# Notes 

Talked online with @kevinrobinson and @jhilde, consensus is that setting up Rollbar for server-side error tracking is a good first step. This PR adds the code to set that up; I added the required ROLLBAR_ACCESS_TOKEN config to our production Heroku app already. 

Let's see how this does in the wild for a couple of weeks or months. My prediction is that it will be a significant improvement over Logentries. The next step in my mind would be some kind of SMS alerts to the team for critical errors like LDAP login errors.
 
# Issue 

+ #1205