### PR TITLE
Fix delete on Assignment Importers to properly handle school scope.

### DIFF
--- a/app/importers/file_importers/educator_section_assignments_importer.rb
+++ b/app/importers/file_importers/educator_section_assignments_importer.rb
@@ -32,7 +32,10 @@ class EducatorSectionAssignmentsImporter < Struct.new :school_scope, :client, :l
 
   def delete_rows
     #Delete all stale rows no longer included in the import
-    EducatorSectionAssignment.where.not(id: @imported_assignments).delete_all
+    #For the schools imported during this run of the importer
+    EducatorSectionAssignment.joins(:section => {:course => :school})
+                             .where.not(id: @imported_assignments)
+                             .where(:schools => {:local_id => school_scope}).delete_all
   end
 
   def import_row(row)

--- a/app/importers/file_importers/student_section_assignments_importer.rb
+++ b/app/importers/file_importers/student_section_assignments_importer.rb
@@ -31,7 +31,11 @@ class StudentSectionAssignmentsImporter < Struct.new :school_scope, :client, :lo
 
   def delete_rows
     #Delete all stale rows no longer included in the import
-    StudentSectionAssignment.where.not(id: @imported_assignments).delete_all
+    #For the schools imported during this run of the importer
+    StudentSectionAssignment.joins(:section => {:course => :school})
+                            .where.not(id: @imported_assignments)
+                            .where(:schools => {:local_id => school_scope}).delete_all
+
   end
 
   def import_row(row)

--- a/spec/importers/file_importers/educator_section_assignments_importer.rb
+++ b/spec/importers/file_importers/educator_section_assignments_importer.rb
@@ -133,5 +133,21 @@ RSpec.describe EducatorSectionAssignmentsImporter do
           expect(EducatorSectionAssignment.count).to eq(1)
         end
       end
+
+      context 'delete only stale assignments from schools being imported' do
+        before do
+          FactoryGirl.create_list(:educator_section_assignment,20)
+          FactoryGirl.create(:educator_section_assignment, educator_id: educator.id, section_id: section.id)
+
+          esa_importer = described_class.new
+          esa_importer.school_scope = ['SHS']
+          esa_importer.import_row(row)
+          esa_importer.delete_rows
+        end
+
+        it 'deletes all student section assignments for this school except the recently imported one' do
+          expect(EducatorSectionAssignment.count).to eq(21)
+        end
+      end
     end
   end

--- a/spec/importers/file_importers/student_section_assignments_importer_spec.rb
+++ b/spec/importers/file_importers/student_section_assignments_importer_spec.rb
@@ -126,5 +126,21 @@ RSpec.describe StudentSectionAssignmentsImporter do
         expect(StudentSectionAssignment.count).to eq(1)
       end
     end
+
+    context 'delete only stale assignments from schools being imported' do
+      before do
+        FactoryGirl.create_list(:student_section_assignment, 20)
+        FactoryGirl.create(:student_section_assignment, student_id: student.id, section_id: section.id)
+
+        ssa_importer = described_class.new
+        ssa_importer.school_scope = ['SHS']
+        ssa_importer.import_row(row)
+        ssa_importer.delete_rows
+      end
+
+      it 'deletes all student section assignments for that school except the recently imported one' do
+        expect(StudentSectionAssignment.count).to eq(21)
+      end
+    end
   end
 end


### PR DESCRIPTION
In response to #1229. Assignment importers were deleting all assignments not imported in the current run as stale. This should only be done for the schools being imported.

For instance, if the school scope doesn't include SHS, the `educator_section_assignments` and `student_section_assignments` for SHS shouldn't be deleted.