### PR TITLE
Add CI script to detect package-lock.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ script:
   - rubocop
   - bundle exec rake db:create db:migrate DATABASE_URL=postgres://localhost/student_insights_test
   - bundle exec rspec spec
+  - ./scripts/ci/detect_package_lock.sh

--- a/scripts/ci/detect_package_lock.sh
+++ b/scripts/ci/detect_package_lock.sh
@@ -1,0 +1,7 @@
+if [ -f package-lock.json ]; then
+    echo "package-lock.json found, that's bad because we're using Yarn!"
+    exit 1;
+else
+    echo "No package-lock.json found, that's good because we're using Yarn!"
+    exit 0;
+fi


### PR DESCRIPTION
# Notes 

+ If `package-lock.json` is present it blocks deploys to Heroku. Heroku won't accept a project with both a `package-lock.json` and a `yarn.lock` file present.