### PR TITLE
Add yarn-error.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ dump.rdb
 
 # Node.js
 node_modules
-npm-debug.log
+yarn-debug.log*
+yarn-error.log*
 
 # This holds configuration for testing production import scripts locally, so it shouldn't be checked into
 # source control.


### PR DESCRIPTION
# Notes 

+ Since we're using yarn, this is the relevant error log file to include in .gitignore, not `npm-debug`

# Example

https://www.gitignore.io/api/node