### PR TITLE
(For discussion) - Move authorization code to Authorizer, add authorized_only API

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,13 +50,13 @@ class ApplicationController < ActionController::Base
 
   # Wrap all database queries with this to enforce authorization
   def authorized(&block)
-    authorizer.authorized(block)
+    authorizer.authorized(&block)
   end
 
   # Enforce authorization and raise if no authorized models
   def authorized_or_raise!(&block)
-    return_value = authorizer.authorized(block)
-    if return_value.nil? || return_value.length == 0
+    return_value = authorizer.authorized(&block)
+    if return_value == nil || return_value == []
       raise Exceptions::EducatorNotAuthorized
     end
     return_value

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,8 +49,17 @@ class ApplicationController < ActionController::Base
   end
 
   # Wrap all database queries with this to enforce authorization
-  def authorized_only(&block)
-    authorizer.authorized_only(block)
+  def authorized(&block)
+    authorizer.authorized(block)
+  end
+
+  # Enforce authorization and raise if no authorized models
+  def authorized_or_raise!(&block)
+    return_value = authorizer.authorized(block)
+    if return_value.nil? || return_value.length == 0
+      raise Exceptions::EducatorNotAuthorized
+    end
+    return_value
   end
 
   # Sugar for filters checking authorization

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,6 +48,11 @@ class ApplicationController < ActionController::Base
     no_sections_path
   end
 
+  # Wrap all database queries with this to enforce authorization
+  def authorized_only(&block)
+    authorizer.authorized_only(block)
+  end
+
   # Sugar for filters checking authorization
   def redirect_unauthorized!
     redirect_to not_authorized_path
@@ -78,5 +83,10 @@ class ApplicationController < ActionController::Base
     logger.info "log_timing:end [#{message}] #{timing_ms.round}ms"
 
     return_value
+  end
+
+  private
+  def authorizer
+    @authorizer ||= Authorizer.new(current_educator)
   end
 end

--- a/app/controllers/homerooms_controller.rb
+++ b/app/controllers/homerooms_controller.rb
@@ -11,7 +11,7 @@ class HomeroomsController < ApplicationController
     @rows = eager_students().map {|student| fat_student_hash(student) }
 
     # Dropdown for homeroom navigation
-    @homerooms_by_name = current_educator.allowed_homerooms_by_name
+    @homerooms_by_name = current_educator.allowed_homerooms.order(:name)
 
     # For JSX Table:
     @serialized_data = {

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -2,6 +2,7 @@ class StudentsController < ApplicationController
   include ApplicationHelper
 
   rescue_from Exceptions::EducatorNotAuthorized do
+    puts "RAISED!"
     if request.format.json?
       render_unauthorized_json! 
     else
@@ -26,7 +27,7 @@ class StudentsController < ApplicationController
     event_notes = authorized { student.event_notes.without_restricted }
     puts "  event_notes: #{event_notes}"
     restricted_notes_count = authorized { student.event_notes.restricted }.size
-    puts "  restricted_notes: #{restricted_notes}"
+    puts "  restricted_notes_count: #{restricted_notes_count}"
     chart_data = StudentProfileChart.new(student).chart_data
 
     @serialized_data = {

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -16,42 +16,26 @@ class StudentsController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound do 
     render json: {}, status: 404
   end
-  
-  # before_action :authorize!, except: [          # The :names and lasids actions are subject to
-  #   :names, :lasids                             # educator authentication via :authenticate_educator!
-  # ]                                             # inherited from ApplicationController.
-  #                                               # They then get further authorization filtering using
-  #                                               # The custom authorization methods below.
-
-  # before_action :authorize_for_districtwide_access_admin, only: [:lasids]
-
-  # def authorize!
-  #   student = Student.find(params[:id])
-  #   raise Exceptions::EducatorNotAuthorized unless current_educator.is_authorized_for_student(student)
-  # end
-
-  # def authorize_for_districtwide_access_admin
-  #   unless current_educator.admin? && current_educator.districtwide_access?
-  #     render json: { error: "You don't have the correct authorization." }
-  #   end
-  # end
 
   def show
     student = authorized_or_raise! { Student.find(params[:id]) }
+    sections = authorized { student.sections_with_grades }
+    event_notes = authorized { student.event_notes.without_restricted }
+    restricted_notes = authorized { student.event_notes.restricted }
     chart_data = StudentProfileChart.new(student).chart_data
 
     @serialized_data = {
       current_educator: current_educator,
-      student: serialize_student_for_profile(student),          # Risk level, school homeroom, most recent school year attendance/discipline counts
-      feed: student_feed(student, restricted_notes: false),     # Notes, services
-      chart_data: chart_data,                                   # STAR, MCAS, discipline, attendance charts
+      student: serialize_student_for_profile(student, restricted_notes), # Risk level, school homeroom, most recent school year attendance/discipline counts
+      feed: student_feed(student, event_notes),                     # Notes, services
+      chart_data: chart_data,                                            # STAR, MCAS, discipline, attendance charts
       dibels: student.student_assessments.by_family('DIBELS'),
       service_types_index: ServiceSerializer.service_types_index,
       event_note_types_index: EventNoteSerializer.event_note_types_index,
       educators_index: Educator.to_index,
       access: student.latest_access_results,
       iep_document: student.iep_document,
-      sections: serialize_student_sections_for_profile(student),
+      sections: serialize_sections_for_profile(sections),
       current_educator_allowed_sections: current_educator.allowed_sections.map(&:id),
       attendance_data: {
         discipline_incidents: student.discipline_incidents.order(occurred_at: :desc),
@@ -66,10 +50,11 @@ class StudentsController < ApplicationController
     raise Exceptions::EducatorNotAuthorized unless current_educator.can_view_restricted_notes
 
     student = authorized_or_raise! { Student.find(params[:id]) }
+    restricted_notes = authorized { student.event_notes.restricted }
     @serialized_data = {
       current_educator: current_educator,
-      student: serialize_student_for_profile(student),
-      feed: student_feed(student, restricted_notes: true),
+      student: serialize_student_for_profile(student, restricted_notes),
+      feed: student_feed(student, restricted_notes),
       event_note_types_index: EventNoteSerializer.event_note_types_index,
       educators_index: Educator.to_index,
     }
@@ -151,7 +136,7 @@ class StudentsController < ApplicationController
 
   private
 
-  def serialize_student_for_profile(student)
+  def serialize_student_for_profile(student, restricted_notes)
     student.as_json.merge({
       student_risk_level: student.student_risk_level.as_json,
       absences_count: student.most_recent_school_year_absences_count,
@@ -160,21 +145,18 @@ class StudentsController < ApplicationController
       school_type: student.try(:school).try(:school_type),
       homeroom_name: student.try(:homeroom).try(:name),
       discipline_incidents_count: student.most_recent_school_year_discipline_incidents_count,
-      restricted_notes_count: student.event_notes.where(is_restricted: true).count,
+      restricted_notes_count: restricted_notes.count,
     }).stringify_keys
   end
 
-  def serialize_student_sections_for_profile(student)
-    student.sections_with_grades.as_json({:include => { :educators => {:only => :full_name}}, :methods => :course_description})
+  def serialize_sections_for_profile(sections)
+    sections.as_json({:include => { :educators => {:only => :full_name}}, :methods => :course_description})
   end
 
   # The feed of mutable data that changes most frequently and is owned by Student Insights.
-  # restricted_notes: If false display non-restricted notes, if true display only restricted notes.
-  def student_feed(student, restricted_notes: false)
+  def student_feed(student, event_notes)
     {
-      event_notes: student.event_notes
-        .select {|note| note.is_restricted == restricted_notes}
-        .map {|event_note| EventNoteSerializer.new(event_note).serialize_event_note },
+      event_notes: event_notes.map {|event_note| EventNoteSerializer.new(event_note).serialize_event_note },
       services: {
         active: student.services.active.map {|service| ServiceSerializer.new(service).serialize_service },
         discontinued: student.services.discontinued.map {|service| ServiceSerializer.new(service).serialize_service }
@@ -185,33 +167,15 @@ class StudentsController < ApplicationController
     }
   end
 
-  def school_year_id_range(from_date, to_date)
-    # Find the years represented by the dates
-
-    #start with to_date and work backward each year until < from_date
-    current_date = to_date
-    school_year_ids = []
-
-    while current_date > from_date do
-      school_year_ids.push(DateToSchoolYear.new(current_date).convert.id)
-
-      current_date = current_date - 1.year
-    end
-
-    return school_year_ids
-
-  end
-
   def set_up_student_report_data
-    @student = Student.find(params[:id])
-    @current_educator = current_educator
-    @sections = (params[:sections] || "").split(",")
-
+    @sections = (params[:sections] || "").split(",") # sections of the report
     @filter_from_date = params[:from_date] ? Date.strptime(params[:from_date],  "%m/%d/%Y") : Date.today()
     @filter_to_date = params[:from_date] ? Date.strptime(params[:to_date],  "%m/%d/%Y") : Date.today()
 
-    # Load event notes that are NOT restricted for the student for the filtered dates
-    @event_notes = @student.event_notes.where(:is_restricted => false).where(recorded_at: @filter_from_date..@filter_to_date)
+    # Load event notes for the student for the filtered dates
+    @current_educator = current_educator
+    @student = authorized_or_raise! { Student.find(params[:id]) }
+    @event_notes = authorized { @student.event_notes.without_restricted.where(recorded_at: @filter_from_date..@filter_to_date) }
 
     # Load services for the student for the filtered dates
     @services = @student.services.where("date_started <= ? AND (discontinued_at >= ? OR discontinued_at IS NULL)", @filter_to_date, @filter_from_date).order('date_started, discontinued_at')

--- a/app/helpers/searchbar_helper.rb
+++ b/app/helpers/searchbar_helper.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 module SearchbarHelper
   def self.names_for(educator)
-    authorized_students = Student.with_school.select do |student|
-      educator.is_authorized_for_student(student)
-    end
-    authorized_students.map do |student|
+    authorizer = Authorizer.new(educator)
+    students = authorizer.authorized { Student.all }
+    students.map do |student|
       {
         label: "#{student.first_name} #{student.last_name} - #{student.school.local_id} - #{student.grade}",
         id: student.id

--- a/app/lib/authorized_dispatcher.rb
+++ b/app/lib/authorized_dispatcher.rb
@@ -29,7 +29,9 @@ class AuthorizedDispatcher
   # clauses and not by filtering based on a Ruby method.
   def filter_relation(relation)
     # This checks that the relation has all fields required for authorization,
-    # and adds them in if not.
+    # and adds them in if not.  The developer was probably trying to optimize the
+    # query, and we can adjust it a bit to get what we need for authorization.
+    # So we do that and continue.
     if relation.klass == Student.class
       relation_with_required_fields = relation.select(*Authorizer.student_fields_for_authorization)
       filter_array(relation_with_required_fields.to_a)
@@ -45,6 +47,8 @@ class AuthorizedDispatcher
   def filter_model(model)
     if model.class == Student
       check_value(model, @authorizer.is_authorized_for_student?(model))
+    elsif model.class == EventNote
+      check_value(model, @authorizer.is_authorized_for_note?(model))
     else
       unchecked_value(model)
     end

--- a/app/lib/authorized_dispatcher.rb
+++ b/app/lib/authorized_dispatcher.rb
@@ -28,8 +28,8 @@ class AuthorizedDispatcher
   # authorization can be applied with simple `where`
   # clauses and not by filtering based on a Ruby method.
   def filter_relation(relation)
-    # This is coupled to the implementation of
-    # Authorizer#is_authorized_for_student.
+    # This checks that the relation has all fields required for authorization,
+    # and adds them in if not.
     if relation.klass == Student.class
       relation_with_required_fields = relation.select(*Authorizer.student_fields_for_authorization)
       filter_array(relation_with_required_fields.to_a)

--- a/app/lib/authorized_dispatcher.rb
+++ b/app/lib/authorized_dispatcher.rb
@@ -1,6 +1,6 @@
 # Dispatches different questions about authorization
 # to specific methods for specific models.
-class AuthorizedOnly
+class AuthorizedDispatcher
   def initialize(authorizer)
     @authorizer = authorizer
   end
@@ -28,7 +28,14 @@ class AuthorizedOnly
   # authorization can be applied with simple `where`
   # clauses and not by filtering based on a Ruby method.
   def filter_relation(relation)
-    filter_array(relation.to_a)
+    # This is coupled to the implementation of
+    # Authorizer#is_authorized_for_student.
+    if relation.klass == Student.class
+      relation_with_required_fields = relation.select(*Authorizer.student_fields_for_authorization)
+      filter_array(relation_with_required_fields.to_a)
+    else
+      filter_array(relation.to_a)
+    end
   end
 
   def filter_array(array)
@@ -52,7 +59,7 @@ class AuthorizedOnly
   # If it does return, it should return the "null" value for something
   # the educator doesn't have access to.
   def unchecked_value(model)
-    message = "AuthorizedOnly#unchecked_value for class: #{model.class.to_s}"
+    message = "Authorized#unchecked_value for class: #{model.class.to_s}"
     raise Exceptions::EducatorNotAuthorized.new(message)
   end
 end

--- a/app/lib/authorized_only.rb
+++ b/app/lib/authorized_only.rb
@@ -1,0 +1,58 @@
+# Dispatches different questions about authorization
+# to specific methods for specific models.
+class AuthorizedOnly
+  def initialize(authorizer)
+    @authorizer = authorizer
+  end
+
+  # Branches by type (Relation, Array, Model)
+  # and by the Model class.
+  def dispatch(&block)
+    return_value = block.call
+
+    # Can't duck type here, since other things like hashes
+    # are iterable or mappable in ways we don't want to
+    # support.
+    if return_value.class < ActiveRecord::Relation # subclass?
+      filter_array(return_value.to_a)
+    elsif return_value.class == Array # subclass?
+      filter_relation(return_value)
+    else
+      filter_model(return_value)
+    end
+  end
+
+  private
+  # This is a seam to optimize for authorization filtering
+  # that stays lazy when possible (only possible when
+  # authorization can be applied with simple `where`
+  # clauses and not by filtering based on a Ruby method.
+  def filter_relation(relation)
+    filter_array(relation)
+  end
+
+  def filter_array(array)
+    array.map {|model| filter_model(model) }.compact
+  end
+
+  def filter_model(model)
+    if model.class == Student
+      check_value(model, @authorizer.is_authorized_for_student?(model))
+    else
+      unchecked_value(model)
+    end
+  end
+
+  # Just a hook for logging, noop
+  def check_value(model, should_allow)
+    if should_allow then model else nil end
+  end
+
+  # This can log, raise or otherwise notifier developers.
+  # If it does return, it should return the "null" value for something
+  # the educator doesn't have access to.
+  def unchecked_value(model)
+    message = "AuthorizedOnly#unchecked_value for class: #{model.class.to_s}"
+    raise Exceptions::EducatorNotAuthorized.new(message)
+  end
+end

--- a/app/lib/authorized_only.rb
+++ b/app/lib/authorized_only.rb
@@ -13,10 +13,10 @@ class AuthorizedOnly
     # Can't duck type here, since other things like hashes
     # are iterable or mappable in ways we don't want to
     # support.
-    if return_value.class < ActiveRecord::Relation # subclass?
-      filter_array(return_value.to_a)
-    elsif return_value.class == Array # subclass?
+    if return_value.class < ActiveRecord::Relation # if subclass
       filter_relation(return_value)
+    elsif return_value.class == Array
+      filter_array(return_value)
     else
       filter_model(return_value)
     end
@@ -28,7 +28,7 @@ class AuthorizedOnly
   # authorization can be applied with simple `where`
   # clauses and not by filtering based on a Ruby method.
   def filter_relation(relation)
-    filter_array(relation)
+    filter_array(relation.to_a)
   end
 
   def filter_array(array)

--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -4,23 +4,23 @@
 # Drop down to calling individual methods if you need to.
 #
 # This class should be fully tested, and all changes should be reviewed.
-# 
+#
 # Controller usage:
 #   student = authorized_only { Student.find(params[:id]) }
 #   homeroom = authorized_only { Homeroom.(params[:id]) }
-#   students = authorized_only { homeroom.students } 
+#   students = authorized_only { homeroom.students }
 #
 # Standalone usage:
 #   authorizer = Authorizer.new(educator)
 #   student = authorizer.authorized_only { Student.find(params[:id]) }
 #   homeroom = authorizer.authorized_only { Homeroom.(params[:id]) }
-#   students = authorizer.authorized_only { homeroom.students } 
+#   students = authorizer.authorized_only { homeroom.students }
 #
 # Instead of:
 #   Homeroom.find(id).students # no authorization check
 #   Section.find(id).students # no authorization check
-#   current_educator.homeroom.students # doesn't consider other roles
-#   current_educator.school.students # doesn't consider other roles
+#   current_educator.homeroom.students # doesn't work for all roles
+#   current_educator.school.students # doesn't work for all roles
 #
 class Authorizer
   def initialize(educator)
@@ -48,5 +48,66 @@ class Authorizer
     return true if student.in?(@educator.students) # Homeroom level access
     return true if student.in?(@educator.section_students) # Section level access
     false
+  end
+
+  def is_authorized_for_school?(school)
+    return true if @educator.districtwide_access?
+    return true if @educator.schoolwide_access? && @educator.school == school
+    return true if @educator.has_access_to_grade_levels? && @educator.school == school
+    false
+  end
+
+  def is_authorized_for_section?(section)
+    return true if @educator.districtwide_access?
+
+    return false if @educator.school.present? && @educator.school != section.course.school
+
+    return true if @educator.schoolwide_access? || @educator.admin?
+    return true if section.in?(@educator.sections)
+    false
+  end
+
+  # TODO(kr) remove implementation
+  def students_for_school_overview
+    return [] unless @educator.school.present?
+
+    if @educator.schoolwide_access?
+      @educator.school.students.active
+    elsif @educator.has_access_to_grade_levels?
+      @educator.school.students
+        .active
+        .where(grade: @educator.grade_level_access)
+    else
+      []
+    end
+  end
+
+  # TODO(kr) remove implementation
+  def homerooms
+    # Educator can visit roster view for these homerooms
+    return [] if @educator.school.nil?
+
+    if @educator.districtwide_access?
+      Homeroom.all
+    elsif @educator.schoolwide_access?
+      @educator.school.homerooms.all
+    elsif @educator.homeroom
+      @educator.school.homerooms.where(grade: @educator.homeroom.grade)
+    elsif @educator.grade_level_access.present?
+      @educator.school.homerooms.where(grade: @educator.grade_level_access)
+    else
+      []
+    end
+  end
+
+  # TODO(kr) remove implementation
+  def sections
+    if @educator.districtwide_access?
+      Section.all
+    elsif @educator.schoolwide_access?
+      Section.joins(:course).where('courses.school_id = ?', @educator.school.id)
+    else
+      @educator.sections
+    end
   end
 end

--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -89,6 +89,12 @@ class Authorizer
     false
   end
 
+  def is_authorized_for_note?(event_note)
+    return false unless is_authorized_for_student?(event_note.student)
+    return false if event_note.is_restricted && !@educator.can_view_restricted_notes
+    true
+  end
+
   # TODO(kr) remove implementation
   def students_for_school_overview
     return [] unless @educator.school.present?

--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -1,0 +1,52 @@
+# This class defines authorization rules.
+# If you want student data, ask through this class.
+# Ideally, start with using `authorized_only`.
+# Drop down to calling individual methods if you need to.
+#
+# This class should be fully tested, and all changes should be reviewed.
+# 
+# Controller usage:
+#   student = authorized_only { Student.find(params[:id]) }
+#   homeroom = authorized_only { Homeroom.(params[:id]) }
+#   students = authorized_only { homeroom.students } 
+#
+# Standalone usage:
+#   authorizer = Authorizer.new(educator)
+#   student = authorizer.authorized_only { Student.find(params[:id]) }
+#   homeroom = authorizer.authorized_only { Homeroom.(params[:id]) }
+#   students = authorizer.authorized_only { homeroom.students } 
+#
+# Instead of:
+#   Homeroom.find(id).students # no authorization check
+#   Section.find(id).students # no authorization check
+#   current_educator.homeroom.students # doesn't consider other roles
+#   current_educator.school.students # doesn't consider other roles
+#
+class Authorizer
+  def initialize(educator)
+    @educator = educator
+    @authorized_only = AuthorizedOnly.new(self)
+  end
+
+  # Usage:
+  #  student = authorized_only { Student.find(params[:id]) }
+  def authorized_only(&block)
+    @authorized_only.dispatch(&block)
+  end
+
+  # This method is the source of truth for whether an educator is authorized to view information about a particular
+  # student.
+  def is_authorized_for_student?(student)
+    return true if @educator.districtwide_access?
+
+    return false if @educator.restricted_to_sped_students && !(student.program_assigned.in? ['Sp Ed', 'SEIP'])
+    return false if @educator.restricted_to_english_language_learners && student.limited_english_proficiency == 'Fluent'
+    return false if @educator.school_id.present? && student.school_id.present? && @educator.school_id != student.school_id
+
+    return true if @educator.schoolwide_access? || @educator.admin? # Schoolwide admin
+    return true if @educator.has_access_to_grade_levels? && student.grade.in?(@educator.grade_level_access) # Grade level access
+    return true if student.in?(@educator.students) # Homeroom level access
+    return true if student.in?(@educator.section_students) # Section level access
+    false
+  end
+end

--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -1,20 +1,20 @@
 # This class defines authorization rules.
 # If you want student data, ask through this class.
-# Ideally, start with using `authorized_only`.
+# Ideally, start with using `authorized`.
 # Drop down to calling individual methods if you need to.
 #
 # This class should be fully tested, and all changes should be reviewed.
 #
 # Controller usage:
-#   student = authorized_only { Student.find(params[:id]) }
-#   homeroom = authorized_only { Homeroom.(params[:id]) }
-#   students = authorized_only { homeroom.students }
+#   student = authorized { Student.find(params[:id]) }
+#   homeroom = authorized { Homeroom.(params[:id]) }
+#   students = authorized { homeroom.students }
 #
 # Standalone usage:
 #   authorizer = Authorizer.new(educator)
-#   student = authorizer.authorized_only { Student.find(params[:id]) }
-#   homeroom = authorizer.authorized_only { Homeroom.(params[:id]) }
-#   students = authorizer.authorized_only { homeroom.students }
+#   student = authorizer.authorized { Student.find(params[:id]) }
+#   homeroom = authorizer.authorized { Homeroom.(params[:id]) }
+#   students = authorizer.authorized { homeroom.students }
 #
 # Instead of:
 #   Homeroom.find(id).students # no authorization check
@@ -23,30 +23,52 @@
 #   current_educator.school.students # doesn't work for all roles
 #
 class Authorizer
+  # These fields are required on the `Student` model for
+  # authorization checks
+  def self.student_fields_for_authorization
+    [
+      :id,
+      :program_assigned,
+      :limited_english_proficiency,
+      :school_id,
+      :grade
+    ]
+  end
+
   def initialize(educator)
     @educator = educator
-    @authorized_only = AuthorizedOnly.new(self)
+    @authorized_dispatcher = AuthorizedDispatcher.new(self)
   end
 
   # Usage:
-  #  student = authorized_only { Student.find(params[:id]) }
-  def authorized_only(&block)
-    @authorized_only.dispatch(&block)
+  #  student = authorized { Student.find(params[:id]) }
+  def authorized(&block)
+    @authorized_dispatcher.dispatch(&block)
   end
 
   # This method is the source of truth for whether an educator is authorized to view information about a particular
   # student.
   def is_authorized_for_student?(student)
-    return true if @educator.districtwide_access?
+    begin
+      return true if @educator.districtwide_access?
 
-    return false if @educator.restricted_to_sped_students && !(student.program_assigned.in? ['Sp Ed', 'SEIP'])
-    return false if @educator.restricted_to_english_language_learners && student.limited_english_proficiency == 'Fluent'
-    return false if @educator.school_id.present? && student.school_id.present? && @educator.school_id != student.school_id
+      return false if @educator.restricted_to_sped_students && !(student.program_assigned.in? ['Sp Ed', 'SEIP'])
+      return false if @educator.restricted_to_english_language_learners && student.limited_english_proficiency == 'Fluent'
+      return false if @educator.school_id.present? && student.school_id.present? && @educator.school_id != student.school_id
 
-    return true if @educator.schoolwide_access? || @educator.admin? # Schoolwide admin
-    return true if @educator.has_access_to_grade_levels? && student.grade.in?(@educator.grade_level_access) # Grade level access
-    return true if student.in?(@educator.students) # Homeroom level access
-    return true if student.in?(@educator.section_students) # Section level access
+      return true if @educator.schoolwide_access? || @educator.admin? # Schoolwide admin
+      return true if @educator.has_access_to_grade_levels? && student.grade.in?(@educator.grade_level_access) # Grade level access
+      return true if student.in?(@educator.students) # Homeroom level access
+      return true if student.in?(@educator.section_students) # Section level access
+    rescue ActiveModel::MissingAttributeError => err
+      # We can't do authorization checks on models with `#select` that are missing
+      # fields.  If this happens, it's probably because the developer is trying to
+      # to optimize a query.  The authorization layer could only recover by making more
+      # queries, so instead we raise and force the developer to figure out how to resolve.
+      #
+      # See `Authorizer.student_fields_for_authorization`
+      raise err
+    end
     false
   end
 

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -17,13 +17,14 @@ class Educator < ActiveRecord::Base
 
   validates :email, presence: true, uniqueness: true
 
-  validate :has_school_unless_districtwide,
-           :admin_gets_access_to_all_students,
-           :grade_level_access_is_array_of_strings,
-           :grade_level_strings_are_valid,
-           :grade_level_strings_are_uniq,
-           :grade_level_access_is_not_nil
+  validate :validate_has_school_unless_districtwide,
+           :validate_admin_gets_access_to_all_students,
+           :validate_grade_level_access_is_array_of_strings,
+           :validate_grade_level_strings_are_valid,
+           :validate_grade_level_strings_are_uniq,
+           :validate_grade_level_access_is_not_nil
 
+  # TODO(kr) this probably needs to be updated, there are a few copies of this
   VALID_GRADES = [ 'PK', 'KF', '1', '2', '3', '4', '5', '6', '7', '8' ].freeze
 
   # override
@@ -34,85 +35,26 @@ class Educator < ActiveRecord::Base
     super(options.merge({ except: [:student_searchbar_json] }))
   end
 
-  def has_school_unless_districtwide
-    if school.blank?
-      errors.add(:school_id, "must be assigned a school") unless districtwide_access?
-    end
-  end
-
-  def admin_gets_access_to_all_students
-    errors.add(:admin, "needs access to all students") if admin? && !has_access_to_all_students?
-  end
-
-  def grade_level_access_is_array_of_strings
-    unless grade_level_access.all? { |grade| grade.instance_of? String }
-      errors.add(:grade_level_access, "should be an array of strings")
-    end
-  end
-
-  def grade_level_strings_are_valid
-    if grade_level_access.any? { |grade| !(VALID_GRADES.include?(grade)) }
-      errors.add(:grade_level_access, "invalid grade")
-    end
-  end
-
-  def grade_level_strings_are_uniq
-    unless grade_level_access.uniq.size == grade_level_access.size
-      errors.add(:grade_level_access, "duplicate values")
-    end
-  end
-
-  def grade_level_access_is_not_nil
-    errors.add(:grade_level_access, "cannot be nil") if grade_level_access.nil?
-  end
-
-  # This method is the source of truth for whether an educator is authorized to view information about a particular
-  # student.
   def is_authorized_for_student(student)
-    return true if self.districtwide_access?
-
-    return false if self.restricted_to_sped_students && !(student.program_assigned.in? ['Sp Ed', 'SEIP'])
-    return false if self.restricted_to_english_language_learners && student.limited_english_proficiency == 'Fluent'
-    return false if self.school_id.present? && self.school_id != student.school_id
-
-    return true if self.schoolwide_access? || self.admin? # Schoolwide admin
-    return true if self.has_access_to_grade_levels? && student.grade.in?(self.grade_level_access) # Grade level access
-    return true if student.in?(self.students) # Homeroom level access
-    return true if student.in?(self.section_students) # Section level access
-    false
+    Authorizer.new(self).is_authorized_for_student?(student)
   end
 
-  def is_authorized_for_school(currentSchool)
-    self.districtwide_access? ||
-    (self.schoolwide_access? && self.school == currentSchool) ||
-    (self.has_access_to_grade_levels? && self.school == currentSchool)
+  def is_authorized_for_school(current_school)
+    Authorizer.new(self).is_authorized_for_school?(current_school)
   end
 
   def is_authorized_for_section(section)
-    return true if self.districtwide_access?
-
-    return false if self.school.present? && self.school != section.course.school
-
-    return true if self.schoolwide_access? || self.admin?
-    return true if section.in?(self.sections)
-    false
+    Authorizer.new(self).is_authorized_for_section?(section)
   end
 
   def students_for_school_overview(*additional_includes)
-    return [] unless school.present?
-
-    if schoolwide_access?
-      school.students
-            .active
-            .includes(additional_includes || [])
-    elsif has_access_to_grade_levels?
-      school.students
-            .active
-            .where(grade: self.grade_level_access)
-            .includes(additional_includes || [])
-    else
+    students = Authorizer.new(self).students_for_school_overview
+    if students.respond_to?(:includes)
+      students.includes(additional_includes || [])
+    elsif students.size == 0
       logger.warn("Fell through to empty array in #students_for_school_overview for educator_id: #{self.id}")
-      []
+    else
+      students
     end
   end
 
@@ -128,39 +70,17 @@ class Educator < ActiveRecord::Base
     raise Exceptions::NoAssignedSections                    # <= Logged-in educator has no assigned section
   end
 
+  # TODO(kr) flagged for next pass
   def has_access_to_grade_levels?
     grade_level_access.present? && grade_level_access.size > 0
   end
 
   def allowed_homerooms
-    # Educator can visit roster view for these homerooms
-    return [] if school.nil?
-
-    if districtwide_access?
-      Homeroom.all
-    elsif schoolwide_access?
-      school.homerooms.all
-    elsif homeroom
-      school.homerooms.where(grade: homeroom.grade)
-    elsif grade_level_access.present?
-      school.homerooms.where(grade: grade_level_access)
-    else
-      []
-    end
+    Authorizer.new(self).homerooms
   end
 
   def allowed_sections
-    if districtwide_access?
-      Section.all
-    elsif schoolwide_access?
-      Section.joins(:course).where('courses.school_id = ?', school.id)
-    else
-      sections
-    end
-  end
-
-  def allowed_homerooms_by_name
-    allowed_homerooms.order(:name)
+    Authorizer.new(self).sections
   end
 
   def self.to_index
@@ -169,17 +89,6 @@ class Educator < ActiveRecord::Base
 
   def for_index
     as_json.symbolize_keys.slice(:id, :email, :full_name)
-  end
-
-  def permissions_hash
-    {
-      admin: admin,
-      school: school,
-      schoolwide_access: schoolwide_access,
-      grade_level_access: grade_level_access,
-      restricted_to_sped_students: restricted_to_sped_students,
-      restricted_to_english_language_learners: restricted_to_english_language_learners,
-    }
   end
 
   def self.save_student_searchbar_json
@@ -198,18 +107,39 @@ class Educator < ActiveRecord::Base
   end
 
   private
-
-  def has_access_to_no_students?
-    schoolwide_access == false && grade_level_access == [] && homeroom.blank?
+  def validate_has_school_unless_districtwide
+    if school.blank?
+      errors.add(:school_id, "must be assigned a school") unless districtwide_access?
+    end
   end
 
-  def has_grade_level_access?
-    grade_level_access != [] && !grade_level_access.nil?
+  def validate_admin_gets_access_to_all_students
+    has_acces_to_all_students = (
+      restricted_to_sped_students == false &&
+      restricted_to_english_language_learners == false
+    )
+    errors.add(:admin, "needs access to all students") if admin? && !has_acces_to_all_students
   end
 
-  def has_access_to_all_students?
-    restricted_to_sped_students == false &&
-    restricted_to_english_language_learners == false
+  def validate_grade_level_access_is_array_of_strings
+    unless grade_level_access.all? { |grade| grade.instance_of? String }
+      errors.add(:grade_level_access, "should be an array of strings")
+    end
   end
 
+  def validate_grade_level_strings_are_valid
+    if grade_level_access.any? { |grade| !(VALID_GRADES.include?(grade)) }
+      errors.add(:grade_level_access, "invalid grade")
+    end
+  end
+
+  def validate_grade_level_strings_are_uniq
+    unless grade_level_access.uniq.size == grade_level_access.size
+      errors.add(:grade_level_access, "duplicate values")
+    end
+  end
+
+  def validate_grade_level_access_is_not_nil
+    errors.add(:grade_level_access, "cannot be nil") if grade_level_access.nil?
+  end
 end

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -25,7 +25,7 @@ class Educator < ActiveRecord::Base
            :validate_grade_level_access_is_not_nil
 
   # TODO(kr) this probably needs to be updated, there are a few copies of this
-  VALID_GRADES = [ 'PK', 'KF', '1', '2', '3', '4', '5', '6', '7', '8' ].freeze
+  VALID_GRADES = [ 'PK', 'KF', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12' ].freeze
 
   # override
   # The `student_searchbar_json` field can be really heavy (~500kb), and

--- a/app/models/event_note.rb
+++ b/app/models/event_note.rb
@@ -9,4 +9,7 @@ class EventNote < ActiveRecord::Base
 
   validates :educator_id, :student_id, :event_note_type_id, :recorded_at, presence: true
   validates :is_restricted, inclusion: { in: [true, false] }
+
+  scope :restricted, -> { where(is_restricted: true) } # no authorization check
+  scope :without_restricted, -> { where(is_restricted: false) }
 end

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -1,5 +1,11 @@
 require 'rails_helper'
 
+# TODO(KR) don't forget to manually merge this with changes that got rebased away
+
+
+
+
+
 def create_service(student, educator)
   FactoryGirl.create(:service, {
     student: student,
@@ -15,19 +21,48 @@ def create_event_note(student, educator)
   })
 end
 
+def expected_service_types_index
+  {
+    502 => {:id=>502, :name=>"Attendance Officer"},
+    503 => {:id=>503, :name=>"Attendance Contract"},
+    504 => {:id=>504, :name=>"Behavior Contract"},
+    505 => {:id=>505, :name=>"Counseling, in-house"},
+    506 => {:id=>506, :name=>"Counseling, outside"},
+    507 => {:id=>507, :name=>"Reading intervention"},
+    508 => {:id=>508, :name=>"Math intervention"},
+    509 => {:id=>509, :name=>"SomerSession"},
+    510 => {:id=>510, :name=>"Summer Program for English Language Learners"},
+    511 => {:id=>511, :name=>"Afterschool Tutoring"},
+    512 => {:id=>512, :name=>"Freedom School"},
+    513 => {:id=>513, :name=>"Community Schools"},
+    514 => {:id=>514, :name=>"X-Block"},
+  }
+end
+
+def expected_event_note_types_index
+  {
+    300 => {:id=>300, :name=>"SST Meeting"},
+    301 => {:id=>301, :name=>"MTSS Meeting"},
+    302 => {:id=>302, :name=>"Parent conversation"},
+    304 => {:id=>304, :name=>"Something else"},
+    305 => {:id=>305, :name=>"9th Grade Experience"},
+    306 => {:id=>306, :name=>"10th Grade Experience"},
+  }
+end
+
+def expected_empty_feed
+  {
+    event_notes: [],
+    services: {active: [], discontinued: []},
+    deprecated: {interventions: []}
+  }
+end
+
+
 describe StudentsController, :type => :controller do
+  let!(:pals) { TestPals.create! }
 
   describe '#show' do
-    let!(:school) { FactoryGirl.create(:school) }
-    let(:educator) { FactoryGirl.create(:educator_with_homeroom) }
-    let(:other_educator) { FactoryGirl.create(:educator, full_name: "Teacher, Louis") }
-    let(:student) { FactoryGirl.create(:student, :with_risk_level, school: school) }
-    let(:course) { FactoryGirl.create(:course, school: school) }
-    let(:section) { FactoryGirl.create(:section, course: course) }
-    let!(:ssa) { FactoryGirl.create(:student_section_assignment, student: student, section: section) }
-    let!(:esa) { FactoryGirl.create(:educator_section_assignment, educator: other_educator, section: section)}
-    let(:homeroom) { student.homeroom }
-
     def make_request(options = { student_id: nil, format: :html })
       request.env['HTTPS'] = 'on'
       get :show, params: {
@@ -36,575 +71,629 @@ describe StudentsController, :type => :controller do
       }
     end
 
-    context 'when educator is not logged in' do
-      it 'redirects to sign in page' do
+    describe 'controls authorization' do
+      it 'limits access to the endpoint' do
+        pending
+      end
+
+      it 'limits information about restricted notes' do
+        pending
+      end
+    end
+
+    describe 'kindergarten student' do
+      let!(:educator) { pals.uri }
+      let!(:student) { pals.healey_kindergarten_student }
+      before { sign_in(educator) }
+
+      it 'assigns serialized data correctly' do
         make_request({ student_id: student.id, format: :html })
-        expect(response).to redirect_to(new_educator_session_path)
-      end
-    end
+        expect(response.status).to eq 200
+        serialized_data = assigns(:serialized_data)
 
-    context 'when educator is logged in' do
-      before { sign_in(educator) }
-
-      context 'educator has schoolwide access' do
-        let(:educator) { FactoryGirl.create(:educator, :admin, school: school) }
-        let(:serialized_data) { assigns(:serialized_data) }
-
-        it 'is successful' do
-          make_request({ student_id: student.id, format: :html })
-          expect(response).to be_success
-        end
-
-        it 'assigns the student\'s serialized data correctly' do
-          make_request({ student_id: student.id, format: :html })
-          expect(serialized_data[:current_educator]).to eq educator
-          expect(serialized_data[:student]["id"]).to eq student.id
-          expect(serialized_data[:student]["restricted_notes_count"]).to eq 0
-
-          expect(serialized_data[:dibels]).to eq []
-          expect(serialized_data[:feed]).to eq ({
-            event_notes: [],
-            services: {active: [], discontinued: []},
-            deprecated: {interventions: []}
-          })
-
-          expect(serialized_data[:service_types_index]).to eq({
-            502 => {:id=>502, :name=>"Attendance Officer"},
-            503 => {:id=>503, :name=>"Attendance Contract"},
-            504 => {:id=>504, :name=>"Behavior Contract"},
-            505 => {:id=>505, :name=>"Counseling, in-house"},
-            506 => {:id=>506, :name=>"Counseling, outside"},
-            507 => {:id=>507, :name=>"Reading intervention"},
-            508 => {:id=>508, :name=>"Math intervention"},
-            509 => {:id=>509, :name=>"SomerSession"},
-            510 => {:id=>510, :name=>"Summer Program for English Language Learners"},
-            511 => {:id=>511, :name=>"Afterschool Tutoring"},
-            512 => {:id=>512, :name=>"Freedom School"},
-            513 => {:id=>513, :name=>"Community Schools"},
-            514 => {:id=>514, :name=>"X-Block"},
-          })
-
-          expect(serialized_data[:event_note_types_index].keys).to match_array([
-            300, 301, 302, 304, 305, 306
-          ])
-
-          expect(serialized_data[:event_note_types_index].values).to match_array([
-            {:id=>300, :name=>"SST Meeting"},
-            {:id=>301, :name=>"MTSS Meeting"},
-            {:id=>302, :name=>"Parent conversation"},
-            {:id=>304, :name=>"Something else"},
-            {:id=>305, :name=>"9th Grade Experience"},
-            {:id=>306, :name=>"10th Grade Experience"},
-          ])
-
-          expect(serialized_data[:educators_index]).to include({
-            educator.id => {:id=>educator.id, :email=>educator.email, :full_name=>nil}
-          })
-
-          expect(serialized_data[:attendance_data].keys).to eq [
-            :discipline_incidents, :tardies, :absences
-          ]
-
-          expect(serialized_data[:sections].length).to equal(1)
-          expect(serialized_data[:sections][0]["id"]).to eq(section.id)
-          expect(serialized_data[:sections][0]["grade_numeric"]).to eq(ssa.grade_numeric)
-          expect(serialized_data[:sections][0]["educators"][0]["full_name"]).to eq(other_educator.full_name)
-          expect(serialized_data[:current_educator_allowed_sections]).to include(section.id)
-        end
-
-        context 'student has multiple discipline incidents' do
-          let!(:student) { FactoryGirl.create(:student, school: school) }
-          let(:most_recent_school_year) { student.most_recent_school_year }
-          let(:serialized_data) { assigns(:serialized_data) }
-          let(:attendance_data) { serialized_data[:attendance_data] }
-          let(:discipline_incidents) { attendance_data[:discipline_incidents] }
-
-          let!(:more_recent_incident) {
-            FactoryGirl.create(
-              :discipline_incident,
-              student: student,
-              occurred_at: Time.now - 1.day
-            )
-          }
-
-          let!(:less_recent_incident) {
-            FactoryGirl.create(
-              :discipline_incident,
-              student: student,
-              occurred_at: Time.now - 2.days
-            )
-          }
-
-          it 'sets the correct order' do
-            make_request({ student_id: student.id, format: :html })
-            expect(discipline_incidents).to eq [more_recent_incident, less_recent_incident]
-          end
-        end
-      end
-
-      context 'educator has grade level access' do
-        let(:educator) { FactoryGirl.create(:educator, grade_level_access: [student.grade], school: school )}
-
-        it 'is successful' do
-          make_request({ student_id: student.id, format: :html })
-          expect(response).to be_success
-        end
-      end
-
-      context 'educator has homeroom access' do
-        let(:educator) { FactoryGirl.create(:educator, school: school) }
-        before { homeroom.update(educator: educator) }
-
-        it 'is successful' do
-          make_request({ student_id: student.id, format: :html })
-          expect(response).to be_success
-        end
-      end
-
-      context 'educator has section access' do
-        let!(:educator) { FactoryGirl.create(:educator, school: school)}
-        let!(:course) { FactoryGirl.create(:course, school: school)}
-        let!(:section) { FactoryGirl.create(:section) }
-        let!(:esa) { FactoryGirl.create(:educator_section_assignment, educator: educator, section: section) }
-        let!(:section_student) { FactoryGirl.create(:student, school: school) }
-        let!(:ssa) { FactoryGirl.create(:student_section_assignment, student: section_student, section: section) }
-
-        it 'is successful' do
-          make_request({ student_id: section_student.id, format: :html })
-          expect(response).to be_success
-        end
-      end
-
-      context 'educator does not have schoolwide, grade level, or homeroom access' do
-        let(:educator) { FactoryGirl.create(:educator, school: school) }
-
-        it 'fails' do
-          make_request({ student_id: student.id, format: :html })
-          expect(response).to redirect_to(not_authorized_path)
-        end
-      end
-
-      context 'educator has some grade level access but for the wrong grade' do
-        let(:student) { FactoryGirl.create(:student, :with_risk_level, grade: '1', school: school) }
-        let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['KF'], school: school) }
-
-        it 'fails' do
-          make_request({ student_id: student.id, format: :html })
-          expect(response).to redirect_to(not_authorized_path)
-        end
-      end
-
-      context 'educator access restricted to SPED students' do
-        let(:educator) { FactoryGirl.create(:educator,
-                                            grade_level_access: ['1'],
-                                            restricted_to_sped_students: true,
-                                            school: school )
-        }
-
-        context 'student in SPED' do
-          let(:student) { FactoryGirl.create(:student,
-                                              :with_risk_level,
-                                              grade: '1',
-                                              program_assigned: 'Sp Ed',
-                                              school: school)
-          }
-
-          it 'is successful' do
-            make_request({ student_id: student.id, format: :html })
-            expect(response).to be_success
-          end
-        end
-
-        context 'student in Reg Ed' do
-          let(:student) { FactoryGirl.create(:student,
-                                              :with_risk_level,
-                                              grade: '1',
-                                              program_assigned: 'Reg Ed')
-          }
-
-          it 'fails' do
-            make_request({ student_id: student.id, format: :html })
-            expect(response).to redirect_to(not_authorized_path)
-          end
-        end
-
-      end
-
-      context 'educator access restricted to ELL students' do
-        let(:educator) { FactoryGirl.create(:educator,
-                                            grade_level_access: ['1'],
-                                            restricted_to_english_language_learners: true,
-                                            school: school )
-        }
-
-        context 'limited English proficiency' do
-          let(:student) { FactoryGirl.create(:student,
-                                              :with_risk_level,
-                                              grade: '1',
-                                              limited_english_proficiency: 'FLEP',
-                                              school: school)
-          }
-
-          it 'is successful' do
-            make_request({ student_id: student.id, format: :html })
-            expect(response).to be_success
-          end
-        end
-
-        context 'fluent in English' do
-          let(:student) { FactoryGirl.create(:student,
-                                              :with_risk_level,
-                                              grade: '1',
-                                              limited_english_proficiency: 'Fluent')
-          }
-
-          it 'fails' do
-            make_request({ student_id: student.id, format: :html })
-            expect(response).to redirect_to(not_authorized_path)
-          end
-        end
-      end
-    end
-  end
-
-  describe '#service' do
-    let!(:school) { FactoryGirl.create(:school) }
-
-    def make_post_request(student, service_params = {})
-      request.env['HTTPS'] = 'on'
-      post :service, params: {
-        format: :json,
-        id: student.id,
-        service: service_params
-      }
-    end
-
-    context 'admin educator logged in' do
-      let!(:educator) { FactoryGirl.create(:educator, :admin, school: school) }
-      let!(:provided_by_educator) { FactoryGirl.create(:educator, school: school) }
-      let!(:student) { FactoryGirl.create(:student, school: school) }
-
-      before do
-        sign_in(educator)
-      end
-
-      context 'when valid request' do
-        let!(:post_params) do
-          {
-            student_id: student.id,
-            service_type_id: 503,
-            date_started: '2016-02-22',
-            provided_by_educator_id: provided_by_educator.id
-          }
-        end
-
-        it 'creates a new service' do
-          expect { make_post_request(student, post_params) }.to change(Service, :count).by 1
-        end
-
-        it 'responds with JSON' do
-          make_post_request(student, post_params)
-          expect(response.status).to eq 200
-          make_post_request(student, post_params)
-          expect(response.headers["Content-Type"]).to eq 'application/json; charset=utf-8'
-          expect(JSON.parse(response.body).keys).to contain_exactly(
-            'id',
-            'student_id',
-            'provided_by_educator_name',
-            'recorded_by_educator_id',
-            'service_type_id',
-            'recorded_at',
-            'date_started',
-            'discontinued_by_educator_id',
-            'discontinued_recorded_at',
-            'estimated_end_date'
-          )
-        end
-      end
-
-      context 'when recorded_by_educator_id' do
-        it 'ignores the educator_id' do
-          make_post_request(student, {
-            student_id: student.id,
-            service_type_id: 503,
-            date_started: '2016-02-22',
-            provided_by_educator_id: provided_by_educator.id,
-            recorded_by_educator_id: 350
-          })
-          response_body = JSON.parse(response.body)
-          expect(response_body['recorded_by_educator_id']).to eq educator.id
-          expect(response_body['recorded_by_educator_id']).not_to eq 350
-        end
-      end
-
-      context 'when missing params' do
-        it 'fails with error messages' do
-          make_post_request(student, { text: 'foo' })
-          expect(response.status).to eq 422
-          response_body = JSON.parse(response.body)
-          expect(response_body).to eq({
-            "errors" => [
-              "Student can't be blank",
-              "Service type can't be blank",
-              "Date started can't be blank"
-            ]
-          })
-        end
-      end
-    end
-  end
-
-  describe '#names' do
-    let(:school) { FactoryGirl.create(:healey) }
-
-    def make_request
-      request.env['HTTPS'] = 'on'
-      get :names, params: { format: :json }
-    end
-
-    context 'admin educator logged in, no cached student names' do
-      let!(:educator) { FactoryGirl.create(:educator, :admin, school: school) }
-      before { sign_in(educator) }
-      let!(:juan) {
-        FactoryGirl.create(
-          :student, first_name: 'Juan', last_name: 'P', school: school, grade: '5'
-        )
-      }
-
-      let!(:jacob) {
-        FactoryGirl.create(:student, first_name: 'Jacob', grade: '5')
-      }
-
-      it 'returns an array of student labels and ids that match educator\'s students' do
-        make_request
-        expect(response).to be_success
-        expect(JSON.parse(response.body)).to eq [
-          { "label" => "Juan P - HEA - 5", "id" => juan.id }
+        expect(serialized_data[:current_educator]).to eq educator
+        expect(serialized_data[:current_educator_allowed_sections]).to eq [
+          pals.shs_tuesday_biology_section.id,
+          pals.shs_thursday_biology_section.id
         ]
-      end
-    end
+        expect(serialized_data[:service_types_index]).to eq expected_service_types_index
+        expect(serialized_data[:event_note_types_index]).to eq expected_event_note_types_index
+        expect(serialized_data[:educators_index]).to include({
+          educator.id => {:id=>educator.id, :email=>educator.email, :full_name=>nil}
+        })
 
-    context 'admin educator logged in, cached student names' do
-      let!(:educator) {
-        FactoryGirl.create(
-          :educator, :admin,
-          school: school,
-          student_searchbar_json: "[{\"label\":\"Juan P - HEA - 5\",\"id\":\"700\"}]"
-        )
-      }
-      before { sign_in(educator) }
-
-      it 'returns an array of student labels and ids that match cached students' do
-        make_request
-        expect(response).to be_success
-        expect(JSON.parse(response.body)).to eq [
-          { "label" => "Juan P - HEA - 5", "id" => "700" }
+        expect(serialized_data[:student]["id"]).to eq student.id
+        expect(serialized_data[:student]["restricted_notes_count"]).to eq 0
+        expect(serialized_data[:dibels]).to eq []
+        expect(serialized_data[:feed]).to eq expected_empty_feed
+        expect(serialized_data[:attendance_data].keys).to eq [
+          :discipline_incidents, :tardies, :absences
         ]
-      end
-
-    end
-
-    context 'educator without authorization to students' do
-      let!(:educator) { FactoryGirl.create(:educator) }
-      before { sign_in(educator) }
-      let(:healey) { FactoryGirl.create(:healey) }
-      let!(:juan) { FactoryGirl.create(:student, first_name: 'Juan', school: healey, grade: '5') }
-
-      it 'returns an empty array' do
-        make_request
-        expect(JSON.parse(response.body)).to eq []
+        expect(serialized_data[:sections].length).to equal(0)
       end
     end
 
-    context 'educator not logged in' do
-      it 'is not successful' do
-        make_request
-        expect(response.status).to eq 401
-        expect(response.body).to include "You need to sign in before continuing."
-      end
-    end
-  end
-
-  describe '#serialize_student_for_profile' do
-    it 'returns a hash with the additional keys that UI code expects' do
-      student = FactoryGirl.create(:student)
-      serialized_student = controller.send(:serialize_student_for_profile, student)
-      expect(serialized_student.keys).to include(*[
-        'student_risk_level',
-        'absences_count',
-        'tardies_count',
-        'school_name',
-        'homeroom_name',
-        'discipline_incidents_count'
-      ])
-    end
-  end
-
-  describe '#student_feed' do
-    let(:student) { FactoryGirl.create(:student) }
-    let(:educator) { FactoryGirl.create(:educator, :admin) }
-    let!(:service) { create_service(student, educator) }
-    let!(:event_note) { create_event_note(student, educator) }
-
-    it 'returns services' do
-      feed = controller.send(:student_feed, student)
-      expect(feed.keys).to eq([:event_notes, :services, :deprecated])
-      expect(feed[:services].keys).to eq [:active, :discontinued]
-      expect(feed[:services][:discontinued].first[:id]).to eq service.id
-    end
-
-    it 'returns event notes' do
-      feed = controller.send(:student_feed, student)
-      event_notes = feed[:event_notes]
-
-      expect(event_notes.size).to eq 1
-      expect(event_notes.first[:student_id]).to eq(student.id)
-      expect(event_notes.first[:educator_id]).to eq(educator.id)
-    end
-
-    context 'after service is discontinued' do
-      it 'filters it' do
-        feed = controller.send(:student_feed, student)
-        expect(feed[:services][:active].size).to eq 0
-        expect(feed[:services][:discontinued].first[:id]).to eq service.id
-      end
-    end
-  end
-
-  describe '#restricted_notes' do
-    let!(:school) { FactoryGirl.create(:school) }
-    let(:educator) { FactoryGirl.create(:educator_with_homeroom) }
-    let(:student) { FactoryGirl.create(:student, school: school) }
-
-    def make_request(student)
-      request.env['HTTPS'] = 'on'
-      get :restricted_notes, params: { id: student.id }
-    end
-
-    context 'when educator is logged in' do
+    describe 'high school student' do
+      let!(:educator) { pals.uri }
+      let!(:student) { pals.shs_freshman_mari }
       before { sign_in(educator) }
 
-      context 'educator cannot view restricted notes' do
-        let(:educator) { FactoryGirl.create(:educator, :admin, can_view_restricted_notes: false, school: school) }
+      it 'assigns serialized_data correctly' do
+        make_request({ student_id: student.id, format: :html })
+        expect(response.status).to eq 200
+        serialized_data = assigns(:serialized_data)
 
-        it 'is not successful' do
-          make_request(student)
-          expect(response).to redirect_to(not_authorized_path)
-        end
-      end
+        expect(serialized_data[:current_educator]).to eq educator
+        expect(serialized_data[:current_educator_allowed_sections]).to eq 'foo'
+        expect(serialized_data[:service_types_index]).to eq expected_service_types_index
+        expect(serialized_data[:event_note_types_index]).to eq expected_event_note_types_index
+        expect(serialized_data[:educators_index]).to include({
+          educator.id => {:id=>educator.id, :email=>educator.email, :full_name=>nil}
+        })
 
-      context 'educator can view restricted notes but is not authorized for student' do
-        let(:educator) { FactoryGirl.create(:educator, schoolwide_access: false, can_view_restricted_notes: true, school: school) }
+        expect(serialized_data[:student]["id"]).to eq student.id
+        expect(serialized_data[:student]["restricted_notes_count"]).to eq 0
+        expect(serialized_data[:dibels]).to eq []
+        expect(serialized_data[:feed]).to eq expected_empty_feed
+        expect(serialized_data[:attendance_data].keys).to eq [
+          :discipline_incidents, :tardies, :absences
+        ]
 
-        it 'is not successful' do
-          make_request(student)
-          expect(response).to redirect_to(not_authorized_path)
-        end
-      end
-
-      context 'educator can view restricted notes' do
-        let(:educator) { FactoryGirl.create(:educator, :admin, can_view_restricted_notes: true, school: school) }
-
-        it 'is successful' do
-          make_request(student)
-          expect(response).to be_success
-        end
-      end
-    end
-  end
-
-  describe '#lasids' do
-    def make_request
-      request.env['HTTPS'] = 'on'
-      get :lasids, params: { format: :json }
-    end
-
-    before do
-      FactoryGirl.create(:student, local_id: '111')
-      FactoryGirl.create(:student, local_id: '222')
-    end
-
-    let(:parsed_response) { JSON.parse(response.body) }
-
-    context 'admin with districtwide access' do
-      let(:educator) { FactoryGirl.create(:educator, districtwide_access: true, admin: true) }
-      it 'returns an array of student lasids' do
-        sign_in(educator)
-        make_request
-        expect(parsed_response).to eq ["111", "222"]
-      end
-    end
-
-    context 'non-admin' do
-      let(:educator) { FactoryGirl.create(:educator) }
-      it 'does not return any lasids' do
-        sign_in(educator)
-        make_request
-        expect(parsed_response).to eq({ "error"=>"You don't have the correct authorization." })
-      end
-    end
-
-    context 'no educator logged in' do
-      it 'returns an error' do
-        make_request
-        expect(parsed_response).to eq({ "error"=>"You need to sign in before continuing." })
-      end
-    end
-  end
-
-  describe '#student_report' do
-    let(:educator) { FactoryGirl.create(:educator, :admin, school: school) }
-    let(:school) { FactoryGirl.create(:school) }
-    let(:student) { FactoryGirl.create(:student, :with_risk_level, school: school) }
-
-    def make_request(options = { student_id: nil, format: :pdf, from_date: '08/15/2015', to_date: '03/16/2017'})
-      request.env['HTTPS'] = 'on'
-      get :student_report, params: {
-        id: options[:student_id],
-        format: options[:format],
-        from_date: options[:from_date],
-        to_date: options[:to_date],
-        disable_js: true
-      }
-    end
-
-    context 'when educator is not logged in' do
-      it 'does not render a student report' do
-        make_request({ student_id: student.id, format: :pdf })
-        expect(response.status).to eq 401
-      end
-    end
-
-    context 'when educator is logged in' do
-      before do
-        sign_in(educator)
-        make_request({ student_id: student.id, format: :pdf, from_date: '08/15/2015', to_date: '03/16/2017' })
-      end
-
-      context 'educator has schoolwide access' do
-
-        it 'is successful' do
-          expect(response).to be_success
-        end
-
-        it 'assigns the student correctly' do
-          expect(assigns(:student)).to eq student
-        end
-
-        it 'assigns the student\'s services correctly with full history' do
-          old_service = FactoryGirl.create(:service, date_started: '2012-02-22', student: student, discontinued_at: '2012-05-21')
-          recent_service = FactoryGirl.create(:service, date_started: '2016-01-13', student: student, discontinued_at: nil)
-          expect(assigns(:services)).not_to include(old_service)
-          expect(assigns(:services)).to include(recent_service)
-        end
-
-        it 'assigns the student\'s notes correctly excluding restricted notes' do
-          restricted_note = FactoryGirl.create(:event_note, :restricted, student: student, educator: educator)
-          note = FactoryGirl.create(:event_note, student: student, educator: educator)
-          expect(assigns(:event_notes)).to include(note)
-          expect(assigns(:event_notes)).not_to include(restricted_note)
-        end
+        expect(serialized_data[:sections].length).to equal(1)
+        expect(serialized_data[:sections][0]["id"]).to eq(section.id)
+        expect(serialized_data[:sections][0]["grade_numeric"]).to eq(ssa.grade_numeric)
+        expect(serialized_data[:sections][0]["educators"][0]["full_name"]).to eq(other_educator.full_name)
       end
     end
   end
 end
+
+#     #     context 'student has multiple discipline incidents' do
+#     #       let!(:student) { FactoryGirl.create(:student, school: school) }
+#     #       let(:most_recent_school_year) { student.most_recent_school_year }
+#     #       let(:serialized_data) { assigns(:serialized_data) }
+#     #       let(:attendance_data) { serialized_data[:attendance_data] }
+#     #       let(:discipline_incidents) { attendance_data[:discipline_incidents] }
+
+#     #       let!(:more_recent_incident) {
+#     #         FactoryGirl.create(
+#     #           :discipline_incident,
+#     #           student: student,
+#     #           occurred_at: Time.now - 1.day
+#     #         )
+#     #       }
+
+#     #       let!(:less_recent_incident) {
+#     #         FactoryGirl.create(
+#     #           :discipline_incident,
+#     #           student: student,
+#     #           occurred_at: Time.now - 2.days
+#     #         )
+#     #       }
+
+#     #       it 'sets the correct order' do
+#     #         make_request({ student_id: student.id, format: :html })
+#     #         expect(discipline_incidents).to eq [more_recent_incident, less_recent_incident]
+#     #       end
+#     #     end
+#     #   end
+
+#       # context 'educator has grade level access' do
+#       #   let(:educator) { FactoryGirl.create(:educator, grade_level_access: [student.grade], school: school )}
+
+#       #   it 'is successful' do
+#       #     make_request({ student_id: student.id, format: :html })
+#       #     expect(response).to be_success
+#       #   end
+#       # end
+
+#       # context 'educator has homeroom access' do
+#       #   let(:educator) { FactoryGirl.create(:educator, school: school) }
+#       #   before { homeroom.update(educator: educator) }
+
+#       #   it 'is successful' do
+#       #     make_request({ student_id: student.id, format: :html })
+#       #     expect(response).to be_success
+#       #   end
+#       # end
+
+#       # context 'educator has section access' do
+#       #   let!(:educator) { FactoryGirl.create(:educator, school: school)}
+#       #   let!(:course) { FactoryGirl.create(:course, school: school)}
+#       #   let!(:section) { FactoryGirl.create(:section) }
+#       #   let!(:esa) { FactoryGirl.create(:educator_section_assignment, educator: educator, section: section) }
+#       #   let!(:section_student) { FactoryGirl.create(:student, school: school) }
+#       #   let!(:ssa) { FactoryGirl.create(:student_section_assignment, student: section_student, section: section) }
+
+#       #   it 'is successful' do
+#       #     make_request({ student_id: section_student.id, format: :html })
+#       #     expect(response).to be_success
+#       #   end
+#       # end
+
+#       # context 'educator does not have schoolwide, grade level, or homeroom access' do
+#       #   let(:educator) { FactoryGirl.create(:educator, school: school) }
+
+#       #   it 'fails' do
+#       #     make_request({ student_id: student.id, format: :html })
+#       #     expect(response).to redirect_to(not_authorized_path)
+#       #   end
+#       # end
+
+#       # context 'educator has some grade level access but for the wrong grade' do
+#       #   let(:student) { FactoryGirl.create(:student, :with_risk_level, grade: '1', school: school) }
+#       #   let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['KF'], school: school) }
+
+#       #   it 'fails' do
+#       #     make_request({ student_id: student.id, format: :html })
+#       #     expect(response).to redirect_to(not_authorized_path)
+#       #   end
+#       # end
+
+#       # context 'educator access restricted to SPED students' do
+#       #   let(:educator) { FactoryGirl.create(:educator,
+#       #                                       grade_level_access: ['1'],
+#       #                                       restricted_to_sped_students: true,
+#       #                                       school: school )
+#       #   }
+
+#       #   context 'student in SPED' do
+#       #     let(:student) { FactoryGirl.create(:student,
+#       #                                         :with_risk_level,
+#       #                                         grade: '1',
+#       #                                         program_assigned: 'Sp Ed',
+#       #                                         school: school)
+#       #     }
+
+#       #     it 'is successful' do
+#       #       make_request({ student_id: student.id, format: :html })
+#       #       expect(response).to be_success
+#       #     end
+#       #   end
+
+#       #   context 'student in Reg Ed' do
+#       #     let(:student) { FactoryGirl.create(:student,
+#       #                                         :with_risk_level,
+#       #                                         grade: '1',
+#       #                                         program_assigned: 'Reg Ed')
+#       #     }
+
+#       #     it 'fails' do
+#       #       make_request({ student_id: student.id, format: :html })
+#       #       expect(response).to redirect_to(not_authorized_path)
+#       #     end
+#       #   end
+
+#       # end
+
+#       # context 'educator access restricted to ELL students' do
+#       #   let(:educator) { FactoryGirl.create(:educator,
+#       #                                       grade_level_access: ['1'],
+#       #                                       restricted_to_english_language_learners: true,
+#       #                                       school: school )
+#       #   }
+
+#       #   context 'limited English proficiency' do
+#       #     let(:student) { FactoryGirl.create(:student,
+#       #                                         :with_risk_level,
+#       #                                         grade: '1',
+#       #                                         limited_english_proficiency: 'FLEP',
+#       #                                         school: school)
+#       #     }
+
+#       #     it 'is successful' do
+#       #       make_request({ student_id: student.id, format: :html })
+#       #       expect(response).to be_success
+#       #     end
+#       #   end
+
+#       #   context 'fluent in English' do
+#       #     let(:student) { FactoryGirl.create(:student,
+#       #                                         :with_risk_level,
+#       #                                         grade: '1',
+#       #                                         limited_english_proficiency: 'Fluent')
+#       #     }
+
+#       #     it 'fails' do
+#       #       make_request({ student_id: student.id, format: :html })
+#       #       expect(response).to redirect_to(not_authorized_path)
+#       #     end
+#       #   end
+#       # end
+#     # end
+#   # end
+
+#   describe '#service' do
+#     let!(:school) { FactoryGirl.create(:school) }
+
+#     def make_post_request(student, service_params = {})
+#       request.env['HTTPS'] = 'on'
+#       post :service, params: {
+#         format: :json,
+#         id: student.id,
+#         service: service_params
+#       }
+#     end
+
+#     context 'teacher logged in' do
+#       let!(:student) { FactoryGirl.create(:student, school: school) }
+#       let!(:homeroom) { student.homeroom }
+#       let!(:educator) { FactoryGirl.create(:educator, school: school, homeroom: homeroom) }
+#       let!(:provided_by_educator) { FactoryGirl.create(:educator, school: school) }
+
+#       before do
+#         sign_in(educator)
+#       end
+
+#       context 'when valid request' do
+#         let!(:post_params) do
+#           {
+#             student_id: student.id,
+#             service_type_id: 503,
+#             date_started: '2016-02-22',
+#             provided_by_educator_id: provided_by_educator.id
+#           }
+#         end
+
+#         it 'creates a new service' do
+#           expect { make_post_request(student, post_params) }.to change(Service, :count).by 1
+#         end
+
+#         it 'responds with JSON' do
+#           make_post_request(student, post_params)
+#           expect(response.status).to eq 200
+#           make_post_request(student, post_params)
+#           expect(response.headers["Content-Type"]).to eq 'application/json; charset=utf-8'
+#           expect(JSON.parse(response.body).keys).to contain_exactly(
+#             'id',
+#             'student_id',
+#             'provided_by_educator_name',
+#             'recorded_by_educator_id',
+#             'service_type_id',
+#             'recorded_at',
+#             'date_started',
+#             'discontinued_by_educator_id',
+#             'discontinued_recorded_at',
+#             'estimated_end_date'
+#           )
+#         end
+#       end
+
+#       context 'when recorded_by_educator_id' do
+#         it 'ignores the educator_id' do
+#           make_post_request(student, {
+#             student_id: student.id,
+#             service_type_id: 503,
+#             date_started: '2016-02-22',
+#             provided_by_educator_id: provided_by_educator.id,
+#             recorded_by_educator_id: 350
+#           })
+#           response_body = JSON.parse(response.body)
+#           expect(response_body['recorded_by_educator_id']).to eq educator.id
+#           expect(response_body['recorded_by_educator_id']).not_to eq 350
+#         end
+#       end
+
+#       context 'when unauthorized student_id' do
+#         it 'returns unauthorized' do
+#           unauthorized_student = FactoryGirl.create(:student)
+#           make_post_request(unauthorized_student, {
+#             student_id: unauthorized_student.id,
+#             text: 'foo'
+#           })
+#           expect(response.status).to eq 403
+#         end
+#       end
+
+#       context 'when malformed params' do
+#         it 'returns 400' do
+#           make_post_request(student, {})
+#           expect(response.status).to eq 400
+#         end
+#       end
+
+#       context 'when missing student_id' do
+#         it 'returns 404' do
+#           make_post_request(student, { text: 'foo' })
+#           expect(response.status).to eq 404
+#         end
+#       end
+
+#       context 'when missing params' do
+#         it 'fails with error messages' do
+#           make_post_request(student, {
+#             student_id: student.id,
+#             text: 'foo'
+#           })
+#           expect(response.status).to eq 422
+#           response_body = JSON.parse(response.body)
+#           expect(response_body).to eq({
+#             "errors" => [
+#               "Service type can't be blank",
+#               "Date started can't be blank"
+#             ]
+#           })
+#         end
+#       end
+#     end
+#   end
+
+#   describe '#names' do
+#     let(:school) { FactoryGirl.create(:healey) }
+
+#     def make_request
+#       request.env['HTTPS'] = 'on'
+#       get :names, params: { format: :json }
+#     end
+
+#     context 'admin educator logged in, no cached student names' do
+#       let!(:educator) { FactoryGirl.create(:educator, :admin, school: school) }
+#       before { sign_in(educator) }
+#       let!(:juan) {
+#         FactoryGirl.create(
+#           :student, first_name: 'Juan', last_name: 'P', school: school, grade: '5'
+#         )
+#       }
+
+#       let!(:jacob) {
+#         FactoryGirl.create(:student, first_name: 'Jacob', grade: '5')
+#       }
+
+#       it 'returns an array of student labels and ids that match educator\'s students' do
+#         make_request
+#         expect(response).to be_success
+#         expect(JSON.parse(response.body)).to eq [
+#           { "label" => "Juan P - HEA - 5", "id" => juan.id }
+#         ]
+#       end
+#     end
+
+#     context 'admin educator logged in, cached student names' do
+#       let!(:educator) {
+#         FactoryGirl.create(
+#           :educator, :admin,
+#           school: school,
+#           student_searchbar_json: "[{\"label\":\"Juan P - HEA - 5\",\"id\":\"700\"}]"
+#         )
+#       }
+#       before { sign_in(educator) }
+
+#       it 'returns an array of student labels and ids that match cached students' do
+#         make_request
+#         expect(response).to be_success
+#         expect(JSON.parse(response.body)).to eq [
+#           { "label" => "Juan P - HEA - 5", "id" => "700" }
+#         ]
+#       end
+
+#     end
+
+#     context 'educator without authorization to students' do
+#       let!(:educator) { FactoryGirl.create(:educator) }
+#       before { sign_in(educator) }
+#       let(:healey) { FactoryGirl.create(:healey) }
+#       let!(:juan) { FactoryGirl.create(:student, first_name: 'Juan', school: healey, grade: '5') }
+
+#       it 'returns an empty array' do
+#         make_request
+#         expect(JSON.parse(response.body)).to eq []
+#       end
+#     end
+
+#     context 'educator not logged in' do
+#       it 'is not successful' do
+#         make_request
+#         expect(response.status).to eq 401
+#         expect(response.body).to include "You need to sign in before continuing."
+#       end
+#     end
+#   end
+
+#   describe '#serialize_student_for_profile' do
+#     it 'returns a hash with the additional keys that UI code expects' do
+#       student = FactoryGirl.create(:student)
+#       restricted_notes = student.event_notes.where(is_restricted: true)
+#       serialized_student = controller.send(:serialize_student_for_profile, student, restricted_notes)
+#       expect(serialized_student.keys).to include(*[
+#         'student_risk_level',
+#         'absences_count',
+#         'tardies_count',
+#         'school_name',
+#         'homeroom_name',
+#         'discipline_incidents_count'
+#       ])
+#     end
+#   end
+
+#   describe '#student_feed' do
+#     let(:student) { FactoryGirl.create(:student) }
+#     let(:educator) { FactoryGirl.create(:educator, :admin) }
+#     let!(:service) { create_service(student, educator) }
+#     let!(:event_note) { create_event_note(student, educator) }
+
+#     it 'returns services' do
+#       feed = controller.send(:student_feed, student, student.event_notes)
+#       expect(feed.keys).to eq([:event_notes, :services, :deprecated])
+#       expect(feed[:services].keys).to eq [:active, :discontinued]
+#       expect(feed[:services][:active].first[:id]).to eq service.id
+#     end
+
+#     it 'returns event notes' do
+#       feed = controller.send(:student_feed, student, student.event_notes)
+#       event_notes = feed[:event_notes]
+
+#       expect(event_notes.size).to eq 1
+#       expect(event_notes.first[:student_id]).to eq(student.id)
+#       expect(event_notes.first[:educator_id]).to eq(educator.id)
+#     end
+
+#     context 'after service is discontinued' do
+#       before do
+#         DiscontinuedService.create!({
+#           service_id: service.id,
+#           recorded_by_educator_id: educator.id,
+#           discontinued_at: Time.now
+#         })
+#       end
+#       it 'filters it' do
+#         feed = controller.send(:student_feed, student, student.event_notes)
+#         expect(feed[:services][:active].size).to eq 0
+#         expect(feed[:services][:discontinued].first[:id]).to eq service.id
+#       end
+#     end
+#   end
+
+#   describe '#restricted_notes' do
+#     let!(:school) { FactoryGirl.create(:school) }
+#     let(:educator) { FactoryGirl.create(:educator_with_homeroom) }
+#     let(:student) { FactoryGirl.create(:student, school: school) }
+
+#     def make_request(student)
+#       request.env['HTTPS'] = 'on'
+#       get :restricted_notes, params: { id: student.id }
+#     end
+
+#     context 'when educator is logged in' do
+#       before { sign_in(educator) }
+
+#       context 'educator cannot view restricted notes' do
+#         let(:educator) { FactoryGirl.create(:educator, :admin, can_view_restricted_notes: false, school: school) }
+
+#         it 'is not successful' do
+#           make_request(student)
+#           expect(response).to redirect_to(not_authorized_path)
+#         end
+#       end
+
+#       context 'educator can view restricted notes but is not authorized for student' do
+#         let(:educator) { FactoryGirl.create(:educator, schoolwide_access: false, can_view_restricted_notes: true, school: school) }
+
+#         it 'is not successful' do
+#           make_request(student)
+#           expect(response).to redirect_to(not_authorized_path)
+#         end
+#       end
+
+#       context 'educator can view restricted notes' do
+#         let(:educator) { FactoryGirl.create(:educator, :admin, can_view_restricted_notes: true, school: school) }
+
+#         it 'is successful' do
+#           make_request(student)
+#           expect(response).to be_success
+#         end
+#       end
+#     end
+#   end
+
+#   describe '#lasids' do
+#     def make_request
+#       request.env['HTTPS'] = 'on'
+#       get :lasids, params: { format: :json }
+#     end
+
+#     before do
+#       School.seed_somerville_schools
+#       FactoryGirl.create(:student, local_id: '111')
+#       FactoryGirl.create(:student, local_id: '222')
+#     end
+
+#     let(:parsed_response) { JSON.parse(response.body) }
+#     let!(:healey) { School.find_by_local_id('HEA') }
+#     let!(:healey_kindergarten_homeroom) { FactoryGirl.create(:homeroom, school: healey) }
+#     let!(:healey_kindergarten_student) do
+#       FactoryGirl.create(:student, {
+#         local_id: '333',
+#         school: healey,
+#         homeroom: healey_kindergarten_homeroom,
+#         grade: 'KF'
+#       })
+#     end
+#     let!(:healey_teacher) do
+#       FactoryGirl.create(:educator, {
+#         school: healey,
+#         homeroom: healey_kindergarten_homeroom
+#       })
+#     end
+
+#     context 'admin with districtwide access' do
+#       let(:educator) { FactoryGirl.create(:educator, districtwide_access: true, admin: true) }
+#       it 'returns an array of student lasids' do
+#         sign_in(educator)
+#         make_request
+#         expect(parsed_response).to eq ['111', '222', '333']
+#       end
+#     end
+
+#     context 'healey_teacher' do
+#       it 'does not return any lasids' do
+#         sign_in(healey_teacher)
+#         make_request
+#         expect(parsed_response).to eq([])
+#       end
+#     end
+
+#     context 'no educator logged in' do
+#       it 'returns an error' do
+#         make_request
+#         expect(parsed_response).to eq({ "error"=>"You need to sign in before continuing." })
+#       end
+#     end
+#   end
+
+#   describe '#student_report' do
+#     let(:educator) { FactoryGirl.create(:educator, :admin, school: school) }
+#     let(:school) { FactoryGirl.create(:school) }
+#     let(:student) { FactoryGirl.create(:student, :with_risk_level, school: school) }
+
+#     def make_request(options = { student_id: nil, format: :pdf, from_date: '08/15/2015', to_date: '03/16/2017'})
+#       request.env['HTTPS'] = 'on'
+#       get :student_report, params: {
+#         id: options[:student_id],
+#         format: options[:format],
+#         from_date: options[:from_date],
+#         to_date: options[:to_date],
+#         disable_js: true
+#       }
+#     end
+
+#     context 'when educator is not logged in' do
+#       it 'does not render a student report' do
+#         make_request({ student_id: student.id, format: :pdf })
+#         expect(response.status).to eq 401
+#       end
+#     end
+
+#     context 'when educator is logged in' do
+#       before do
+#         sign_in(educator)
+#         make_request({ student_id: student.id, format: :pdf, from_date: '08/15/2015', to_date: '03/16/2017' })
+#       end
+
+#       context 'educator has schoolwide access' do
+
+#         it 'is successful' do
+#           expect(response).to be_success
+#         end
+
+#         it 'assigns the student correctly' do
+#           expect(assigns(:student)).to eq student
+#         end
+
+#         it 'assigns the student\'s services correctly with full history' do
+#           old_service = FactoryGirl.create(:service, date_started: '2012-02-22', student: student)
+#           FactoryGirl.create(:discontinued_service, service: old_service, discontinued_at: '2012-05-21')
+#           recent_service = FactoryGirl.create(:service, date_started: '2016-01-13', student: student)
+#           expect(assigns(:services)).not_to include(old_service)
+#           expect(assigns(:services)).to include(recent_service)
+#         end
+
+#         it 'assigns the student\'s notes correctly excluding restricted notes' do
+#           restricted_note = FactoryGirl.create(:event_note, :restricted, student: student, educator: educator)
+#           note = FactoryGirl.create(:event_note, student: student, educator: educator)
+#           expect(assigns(:event_notes)).to include(note)
+#           expect(assigns(:event_notes)).not_to include(restricted_note)
+#         end
+#       end
+#     end
+#   end
+# end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -1,6 +1,9 @@
 FactoryGirl.define do
 
   factory :school do
+    sequence(:state_id) {|n| n }
+    sequence(:slug) {|n| "slug#{n}" }
+    sequence(:local_id) {|n| "LOCAL_ID_#{n}" }
   end
 
   factory :healey, class: School do

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -1,0 +1,115 @@
+require 'spec_helper'
+
+# This is just sugar
+def authorized_only(educator, &block)
+  Authorizer.new(educator).authorized_only(&block)
+end
+
+def setup_test_context
+  {
+    # educators
+    districtwide_admin: FactoryGirl.create(:educator, districtwide_access: true),
+
+    # healey
+    healey: School.find_by_local_id('HEA'),
+    healey_kindergarten_homeroom: FactoryGirl.create(:homeroom, school: healey),
+    healey_kindergarten_student: FactoryGirl.create(:student, {
+      school: healey,
+      homeroom: healey_kindergarten_homeroom,
+      grade: 'KF'
+    }),
+    healey_teacher: FactoryGirl.create(:educator, {
+      school: healey,
+      homeroom: healey_kindergarten_homeroom
+    }),
+
+    # high school
+    shs: School.find_by_local_id('SHS'),
+    shs_homeroom: FactoryGirl.create(:homeroom, school: shs),
+    shs_student: FactoryGirl.create(:student, {
+      school: shs,
+      homeroom: shs_homeroom,
+      grade: '9'
+    }),
+    shs_teacher: FactoryGirl.create(:educator, school: shs)
+  }
+end
+
+RSpec.describe Authorizer do
+  before { School.seed_somerville_schools }
+  
+  # districtwide
+  let!(:districtwide_admin) do
+    FactoryGirl.create(:educator, districtwide_access: true)
+  end
+
+  # healey
+  let!(:healey) { School.find_by_local_id('HEA') }
+  let!(:healey_kindergarten_homeroom) { FactoryGirl.create(:homeroom, school: healey) }
+  let!(:healey_kindergarten_student) do
+    FactoryGirl.create(:student, {
+      school: healey,
+      homeroom: healey_kindergarten_homeroom,
+      grade: 'KF'
+    })
+  end
+  let!(:healey_teacher) do
+    FactoryGirl.create(:educator, {
+      school: healey,
+      homeroom: healey_kindergarten_homeroom
+    })
+  end
+
+  # high school
+  let!(:shs) { School.find_by_local_id('SHS') }
+  let!(:shs_homeroom) { FactoryGirl.create(:homeroom, school: shs) }
+  let!(:shs_student) do
+    FactoryGirl.create(:student, {
+      school: shs,
+      homeroom: shs_homeroom,
+      grade: '9'
+    })
+  end
+  let!(:shs_teacher) do
+    FactoryGirl.create(:educator, {
+      school: shs,
+      homeroom: shs_homeroom
+    })
+  end
+
+  it 'test context is setup correctly' do
+    expect(School.all.size).to eq 12
+    expect(Homeroom.all.size).to eq 2
+    expect(Student.unscoped.all.size).to eq 2
+    expect(Educator.all.size).to eq 3
+  end
+
+  describe 'Student' do
+    it 'limits access with Student.all' do
+      expect(authorized_only(districtwide_admin) { Student.all }).to eq [
+        healey_kindergarten_student,
+        shs_student
+      ]
+      expect(authorized_only(healey_teacher) { Student.all }).to eq [
+        healey_kindergarten_student
+      ]
+      expect(authorized_only(shs_teacher) { Student.all }).to eq [
+        shs_student
+      ]
+    end
+
+    it 'limits access for Student.find' do
+      expect(authorized_only(healey_teacher) { Student.find(shs_student.id) }).to eq nil
+    end
+
+    it 'limits access for arrays' do
+      expect(authorized_only(healey_teacher) { [shs_student, healey_kindergarten_student] }).to eq [healey_kindergarten_student]
+    end
+  end
+
+  describe 'other models' do
+    it 'raises on calls with unchecked models' do
+      expect { authorized_only(districtwide_admin) { Educator.all } }.to raise_error(Exceptions::EducatorNotAuthorized)
+    end
+  end
+end

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -5,70 +5,36 @@ def authorized(educator, &block)
   Authorizer.new(educator).authorized(&block)
 end
 
+# Take `as` and `bs`, and cross them all through the given block.
+# Return a list of results, with triples `[a, b, value]`
+# Useful for testing combinations of educators with different permissions,
+# and models with different properties.
+def test_grid(as, bs, &block)
+  triples = []
+  as.each do |a|
+    bs.each do |b|
+      value = block.call(a, b)
+      triples << [a, b, value]
+    end
+  end
+  triples
+end
+
+# Test that each line in a grid matches.
+# Do this individually for each line to get better
+# failure messages.
+def expect_grid_equals(actual, expected)
+  actual.each_with_index do |triple, index|
+    expect(actual[index]).to eq expected[index]
+  end
+end
+
 
 RSpec.describe Authorizer do
-  before { School.seed_somerville_schools }
-
-  # districtwide
-  let!(:districtwide_admin) do
-    FactoryGirl.create(:educator, districtwide_access: true)
-  end
-
-  # healey
-  let!(:healey) { School.find_by_local_id('HEA') }
-  let!(:healey_kindergarten_homeroom) { FactoryGirl.create(:homeroom, school: healey) }
-  let!(:healey_kindergarten_student) do
-    FactoryGirl.create(:student, {
-      school: healey,
-      homeroom: healey_kindergarten_homeroom,
-      grade: 'KF'
-    })
-  end
-  let!(:healey_teacher) do
-    FactoryGirl.create(:educator, {
-      school: healey,
-      homeroom: healey_kindergarten_homeroom
-    })
-  end
-  let!(:healey_ell_teacher) do
-    FactoryGirl.create(:educator, {
-      restricted_to_english_language_learners: true,
-      school: healey
-    })
-  end
-  let!(:healey_sped_teacher) do
-    FactoryGirl.create(:educator, {
-      restricted_to_sped_students: true,
-      school: healey
-    })
-  end
-
-  # high school
-  let!(:shs) { School.find_by_local_id('SHS') }
-  let!(:shs_homeroom) { FactoryGirl.create(:homeroom, school: shs) }
-  let!(:shs_student) do
-    FactoryGirl.create(:student, {
-      school: shs,
-      homeroom: shs_homeroom,
-      grade: '9'
-    })
-  end
-  let!(:shs_teacher) do
-    FactoryGirl.create(:educator, {
-      school: shs,
-      homeroom: shs_homeroom
-    })
-  end
-  let!(:shs_ninth_grade_counselor) do
-    FactoryGirl.create(:educator, {
-      school: shs,
-      grade_level_access: ['9']
-    })
-  end
-  
+  let!(:pals) { TestPals.create! }
 
   it 'sets up test context correctly' do
-    expect(School.all.size).to eq 12
+    expect(School.all.size).to eq 11
     expect(Homeroom.all.size).to eq 2
     expect(Student.all.size).to eq 2
     expect(Educator.all.size).to eq 6
@@ -87,12 +53,12 @@ RSpec.describe Authorizer do
 
     it 'works for authorization' do
       students = Student.select(*Authorizer.student_fields_for_authorization).all
-      expect(authorized(districtwide_admin) { students }).to eq [
-        healey_kindergarten_student,
-        shs_student
+      expect(authorized(pals.uri) { students }).to eq [
+        pals.healey_kindergarten_student,
+        pals.shs_student
       ]
-      expect(authorized(healey_teacher) { students }).to eq [healey_kindergarten_student]
-      expect(authorized(shs_teacher) { students }).to eq [shs_student]
+      expect(authorized(pals.healey_teacher) { students }).to eq [pals.healey_kindergarten_student]
+      expect(authorized(pals.shs_teacher) { students }).to eq [pals.shs_student]
     end
 
     it 'does not work when fields are missing' do
@@ -108,12 +74,12 @@ RSpec.describe Authorizer do
         # one of these educators should raise an error about a missing
         # attribute.
         expect do
-          authorized(districtwide_admin) { students }
-          authorized(healey_teacher) { students }
-          authorized(healey_ell_teacher) { students }
-          authorized(healey_sped_teacher) { students }
-          authorized(shs_teacher) { students }
-          authorized(shs_ninth_grade_counselor) { students }
+          authorized(pals.uri) { students }
+          authorized(pals.healey_teacher) { students }
+          authorized(pals.healey_ell_teacher) { students }
+          authorized(pals.healey_sped_teacher) { students }
+          authorized(pals.shs_teacher) { students }
+          authorized(pals.shs_ninth_grade_counselor) { students }
         end.to raise_error(ActiveModel::MissingAttributeError)
       end
     end
@@ -122,86 +88,125 @@ RSpec.describe Authorizer do
   describe '#authorized' do
     describe 'Student' do
       it 'limits access with Student.all' do
-        expect(authorized(districtwide_admin) { Student.all }).to eq [
-          healey_kindergarten_student,
-          shs_student
+        expect(authorized(pals.uri) { Student.all }).to eq [
+          pals.healey_kindergarten_student,
+          pals.shs_student
         ]
-        expect(authorized(healey_teacher) { Student.all }).to eq [
-          healey_kindergarten_student
+        expect(authorized(pals.healey_teacher) { Student.all }).to eq [
+          pals.healey_kindergarten_student
         ]
-        expect(authorized(shs_teacher) { Student.all }).to eq [
-          shs_student
+        expect(authorized(pals.shs_teacher) { Student.all }).to eq [
+          pals.shs_student
         ]
       end
 
       it 'limits access for Student.find' do
-        expect(authorized(healey_teacher) { Student.find(shs_student.id) }).to eq nil
+        expect(authorized(pals.healey_teacher) { Student.find(pals.shs_student.id) }).to eq nil
       end
 
       it 'limits access for arrays' do
-        expect(authorized(healey_teacher) { [shs_student, healey_kindergarten_student] }).to eq [healey_kindergarten_student]
+        expect(authorized(pals.healey_teacher) { [pals.shs_student, pals.healey_kindergarten_student] }).to eq [pals.healey_kindergarten_student]
       end
 
       it 'raises if given a Student model with `#select` filtering out fields needed for authorization' do
-        thin_student = Student.select(:id, :local_id).find(shs_student.id)
-        expect(authorized(districtwide_admin) { thin_student }.attributes).to eq({
-          'id' => shs_student.id,
-          'local_id' => shs_student.local_id 
+        thin_student = Student.select(:id, :local_id).find(pals.shs_student.id)
+        expect(authorized(pals.uri) { thin_student }.attributes).to eq({
+          'id' => pals.shs_student.id,
+          'local_id' => pals.shs_student.local_id 
         })
-        expect { authorized(healey_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
-        expect { authorized(shs_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
+        expect { authorized(pals.healey_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
+        expect { authorized(pals.shs_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
       end
 
-      # Here the developer was probably trying to optimize the query, and we can adjust it
-      # a bit to get what we need for authorization.  So we do that and continue.
       it 'if `select` was used on an ActiveRecord::Relation for students, fields needed for authorization are added in' do
-        thin_student = Student.select(:id, :local_id).find(shs_student.id)
-        expect(authorized(districtwide_admin) { thin_student }.attributes).to eq({
-          'id' => shs_student.id,
-          'local_id' => shs_student.local_id 
+        thin_student = Student.select(:id, :local_id).find(pals.shs_student.id)
+        expect(authorized(pals.uri) { thin_student }.attributes).to eq({
+          'id' => pals.shs_student.id,
+          'local_id' => pals.shs_student.local_id 
         })
-        expect { authorized(healey_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
-        expect { authorized(shs_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
+        expect { authorized(pals.healey_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
+        expect { authorized(pals.shs_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
       end
     end
 
     describe 'EventNote' do
-      it 'works for EventNote.all' do
-        healey_public_note = FactoryGirl.create(:event_note, student: healey_kindergarten_student)
-        healey_restricted_note = FactoryGirl.create(:event_note, student: healey_kindergarten_student, is_restricted: true)
-        shs_public_note = FactoryGirl.create(:event_note, student: shs_student)
-        shs_restricted_note = FactoryGirl.create(:event_note, student: shs_student, is_restricted: true)
+      let!(:healey_public_note) { FactoryGirl.create(:event_note, student: pals.healey_kindergarten_student) }
+      let!(:healey_restricted_note) { FactoryGirl.create(:event_note, student: pals.healey_kindergarten_student, is_restricted: true) }
+      let!(:shs_public_note) { FactoryGirl.create(:event_note, student: pals.shs_student) }
+      let!(:shs_restricted_note) { FactoryGirl.create(:event_note, student: pals.shs_student, is_restricted: true) }
 
-        expect(authorized(districtwide_admin) { EventNote.all }).to eq [
+      it 'limits access for relation' do
+        expect(authorized(pals.uri) { EventNote.all }).to eq [
           healey_public_note,
           healey_restricted_note,
           shs_public_note,
           shs_restricted_note
         ]
-        expect(authorized(healey_teacher) { EventNote.all }).to eq [
+        expect(authorized(pals.healey_teacher) { EventNote.all }).to eq [
           healey_public_note
         ]
-        expect(authorized(shs_teacher) { EventNote.all }).to eq [
+        expect(authorized(pals.shs_teacher) { EventNote.all }).to eq [
           shs_public_note
+        ]
+      end
+
+      it 'limits access for array' do
+        all_notes = [
+          healey_public_note,
+          healey_restricted_note,
+          shs_public_note,
+          shs_restricted_note
+        ]
+        expect(authorized(pals.uri) { all_notes }).to eq [
+          healey_public_note,
+          healey_restricted_note,
+          shs_public_note,
+          shs_restricted_note
+        ]
+        expect(authorized(pals.healey_teacher) { all_notes }).to eq [
+          healey_public_note
+        ]
+        expect(authorized(pals.shs_teacher) { all_notes }).to eq [
+          shs_public_note
+        ]
+      end
+
+      it 'limits access for model' do
+        educators = [pals.uri, pals.healey_teacher, pals.shs_teacher]
+        notes = [healey_public_note, healey_restricted_note, shs_public_note, shs_restricted_note]
+        grid = test_grid(educators, notes) do |educator, note|
+          authorized(educator) { note } == note # check that they can access it
+        end
+        expect_grid_equals grid, [
+          [pals.uri, healey_public_note, true],
+          [pals.uri, healey_restricted_note, true],
+          [pals.uri, shs_public_note, true],
+          [pals.uri, shs_restricted_note, true],
+          [pals.healey_teacher, healey_public_note, true],
+          [pals.healey_teacher, healey_restricted_note, false],
+          [pals.healey_teacher, shs_public_note, false],
+          [pals.healey_teacher, shs_restricted_note, false],
+          [pals.shs_teacher, healey_public_note, false],
+          [pals.shs_teacher, healey_restricted_note, false],
+          [pals.shs_teacher, shs_public_note, true],
+          [pals.shs_teacher, shs_restricted_note, false]
         ]
       end
     end
 
     describe 'other models' do
       it 'raises on calls with unchecked models' do
-        expect { authorized(districtwide_admin) { Educator.all } }.to raise_error(Exceptions::EducatorNotAuthorized)
+        expect { authorized(pals.uri) { Educator.all } }.to raise_error(Exceptions::EducatorNotAuthorized)
       end
     end
   end
 
   describe '#is_authorized_for_student?' do
-    # This is built-in Rails behavior; we wait to raise if this happens, since developers are likely
-    # trying to write an optimization that the authorization layer will have to undo.
     it 'raises if `#select` was used on the `student` argument, and fields needed for authorization are missing' do
-      thin_student = Student.select(:id, :local_id).find(shs_student.id)
-      expect(Authorizer.new(districtwide_admin).is_authorized_for_student?(thin_student)).to eq true
-      expect { Authorizer.new(healey_teacher).is_authorized_for_student?(thin_student) }.to raise_error(ActiveModel::MissingAttributeError)
-      expect { Authorizer.new(shs_teacher).is_authorized_for_student?(thin_student) }.to raise_error(ActiveModel::MissingAttributeError)
+      thin_student = Student.select(:id, :local_id).find(pals.shs_student.id)
+      expect(Authorizer.new(pals.uri).is_authorized_for_student?(thin_student)).to eq true
+      expect { Authorizer.new(pals.healey_teacher).is_authorized_for_student?(thin_student) }.to raise_error(ActiveModel::MissingAttributeError)
+      expect { Authorizer.new(pals.shs_teacher).is_authorized_for_student?(thin_student) }.to raise_error(ActiveModel::MissingAttributeError)
     end
   end
 end

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -37,7 +37,7 @@ end
 
 RSpec.describe Authorizer do
   before { School.seed_somerville_schools }
-  
+
   # districtwide
   let!(:districtwide_admin) do
     FactoryGirl.create(:educator, districtwide_access: true)

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -1,39 +1,10 @@
 require 'spec_helper'
 
 # This is just sugar
-def authorized_only(educator, &block)
-  Authorizer.new(educator).authorized_only(&block)
+def authorized(educator, &block)
+  Authorizer.new(educator).authorized(&block)
 end
 
-def setup_test_context
-  {
-    # educators
-    districtwide_admin: FactoryGirl.create(:educator, districtwide_access: true),
-
-    # healey
-    healey: School.find_by_local_id('HEA'),
-    healey_kindergarten_homeroom: FactoryGirl.create(:homeroom, school: healey),
-    healey_kindergarten_student: FactoryGirl.create(:student, {
-      school: healey,
-      homeroom: healey_kindergarten_homeroom,
-      grade: 'KF'
-    }),
-    healey_teacher: FactoryGirl.create(:educator, {
-      school: healey,
-      homeroom: healey_kindergarten_homeroom
-    }),
-
-    # high school
-    shs: School.find_by_local_id('SHS'),
-    shs_homeroom: FactoryGirl.create(:homeroom, school: shs),
-    shs_student: FactoryGirl.create(:student, {
-      school: shs,
-      homeroom: shs_homeroom,
-      grade: '9'
-    }),
-    shs_teacher: FactoryGirl.create(:educator, school: shs)
-  }
-end
 
 RSpec.describe Authorizer do
   before { School.seed_somerville_schools }
@@ -59,6 +30,18 @@ RSpec.describe Authorizer do
       homeroom: healey_kindergarten_homeroom
     })
   end
+  let!(:healey_ell_teacher) do
+    FactoryGirl.create(:educator, {
+      restricted_to_english_language_learners: true,
+      school: healey
+    })
+  end
+  let!(:healey_sped_teacher) do
+    FactoryGirl.create(:educator, {
+      restricted_to_sped_students: true,
+      school: healey
+    })
+  end
 
   # high school
   let!(:shs) { School.find_by_local_id('SHS') }
@@ -76,40 +59,127 @@ RSpec.describe Authorizer do
       homeroom: shs_homeroom
     })
   end
+  let!(:shs_ninth_grade_counselor) do
+    FactoryGirl.create(:educator, {
+      school: shs,
+      grade_level_access: ['9']
+    })
+  end
+  
 
-  it 'test context is setup correctly' do
+  it 'sets up test context correctly' do
     expect(School.all.size).to eq 12
     expect(Homeroom.all.size).to eq 2
-    expect(Student.unscoped.all.size).to eq 2
-    expect(Educator.all.size).to eq 3
+    expect(Student.all.size).to eq 2
+    expect(Educator.all.size).to eq 6
   end
 
-  describe 'Student' do
-    it 'limits access with Student.all' do
-      expect(authorized_only(districtwide_admin) { Student.all }).to eq [
+  describe '.student_fields_for_authorization' do
+    it 'has the expected fields' do
+      expect(Authorizer.student_fields_for_authorization).to eq [
+        :id,
+        :program_assigned,
+        :limited_english_proficiency,
+        :school_id,
+        :grade
+      ]
+    end
+
+    it 'works for authorization' do
+      students = Student.select(*Authorizer.student_fields_for_authorization).all
+      expect(authorized(districtwide_admin) { students }).to eq [
         healey_kindergarten_student,
         shs_student
       ]
-      expect(authorized_only(healey_teacher) { Student.all }).to eq [
-        healey_kindergarten_student
-      ]
-      expect(authorized_only(shs_teacher) { Student.all }).to eq [
-        shs_student
-      ]
+      expect(authorized(healey_teacher) { students }).to eq [healey_kindergarten_student]
+      expect(authorized(shs_teacher) { students }).to eq [shs_student]
     end
 
-    it 'limits access for Student.find' do
-      expect(authorized_only(healey_teacher) { Student.find(shs_student.id) }).to eq nil
-    end
+    it 'does not work when fields are missing' do
+      test_fields = Authorizer.student_fields_for_authorization - [:id]
 
-    it 'limits access for arrays' do
-      expect(authorized_only(healey_teacher) { [shs_student, healey_kindergarten_student] }).to eq [healey_kindergarten_student]
+      # Test each of the required fields individually
+      test_fields.each do |missing_field|
+        some_fields = test_fields - [missing_field]
+        students = Student.select(*some_fields).all
+
+        # Different educator permissions check different field.
+        # When this particular required field is missing, the check for
+        # one of these educators should raise an error about a missing
+        # attribute.
+        expect do
+          authorized(districtwide_admin) { students }
+          authorized(healey_teacher) { students }
+          authorized(healey_ell_teacher) { students }
+          authorized(healey_sped_teacher) { students }
+          authorized(shs_teacher) { students }
+          authorized(shs_ninth_grade_counselor) { students }
+        end.to raise_error(ActiveModel::MissingAttributeError)
+      end
     end
   end
 
-  describe 'other models' do
-    it 'raises on calls with unchecked models' do
-      expect { authorized_only(districtwide_admin) { Educator.all } }.to raise_error(Exceptions::EducatorNotAuthorized)
+  describe '#authorized' do
+    describe 'Student' do
+      it 'limits access with Student.all' do
+        expect(authorized(districtwide_admin) { Student.all }).to eq [
+          healey_kindergarten_student,
+          shs_student
+        ]
+        expect(authorized(healey_teacher) { Student.all }).to eq [
+          healey_kindergarten_student
+        ]
+        expect(authorized(shs_teacher) { Student.all }).to eq [
+          shs_student
+        ]
+      end
+
+      it 'limits access for Student.find' do
+        expect(authorized(healey_teacher) { Student.find(shs_student.id) }).to eq nil
+      end
+
+      it 'limits access for arrays' do
+        expect(authorized(healey_teacher) { [shs_student, healey_kindergarten_student] }).to eq [healey_kindergarten_student]
+      end
+
+      it 'raises if given a Student model with `#select` filtering out fields needed for authorization' do
+        thin_student = Student.select(:id, :local_id).find(shs_student.id)
+        expect(authorized(districtwide_admin) { thin_student }.attributes).to eq({
+          'id' => shs_student.id,
+          'local_id' => shs_student.local_id 
+        })
+        expect { authorized(healey_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
+        expect { authorized(shs_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
+      end
+
+      # Here the developer was probably trying to optimize the query, and we can adjust it
+      # a bit to get what we need for authorization.  So we do that and continue.
+      it 'if `select` was used on an ActiveRecord::Relation for students, fields needed for authorization are added in' do
+        thin_student = Student.select(:id, :local_id).find(shs_student.id)
+        expect(authorized(districtwide_admin) { thin_student }.attributes).to eq({
+          'id' => shs_student.id,
+          'local_id' => shs_student.local_id 
+        })
+        expect { authorized(healey_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
+        expect { authorized(shs_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
+      end
+    end
+
+    describe 'other models' do
+      it 'raises on calls with unchecked models' do
+        expect { authorized(districtwide_admin) { Educator.all } }.to raise_error(Exceptions::EducatorNotAuthorized)
+      end
+    end
+  end
+
+  describe '#is_authorized_for_student?' do
+    # This is built-in Rails behavior; we wait to raise if this happens, since developers are likely
+    # trying to write an optimization that the authorization layer will have to undo.
+    it 'raises if `#select` was used on the `student` argument, and fields needed for authorization are missing' do
+      thin_student = Student.select(:id, :local_id).find(shs_student.id)
+      expect(Authorizer.new(districtwide_admin).is_authorized_for_student?(thin_student)).to eq true
+      expect { Authorizer.new(healey_teacher).is_authorized_for_student?(thin_student) }.to raise_error(ActiveModel::MissingAttributeError)
+      expect { Authorizer.new(shs_teacher).is_authorized_for_student?(thin_student) }.to raise_error(ActiveModel::MissingAttributeError)
     end
   end
 end

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -165,6 +165,28 @@ RSpec.describe Authorizer do
       end
     end
 
+    describe 'EventNote' do
+      it 'works for EventNote.all' do
+        healey_public_note = FactoryGirl.create(:event_note, student: healey_kindergarten_student)
+        healey_restricted_note = FactoryGirl.create(:event_note, student: healey_kindergarten_student, is_restricted: true)
+        shs_public_note = FactoryGirl.create(:event_note, student: shs_student)
+        shs_restricted_note = FactoryGirl.create(:event_note, student: shs_student, is_restricted: true)
+
+        expect(authorized(districtwide_admin) { EventNote.all }).to eq [
+          healey_public_note,
+          healey_restricted_note,
+          shs_public_note,
+          shs_restricted_note
+        ]
+        expect(authorized(healey_teacher) { EventNote.all }).to eq [
+          healey_public_note
+        ]
+        expect(authorized(shs_teacher) { EventNote.all }).to eq [
+          shs_public_note
+        ]
+      end
+    end
+
     describe 'other models' do
       it 'raises on calls with unchecked models' do
         expect { authorized(districtwide_admin) { Educator.all } }.to raise_error(Exceptions::EducatorNotAuthorized)

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -241,20 +241,6 @@ RSpec.describe Educator do
 
   end
 
-  describe '#allowed_homerooms_by_name' do
-    context 'admin' do
-      let(:school) { FactoryGirl.create(:healey) }
-      let(:educator) { FactoryGirl.create(:educator, schoolwide_access: true, school: school) }
-      let!(:homeroom_101) { FactoryGirl.create(:homeroom, name: 'Muskrats', school: school) }
-      let!(:homeroom_102) { FactoryGirl.create(:homeroom, name: 'Hawks', school: school) }
-      let!(:homeroom_103) { FactoryGirl.create(:homeroom, name: 'Badgers', school: school) }
-
-      it 'returns all homerooms\', ordered alphabetically by name' do
-        expect(educator.allowed_homerooms_by_name).to eq [homeroom_103, homeroom_102, homeroom_101]
-      end
-    end
-  end
-
   describe '#save_student_searchbar_json' do
     context 'educator has permissions for a few students' do
       let(:school) { FactoryGirl.create(:school, local_id: 'Big River High') }

--- a/spec/support/TestPals.rb
+++ b/spec/support/TestPals.rb
@@ -1,0 +1,84 @@
+# This class defines a set of users, schools, homerooms and students
+# that can be used for testing authorization rules.
+#
+# These can be re-used for any other test code, but changes here will impact
+# many tests, so the intention is that these should not change frequently.
+# If new attributes are added to models, update the factories instead.
+class TestPals
+  def self.create!
+    pals = TestPals.new
+    pals.create!
+    pals
+  end
+
+  attr_reader :uri
+  attr_reader :healey
+  attr_reader :healey_kindergarten_homeroom
+  attr_reader :healey_kindergarten_student
+  attr_reader :healey_teacher
+  attr_reader :healey_ell_teacher
+  attr_reader :healey_sped_teacher
+  attr_reader :shs
+  attr_reader :shs_homeroom
+  attr_reader :shs_student
+  attr_reader :shs_teacher
+  attr_reader :shs_ninth_grade_counselor
+
+  def create!
+    School.seed_somerville_schools
+
+    # Uri works in the central office, and is the admin for the entire
+    # project at the district.
+    @uri = FactoryGirl.create(:educator, {
+      email: 'uri@studentinsights.org',
+      districtwide_access: true,
+      admin: true,
+      schoolwide_access: true,
+      restricted_to_sped_students: false,
+      restricted_to_english_language_learners: false,
+      grade_level_access: [],
+      can_view_restricted_notes: true,
+      school: School.find_by_local_id('HEA')
+    })
+
+    # Healey is a K8 school.
+    @healey = School.find_by_local_id('HEA')
+    @healey_kindergarten_homeroom = FactoryGirl.create(:homeroom, school: healey)
+    @healey_kindergarten_student = FactoryGirl.create(:student, {
+      school: @healey,
+      homeroom: @healey_kindergarten_homeroom,
+      grade: 'KF'
+    })
+    @healey_teacher = FactoryGirl.create(:educator, {
+      school: @healey,
+      homeroom: @healey_kindergarten_homeroom
+    })
+    @healey_ell_teacher = FactoryGirl.create(:educator, {
+      restricted_to_english_language_learners: true,
+      school: @healey
+    })
+    @healey_sped_teacher = FactoryGirl.create(:educator, {
+      restricted_to_sped_students: true,
+      school: @healey
+    })
+
+    # high school
+    @shs = School.find_by_local_id('SHS')
+    @shs_homeroom = FactoryGirl.create(:homeroom, school: @shs)
+    @shs_student = FactoryGirl.create(:student, {
+      school: @shs,
+      homeroom: @shs_homeroom,
+      grade: '9'
+    })
+    @shs_teacher = FactoryGirl.create(:educator, {
+      school: @shs,
+      homeroom: @shs_homeroom
+    })
+    @shs_ninth_grade_counselor = FactoryGirl.create(:educator, {
+      school: @shs,
+      grade_level_access: ['9']
+    })
+
+    self
+  end
+end

--- a/spec/support/TestPals.rb
+++ b/spec/support/TestPals.rb
@@ -13,16 +13,20 @@ class TestPals
 
   attr_reader :uri
   attr_reader :healey
-  attr_reader :healey_kindergarten_homeroom
   attr_reader :healey_kindergarten_student
   attr_reader :healey_teacher
   attr_reader :healey_ell_teacher
   attr_reader :healey_sped_teacher
+  attr_reader :healey_kindergarten_homeroom
   attr_reader :shs
-  attr_reader :shs_homeroom
-  attr_reader :shs_student
-  attr_reader :shs_teacher
+  attr_reader :shs_freshman_mari
+  attr_reader :shs_jodi
+  attr_reader :shs_bill_nye
   attr_reader :shs_ninth_grade_counselor
+  attr_reader :shs_jodi_homeroom
+  attr_reader :shs_biology_course
+  attr_reader :shs_tuesday_biology_section
+  attr_reader :shs_thursday_biology_section
 
   def create!
     School.seed_somerville_schools
@@ -64,21 +68,41 @@ class TestPals
 
     # high school
     @shs = School.find_by_local_id('SHS')
-    @shs_homeroom = FactoryGirl.create(:homeroom, school: @shs)
-    @shs_student = FactoryGirl.create(:student, {
-      school: @shs,
-      homeroom: @shs_homeroom,
-      grade: '9'
-    })
-    @shs_teacher = FactoryGirl.create(:educator, {
-      school: @shs,
-      homeroom: @shs_homeroom
-    })
     @shs_ninth_grade_counselor = FactoryGirl.create(:educator, {
       school: @shs,
       grade_level_access: ['9']
     })
 
+    # Jodi has a homeroom period at the high school.
+    @shs_jodi_homeroom = FactoryGirl.create(:homeroom, school: @shs)
+    @shs_jodi = FactoryGirl.create(:educator, {
+      email: 'jodi@studentinsights.org',
+      school: @shs,
+      homeroom: @shs_jodi_homeroom
+    })
+
+    # Bill Nye is a biology teacher at Somerville High School.  He teaches sections
+    # on Tuesday and Thursday and has a homeroom period.
+    @shs_bill_nye_homeroom = FactoryGirl.create(:homeroom, school: @shs)
+    @shs_bill_nye = FactoryGirl.create(:educator, {
+      email: 'billnye@studentinsights.org',
+      school: @shs,
+      homeroom: @shs_bill_nye_homeroom
+    })
+    @shs_biology_course = FactoryGirl.create(:course, school: @shs)
+    @shs_tuesday_biology_section = FactoryGirl.create(:section, course: @shs_biology_course)
+    @shs_thursday_biology_section = FactoryGirl.create(:section, course: @shs_biology_course)
+    FactoryGirl.create(:educator_section_assignment, educator: @shs_bill_nye, section: @shs_tuesday_biology_section)
+    FactoryGirl.create(:educator_section_assignment, educator: @shs_bill_nye, section: @shs_thursday_biology_section)
+
+    # Mari is a freshman at the high school, enrolled in biology and in Jodi's homeroom.
+    @shs_freshman_mari = FactoryGirl.create(:student, {
+      school: @shs,
+      homeroom: @shs_jodi_homeroom,
+      grade: '9'
+    })
+    FactoryGirl.create(:student_section_assignment, student: @shs_freshman_mari, section: @shs_tuesday_biology_section)
+    
     self
   end
 end


### PR DESCRIPTION
This is for discussion with https://github.com/studentinsights/studentinsights/issues/1080.  This has two commits.

The first commit adds an Authorizer class, with a minimal implementation of what was called the "blocks-based API" in https://github.com/studentinsights/studentinsights/issues/1080.  The comments and tests there are consistent, and sketch the idea and usage.

The second commit is aimed at moving authorization code into the Authorizer class.  It doesn't update the call sites, and so Educator methods become shims into the Authorizer method calls for now.  This reveals in the Authorizer methods how there's different implementations of the authorization rules (even just from gathering together the methods in Educator, without looking at controller code yet).

The intention here is to give folks something concrete to look at and give feedback on in regards to https://github.com/studentinsights/studentinsights/issues/1080.  If this seems like a good direction, the next step might be "How would this work for the students_controller?" or "How would this affect performance?"  Those might be two additional commits, and then a natural point to decide about merging a chunk of work, and listing out what else would be needed to finish this off altogether.