### PR TITLE
Turn off ldap_create_user Devise config

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,7 +3,6 @@
 Devise.setup do |config|
   config.ldap_auth_username_builder = Proc.new() {|attribute, login, ldap| "#{login}" }
 
-  config.ldap_create_user = true
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.


### PR DESCRIPTION
# Notes 

I started digging around in the logs to start work on #1227 looking for LDAP-related errors in the logs.

I noticed some errors that weren't related to the LDAP fail during the Argenziano power outage. 

The errors looked like this: 

```
ActiveRecord::RecordInvalid (Validation failed: School must be assigned a school):
vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.3/lib/active_record/validations.rb:78:in `raise_validation_error'
vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.3/lib/active_record/validations.rb:50:in `save!'
```

These logs were from an educator trying to log in via LDAP. Her educator record hadn't been imported into the app from Aspen/X2, so LDAP was trying to create a new record for her because we had this config turned on:

```
config.ldap_create_user = true
```

The default for `ldap_create_user` is false and we should restore it to false for Student Insights. Any user record that Somerville's LDAP system tries to create will fail to save because it doesn't have the necessary data to pass validation, such as a school assignment. The sole source of educator records should be data from Aspen/X2, not LDAP, because Aspen/X2 carries important contextual information like school and user role. 

This PR will remove noisy LDAP errors related to this situation from the logs going forward.

A next-step improvement would be to catch-and-handle this error by surfacing a useful error message to the educator trying to log in. The message could include some next-steps text like "Contact your school secretary to check on whether your data has been added to Aspen/X2. If your data has been entered into Aspen, try again tomorrow since Student Insights syncs with Aspen/X2 nightly."