### PR TITLE
Limiting dashboard data to school year

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/date_slider.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/date_slider.jsx
@@ -8,12 +8,14 @@ export default React.createClass({
   displayName: 'DateSlider',
 
   propTypes: {
-    setDate: React.PropTypes.func.isRequired
+    setDate: React.PropTypes.func.isRequired,
+    rangeStart: React.PropTypes.number.isRequired,
+    rangeEnd: React.PropTypes.number.isRequired
   },
 
   getInitialState: function() {
     return {
-      value: [parseInt(moment("2016-08-01").format("X")), parseInt(moment().format("X"))]
+      value: [this.props.rangeStart, this.props.rangeEnd]
     };
   },
 
@@ -32,17 +34,15 @@ export default React.createClass({
   },
 
   render: function() {
-    const startRange = parseInt(moment("2016-08-01").format("X"));
-    const endRange = parseInt(moment().format("X"));
     return (
       <div style={style}>
         <input style={{marginBottom: '5px'}} type="date" value={moment.unix(this.state.value[0]).format("YYYY-MM-DD")} onChange={this.onBeginningDateInput} />
         <input type="date" value={moment.unix(this.state.value[1]).format("YYYY-MM-DD")} onChange={this.onEndingDateInput} />
         <Range
           allowCross={false}
-          min = {startRange}
-          max = {endRange}
-          defaultValue = {[startRange, endRange]}
+          min = {this.props.rangeStart}
+          max = {this.props.rangeEnd}
+          defaultValue = {[this.props.rangeStart, this.props.rangeEnd]}
           value = {this.state.value}
           onChange = {this.onSliderChange}
           tipFormatter={(value) => moment.unix(value).format("MM-DD-YYYY")}

--- a/app/assets/javascripts/school_administrator_dashboard/page_container.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/page_container.jsx
@@ -116,12 +116,12 @@ export default React.createClass({
   render: function() {
     const schoolAttendance = this.monthlyAttendanceBySchool();
     const schoolAttendanceMonths = Object.keys(schoolAttendance).sort();
-    const homeRoomAttendance = this.attendanceByHomeroom();
     return (
         <SchoolAbsenceDashboard
-          schoolAttendance = {schoolAttendance}
+          schoolAttendance = {this.attendanceBySchool()}
           schoolAttendanceMonths = {schoolAttendanceMonths}
-          homeRoomAttendance = {homeRoomAttendance}
-          students = {this.props.attendanceData}/>);
+          homeRoomAttendance = {this.attendanceByHomeroom()}
+          students = {this.props.attendanceData}
+          dateRange = {Object.keys(this.attendanceBySchool()).sort()}/>);
   }
 });

--- a/app/assets/javascripts/school_administrator_dashboard/page_container.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/page_container.jsx
@@ -59,22 +59,6 @@ export default React.createClass({
     return Object.keys(this.attendanceBySchool());
   },
 
-  //Returns average monthly attendance given a set of daily averages.
-  monthlyAttendanceBySchool: function () {
-    const schoolAttendance = this.attendanceBySchool();
-    let monthlyAttendance = {};
-    Object.keys(schoolAttendance).forEach((day) => {
-      //'date' here is the first day of the month in which 'day' occurs
-      let date = moment(day).date(1).format("YYYY-MM-DD");
-      if (monthlyAttendance[date] === undefined) { //if there's no data for this month yet
-        monthlyAttendance[date] = [schoolAttendance[day]];
-      } else {
-        monthlyAttendance[date]= monthlyAttendance[date].concat(schoolAttendance[day]); //if there is data, append this day's absences to what exists already
-      }
-    });
-    return monthlyAttendance;
-  },
-
   averageDailyAttendance: function(dailyAbsences, size) {
     let averageDailyAttendance = {};
     //mapping each homeroom to an array of day buckets containing all absences for each day w/in the homeroom
@@ -114,12 +98,9 @@ export default React.createClass({
   },
 
   render: function() {
-    const schoolAttendance = this.monthlyAttendanceBySchool();
-    const schoolAttendanceMonths = Object.keys(schoolAttendance).sort();
     return (
         <SchoolAbsenceDashboard
           schoolAttendance = {this.attendanceBySchool()}
-          schoolAttendanceMonths = {schoolAttendanceMonths}
           homeRoomAttendance = {this.attendanceByHomeroom()}
           students = {this.props.attendanceData}
           dateRange = {Object.keys(this.attendanceBySchool()).sort()}/>);

--- a/app/assets/javascripts/school_administrator_dashboard/school_absence_dashboard.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/school_absence_dashboard.jsx
@@ -19,7 +19,7 @@ export default React.createClass({
 
   getInitialState: function() {
     return {
-      start_date: "2016-08-01",
+      start_date: "2017-08-30",
       end_date: moment.utc().format("YYYY-MM-DD")
     };
   },

--- a/app/assets/javascripts/school_administrator_dashboard/school_absence_dashboard.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/school_absence_dashboard.jsx
@@ -19,8 +19,6 @@ export default React.createClass({
 
   getInitialState: function() {
     return {
-      start_date: "2017-08-30",
-      end_date: moment.utc().format("YYYY-MM-DD"),
       display_dates: this.props.dateRange
     };
   },
@@ -85,7 +83,7 @@ export default React.createClass({
 
   renderMonthlyAbsenceChart: function() {
     const monthlyAttendance = this.monthlySchoolAttendance(this.props.schoolAttendance);
-    let filteredAttendanceSeries = Object.keys(monthlyAttendance).map( (month) => {
+    const filteredAttendanceSeries = Object.keys(monthlyAttendance).map( (month) => {
       const rawAvg = _.sum(monthlyAttendance[month])/monthlyAttendance[month].length;
       return Math.round(rawAvg*10)/10;
     });

--- a/app/assets/javascripts/school_administrator_dashboard/school_absence_dashboard.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/school_absence_dashboard.jsx
@@ -14,13 +14,15 @@ export default React.createClass({
     schoolAttendance: React.PropTypes.object.isRequired,
     schoolAttendanceMonths: React.PropTypes.array.isRequired,
     homeRoomAttendance: React.PropTypes.object.isRequired,
-    students: React.PropTypes.object.isRequired
+    students: React.PropTypes.object.isRequired,
+    dateRange: React.PropTypes.array.isRequired
   },
 
   getInitialState: function() {
     return {
       start_date: "2017-08-30",
-      end_date: moment.utc().format("YYYY-MM-DD")
+      end_date: moment.utc().format("YYYY-MM-DD"),
+      display_dates: this.props.dateRange
     };
   },
 
@@ -40,13 +42,31 @@ export default React.createClass({
   },
 
   filterDates: function(dates, start_date, end_date) {
-    return _.slice(dates, this.getFirstDateIndex(dates, start_date), this.getLastDateIndex(dates, end_date));
+    return dates.sort().slice(this.getFirstDateIndex(dates, start_date), this.getLastDateIndex(dates, end_date));
   },
 
-  studentAbsenceCount: function(absences, start_date, end_date) {
+  studentAbsenceCount: function(absences) {
     return absences.filter((event) => {
+      const start_date = this.state.display_dates[0];
+      const end_date = this.state.display_dates[this.state.display_dates.length-1];
       return moment.utc(event.occurred_at).isBetween(start_date, end_date, null, '[]');
     }).length;
+  },
+
+  //Monthly attendance for the school must be calculated after the range filter is applied
+  monthlySchoolAttendance: function(dailyAttendance) {
+    let monthlyAttendance = {};
+    //Use the filtered daterange to find the days to include
+    this.state.display_dates.forEach((day) => {
+      //'date' here is the first day of the month in which 'day' occurs
+      let date = moment(day).date(1).format("YYYY-MM-DD");
+      if (monthlyAttendance[date] === undefined) { //if there's no data for this month yet
+        monthlyAttendance[date] = [dailyAttendance[day]];
+      } else {
+        monthlyAttendance[date]= monthlyAttendance[date].concat(dailyAttendance[day]); //if there is data, append this day's absences to what exists already
+      }
+    });
+    return monthlyAttendance;
   },
 
   render: function() {
@@ -65,14 +85,12 @@ export default React.createClass({
   },
 
   renderMonthlyAbsenceChart: function() {
-    const {GraphHelpers} = window.shared;
-    let filteredDates = this.filterDates(this.props.schoolAttendanceMonths, this.state.start_date, this.state.end_date);
-    let filteredAttendanceSeries = filteredDates.map( (month) => {
-      const rawAvg = _.sum(this.props.schoolAttendance[month])/this.props.schoolAttendance[month].length;
+    const monthlyAttendance = this.monthlySchoolAttendance(this.props.schoolAttendance);
+    let filteredAttendanceSeries = Object.keys(monthlyAttendance).map( (month) => {
+      const rawAvg = _.sum(monthlyAttendance[month])/monthlyAttendance[month].length;
       return Math.round(rawAvg*10)/10;
     });
-    const categories = filteredDates.map((month) => moment.utc(month).format("YYYY-MM"));
-    const yearCategories = GraphHelpers.yearCategories(categories);
+    const categories = Object.keys(monthlyAttendance);
 
     return (
         <DashboardBarChart
@@ -81,28 +99,18 @@ export default React.createClass({
           seriesData = {filteredAttendanceSeries}
           monthsBack = {categories.length}
           titleText = {'Average Attendance By Month'}
-          measureText = {'Attendance (Percent)'}
-          categoryGroups = {{
-            offset: 50,
-            linkedTo: 0,
-            categories: yearCategories,
-            tickPositions: Object.keys(yearCategories).map(Number),
-            tickmarkPlacement: "on"
-          }}/>
+          measureText = {'Attendance (Percent)'}/>
     );
   },
 
   renderHomeroomAbsenceChart: function() {
     const homeRoomAttendance = this.props.homeRoomAttendance;
-    //todo: either the index or the filtered date list should be accessed as state since it should be the same for all renders
-    const index0 = this.getFirstDateIndex(homeRoomAttendance, this.state.start_date);
-    const index1 = this.getFirstDateIndex(homeRoomAttendance, this.state.start_date);
-    let percentages = _.map(homeRoomAttendance, (homeroom) => {
-      return Object.keys(homeroom.absences).sort().slice(index0, index1).map((date) => {
+    const filteredHomeRoomAttendance = _.map(homeRoomAttendance, (homeroom) => {
+      return this.state.display_dates.map((date) => {
         return homeroom.absences[date];
       });
     });
-    let homeroomSeries = percentages.map((homeroom) => {
+    const homeroomSeries = filteredHomeRoomAttendance.map((homeroom) => {
       const rawAvg = _.sum(homeroom)/homeroom.length;
       return Math.round(rawAvg*10)/10;
     });
@@ -124,7 +132,7 @@ export default React.createClass({
       students.push({
         first_name: student.first_name,
         last_name: student.last_name,
-        absences: this.studentAbsenceCount(student.absences, this.state.start_date, this.state.end_date)
+        absences: this.studentAbsenceCount(student.absences)
       });
     });
 
@@ -135,11 +143,16 @@ export default React.createClass({
   },
 
   renderDateRangeSlider: function() {
+    const firstDate = this.props.dateRange[0];
+    const lastDate = this.props.dateRange[this.props.dateRange.length - 1];
     return (
       <DateSlider
+        rangeStart = {parseInt(moment(firstDate).format("X"))}
+        rangeEnd = {parseInt(moment(lastDate).format("X"))}
         setDate={(range) => this.setState({
-          start_date: moment.unix(range[0]).format("YYYY-MM-DD"),
-          end_date: moment.unix(range[1]).format("YYYY-MM-DD")
+          display_dates: this.filterDates(this.props.dateRange,
+                                      moment.unix(range[0]).format("YYYY-MM-DD"),
+                                      moment.unix(range[1]).format("YYYY-MM-DD"))
         })}/>
     );
   }

--- a/app/assets/javascripts/school_administrator_dashboard/school_absence_dashboard.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/school_absence_dashboard.jsx
@@ -12,7 +12,6 @@ export default React.createClass({
 
   propTypes: {
     schoolAttendance: React.PropTypes.object.isRequired,
-    schoolAttendanceMonths: React.PropTypes.array.isRequired,
     homeRoomAttendance: React.PropTypes.object.isRequired,
     students: React.PropTypes.object.isRequired,
     dateRange: React.PropTypes.array.isRequired

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -38,7 +38,10 @@ class SchoolsController < ApplicationController
       redirect_to not_authorized_path and return #TodDo: determine whether there's a more appropriate action here
     end
 
-    dashboard_students = students_for_dashboard(@school).includes(:absences, :homeroom).map { |student| individual_student_dashboard_data(student) }
+    dashboard_students = students_for_dashboard(@school).includes(:homeroom, :absences)
+                                                        .where('absences.occurred_at > ?', '2016-08-01')
+                                                        .references(:absences)
+                                                        .map { |student| individual_student_dashboard_data(student) }
 
     @serialized_data = {
       absences: dashboard_students.to_json

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -39,7 +39,7 @@ class SchoolsController < ApplicationController
     end
 
     dashboard_students = students_for_dashboard(@school).includes(:homeroom, :absences)
-                                                        .where('absences.occurred_at >= ?', school_year_start)
+                                                        .where('absences.occurred_at >= ?', 1.year.ago)
                                                         .references(:absences)
                                                         .map { |student| individual_student_dashboard_data(student) }
 
@@ -130,11 +130,6 @@ class SchoolsController < ApplicationController
 
   def students_for_dashboard(school)
     school.students.active
-  end
-
-  def school_year_start
-    current_year = Date.today.year
-    Date.today.to_s > current_year.to_s + "-08-01" ? current_year.to_s + "-08-01" : (current_year -1).to_s + "-08-01"
   end
 
 end

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -39,7 +39,7 @@ class SchoolsController < ApplicationController
     end
 
     dashboard_students = students_for_dashboard(@school).includes(:homeroom, :absences)
-                                                        .where('absences.occurred_at >= ?', '2017-08-30')
+                                                        .where('absences.occurred_at >= ?', school_year_start)
                                                         .references(:absences)
                                                         .map { |student| individual_student_dashboard_data(student) }
 
@@ -130,6 +130,11 @@ class SchoolsController < ApplicationController
 
   def students_for_dashboard(school)
     school.students.active
+  end
+
+  def school_year_start
+    current_year = Date.today.year
+    Date.today.to_s > current_year.to_s + "-08-01" ? current_year.to_s + "-08-01" : (current_year -1).to_s + "-08-01"
   end
 
 end

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -39,7 +39,7 @@ class SchoolsController < ApplicationController
     end
 
     dashboard_students = students_for_dashboard(@school).includes(:homeroom, :absences)
-                                                        .where('absences.occurred_at > ?', '2016-08-01')
+                                                        .where('absences.occurred_at >= ?', '2017-08-30')
                                                         .references(:absences)
                                                         .map { |student| individual_student_dashboard_data(student) }
 


### PR DESCRIPTION
# Who is this PR for?
School Administrators

# What problem does this PR fix?
Slow loading times on the administrator dashboard, cf #1244  

# What does this PR do?
Limits the student data to what occurred within the school year.

# Screenshot (if adding a client-side feature)

# Checklist

+ [X] Tested latest version in an Internet Explorer virtual machine? *(If the PR adds Javascript.)*
