### PR TITLE
Enforce foreign key contraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,6 @@ script:
   - yarn test-cli
   - rubocop
   - bundle exec rake db:create db:migrate DATABASE_URL=postgres://localhost/student_insights_test
+  - bundle exec rake immigrant:check_keys
   - bundle exec rspec spec
   - ./scripts/ci/detect_package_lock.sh

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'wkhtmltopdf-binary'
 gem 'selenium-webdriver'
 gem 'delayed_job_active_record'
 gem 'scout_apm'
+gem 'immigrant'
 
 #code for browserstack api usage and storing the png to slack:
 #gem 'slack-ruby-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,8 @@ GEM
       sprockets (>= 2.0.0)
       tilt (>= 1.2)
     i18n (0.8.6)
+    immigrant (0.3.6)
+      activerecord (>= 3.0)
     jmespath (1.3.1)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
@@ -334,6 +336,7 @@ DEPENDENCIES
   faker
   friendly_id (~> 5.1.0)
   handlebars_assets
+  immigrant
   jquery-rails
   jquery-ui-rails (~> 5.0.3)
   launchy
@@ -372,4 +375,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/db/migrate/20171126024254_add_keys.rb
+++ b/db/migrate/20171126024254_add_keys.rb
@@ -1,0 +1,28 @@
+class AddKeys < ActiveRecord::Migration[5.1]
+  def change
+    add_foreign_key "courses", "schools", name: "courses_school_id_fk"
+    add_foreign_key "educators", "schools", name: "educators_school_id_fk"
+    add_foreign_key "event_note_attachments", "event_notes", name: "event_note_attachments_event_note_id_fk"
+    add_foreign_key "event_note_revisions", "event_notes", name: "event_note_revisions_event_note_id_fk"
+    add_foreign_key "event_notes", "educators", name: "event_notes_educator_id_fk"
+    add_foreign_key "event_notes", "event_note_types", name: "event_notes_event_note_type_id_fk"
+    add_foreign_key "event_notes", "students", name: "event_notes_student_id_fk"
+    add_foreign_key "homerooms", "educators", name: "homerooms_educator_id_fk"
+    add_foreign_key "homerooms", "schools", name: "homerooms_school_id_fk"
+    add_foreign_key "iep_documents", "students", name: "iep_documents_student_id_fk"
+    add_foreign_key "interventions", "educators", name: "interventions_educator_id_fk"
+    add_foreign_key "interventions", "intervention_types", name: "interventions_intervention_type_id_fk"
+    add_foreign_key "interventions", "students", name: "interventions_student_id_fk"
+    add_foreign_key "sections", "courses", name: "sections_course_id_fk"
+    add_foreign_key "service_uploads", "educators", column: "uploaded_by_educator_id", name: "service_uploads_uploaded_by_educator_id_fk"
+    add_foreign_key "services", "educators", column: "recorded_by_educator_id", name: "services_recorded_by_educator_id_fk"
+    add_foreign_key "services", "service_types", name: "services_service_type_id_fk"
+    add_foreign_key "services", "service_uploads", name: "services_service_upload_id_fk"
+    add_foreign_key "services", "students", name: "services_student_id_fk"
+    add_foreign_key "student_assessments", "assessments", name: "student_assessments_assessment_id_fk"
+    add_foreign_key "student_assessments", "students", name: "student_assessments_student_id_fk"
+    add_foreign_key "student_risk_levels", "students", name: "student_risk_levels_student_id_fk"
+    add_foreign_key "students", "homerooms", name: "students_homeroom_id_fk"
+    add_foreign_key "students", "schools", name: "students_school_id_fk"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171117142933) do
+ActiveRecord::Schema.define(version: 20171126024254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -350,10 +350,34 @@ ActiveRecord::Schema.define(version: 20171117142933) do
   end
 
   add_foreign_key "absences", "students"
+  add_foreign_key "courses", "schools", name: "courses_school_id_fk"
   add_foreign_key "discipline_incidents", "students"
   add_foreign_key "educator_section_assignments", "educators"
   add_foreign_key "educator_section_assignments", "sections"
+  add_foreign_key "educators", "schools", name: "educators_school_id_fk"
+  add_foreign_key "event_note_attachments", "event_notes", name: "event_note_attachments_event_note_id_fk"
+  add_foreign_key "event_note_revisions", "event_notes", name: "event_note_revisions_event_note_id_fk"
+  add_foreign_key "event_notes", "educators", name: "event_notes_educator_id_fk"
+  add_foreign_key "event_notes", "event_note_types", name: "event_notes_event_note_type_id_fk"
+  add_foreign_key "event_notes", "students", name: "event_notes_student_id_fk"
+  add_foreign_key "homerooms", "educators", name: "homerooms_educator_id_fk"
+  add_foreign_key "homerooms", "schools", name: "homerooms_school_id_fk"
+  add_foreign_key "iep_documents", "students", name: "iep_documents_student_id_fk"
+  add_foreign_key "interventions", "educators", name: "interventions_educator_id_fk"
+  add_foreign_key "interventions", "intervention_types", name: "interventions_intervention_type_id_fk"
+  add_foreign_key "interventions", "students", name: "interventions_student_id_fk"
+  add_foreign_key "sections", "courses", name: "sections_course_id_fk"
+  add_foreign_key "service_uploads", "educators", column: "uploaded_by_educator_id", name: "service_uploads_uploaded_by_educator_id_fk"
+  add_foreign_key "services", "educators", column: "recorded_by_educator_id", name: "services_recorded_by_educator_id_fk"
+  add_foreign_key "services", "service_types", name: "services_service_type_id_fk"
+  add_foreign_key "services", "service_uploads", name: "services_service_upload_id_fk"
+  add_foreign_key "services", "students", name: "services_student_id_fk"
+  add_foreign_key "student_assessments", "assessments", name: "student_assessments_assessment_id_fk"
+  add_foreign_key "student_assessments", "students", name: "student_assessments_student_id_fk"
+  add_foreign_key "student_risk_levels", "students", name: "student_risk_levels_student_id_fk"
   add_foreign_key "student_section_assignments", "sections"
   add_foreign_key "student_section_assignments", "students"
+  add_foreign_key "students", "homerooms", name: "students_homeroom_id_fk"
+  add_foreign_key "students", "schools", name: "students_school_id_fk"
   add_foreign_key "tardies", "students"
 end


### PR DESCRIPTION
# Who is this PR for?

Add foreign key constraints for all models

# What problem does this PR fix?
Issues around data integrity with DiscontinuedServices being connected to deleted ServiceUploads

# What does this PR do?
Add the [immigrant](https://github.com/jenseng/immigrant) gem and add the migration it creates that will add foreign keys

# Screenshot (if adding a client-side feature)

# Checklist

+ [x] Tested latest version in an Internet Explorer virtual machine? *(If the PR adds Javascript.)*

# Questions/Concerns

+ [x] it appears I've committed a different version of bundle, should I reverse that?
+ [x] Immigrant recommends adding a rake task to our CI to ensure we continue adding keys (`rake immigrant:check_keys`). Is that something we want to do?
+ [x] [1275](https://github.com/studentinsights/studentinsights/pull/1275) needs to be merged before we can safely merge this one
- I've downloaded VirtualBox and the two Windows images and if I am correct, it is currently installing on my machine. If however it is not, can someone help me kick off the installation process or point me to some good installation instructions? Google is not being helpful.