### PR TITLE
Turn on Parent Information Center import from Aspen/X2

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -29,7 +29,8 @@ class School < ActiveRecord::Base
       { state_id: 410, local_id: "NW", name: "Next Wave Junior High", school_type: "MS" },
       { state_id: 505, local_id: "SHS", name: "Somerville High", school_type: "HS" },
       { state_id: 510, local_id: "FC", name: "Full Circle High School", school_type: "HS" },
-      { local_id: "CAP", name: "Capuano Early Childhood Center" }
+      { local_id: "CAP", name: "Capuano Early Childhood Center" },
+      { local_id: "PIC", name: "Parent Information Center" },
     ])
   end
 

--- a/lib/tasks/data_migrations/add_pic_school.rake
+++ b/lib/tasks/data_migrations/add_pic_school.rake
@@ -1,0 +1,6 @@
+namespace :data_migration do
+  desc "Add Capuano school"
+  task add_pic: :environment do
+    School.create(local_id: "PIC", name: "Parent Information Center")
+  end
+end

--- a/lib/tasks/data_migrations/add_pic_school.rake
+++ b/lib/tasks/data_migrations/add_pic_school.rake
@@ -1,5 +1,5 @@
 namespace :data_migration do
-  desc "Add Capuano school"
+  desc "Add Parent Information Center school"
   task add_pic: :environment do
     School.create(local_id: "PIC", name: "Parent Information Center")
   end

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -16,7 +16,7 @@ class Import
     desc "Import data into your Student Insights instance"
 
     DEFAULT_SCHOOLS = [
-      'HEA', 'WSNS', 'ESCS', 'BRN', 'KDY', 'AFAS', 'WHCS', 'SHS', 'FC', 'CAP'
+      'HEA', 'WSNS', 'ESCS', 'BRN', 'KDY', 'AFAS', 'WHCS', 'SHS', 'FC', 'CAP', 'PIC'
     ]
 
     SCHOOL_SHORTCODE_EXPANSIONS = {

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Import do
       expect(commands[1]).to be_a ImportRecord
       expect(commands[2]).to eq nil
       expect(commands[3]).to eq [
-        "HEA", "WSNS", "ESCS", "BRN", "KDY", "AFAS", "WHCS", "SHS", "FC", "CAP"
+        "HEA", "WSNS", "ESCS", "BRN", "KDY",
+        "AFAS", "WHCS", "SHS", "FC", "CAP", "PIC"
       ]
       expect(commands[4]).to be_a Array
       expect(commands[5]).to eq []


### PR DESCRIPTION
# Who is this PR for?

+ Educators (mostly administrators) at Somerville who can't log in to Insights yet because they are assigned to the Parent Information Center (PIC) in Aspen/X2

# What problem does this PR fix?

+ Allow district-wide admins assigned to PIC to log on and use Insights

# Checklist 

+ [x] Test PIC data import locally
+ [ ] Deploy to production Heroku app
+ [ ] Run data migration:  `rake data_migration:add_pic`
