### PR TITLE
Change discontinued services migration to fail noisily

### DIFF
--- a/lib/tasks/move_discontinued_at_to_services.rake
+++ b/lib/tasks/move_discontinued_at_to_services.rake
@@ -9,7 +9,7 @@ namespace :services do
         if service.discontinued_services.exists?
           service.discontinued_at = service.discontinued_services.first.discontinued_at
           service.discontinued_by_educator_id = service.discontinued_services.first.recorded_by_educator_id
-          service.save
+          service.save!
           puts "saving service"
         end
       end


### PR DESCRIPTION
# Notes 

+ Good catch by @kevinrobinson -- if any of the services in this migration fail to save, they'll fail silently and we'd never know. 
+ Switching to use the bang version of save so that the migration will let us know if any of the services fail to update. 
+ After this merges I'll re-run the migration.
+ cc @Jngai, good learning here, wish I had caught this myself!