### PR TITLE
Import SPED educators and students from X2

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -31,6 +31,7 @@ class School < ActiveRecord::Base
       { state_id: 510, local_id: "FC", name: "Full Circle High School", school_type: "HS" },
       { local_id: "CAP", name: "Capuano Early Childhood Center" },
       { local_id: "PIC", name: "Parent Information Center" },
+      { local_id: "SPED", name: "Special Education" },
     ])
   end
 

--- a/lib/tasks/data_migrations/add_sped_school.rake
+++ b/lib/tasks/data_migrations/add_sped_school.rake
@@ -1,0 +1,6 @@
+namespace :data_migration do
+  desc "Add SPED as a school for importing SPED-associated educators/students"
+  task add_sped_school: :environment do
+    School.create(local_id: "SPED", name: "Special Education")
+  end
+end

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -16,7 +16,9 @@ class Import
     desc "Import data into your Student Insights instance"
 
     DEFAULT_SCHOOLS = [
-      'HEA', 'WSNS', 'ESCS', 'BRN', 'KDY', 'AFAS', 'WHCS', 'SHS', 'FC', 'CAP', 'PIC'
+      'HEA', 'WSNS', 'ESCS', 'BRN', 'KDY', 'AFAS', 'WHCS',
+      'FC', 'CAP', 'PIC', 'SPED',
+      'SHS',
     ]
 
     SCHOOL_SHORTCODE_EXPANSIONS = {

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Import do
     it 'invokes all the commands and returns the correct kind of values' do
       expect(commands[1]).to be_a ImportRecord
       expect(commands[2]).to eq nil
-      expect(commands[3]).to eq [
+      expect(commands[3]).to match_array [
         "HEA", "WSNS", "ESCS", "BRN", "KDY",
-        "AFAS", "WHCS", "SHS", "FC", "CAP", "PIC"
+        "AFAS", "WHCS", "SHS", "FC", "CAP", "PIC", "SPED"
       ]
       expect(commands[4]).to be_a Array
       expect(commands[5]).to eq []


### PR DESCRIPTION
# Who is this PR for?

+ Educators who are listed with "SPED" (Special Education) as their school in Aspen/X2.

# What problem does this PR fix?

+ Allows those educators to log in! @snoopyuri wants to make sure that a few in particular have access to Insights, this is the quickest way to expand access. #1266 might be a better longer term path but would involve changing some mission-critical code which takes more time. 

# What does this PR do?

+ Adds a school called "SPED" to the Insights database via rake task: `rake data_migration:add_sped_school`. There's no school in Somerville with that name but that's how many educators and students are listed in the Aspen/X2 exports. 
