### PR TITLE
Move authorization methods into Authorizer, simplify Educator model

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,6 +48,20 @@ class ApplicationController < ActionController::Base
     no_sections_path
   end
 
+  # Wrap all database queries with this to enforce authorization
+  def authorized(&block)
+    authorizer.authorized(&block)
+  end
+
+  # Enforce authorization and raise if no authorized models
+  def authorized_or_raise!(&block)
+    return_value = authorizer.authorized(&block)
+    if return_value == nil || return_value == []
+      raise Exceptions::EducatorNotAuthorized
+    end
+    return_value
+  end
+
   # Sugar for filters checking authorization
   def redirect_unauthorized!
     redirect_to not_authorized_path
@@ -78,5 +92,10 @@ class ApplicationController < ActionController::Base
     logger.info "log_timing:end [#{message}] #{timing_ms.round}ms"
 
     return_value
+  end
+
+  private
+  def authorizer
+    @authorizer ||= Authorizer.new(current_educator)
   end
 end

--- a/app/controllers/homerooms_controller.rb
+++ b/app/controllers/homerooms_controller.rb
@@ -11,7 +11,7 @@ class HomeroomsController < ApplicationController
     @rows = eager_students().map {|student| fat_student_hash(student) }
 
     # Dropdown for homeroom navigation
-    @homerooms_by_name = current_educator.allowed_homerooms_by_name
+    @homerooms_by_name = current_educator.allowed_homerooms.order(:name)
 
     # For JSX Table:
     @serialized_data = {

--- a/app/lib/authorized_dispatcher.rb
+++ b/app/lib/authorized_dispatcher.rb
@@ -1,0 +1,69 @@
+# Dispatches different questions about authorization
+# to specific methods for specific models.
+class AuthorizedDispatcher
+  def initialize(authorizer)
+    @authorizer = authorizer
+  end
+
+  # Branches by type (Relation, Array, Model)
+  # and by the Model class.
+  def dispatch(&block)
+    return_value = block.call
+
+    # Can't duck type here, since other things like hashes
+    # are iterable or mappable in ways we don't want to
+    # support.
+    if return_value.class < ActiveRecord::Relation # if subclass
+      filter_relation(return_value)
+    elsif return_value.class == Array
+      filter_array(return_value)
+    else
+      filter_model(return_value)
+    end
+  end
+
+  private
+  # This is a seam to optimize for authorization filtering
+  # that stays lazy when possible (only possible when
+  # authorization can be applied with simple `where`
+  # clauses and not by filtering based on a Ruby method.
+  def filter_relation(relation)
+    # This checks that the relation has all fields required for authorization,
+    # and adds them in if not.  The developer was probably trying to optimize the
+    # query, and we can adjust it a bit to get what we need for authorization.
+    # So we do that and continue.
+    if relation.klass == Student.class
+      relation_with_required_fields = relation.select(*Authorizer.student_fields_for_authorization)
+      filter_array(relation_with_required_fields.to_a)
+    else
+      filter_array(relation.to_a)
+    end
+  end
+
+  def filter_array(array)
+    array.map {|model| filter_model(model) }.compact
+  end
+
+  def filter_model(model)
+    if model.class == Student
+      check_value(model, @authorizer.is_authorized_for_student?(model))
+    elsif model.class == EventNote
+      check_value(model, @authorizer.is_authorized_for_note?(model))
+    else
+      unchecked_value(model)
+    end
+  end
+
+  # Just a hook for logging, noop
+  def check_value(model, should_allow)
+    if should_allow then model else nil end
+  end
+
+  # This can log, raise or otherwise notifier developers.
+  # If it does return, it should return the "null" value for something
+  # the educator doesn't have access to.
+  def unchecked_value(model)
+    message = "Authorized#unchecked_value for class: #{model.class.to_s}"
+    raise Exceptions::EducatorNotAuthorized.new(message)
+  end
+end

--- a/app/lib/authorized_dispatcher.rb
+++ b/app/lib/authorized_dispatcher.rb
@@ -32,7 +32,7 @@ class AuthorizedDispatcher
     # and adds them in if not.  The developer was probably trying to optimize the
     # query, and we can adjust it a bit to get what we need for authorization.
     # So we do that and continue.
-    if relation.klass == Student.class
+    if relation.klass == Student
       relation_with_required_fields = relation.select(*Authorizer.student_fields_for_authorization)
       filter_array(relation_with_required_fields.to_a)
     else

--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -1,0 +1,141 @@
+# This class defines authorization rules.
+# If you want student data, ask through this class.
+# Ideally, start with using `authorized`.
+# Drop down to calling individual methods if you need to.
+#
+# This class should be fully tested, and all changes should be reviewed.
+#
+# Controller usage:
+#   student = authorized { Student.find(params[:id]) }
+#   homeroom = authorized { Homeroom.(params[:id]) }
+#   students = authorized { homeroom.students }
+#
+# Standalone usage:
+#   authorizer = Authorizer.new(educator)
+#   student = authorizer.authorized { Student.find(params[:id]) }
+#   homeroom = authorizer.authorized { Homeroom.(params[:id]) }
+#   students = authorizer.authorized { homeroom.students }
+#
+# Instead of:
+#   Homeroom.find(id).students # no authorization check
+#   Section.find(id).students # no authorization check
+#   current_educator.homeroom.students # doesn't work for all roles
+#   current_educator.school.students # doesn't work for all roles
+#
+class Authorizer
+  # These fields are required on the `Student` model for
+  # authorization checks
+  def self.student_fields_for_authorization
+    [
+      :id,
+      :program_assigned,
+      :limited_english_proficiency,
+      :school_id,
+      :grade
+    ]
+  end
+
+  def initialize(educator)
+    @educator = educator
+    @authorized_dispatcher = AuthorizedDispatcher.new(self)
+  end
+
+  # Usage:
+  #  student = authorized { Student.find(params[:id]) }
+  def authorized(&block)
+    @authorized_dispatcher.dispatch(&block)
+  end
+
+  # This method is the source of truth for whether an educator is authorized to view information about a particular
+  # student.
+  def is_authorized_for_student?(student)
+    begin
+      return true if @educator.districtwide_access?
+
+      return false if @educator.restricted_to_sped_students && !(student.program_assigned.in? ['Sp Ed', 'SEIP'])
+      return false if @educator.restricted_to_english_language_learners && student.limited_english_proficiency == 'Fluent'
+      return false if @educator.school_id.present? && student.school_id.present? && @educator.school_id != student.school_id
+
+      return true if @educator.schoolwide_access? || @educator.admin? # Schoolwide admin
+      return true if @educator.has_access_to_grade_levels? && student.grade.in?(@educator.grade_level_access) # Grade level access
+      return true if student.in?(@educator.students) # Homeroom level access
+      return true if student.in?(@educator.section_students) # Section level access
+    rescue ActiveModel::MissingAttributeError => err
+      # We can't do authorization checks on models with `#select` that are missing
+      # fields.  If this happens, it's probably because the developer is trying to
+      # to optimize a query.  The authorization layer could only recover by making more
+      # queries, so instead we raise and force the developer to figure out how to resolve.
+      #
+      # See `Authorizer.student_fields_for_authorization`
+      raise err
+    end
+    false
+  end
+
+  def is_authorized_for_school?(school)
+    return true if @educator.districtwide_access?
+    return true if @educator.schoolwide_access? && @educator.school == school
+    return true if @educator.has_access_to_grade_levels? && @educator.school == school
+    false
+  end
+
+  def is_authorized_for_section?(section)
+    return true if @educator.districtwide_access?
+
+    return false if @educator.school.present? && @educator.school != section.course.school
+
+    return true if @educator.schoolwide_access? || @educator.admin?
+    return true if section.in?(@educator.sections)
+    false
+  end
+
+  def is_authorized_for_note?(event_note)
+    return false unless is_authorized_for_student?(event_note.student)
+    return false if event_note.is_restricted && !@educator.can_view_restricted_notes
+    true
+  end
+
+  # TODO(kr) remove implementation
+  def students_for_school_overview
+    return [] unless @educator.school.present?
+
+    if @educator.schoolwide_access?
+      @educator.school.students.active
+    elsif @educator.has_access_to_grade_levels?
+      @educator.school.students
+        .active
+        .where(grade: @educator.grade_level_access)
+    else
+      []
+    end
+  end
+
+  # TODO(kr) remove implementation
+  def homerooms
+    # Educator can visit roster view for these homerooms
+    return [] if @educator.school.nil?
+
+    if @educator.districtwide_access?
+      Homeroom.all
+    elsif @educator.schoolwide_access?
+      @educator.school.homerooms.all
+    elsif @educator.homeroom
+      @educator.school.homerooms.where(grade: @educator.homeroom.grade)
+    elsif @educator.grade_level_access.present?
+      @educator.school.homerooms.where(grade: @educator.grade_level_access)
+    else
+      []
+    end
+  end
+
+  # TODO(kr) remove implementation
+  def sections
+    if @educator.districtwide_access?
+      Section.all
+    elsif @educator.schoolwide_access?
+      Section.joins(:course).where('courses.school_id = ?', @educator.school.id)
+    else
+      @educator.sections
+    end
+  end
+end

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -17,14 +17,14 @@ class Educator < ActiveRecord::Base
 
   validates :email, presence: true, uniqueness: true
 
-  validate :has_school_unless_districtwide,
-           :admin_gets_access_to_all_students,
-           :grade_level_access_is_array_of_strings,
-           :grade_level_strings_are_valid,
-           :grade_level_strings_are_uniq,
-           :grade_level_access_is_not_nil
+  validate :validate_has_school_unless_districtwide,
+           :validate_admin_gets_access_to_all_students,
+           :validate_grade_level_access_is_array_of_strings,
+           :validate_grade_level_strings_are_valid,
+           :validate_grade_level_strings_are_uniq,
+           :validate_grade_level_access_is_not_nil
 
-  VALID_GRADES = [ 'PK', 'KF', '1', '2', '3', '4', '5', '6', '7', '8' ].freeze
+  VALID_GRADES = [ 'PK', 'KF', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12' ].freeze
 
   # override
   # The `student_searchbar_json` field can be really heavy (~500kb), and
@@ -34,85 +34,26 @@ class Educator < ActiveRecord::Base
     super(options.merge({ except: [:student_searchbar_json] }))
   end
 
-  def has_school_unless_districtwide
-    if school.blank?
-      errors.add(:school_id, "must be assigned a school") unless districtwide_access?
-    end
-  end
-
-  def admin_gets_access_to_all_students
-    errors.add(:admin, "needs access to all students") if admin? && !has_access_to_all_students?
-  end
-
-  def grade_level_access_is_array_of_strings
-    unless grade_level_access.all? { |grade| grade.instance_of? String }
-      errors.add(:grade_level_access, "should be an array of strings")
-    end
-  end
-
-  def grade_level_strings_are_valid
-    if grade_level_access.any? { |grade| !(VALID_GRADES.include?(grade)) }
-      errors.add(:grade_level_access, "invalid grade")
-    end
-  end
-
-  def grade_level_strings_are_uniq
-    unless grade_level_access.uniq.size == grade_level_access.size
-      errors.add(:grade_level_access, "duplicate values")
-    end
-  end
-
-  def grade_level_access_is_not_nil
-    errors.add(:grade_level_access, "cannot be nil") if grade_level_access.nil?
-  end
-
-  # This method is the source of truth for whether an educator is authorized to view information about a particular
-  # student.
   def is_authorized_for_student(student)
-    return true if self.districtwide_access?
-
-    return false if self.restricted_to_sped_students && !(student.program_assigned.in? ['Sp Ed', 'SEIP'])
-    return false if self.restricted_to_english_language_learners && student.limited_english_proficiency == 'Fluent'
-    return false if self.school_id.present? && self.school_id != student.school_id
-
-    return true if self.schoolwide_access? || self.admin? # Schoolwide admin
-    return true if self.has_access_to_grade_levels? && student.grade.in?(self.grade_level_access) # Grade level access
-    return true if student.in?(self.students) # Homeroom level access
-    return true if student.in?(self.section_students) # Section level access
-    false
+    Authorizer.new(self).is_authorized_for_student?(student)
   end
 
-  def is_authorized_for_school(currentSchool)
-    self.districtwide_access? ||
-    (self.schoolwide_access? && self.school == currentSchool) ||
-    (self.has_access_to_grade_levels? && self.school == currentSchool)
+  def is_authorized_for_school(current_school)
+    Authorizer.new(self).is_authorized_for_school?(current_school)
   end
 
   def is_authorized_for_section(section)
-    return true if self.districtwide_access?
-
-    return false if self.school.present? && self.school != section.course.school
-
-    return true if self.schoolwide_access? || self.admin?
-    return true if section.in?(self.sections)
-    false
+    Authorizer.new(self).is_authorized_for_section?(section)
   end
 
   def students_for_school_overview(*additional_includes)
-    return [] unless school.present?
-
-    if schoolwide_access?
-      school.students
-            .active
-            .includes(additional_includes || [])
-    elsif has_access_to_grade_levels?
-      school.students
-            .active
-            .where(grade: self.grade_level_access)
-            .includes(additional_includes || [])
-    else
+    students = Authorizer.new(self).students_for_school_overview
+    if students.respond_to?(:includes)
+      students.includes(additional_includes || [])
+    elsif students.size == 0
       logger.warn("Fell through to empty array in #students_for_school_overview for educator_id: #{self.id}")
-      []
+    else
+      students
     end
   end
 
@@ -133,34 +74,11 @@ class Educator < ActiveRecord::Base
   end
 
   def allowed_homerooms
-    # Educator can visit roster view for these homerooms
-    return [] if school.nil?
-
-    if districtwide_access?
-      Homeroom.all
-    elsif schoolwide_access?
-      school.homerooms.all
-    elsif homeroom
-      school.homerooms.where(grade: homeroom.grade)
-    elsif grade_level_access.present?
-      school.homerooms.where(grade: grade_level_access)
-    else
-      []
-    end
+    Authorizer.new(self).homerooms
   end
 
   def allowed_sections
-    if districtwide_access?
-      Section.all
-    elsif schoolwide_access?
-      Section.joins(:course).where('courses.school_id = ?', school.id)
-    else
-      sections
-    end
-  end
-
-  def allowed_homerooms_by_name
-    allowed_homerooms.order(:name)
+    Authorizer.new(self).sections
   end
 
   def self.to_index
@@ -169,17 +87,6 @@ class Educator < ActiveRecord::Base
 
   def for_index
     as_json.symbolize_keys.slice(:id, :email, :full_name)
-  end
-
-  def permissions_hash
-    {
-      admin: admin,
-      school: school,
-      schoolwide_access: schoolwide_access,
-      grade_level_access: grade_level_access,
-      restricted_to_sped_students: restricted_to_sped_students,
-      restricted_to_english_language_learners: restricted_to_english_language_learners,
-    }
   end
 
   def self.save_student_searchbar_json
@@ -198,18 +105,39 @@ class Educator < ActiveRecord::Base
   end
 
   private
-
-  def has_access_to_no_students?
-    schoolwide_access == false && grade_level_access == [] && homeroom.blank?
+  def validate_has_school_unless_districtwide
+    if school.blank?
+      errors.add(:school_id, "must be assigned a school") unless districtwide_access?
+    end
   end
 
-  def has_grade_level_access?
-    grade_level_access != [] && !grade_level_access.nil?
+  def validate_admin_gets_access_to_all_students
+    has_access_to_all_students = (
+      restricted_to_sped_students == false &&
+      restricted_to_english_language_learners == false
+    )
+    errors.add(:admin, "needs access to all students") if admin? && !has_access_to_all_students
   end
 
-  def has_access_to_all_students?
-    restricted_to_sped_students == false &&
-    restricted_to_english_language_learners == false
+  def validate_grade_level_access_is_array_of_strings
+    unless grade_level_access.all? { |grade| grade.instance_of? String }
+      errors.add(:grade_level_access, "should be an array of strings")
+    end
   end
 
+  def validate_grade_level_strings_are_valid
+    if grade_level_access.any? { |grade| !(VALID_GRADES.include?(grade)) }
+      errors.add(:grade_level_access, "invalid grade")
+    end
+  end
+
+  def validate_grade_level_strings_are_uniq
+    unless grade_level_access.uniq.size == grade_level_access.size
+      errors.add(:grade_level_access, "duplicate values")
+    end
+  end
+
+  def validate_grade_level_access_is_not_nil
+    errors.add(:grade_level_access, "cannot be nil") if grade_level_access.nil?
+  end
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -1,6 +1,9 @@
 FactoryGirl.define do
 
   factory :school do
+    sequence(:state_id) {|n| n }
+    sequence(:slug) {|n| "slug#{n}" }
+    sequence(:local_id) {|n| "LOCAL_ID_#{n}" }
   end
 
   factory :healey, class: School do

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe Authorizer do
       expect(authorized(pals.shs_bill_nye) { students }).to eq [pals.shs_freshman_mari]
     end
 
-    it 'does not work when fields are missing' do
+    it 'does not work when fields are missing on concrete models' do
       test_fields = Authorizer.student_fields_for_authorization - [:id]
 
       # Test each of the required fields individually
       test_fields.each do |missing_field|
         some_fields = test_fields - [missing_field]
-        students = Student.select(*some_fields).all
+        students = Student.select(*some_fields).all.to_a
 
         # Different educator permissions check different field.
         # When this particular required field is missing, the check for

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -1,0 +1,190 @@
+require 'spec_helper'
+
+# This is just sugar, mirroring how this is used in controller code
+def authorized(educator, &block)
+  Authorizer.new(educator).authorized(&block)
+end
+
+
+RSpec.describe Authorizer do
+  let!(:pals) { TestPals.create! }
+
+  it 'sets up test context correctly' do
+    expect(School.all.size).to eq 13
+    expect(Homeroom.all.size).to eq 3
+    expect(Student.all.size).to eq 2
+    expect(Educator.all.size).to eq 7
+    expect(Course.all.size).to eq 1
+    expect(Section.all.size).to eq 2
+  end
+
+  describe '.student_fields_for_authorization' do
+    it 'has the expected fields' do
+      expect(Authorizer.student_fields_for_authorization).to eq [
+        :id,
+        :program_assigned,
+        :limited_english_proficiency,
+        :school_id,
+        :grade
+      ]
+    end
+
+    it 'works for authorization' do
+      students = Student.select(*Authorizer.student_fields_for_authorization).all
+      expect(authorized(pals.uri) { students }).to eq [
+        pals.healey_kindergarten_student,
+        pals.shs_freshman_mari
+      ]
+      expect(authorized(pals.healey_teacher) { students }).to eq [pals.healey_kindergarten_student]
+      expect(authorized(pals.shs_bill_nye) { students }).to eq [pals.shs_freshman_mari]
+    end
+
+    it 'does not work when fields are missing' do
+      test_fields = Authorizer.student_fields_for_authorization - [:id]
+
+      # Test each of the required fields individually
+      test_fields.each do |missing_field|
+        some_fields = test_fields - [missing_field]
+        students = Student.select(*some_fields).all
+
+        # Different educator permissions check different field.
+        # When this particular required field is missing, the check for
+        # one of these educators should raise an error about a missing
+        # attribute.
+        expect do
+          authorized(pals.uri) { students }
+          authorized(pals.healey_teacher) { students }
+          authorized(pals.healey_ell_teacher) { students }
+          authorized(pals.healey_sped_teacher) { students }
+          authorized(pals.shs_bill_nye) { students }
+          authorized(pals.shs_ninth_grade_counselor) { students }
+        end.to raise_error(ActiveModel::MissingAttributeError)
+      end
+    end
+  end
+
+  describe '#authorized' do
+    describe 'Student' do
+      it 'limits access with Student.all' do
+        expect(authorized(pals.uri) { Student.all }).to eq [
+          pals.healey_kindergarten_student,
+          pals.shs_freshman_mari
+        ]
+        expect(authorized(pals.healey_teacher) { Student.all }).to eq [
+          pals.healey_kindergarten_student
+        ]
+        expect(authorized(pals.shs_jodi) { Student.all }).to eq [
+          pals.shs_freshman_mari
+        ]
+        expect(authorized(pals.shs_bill_nye) { Student.all }).to eq [
+          pals.shs_freshman_mari
+        ]
+      end
+
+      it 'limits access for Student.find' do
+        expect(authorized(pals.healey_teacher) { Student.find(pals.shs_freshman_mari.id) }).to eq nil
+      end
+
+      it 'limits access for arrays' do
+        expect(authorized(pals.healey_teacher) { [pals.shs_freshman_mari, pals.healey_kindergarten_student] }).to eq [pals.healey_kindergarten_student]
+      end
+
+      it 'raises if given a Student model with `#select` filtering out fields needed for authorization' do
+        thin_student = Student.select(:id, :local_id).find(pals.shs_freshman_mari.id)
+        expect(authorized(pals.uri) { thin_student }.attributes).to eq({
+          'id' => pals.shs_freshman_mari.id,
+          'local_id' => pals.shs_freshman_mari.local_id 
+        })
+        expect { authorized(pals.healey_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
+        expect { authorized(pals.shs_bill_nye) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
+      end
+
+      it 'if `select` was used on an ActiveRecord::Relation for students, fields needed for authorization are added in' do
+        thin_student = Student.select(:id, :local_id).find(pals.shs_freshman_mari.id)
+        expect(authorized(pals.uri) { thin_student }.attributes).to eq({
+          'id' => pals.shs_freshman_mari.id,
+          'local_id' => pals.shs_freshman_mari.local_id 
+        })
+        expect { authorized(pals.healey_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
+        expect { authorized(pals.shs_bill_nye) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
+      end
+    end
+
+    describe 'EventNote' do
+      let!(:healey_public_note) { FactoryGirl.create(:event_note, student: pals.healey_kindergarten_student) }
+      let!(:healey_restricted_note) { FactoryGirl.create(:event_note, student: pals.healey_kindergarten_student, is_restricted: true) }
+      let!(:shs_public_note) { FactoryGirl.create(:event_note, student: pals.shs_freshman_mari) }
+      let!(:shs_restricted_note) { FactoryGirl.create(:event_note, student: pals.shs_freshman_mari, is_restricted: true) }
+
+      it 'limits access for relation' do
+        expect(authorized(pals.uri) { EventNote.all }).to eq [
+          healey_public_note,
+          healey_restricted_note,
+          shs_public_note,
+          shs_restricted_note
+        ]
+        expect(authorized(pals.healey_teacher) { EventNote.all }).to eq [
+          healey_public_note
+        ]
+        expect(authorized(pals.shs_bill_nye) { EventNote.all }).to eq [
+          shs_public_note
+        ]
+      end
+
+      it 'limits access for array' do
+        all_notes = [
+          healey_public_note,
+          healey_restricted_note,
+          shs_public_note,
+          shs_restricted_note
+        ]
+        expect(authorized(pals.uri) { all_notes }).to eq [
+          healey_public_note,
+          healey_restricted_note,
+          shs_public_note,
+          shs_restricted_note
+        ]
+        expect(authorized(pals.healey_teacher) { all_notes }).to eq [
+          healey_public_note
+        ]
+        expect(authorized(pals.shs_bill_nye) { all_notes }).to eq [
+          shs_public_note
+        ]
+      end
+
+      it 'limits access for model' do
+        def is_authorized(educator, note)
+          authorized(educator) { note } == note # check that they can access it
+        end
+
+        expect(is_authorized(pals.uri, healey_public_note)).to eq true
+        expect(is_authorized(pals.uri, healey_restricted_note)).to eq true
+        expect(is_authorized(pals.uri, shs_public_note)).to eq true
+        expect(is_authorized(pals.uri, shs_restricted_note)).to eq true
+        expect(is_authorized(pals.healey_teacher, healey_public_note)).to eq true
+        expect(is_authorized(pals.healey_teacher, healey_restricted_note)).to eq false
+        expect(is_authorized(pals.healey_teacher, shs_public_note)).to eq false
+        expect(is_authorized(pals.healey_teacher, shs_restricted_note)).to eq false
+        expect(is_authorized(pals.shs_bill_nye, healey_public_note)).to eq false
+        expect(is_authorized(pals.shs_bill_nye, healey_restricted_note)).to eq false
+        expect(is_authorized(pals.shs_bill_nye, shs_public_note)).to eq true
+        expect(is_authorized(pals.shs_bill_nye, shs_restricted_note)).to eq false
+      end
+    end
+
+    describe 'other models' do
+      it 'raises on calls with unchecked models' do
+        expect { authorized(pals.uri) { Educator.all } }.to raise_error(Exceptions::EducatorNotAuthorized)
+      end
+    end
+  end
+
+  describe '#is_authorized_for_student?' do
+    it 'raises if `#select` was used on the `student` argument, and fields needed for authorization are missing' do
+      thin_student = Student.select(:id, :local_id).find(pals.shs_freshman_mari.id)
+      expect(Authorizer.new(pals.uri).is_authorized_for_student?(thin_student)).to eq true
+      expect { Authorizer.new(pals.healey_teacher).is_authorized_for_student?(thin_student) }.to raise_error(ActiveModel::MissingAttributeError)
+      expect { Authorizer.new(pals.shs_bill_nye).is_authorized_for_student?(thin_student) }.to raise_error(ActiveModel::MissingAttributeError)
+    end
+  end
+end

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -99,13 +99,17 @@ RSpec.describe Authorizer do
       end
 
       it 'if `select` was used on an ActiveRecord::Relation for students, fields needed for authorization are added in' do
-        thin_student = Student.select(:id, :local_id).find(pals.shs_freshman_mari.id)
-        expect(authorized(pals.uri) { thin_student }.attributes).to eq({
-          'id' => pals.shs_freshman_mari.id,
-          'local_id' => pals.shs_freshman_mari.local_id
-        })
-        expect { authorized(pals.healey_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
-        expect { authorized(pals.shs_bill_nye) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
+        thin_relation = Student.select(:id, :local_id).all
+        expect((authorized(pals.uri) { thin_relation }).map(&:id)).to eq([
+          pals.healey_kindergarten_student.id,
+          pals.shs_freshman_mari.id
+        ])
+        expect((authorized(pals.healey_teacher) { thin_relation }).map(&:id)).to eq([
+          pals.healey_kindergarten_student.id
+        ])
+        expect((authorized(pals.shs_bill_nye) { thin_relation }).map(&:id)).to eq([
+          pals.shs_freshman_mari.id
+        ])
       end
     end
 

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -241,20 +241,6 @@ RSpec.describe Educator do
 
   end
 
-  describe '#allowed_homerooms_by_name' do
-    context 'admin' do
-      let(:school) { FactoryGirl.create(:healey) }
-      let(:educator) { FactoryGirl.create(:educator, schoolwide_access: true, school: school) }
-      let!(:homeroom_101) { FactoryGirl.create(:homeroom, name: 'Muskrats', school: school) }
-      let!(:homeroom_102) { FactoryGirl.create(:homeroom, name: 'Hawks', school: school) }
-      let!(:homeroom_103) { FactoryGirl.create(:homeroom, name: 'Badgers', school: school) }
-
-      it 'returns all homerooms\', ordered alphabetically by name' do
-        expect(educator.allowed_homerooms_by_name).to eq [homeroom_103, homeroom_102, homeroom_101]
-      end
-    end
-  end
-
   describe '#save_student_searchbar_json' do
     context 'educator has permissions for a few students' do
       let(:school) { FactoryGirl.create(:school, local_id: 'Big River High') }

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -1,0 +1,108 @@
+# This class defines a set of users, schools, homerooms and students
+# that can be used for testing authorization rules.
+#
+# These can be re-used for any other test code, but changes here will impact
+# many tests, so the intention is that these should not change frequently.
+# If new attributes are added to models, update the factories instead.
+class TestPals
+  def self.create!
+    pals = TestPals.new
+    pals.create!
+    pals
+  end
+
+  attr_reader :uri
+  attr_reader :healey
+  attr_reader :healey_kindergarten_student
+  attr_reader :healey_teacher
+  attr_reader :healey_ell_teacher
+  attr_reader :healey_sped_teacher
+  attr_reader :healey_kindergarten_homeroom
+  attr_reader :shs
+  attr_reader :shs_freshman_mari
+  attr_reader :shs_jodi
+  attr_reader :shs_bill_nye
+  attr_reader :shs_ninth_grade_counselor
+  attr_reader :shs_jodi_homeroom
+  attr_reader :shs_biology_course
+  attr_reader :shs_tuesday_biology_section
+  attr_reader :shs_thursday_biology_section
+
+  def create!
+    School.seed_somerville_schools
+
+    # Uri works in the central office, and is the admin for the entire
+    # project at the district.
+    @uri = FactoryGirl.create(:educator, {
+      email: 'uri@studentinsights.org',
+      districtwide_access: true,
+      admin: true,
+      schoolwide_access: true,
+      restricted_to_sped_students: false,
+      restricted_to_english_language_learners: false,
+      grade_level_access: [],
+      can_view_restricted_notes: true,
+      school: School.find_by_local_id('HEA')
+    })
+
+    # Healey is a K8 school.
+    @healey = School.find_by_local_id('HEA')
+    @healey_kindergarten_homeroom = FactoryGirl.create(:homeroom, school: healey)
+    @healey_kindergarten_student = FactoryGirl.create(:student, {
+      school: @healey,
+      homeroom: @healey_kindergarten_homeroom,
+      grade: 'KF'
+    })
+    @healey_teacher = FactoryGirl.create(:educator, {
+      school: @healey,
+      homeroom: @healey_kindergarten_homeroom
+    })
+    @healey_ell_teacher = FactoryGirl.create(:educator, {
+      restricted_to_english_language_learners: true,
+      school: @healey
+    })
+    @healey_sped_teacher = FactoryGirl.create(:educator, {
+      restricted_to_sped_students: true,
+      school: @healey
+    })
+
+    # high school
+    @shs = School.find_by_local_id('SHS')
+    @shs_ninth_grade_counselor = FactoryGirl.create(:educator, {
+      school: @shs,
+      grade_level_access: ['9']
+    })
+
+    # Jodi has a homeroom period at the high school.
+    @shs_jodi_homeroom = FactoryGirl.create(:homeroom, school: @shs)
+    @shs_jodi = FactoryGirl.create(:educator, {
+      email: 'jodi@studentinsights.org',
+      school: @shs,
+      homeroom: @shs_jodi_homeroom
+    })
+
+    # Bill Nye is a biology teacher at Somerville High School.  He teaches sections
+    # on Tuesday and Thursday and has a homeroom period.
+    @shs_bill_nye_homeroom = FactoryGirl.create(:homeroom, school: @shs)
+    @shs_bill_nye = FactoryGirl.create(:educator, {
+      email: 'billnye@studentinsights.org',
+      school: @shs,
+      homeroom: @shs_bill_nye_homeroom
+    })
+    @shs_biology_course = FactoryGirl.create(:course, school: @shs)
+    @shs_tuesday_biology_section = FactoryGirl.create(:section, course: @shs_biology_course)
+    @shs_thursday_biology_section = FactoryGirl.create(:section, course: @shs_biology_course)
+    FactoryGirl.create(:educator_section_assignment, educator: @shs_bill_nye, section: @shs_tuesday_biology_section)
+    FactoryGirl.create(:educator_section_assignment, educator: @shs_bill_nye, section: @shs_thursday_biology_section)
+
+    # Mari is a freshman at the high school, enrolled in biology and in Jodi's homeroom.
+    @shs_freshman_mari = FactoryGirl.create(:student, {
+      school: @shs,
+      homeroom: @shs_jodi_homeroom,
+      grade: '9'
+    })
+    FactoryGirl.create(:student_section_assignment, student: @shs_freshman_mari, section: @shs_tuesday_biology_section)
+    
+    self
+  end
+end


### PR DESCRIPTION
# Who is this PR for?
- Developers, mostly

# What problem does this PR fix?
- It's step towards https://github.com/studentinsights/studentinsights/issues/1080, as discussed in https://github.com/studentinsights/studentinsights/pull/1237.  It's intended to isolate and simplify the authorization rules, so that it's easier to do authorization checks in controller and model code when writing new features.

# What does this PR do?
- Adds `TestPals` class that creates a set of users, students, schools and homerooms that have valid and meaningful relationships, so that we can test authorization rules with them.  This helps since authorization rules are complex and to know if an educator has access to a student often involves traversing a bunch of relations.  The thought here is that this class won't change often, and when it does it will be an expensive change.
- Adds an `Authorizer` class that owns authorization logic.  It adds a helper into `ApplicationController` which is sugar for making this accessible within controller code.  It also uses a collaborator, `AuthorizedDispatcher`, which handles dispatching calls for the block-based API (which isn't used anywhere yet other than in tests).
- Updates the `Educator` model to use `Authorizer`, and refactors to clarify and simplify.