### PR TITLE
Rake task check foreign keys

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -29,7 +29,7 @@ class Educator < ActiveRecord::Base
   # override
   # The `student_searchbar_json` field can be really heavy (~500kb), and
   # there's no circumstances where we want to include it when serializing
-  # an educator model.  So override `as_json to omit it by default.
+  # an educator model.  So override `as_json` to omit it by default.
   def as_json(options = {})
     super(options.merge({ except: [:student_searchbar_json] }))
   end

--- a/lib/tasks/scan_for_missing_records.rake
+++ b/lib/tasks/scan_for_missing_records.rake
@@ -1,0 +1,134 @@
+desc 'Scan for missing foreign key records'
+namespace :missing_foreign_key_relations do
+    task scan: :environment do
+        puts "Missing School IDs on Course"
+        missing = []
+        Course.find_each do |course|
+            if !course.school
+                missing << course.school_id
+            end
+        end
+        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts ""
+        
+        puts "Missing School IDs on Educator"
+        missing = []
+        Educator.find_each do |educator|
+            if !educator.school
+                missing << educator.school_id
+            end
+        end
+        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts ""
+        
+        puts "Missing EventNote IDs on EventNoteAttachment"
+        missing = []
+        EventNoteAttachment.find_each do |attachment|
+            if !attachment.event_note
+                missing << attachment.event_note_id
+            end
+        end
+        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts ""
+
+        puts "Missing EventNote IDs on EventNoteRevision"
+        missing = []
+        EventNoteRevision.find_each do |revision|
+            if !revision.event_note
+                missing << revision.event_note_id
+            end
+        end
+        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts ""
+
+        puts "Missing Educator IDs on EventNote"
+        missing = []
+        EventNote.find_each do |note|
+            if !note.educator
+                missing << note.educator_id
+            end
+        end
+        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts ""
+
+        puts "Missing EventNoteType IDs on EventNote"
+        missing = []
+        EventNote.find_each do |note|
+            if !note.event_note_type
+                missing << note.event_note_type_id
+            end
+        end
+        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts ""
+
+        puts "Missing Student IDs on EventNote"
+        missing = []
+        EventNote.find_each do |note|
+            if !note.student
+                missing << note.student_id
+            end
+        end
+        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts ""
+
+        puts "Missing Educator IDs on Homeroom"
+        missing = []
+        Homeroom.find_each do |homeroom|
+            if !homeroom.educator
+                missing << homeroom.educator_id
+            end
+        end
+        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts ""
+
+        puts "Missing School IDs on Homeroom"
+        missing = []
+        Homeroom.find_each do |homeroom|
+            if !homeroom.school
+                missing << homeroom.school_id
+            end
+        end
+        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts ""
+
+        puts "Missing Student IDs on IepDocument"
+        missing = []
+        IepDocument.find_each do |document|
+            if !document.student
+                missing << document.student_id
+            end
+        end
+        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts ""
+
+        puts "Missing Educator IDs on Intervention"
+        missing = []
+        Intervention.find_each do |intervention|
+            if !intervention.educator
+                missing << intervention.educator_id
+            end
+        end
+        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts ""
+
+        puts "Missing InterventionType IDs on Intervention"
+        missing = []
+        Intervention.find_each do |intervention|
+            if !intervention.intervention_type
+                missing << intervention.intervention_type_id
+            end
+        end
+        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts ""
+
+        puts "Missing Student IDs on Intervention"
+        missing = []
+        Intervention.find_each do |intervention|
+            if !intervention.student
+                missing << intervention.student_id
+            end
+        end
+        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts ""
+    end
+end

--- a/lib/tasks/scan_for_missing_records.rake
+++ b/lib/tasks/scan_for_missing_records.rake
@@ -130,5 +130,115 @@ namespace :missing_foreign_key_relations do
         end
         puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
+
+        puts "Missing Course IDs on Section"
+        missing = []
+        Section.find_each do |section|
+            if !section.course
+                missing << section.course_id
+            end
+        end
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+        puts ""
+
+        puts "Missing Educator IDs on ServiceUpload"
+        missing = []
+        ServiceUpload.find_each do |upload|
+            if !upload.uploaded_by_educator
+                missing << upload.uploaded_by_educator_id
+            end
+        end
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+        puts ""
+
+        puts "Missing Educator IDs on Service"
+        missing = []
+        Service.find_each do |service|
+            if !service.recorded_by_educator
+                missing << service.recorded_by_educator_id
+            end
+        end
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+        puts ""
+
+        puts "Missing ServiceType IDs on Service"
+        missing = []
+        Service.find_each do |service|
+            if !service.service_type
+                missing << service.service_type_id
+            end
+        end
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+        puts ""
+
+        puts "Missing ServiceUploads IDs on Service"
+        missing = []
+        Service.find_each do |service|
+            if !service.service_upload
+                missing << service.service_upload_id
+            end
+        end
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+        puts ""
+
+        puts "Missing Student IDs on Service"
+        missing = []
+        Service.find_each do |service|
+            if !service.student
+                missing << service.student_id
+            end
+        end
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+        puts ""
+
+        puts "Missing Assessment IDs on StudentAssessment"
+        missing = []
+        StudentAssessment.find_each do |student_assesment|
+            if !student_assesment.assessment
+                missing << student_assesment.assessment_id
+            end
+        end
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+        puts ""
+
+        puts "Missing Student IDs on StudentAssessment"
+        missing = []
+        StudentAssessment.find_each do |student_assesment|
+            if !student_assesment.student
+                missing << student_assesment.student_id
+            end
+        end
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+        puts ""
+
+        puts "Missing Student IDs on StudentRiskLevel"
+        missing = []
+        StudentRiskLevel.find_each do |risk_level|
+            if !risk_level.student
+                missing << risk_level.student_id
+            end
+        end
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+        puts ""
+
+        puts "Missing Homeroom IDs on Student"
+        missing = []
+        Student.find_each do |student|
+            if !student.homeroom
+                missing << student.homeroom_id
+            end
+        end
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+        puts ""
+
+        puts "Missing School IDs on Student"
+        missing = []
+        Student.find_each do |student|
+            if !student.school
+                missing << student.school_id
+            end
+        end
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+        puts ""
     end
 end

--- a/lib/tasks/scan_for_missing_records.rake
+++ b/lib/tasks/scan_for_missing_records.rake
@@ -8,9 +8,9 @@ namespace :missing_foreign_key_relations do
                 missing << course.school_id
             end
         end
-        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
-        
+
         puts "Missing School IDs on Educator"
         missing = []
         Educator.find_each do |educator|
@@ -18,9 +18,9 @@ namespace :missing_foreign_key_relations do
                 missing << educator.school_id
             end
         end
-        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
-        
+
         puts "Missing EventNote IDs on EventNoteAttachment"
         missing = []
         EventNoteAttachment.find_each do |attachment|
@@ -28,7 +28,7 @@ namespace :missing_foreign_key_relations do
                 missing << attachment.event_note_id
             end
         end
-        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
 
         puts "Missing EventNote IDs on EventNoteRevision"
@@ -38,7 +38,7 @@ namespace :missing_foreign_key_relations do
                 missing << revision.event_note_id
             end
         end
-        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
 
         puts "Missing Educator IDs on EventNote"
@@ -48,7 +48,7 @@ namespace :missing_foreign_key_relations do
                 missing << note.educator_id
             end
         end
-        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
 
         puts "Missing EventNoteType IDs on EventNote"
@@ -58,7 +58,7 @@ namespace :missing_foreign_key_relations do
                 missing << note.event_note_type_id
             end
         end
-        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
 
         puts "Missing Student IDs on EventNote"
@@ -68,7 +68,7 @@ namespace :missing_foreign_key_relations do
                 missing << note.student_id
             end
         end
-        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
 
         puts "Missing Educator IDs on Homeroom"
@@ -78,7 +78,7 @@ namespace :missing_foreign_key_relations do
                 missing << homeroom.educator_id
             end
         end
-        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
 
         puts "Missing School IDs on Homeroom"
@@ -88,7 +88,7 @@ namespace :missing_foreign_key_relations do
                 missing << homeroom.school_id
             end
         end
-        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
 
         puts "Missing Student IDs on IepDocument"
@@ -98,7 +98,7 @@ namespace :missing_foreign_key_relations do
                 missing << document.student_id
             end
         end
-        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
 
         puts "Missing Educator IDs on Intervention"
@@ -108,7 +108,7 @@ namespace :missing_foreign_key_relations do
                 missing << intervention.educator_id
             end
         end
-        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
 
         puts "Missing InterventionType IDs on Intervention"
@@ -118,7 +118,7 @@ namespace :missing_foreign_key_relations do
                 missing << intervention.intervention_type_id
             end
         end
-        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
 
         puts "Missing Student IDs on Intervention"
@@ -128,7 +128,7 @@ namespace :missing_foreign_key_relations do
                 missing << intervention.student_id
             end
         end
-        puts "#{ missing.length } records missing an object. Missing IDs: #{ missing.uniq }"
+        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
     end
 end


### PR DESCRIPTION
# Who is this PR for?

# What problem does this PR fix?

Checks that foreign keys on an object point to an existing other objects; if not, prints the ID of the missing object.

# What does this PR do?

Add a rake task that does the above. To run the task:
`rake missing_foreign_key_relations:scan`

# Screenshot (if adding a client-side feature)

# Checklist

+ [x] Tested latest version in an Internet Explorer virtual machine? *(If the PR adds Javascript.)*

# Questions / Concerns
- feedback wanted on better names for task, namespace, etc
- I am posting below the output of the rake task, let me know if I can improve it in any way
- locally, the task takes 26 seconds to complete, w/ a total of 447 IDs missing (I deleted some things locally to test)

# Output
```
Missing School IDs on Course
2 records missing an object. Missing IDs: [9]

Missing School IDs on Educator
3 records missing an object. Missing IDs: [nil, 9]

Missing EventNote IDs on EventNoteAttachment
0 records missing an object. Missing IDs: []

Missing EventNote IDs on EventNoteRevision
0 records missing an object. Missing IDs: []

Missing Educator IDs on EventNote
326 records missing an object. Missing IDs: [1]

Missing EventNoteType IDs on EventNote
0 records missing an object. Missing IDs: []

Missing Student IDs on EventNote
0 records missing an object. Missing IDs: []

Missing Educator IDs on Homeroom
1 records missing an object. Missing IDs: [nil]

Missing School IDs on Homeroom
1 records missing an object. Missing IDs: [9]

Missing Student IDs on IepDocument
0 records missing an object. Missing IDs: []

Missing Educator IDs on Intervention
39 records missing an object. Missing IDs: [1]

Missing InterventionType IDs on Intervention
0 records missing an object. Missing IDs: []

Missing Student IDs on Intervention
0 records missing an object. Missing IDs: []

Missing Course IDs on Section
0 records missing an object. Missing IDs: []

Missing Educator IDs on ServiceUpload
4 records missing an object. Missing IDs: [nil]

Missing Educator IDs on Service
6 records missing an object. Missing IDs: [1]

Missing ServiceType IDs on Service
0 records missing an object. Missing IDs: []

Missing ServiceUploads IDs on Service
15 records missing an object. Missing IDs: [nil]

Missing Student IDs on Service
0 records missing an object. Missing IDs: []

Missing Assessment IDs on StudentAssessment
0 records missing an object. Missing IDs: []

Missing Student IDs on StudentAssessment
0 records missing an object. Missing IDs: []

Missing Student IDs on StudentRiskLevel
0 records missing an object. Missing IDs: []

Missing Homeroom IDs on Student
10 records missing an object. Missing IDs: [nil]

Missing School IDs on Student
40 records missing an object. Missing IDs: [9]
```
