### PR TITLE
Patch: strip out extra whitespace from feature/authorization-simple

### DIFF
--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -5,7 +5,6 @@ def authorized(educator, &block)
   Authorizer.new(educator).authorized(&block)
 end
 
-
 RSpec.describe Authorizer do
   let!(:pals) { TestPals.create! }
 
@@ -93,7 +92,7 @@ RSpec.describe Authorizer do
         thin_student = Student.select(:id, :local_id).find(pals.shs_freshman_mari.id)
         expect(authorized(pals.uri) { thin_student }.attributes).to eq({
           'id' => pals.shs_freshman_mari.id,
-          'local_id' => pals.shs_freshman_mari.local_id 
+          'local_id' => pals.shs_freshman_mari.local_id
         })
         expect { authorized(pals.healey_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
         expect { authorized(pals.shs_bill_nye) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
@@ -103,7 +102,7 @@ RSpec.describe Authorizer do
         thin_student = Student.select(:id, :local_id).find(pals.shs_freshman_mari.id)
         expect(authorized(pals.uri) { thin_student }.attributes).to eq({
           'id' => pals.shs_freshman_mari.id,
-          'local_id' => pals.shs_freshman_mari.local_id 
+          'local_id' => pals.shs_freshman_mari.local_id
         })
         expect { authorized(pals.healey_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
         expect { authorized(pals.shs_bill_nye) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -102,7 +102,7 @@ class TestPals
       grade: '9'
     })
     FactoryGirl.create(:student_section_assignment, student: @shs_freshman_mari, section: @shs_tuesday_biology_section)
-    
+
     self
   end
 end


### PR DESCRIPTION
# Notes 

+ This PR is a patch onto the `feature/authorization-simple` branch. 
+ @kevinrobinson: Minor, but rubocop is throwing failures because of trailing whitespace. Of course getting authorization logic right is 100,000 times more important than getting whitespace right, but whitespace consistency makes PRs easier to review because it strips out meaningless diffs. This PR should make rubocop pass. 