### PR TITLE
Patch: add a little more explanation to code comments in authorizer.rb

### DIFF
--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -19,8 +19,11 @@
 # Instead of:
 #   Homeroom.find(id).students # no authorization check
 #   Section.find(id).students # no authorization check
-#   current_educator.homeroom.students # doesn't work for all roles
-#   current_educator.school.students # doesn't work for all roles
+#   current_educator.homeroom.students # doesn't work for all roles because
+#     some roles don't have homeroom associations (e.g. if they're school-wide)
+#   current_educator.school.students # doesn't work for all roles because
+#     some roles don't have school associations (e.g. if they're district-wide)
+
 #
 class Authorizer
   # These fields are required on the `Student` model for


### PR DESCRIPTION
# Notes 

+ This PR is a patch onto the `feature/authorization-simple` branch. 
+ @kevinrobinson: Adding a little more explanation to some of the code comments in `authorizer.rb` to make them more explicit about why code like `current_educator.homeroom.students` doesn't work for all roles.