### PR TITLE
Remove skylight gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,6 @@ gem 'scout_apm'
 
 group :production do
   gem 'rails_12factor'
-  gem 'skylight'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,8 +286,6 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.1)
-    skylight (1.3.1)
-      activesupport (>= 3.0.0)
     slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -366,7 +364,6 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers
   simplecov
-  skylight
   spring
   sprockets
   thor


### PR DESCRIPTION
# Notes

+ I don't believe we're using https://skylight.io anymore for code profiling/insights. Scout (https://scoutapp.com), which we're also using, does the same thing.
+ If we're not using skylight, let's remove it from our Gemfile to cut down on memory (#1279). 