### PR TITLE
Bump moment js version to 2.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jquery": "^3.2.1",
     "js-cookie": "^2.1.4",
     "lodash": "3.10.1",
-    "moment": "2.11.1",
+    "moment": "2.11.2",
     "object-assign": "^4.1.1",
     "promise-polyfill": "^6.0.2",
     "rc-slider": "^8.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3086,9 +3086,9 @@ minimist@^1.1.1, minimist@^1.2.0:
   dependencies:
     minimist "0.0.8"
 
-moment@2.11.1:
-  version "2.11.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.11.1.tgz#bf4026413640d1b802467cf353607f8464d6af47"
+moment@2.11.2:
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.11.2.tgz#87968e5f95ac038c2e42ac959c75819cd3f52901"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Notes 

+ GitHub is warning about a security vuln in Moment.js 2.11. I took a look and it's a DDOS vulnerability, probably not something that's likely to apply to us since (a) our site's not a DDOS target and (b) someone would have to get behind authentication to exploit it anyway.
+ That said, why not bump the version to resolve the warning.