### PR TITLE
Fix missing uploaded_by_educator_id column on Service Uploads table

### DIFF
--- a/app/assets/javascripts/service_uploads/service_uploads_page.jsx
+++ b/app/assets/javascripts/service_uploads/service_uploads_page.jsx
@@ -14,10 +14,8 @@ import {merge} from '../helpers/react_helpers.jsx';
 
     getInitialState: function () {
       return {
-        serviceUploads: this.props.serializedData.serviceUploads, // Past uploads
-
-        // Data that goes to the Rails controller
-        formData: {},
+        serviceUploads: this.props.serializedData.serviceUploads, // Existing service uploads
+        formData: {},                                             // New service upload form data
 
         // Student LASID validation
         studentLasidsReceivedFromBackend: false,

--- a/app/assets/javascripts/service_uploads/service_uploads_page.jsx
+++ b/app/assets/javascripts/service_uploads/service_uploads_page.jsx
@@ -45,6 +45,8 @@ import {merge} from '../helpers/react_helpers.jsx';
     },
 
     upload: function () {
+      const { serializedData } = this.props;
+
       this.setState({
         serverSideErrors: [],
         uploadingInProgress: true,

--- a/app/assets/javascripts/service_uploads/service_uploads_page.jsx
+++ b/app/assets/javascripts/service_uploads/service_uploads_page.jsx
@@ -19,9 +19,7 @@ import {merge} from '../helpers/react_helpers.jsx';
         serviceUploads: serializedData.serviceUploads, // Past uploads
 
         // Data that goes to the Rails controller
-        formData: {
-          uploaded_by_educator_id: serializedData.currentEducator.id
-        },
+        formData: {},
 
         // Student LASID validation
         studentLasidsReceivedFromBackend: false,
@@ -52,12 +50,18 @@ import {merge} from '../helpers/react_helpers.jsx';
         uploadingInProgress: true,
       });  // Clear out any errors
 
+      const formData = merge(this.state.formData, {
+        uploaded_by_educator_id: serializedData.currentEducator.id
+      });
+
+      const jsonFormData = JSON.stringify(formData);
+
       $.ajax({
         url: '/service_uploads.json',
         method: 'POST',
         contentType: 'application/json; charset=UTF-8',
         dataType: 'json',
-        data: JSON.stringify(this.state.formData),
+        data: jsonFormData,
         success: function (data) {
           if (data.service_upload) {
             this.setState({

--- a/app/assets/javascripts/service_uploads/service_uploads_page.jsx
+++ b/app/assets/javascripts/service_uploads/service_uploads_page.jsx
@@ -53,7 +53,7 @@ import {merge} from '../helpers/react_helpers.jsx';
         method: 'POST',
         contentType: 'application/json; charset=UTF-8',
         dataType: 'json',
-        data: JSON.stringify(formData),
+        data: JSON.stringify(this.state.formData),
         success: function (data) {
           if (data.service_upload) {
             this.setState({

--- a/app/assets/javascripts/service_uploads/service_uploads_page.jsx
+++ b/app/assets/javascripts/service_uploads/service_uploads_page.jsx
@@ -13,9 +13,15 @@ import {merge} from '../helpers/react_helpers.jsx';
     },
 
     getInitialState: function () {
+      const { serializedData } = this.props;
+
       return {
-        serviceUploads: this.props.serializedData.serviceUploads, // Existing service uploads
-        formData: {},                                             // New service upload form data
+        serviceUploads: serializedData.serviceUploads, // Past uploads
+
+        // Data that goes to the Rails controller
+        formData: {
+          uploaded_by_educator_id: serializedData.currentEducator.id
+        },
 
         // Student LASID validation
         studentLasidsReceivedFromBackend: false,

--- a/app/assets/javascripts/service_uploads/service_uploads_page.jsx
+++ b/app/assets/javascripts/service_uploads/service_uploads_page.jsx
@@ -13,10 +13,8 @@ import {merge} from '../helpers/react_helpers.jsx';
     },
 
     getInitialState: function () {
-      const { serializedData } = this.props;
-
       return {
-        serviceUploads: serializedData.serviceUploads, // Past uploads
+        serviceUploads: this.props.serializedData.serviceUploads, // Past uploads
 
         // Data that goes to the Rails controller
         formData: {},
@@ -45,25 +43,17 @@ import {merge} from '../helpers/react_helpers.jsx';
     },
 
     upload: function () {
-      const { serializedData } = this.props;
-
       this.setState({
         serverSideErrors: [],
         uploadingInProgress: true,
       });  // Clear out any errors
-
-      const formData = merge(this.state.formData, {
-        uploaded_by_educator_id: serializedData.currentEducator.id
-      });
-
-      const jsonFormData = JSON.stringify(formData);
 
       $.ajax({
         url: '/service_uploads.json',
         method: 'POST',
         contentType: 'application/json; charset=UTF-8',
         dataType: 'json',
-        data: jsonFormData,
+        data: JSON.stringify(formData),
         success: function (data) {
           if (data.service_upload) {
             this.setState({

--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -55,7 +55,7 @@ class ServiceUploadsController < ApplicationController
     end
 
     render json: { service_upload: service_upload.as_json(
-      only: [:created_at, :file_name, :id, :uploaded_by_educator_id],
+      only: [:created_at, :file_name, :id],
       include: {
         services: {
           only: [],

--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -12,7 +12,7 @@ class ServiceUploadsController < ApplicationController
   def create
     service_upload = ServiceUpload.new(
       file_name: params['file_name'],
-      uploaded_by_educator_id: params['uploaded_by_educator_id']
+      uploaded_by_educator_id: current_educator.id
     )
 
     if service_upload.invalid?

--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -10,7 +10,10 @@ class ServiceUploadsController < ApplicationController
   end
 
   def create
-    service_upload = ServiceUpload.new(file_name: params['file_name'])
+    service_upload = ServiceUpload.new(
+      file_name: params['file_name'],
+      uploaded_by_educator_id: params['uploaded_by_educator_id']
+    )
 
     if service_upload.invalid?
       return render json: {
@@ -52,7 +55,7 @@ class ServiceUploadsController < ApplicationController
     end
 
     render json: { service_upload: service_upload.as_json(
-      only: [:created_at, :file_name, :id],
+      only: [:created_at, :file_name, :id, :uploaded_by_educator_id],
       include: {
         services: {
           only: [],

--- a/lib/tasks/data_migrations/backfill_service_upload_educator_ids.rake
+++ b/lib/tasks/data_migrations/backfill_service_upload_educator_ids.rake
@@ -1,6 +1,8 @@
 namespace :data_migration do
   desc "Backfill all service upload IDs"
   task backfill_service_upload_ids: :environment do
+    raise "Need an Uri ID!" unless ENV['URI_ID']
+
     puts "Updating service upload records..."; puts;
 
     ActiveRecord::Base.transaction do

--- a/lib/tasks/data_migrations/backfill_service_upload_educator_ids.rake
+++ b/lib/tasks/data_migrations/backfill_service_upload_educator_ids.rake
@@ -4,7 +4,7 @@ namespace :data_migration do
     puts "Updating service upload records..."; puts;
 
     ActiveRecord::Base.transaction do
-      ServiceUpload.each do |service_upload|
+      ServiceUpload.all.each do |service_upload|
         service_upload.uploaded_by_educator_id = ENV.fetch('URI_ID')
         service_upload.save!
 

--- a/lib/tasks/data_migrations/backfill_service_upload_educator_ids.rake
+++ b/lib/tasks/data_migrations/backfill_service_upload_educator_ids.rake
@@ -7,10 +7,14 @@ namespace :data_migration do
 
     ActiveRecord::Base.transaction do
       ServiceUpload.all.each do |service_upload|
-        service_upload.uploaded_by_educator_id = ENV.fetch('URI_ID')
-        service_upload.save!
+        if service_upload.uploaded_by_educator_id.nil?
+          service_upload.uploaded_by_educator_id = ENV.fetch('URI_ID')
+          service_upload.save!
 
-        print "."
+          print "*"
+        else
+          print "."
+        end
       end
     end
 

--- a/lib/tasks/data_migrations/backfill_service_upload_educator_ids.rake
+++ b/lib/tasks/data_migrations/backfill_service_upload_educator_ids.rake
@@ -1,0 +1,17 @@
+namespace :data_migration do
+  desc "Backfill all service upload IDs"
+  task backfill_service_upload_ids: :environment do
+    puts "Updating service upload records..."; puts;
+
+    ActiveRecord::Base.transaction do
+      ServiceUpload.each do |service_upload|
+        service_upload.uploaded_by_educator_id = ENV.fetch('URI_ID')
+        service_upload.save!
+
+        print "."
+      end
+    end
+
+    puts; puts "All done!"
+  end
+end

--- a/spec/controllers/service_uploads_controller_spec.rb
+++ b/spec/controllers/service_uploads_controller_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ServiceUploadsController, type: :controller do
           recorded_at: '01/19/2017',
           date_started: '01/01/2017',
           date_ended: '03/03/2017',
+          uploaded_by_educator_id: 999
         }
       }
 
@@ -36,8 +37,11 @@ RSpec.describe ServiceUploadsController, type: :controller do
 
       it 'returns the correct JSON' do
         make_post_request(params)
-        expect(response_json['service_upload']['file_name']).to eq('unique_file_name.csv')
-        expect(response_json['service_upload']['services'].count).to eq 2
+        service_upload = response_json['service_upload']
+
+        expect(service_upload['file_name']).to eq('unique_file_name.csv')
+        expect(service_upload['services'].count).to eq 2
+        expect(service_upload['uploaded_by_educator_id']).to eq 999
       end
     end
 

--- a/spec/controllers/service_uploads_controller_spec.rb
+++ b/spec/controllers/service_uploads_controller_spec.rb
@@ -36,11 +36,8 @@ RSpec.describe ServiceUploadsController, type: :controller do
 
       it 'returns the correct JSON' do
         make_post_request(params)
-        service_upload = response_json['service_upload']
-
-        expect(service_upload['file_name']).to eq('unique_file_name.csv')
-        expect(service_upload['services'].count).to eq 2
-        expect(service_upload['uploaded_by_educator_id']).to eq(educator.id)
+        expect(response_json['service_upload']['file_name']).to eq('unique_file_name.csv')
+        expect(response_json['service_upload']['services'].count).to eq 2
       end
     end
 

--- a/spec/controllers/service_uploads_controller_spec.rb
+++ b/spec/controllers/service_uploads_controller_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe ServiceUploadsController, type: :controller do
           recorded_at: '01/19/2017',
           date_started: '01/01/2017',
           date_ended: '03/03/2017',
-          uploaded_by_educator_id: 999
         }
       }
 
@@ -41,7 +40,7 @@ RSpec.describe ServiceUploadsController, type: :controller do
 
         expect(service_upload['file_name']).to eq('unique_file_name.csv')
         expect(service_upload['services'].count).to eq 2
-        expect(service_upload['uploaded_by_educator_id']).to eq 999
+        expect(service_upload['uploaded_by_educator_id']).to eq(educator.id)
       end
     end
 

--- a/spec/controllers/service_uploads_controller_spec.rb
+++ b/spec/controllers/service_uploads_controller_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe ServiceUploadsController, type: :controller do
         expect(response_json['service_upload']['file_name']).to eq('unique_file_name.csv')
         expect(response_json['service_upload']['services'].count).to eq 2
       end
+
+      it 'sets the correct uploaded_by_educator_id' do
+        make_post_request(params)
+        expect(ServiceUpload.last.uploaded_by_educator_id).to eq educator.id
+      end
     end
 
     context 'end date before start date (invalid!)' do


### PR DESCRIPTION
# What problem does this PR fix?

+ Right now back-end isn't storing any values for the `uploaded_by_educator_id` column in the `service_uploads` table. This isn't a huge problem since Uri is the only educator creating service upload records using the UI. 
+ Fix #1282.

# Checklist 

+ [x] Test migration locally
+ [x] Verify uploaded_by_educator_id gets set correctly in local development mode
+ [ ] Code review 
+ [ ] Deploy
+ [ ] Run `heroku run rake data_migration:backfill_service_upload_ids`