### PR TITLE
Fix empty attendance charts

### DIFF
--- a/app/assets/javascripts/helpers/graph_helpers.js
+++ b/app/assets/javascripts/helpers/graph_helpers.js
@@ -25,7 +25,7 @@ export function defaultMonthKey(event) {
 // Given a list of monthKeys, map over that to return a list of all events that fall within
 // that month.
 export function eventsToMonthBuckets(monthKeys, events) {
-  const eventsByMonth = _.groupBy(events, this.defaultMonthKey);
+  const eventsByMonth = _.groupBy(events, defaultMonthKey);
   return monthKeys.map(function(monthKey) {
     return eventsByMonth[monthKey] || [];
   });


### PR DESCRIPTION
# What was broken?

+ GraphHelpers was converted to a list of ES6 functions, but `this` statements needed to be updated to plain function calls. This is the exact same kind of error as #1283.

# Issue 

+ Closes #1290.

# Screenshot (if adding a client-side feature)

Non-empty attendance charts! (Local, demo data.) 

![screen shot 2017-11-30 at 11 29 37 am](https://user-images.githubusercontent.com/3209501/33445174-cba265c4-d5c1-11e7-86b0-36cf31682753.png)
