### PR TITLE
Student list now links to student profile

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/school_absence_dashboard.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/school_absence_dashboard.jsx
@@ -136,6 +136,7 @@ export default React.createClass({
     let rows =[];
     students.forEach((student) => {
       rows.push({
+        id: student.id,
         first_name: student.first_name,
         last_name: student.last_name,
         absences: studentAbsenceCounts[student.id] || 0

--- a/app/assets/javascripts/school_administrator_dashboard/students_table.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/students_table.jsx
@@ -96,7 +96,7 @@ export default React.createClass({
           <tbody>
             {this.orderedRows().map(student => {
               return (
-                <tr>
+                <tr key={student.id}>
                   <td width="66.66%">
                     <a href={Routes.studentProfile(student.id)}>
                       {student.last_name}, {student.first_name}

--- a/app/assets/javascripts/school_administrator_dashboard/students_table.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/students_table.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import SortHelpers from '../helpers/sort_helpers.jsx';
+import * as Routes from '../helpers/Routes';
 
 
 export default React.createClass({
@@ -77,9 +79,12 @@ export default React.createClass({
           <caption>{this.renderCaption()}</caption>
           <thead>
             <tr>
-              {this.renderHeader('Last Name', 'last_name', 'string')}
-              {this.renderHeader('First Name', 'first_name', 'string')}
-              {this.renderHeader('Absences', 'absences', 'number')}
+              <th width="66.66%"
+                  onClick={this.onClickHeader.bind(null, 'last_name', 'string')}
+                  className={this.headerClassName('last_name')}>Name</th>
+              <th width="33.33"
+                  onClick={this.onClickHeader.bind(null, 'absences', 'number')}
+                  className={this.headerClassName('absences')}>Absences</th>
             </tr>
           </thead>
           <tfoot>
@@ -92,9 +97,12 @@ export default React.createClass({
             {this.orderedRows().map(student => {
               return (
                 <tr>
-                  <td>{student.last_name}</td>
-                  <td>{student.first_name}</td>
-                  <td>{student.absences}</td>
+                  <td width="66.66%">
+                    <a href={Routes.studentProfile(student.id)}>
+                      {student.last_name}, {student.first_name}
+                    </a>
+                  </td>
+                  <td width="33.33%">{student.absences}</td>
                 </tr>
               );
             })}
@@ -104,9 +112,10 @@ export default React.createClass({
     );
   },
 
-  renderHeader (caption, sortBy, sortType) {
+  renderHeader (caption, sortBy, sortType, colSpan) {
     return (
-      <th onClick={this.onClickHeader.bind(null, sortBy, sortType)}
+      <th colSpan={colSpan}
+          onClick={this.onClickHeader.bind(null, sortBy, sortType)}
           className={this.headerClassName(sortBy)}>
         {caption}
       </th>

--- a/app/assets/javascripts/school_administrator_dashboard/students_table.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/students_table.jsx
@@ -112,16 +112,6 @@ export default React.createClass({
     );
   },
 
-  renderHeader (caption, sortBy, sortType, colSpan) {
-    return (
-      <th colSpan={colSpan}
-          onClick={this.onClickHeader.bind(null, sortBy, sortType)}
-          className={this.headerClassName(sortBy)}>
-        {caption}
-      </th>
-    );
-  },
-
   renderCaption () {
     return this.props.selectedHomeroom ? this.props.selectedHomeroom : "All Students";
   }

--- a/app/assets/stylesheets/components/school_dashboard.scss
+++ b/app/assets/stylesheets/components/school_dashboard.scss
@@ -40,7 +40,7 @@ table.students-list {
     border-bottom: 1px solid #ccc;
   }
 
-  tfoot td {
+  tbody td, thead th, tfoot td {
     float: left;
   }
 
@@ -50,11 +50,6 @@ table.students-list {
     overflow-x: hidden;
     border-top: 1px solid #ccc;
     border-bottom: 1px solid #ccc;
-  }
-
-  tbody td, thead th {
-    width: 33.3%;
-    float: left;
   }
 }
 


### PR DESCRIPTION
# Who is this PR for?
Administrators using the attendance dashbord

# What problem does this PR fix?
In #1264 @alexsoble suggested adding links to the student profiles of the students in the attendance list. This would allow admins to quickly get contact info for a student

# What does this PR do?
Adds links to student profile from dashboard

# Screenshot (if adding a client-side feature)

# Checklist

+ [X] Tested latest version in an Internet Explorer virtual machine? *(If the PR adds Javascript.)*
