### PR TITLE
Patch: Send down empty array if educator is authorized for no students

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -48,10 +48,12 @@ class Educator < ActiveRecord::Base
 
   def students_for_school_overview(*additional_includes)
     students = Authorizer.new(self).students_for_school_overview
+
     if students.respond_to?(:includes)
       students.includes(additional_includes || [])
     elsif students.size == 0
       logger.warn("Fell through to empty array in #students_for_school_overview for educator_id: #{self.id}")
+      []
     else
       students
     end


### PR DESCRIPTION
# Notes 

+ Otherwise, Rails returns `true` which isn't mappable, the precompute job needs a mappable array to work.
+ Tested this patch with a local `rake db:reset`, it worked.