### PR TITLE
Add another test case to PrecomputeStudentHashesJob spec

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -112,7 +112,7 @@ class Educator < ActiveRecord::Base
             .includes(additional_includes || [])
     else
       logger.warn("Fell through to empty array in #students_for_school_overview for educator_id: #{self.id}")
-      []
+      # []
     end
   end
 

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -112,7 +112,7 @@ class Educator < ActiveRecord::Base
             .includes(additional_includes || [])
     else
       logger.warn("Fell through to empty array in #students_for_school_overview for educator_id: #{self.id}")
-      # []
+      []
     end
   end
 

--- a/spec/jobs/precompute_student_hashes_job_spec.rb
+++ b/spec/jobs/precompute_student_hashes_job_spec.rb
@@ -31,9 +31,10 @@ RSpec.describe PrecomputeStudentHashesJob do
       end
     end
 
-    context 'educator without students' do
+    context 'educators without students' do
       let!(:school) { FactoryGirl.create(:healey) }
       let!(:educator) { FactoryGirl.create(:educator, school: school, schoolwide_access: true) }
+      let!(:educator_not_schoolwide) { FactoryGirl.create(:educator, school: school) }
 
       before { PrecomputeStudentHashesJob.new(log).precompute_all!(Time.now) }
 


### PR DESCRIPTION
# Notes 

+ This test case would have caught this issue in #1274: https://github.com/studentinsights/studentinsights/pull/1274#issuecomment-348531704
+ Adds a test for how the precomputing job handles classroom teachers who don't get any school overview precomputing; if the API sends down a non-mappable value for one of these teachers, the precomputing job will break; so we should test that all the values being sent down by the `students_for_school_overview` API are mappable (like an array, AR relation, or another enum)