### PR TITLE
Remove incorrect isRequired statements

### DIFF
--- a/app/assets/javascripts/student_profile/ela_details.jsx
+++ b/app/assets/javascripts/student_profile/ela_details.jsx
@@ -49,7 +49,7 @@ import {merge} from '../helpers/react_helpers.jsx';
 
     propTypes: {
       chartData: React.PropTypes.shape({
-        star_series_reading_percentile: React.PropTypes.array,
+        star_series_reading_percentile: React.PropTypes.array.isRequired,
         mcas_series_ela_scaled: React.PropTypes.array,
         next_gen_mcas_ela_scaled: React.PropTypes.array,
         mcas_series_ela_growth: React.PropTypes.array

--- a/app/assets/javascripts/student_profile/ela_details.jsx
+++ b/app/assets/javascripts/student_profile/ela_details.jsx
@@ -49,10 +49,10 @@ import {merge} from '../helpers/react_helpers.jsx';
 
     propTypes: {
       chartData: React.PropTypes.shape({
-        star_series_reading_percentile: React.PropTypes.array.isRequired,
-        mcas_series_ela_scaled: React.PropTypes.array.isRequired,
-        next_gen_mcas_ela_scaled: React.PropTypes.array.isRequired,
-        mcas_series_ela_growth: React.PropTypes.array.isRequired
+        star_series_reading_percentile: React.PropTypes.array,
+        mcas_series_ela_scaled: React.PropTypes.array,
+        next_gen_mcas_ela_scaled: React.PropTypes.array,
+        mcas_series_ela_growth: React.PropTypes.array
       }).isRequired,
       student: React.PropTypes.object.isRequired
     },

--- a/app/assets/javascripts/student_profile/ela_details.jsx
+++ b/app/assets/javascripts/student_profile/ela_details.jsx
@@ -52,7 +52,7 @@ import {merge} from '../helpers/react_helpers.jsx';
         star_series_reading_percentile: React.PropTypes.array.isRequired,
         mcas_series_ela_scaled: React.PropTypes.array,
         next_gen_mcas_ela_scaled: React.PropTypes.array,
-        mcas_series_ela_growth: React.PropTypes.array
+        mcas_series_ela_growth: React.PropTypes.array.isRequired
       }).isRequired,
       student: React.PropTypes.object.isRequired
     },

--- a/app/assets/javascripts/student_profile/math_details.jsx
+++ b/app/assets/javascripts/student_profile/math_details.jsx
@@ -49,10 +49,10 @@ import {merge} from '../helpers/react_helpers.jsx';
 
     propTypes: {
       chartData: React.PropTypes.shape({
-        star_series_math_percentile: React.PropTypes.array.isRequired,
-        mcas_series_math_scaled: React.PropTypes.array.isRequired,
-        next_gen_mcas_mathematics_scaled: React.PropTypes.array.isRequired,
-        mcas_series_math_growth: React.PropTypes.array.isRequired
+        star_series_math_percentile: React.PropTypes.array,
+        mcas_series_math_scaled: React.PropTypes.array,
+        next_gen_mcas_mathematics_scaled: React.PropTypes.array,
+        mcas_series_math_growth: React.PropTypes.array
       }).isRequired,
       student: React.PropTypes.object.isRequired
     },

--- a/app/assets/javascripts/student_profile/math_details.jsx
+++ b/app/assets/javascripts/student_profile/math_details.jsx
@@ -52,7 +52,7 @@ import {merge} from '../helpers/react_helpers.jsx';
         star_series_math_percentile: React.PropTypes.array.isRequired,
         mcas_series_math_scaled: React.PropTypes.array,
         next_gen_mcas_mathematics_scaled: React.PropTypes.array,
-        mcas_series_math_growth: React.PropTypes.array
+        mcas_series_math_growth: React.PropTypes.array.isRequired
       }).isRequired,
       student: React.PropTypes.object.isRequired
     },

--- a/app/assets/javascripts/student_profile/math_details.jsx
+++ b/app/assets/javascripts/student_profile/math_details.jsx
@@ -49,7 +49,7 @@ import {merge} from '../helpers/react_helpers.jsx';
 
     propTypes: {
       chartData: React.PropTypes.shape({
-        star_series_math_percentile: React.PropTypes.array,
+        star_series_math_percentile: React.PropTypes.array.isRequired,
         mcas_series_math_scaled: React.PropTypes.array,
         next_gen_mcas_mathematics_scaled: React.PropTypes.array,
         mcas_series_math_growth: React.PropTypes.array


### PR DESCRIPTION
# Issue 

+ Fix #1219. 

# Notes 

+ it's not the case that every student needs to have both next-gen and classic MCAS scores in ELA and Math. Some students will have only one type, some will have both, and some will have neither. See https://github.com/studentinsights/studentinsights/issues/1219#issuecomment-340575572 for more detail.

# Checklists

+ I don't think this needs tooooo much JS IE review because it doesn't touch any functionality, just prop type checking. 