### PR TITLE
Show which input fields for recording a service are required in the UI

### DIFF
--- a/app/assets/javascripts/student_profile/record_service.jsx
+++ b/app/assets/javascripts/student_profile/record_service.jsx
@@ -137,7 +137,7 @@ import {merge} from '../helpers/react_helpers.jsx';
       return (
         <div>
           <div style={{ marginBottom: 5, display: 'inline' }}>
-            Which service?
+            Which service? <span style={{color: 'red', fontWeight: 'bold'}}>*</span>
           </div>
           <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
             <div style={styles.buttonWidth}>
@@ -199,7 +199,7 @@ import {merge} from '../helpers/react_helpers.jsx';
             </div>
           </div>
           <div style={{ marginTop: 20 }}>
-            When did they start?
+            When did they start? <span style={{color: 'red', fontWeight: 'bold'}}>*</span>
           </div>
           <Datepicker
             styles={{
@@ -258,9 +258,14 @@ import {merge} from '../helpers/react_helpers.jsx';
             onClick={this.onClickCancel}>
             Cancel
           </button>
-          {(this.props.requestState === 'pending') ? <span>
-            Saving...
-          </span> : this.props.requestState}
+          <span>
+            {(this.props.requestState === 'pending') ? <span>
+              Saving...
+            </span> : this.props.requestState}
+          </span>
+          <div style={{color: 'red', marginTop: 15}}>
+            <span style={{fontWeight: 'bold'}}>*</span> = required field
+          </div>
         </div>
       );
     }


### PR DESCRIPTION
# Who is this PR for?

+ Educators who record services using our UI and aren't sure which fields are optional and which are required!

# What does this PR do?

+ Adds bold red asterisks to the required fields and a note explaining what the asterisks mean. 

# Screenshot (if adding a client-side feature)

![show-required-services](https://user-images.githubusercontent.com/3209501/33630404-da9a5596-d9cc-11e7-9c17-4459b953572b.png)

# Checklists

## Javascript QA

+ [x] Author checked latest in IE - Record Service area of Student Profile
+ [ ] Reviewer checked latest in IE - Record Service area of Student Profile

# Why adding it now?

+ Working on #1307, I started writing code to show users if the end dates they enter are valid or not. As I wrote that code, I realized that according to our server-side code, end dates aren't required, whereas start dates are. The client-side validation should reflect that. If the client-side validation reflects that, we should also have a clear, easy-to-find indications so the user doesn't have to enter invalid data to find out.

# GitHub issue

+ This implements one half of #152. The other half is doing the same thing for the Event Note side of the page. This has only one required input, "What are these notes from?", assuming we don't count the textarea itself as an input. 
+ We've added more fields during the past year, which make this comment (totally valid at the time!) a little dated now: https://github.com/studentinsights/studentinsights/issues/152#issuecomment-191351682
