### PR TITLE
Remove incorrect, non-deterministic test for fake_student.rb

### DIFF
--- a/spec/demo_data/fake_student_spec.rb
+++ b/spec/demo_data/fake_student_spec.rb
@@ -26,10 +26,6 @@ RSpec.describe FakeStudent do
     expect(student.race).not_to be_nil
   end
 
-  it 'adds student assessments' do
-    expect(student.student_assessments).not_to be_empty
-  end
-
   context 'd is 1 always' do
     let(:d) { {1 => 1.0} }
     it 'samples from a distribution correctly' do


### PR DESCRIPTION
# Notes 

+ Expectation says that generated fake students should always have student assessment results. But 1/20 generated students has `@newstudent == true`, which means they have no assessment results, so our CI suite fails 5% of the time non-deterministically.
+ Fix #1313.