### PR TITLE
Use TestPals in development, add admin/authorization overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,15 @@
 
 Student Insights gives educators an overview of student progress at their school, classroom-level rosters and individual student profiles.  It also allows them to capture interventions and notes during weekly or bi-weekly student support meetings focused on the most at-risk students.
 
-Check out the [demo site](https://somerville-teacher-tool-demo.herokuapp.com/):
-  - username: `demo@example.com`
-  - password: `demo-password`
+Check out the [demo site](https://somerville-teacher-tool-demo.herokuapp.com/) with different roles:
+
+  - District admin: `uri@demo.studentinsights.org`
+  - K8 principal: `laura@demo.studentinsights.org`
+  - Kindergarten teacher: `vivian@demo.studentinsights.org`
+  - HS physics teacher: `hugo@demo.studentinsights.org`
+  - 9th grade counselor: `sofia@demo.studentinsights.org`
+
+All accounts use the password: `demo-password`.
 
 Our presentation at [Code for Boston demo night](docs/readme_images/Student%20Insights%20-%20Demo%20Night%20slides.pdf) in May 2016 also has a good product overview.
 
@@ -134,7 +140,7 @@ $ yarn install
 bundle exec rake db:create db:migrate db:seed
 ```
 
-This will create demo students with fake student information. The demo educator username is `demo@example.com` and the demo password is `demo-password`.
+This will create demo students with fake student information.  See the demo site above for the set of educators you can use (or look at `test_pals.rb`).
 
 ## 3. Start the app
 Once you've created the data, start the app by running `yarn start` from the root of your project.  This runs two processes in parallel: the Rails server and a Webpack process that watches and rebuilds JavaScript files.  When the local server is up and running, visit http://localhost:3000/ and log in with your demo login information. You should see the roster view for your data.  You can stop both processes with `command+c` like normal, and look at `package.json` if you want to run them in individual terminals.

--- a/app/assets/stylesheets/no_default_page.scss
+++ b/app/assets/stylesheets/no_default_page.scss
@@ -1,0 +1,5 @@
+.no_default_page .info-area {
+  text-align: center;
+  margin-top: 55px;
+  padding: 55px;
+}

--- a/app/assets/stylesheets/no_homeroom.scss
+++ b/app/assets/stylesheets/no_homeroom.scss
@@ -1,7 +1,0 @@
-/* Is this used? */
-
-.no_homeroom .info-area, .no_homerooms .info-area {
-  text-align: center;
-  margin-top: 55px;
-  padding: 55px;
-}

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -18,7 +18,7 @@
 @import 'tooltip';
 @import 'override';
 @import 'buttons';
-@import 'no_homeroom';
+@import 'no_default_page';
 @import 'student_profile_page';
 @import 'districtwide_admin_homepage';
 @import 'modal_help';

--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -19,6 +19,21 @@ module Admin
       requested_resource.save_student_searchbar_json
     end
 
+    def authorization
+      @districtwide_educators = []
+      @can_set_educators = []
+      @admin_educators = []
+      @restricted_notes_educators = []
+      Educator.all.each do |educator|
+        @districtwide_educators << educator if educator.districtwide_access
+        @can_set_educators << educator if educator.can_set_districtwide_access
+        @admin_educators << educator if educator.admin
+        @restricted_notes_educators << educator if educator.can_view_restricted_notes
+      end
+      @all_educators = Educator.all
+      render layout: false
+    end
+
     def resource_params
       params["educator"]["grade_level_access"] = params["educator"]["grade_level_access"].try(:keys) || []
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,35 +17,7 @@ class ApplicationController < ActionController::Base
 
   # Return the homepage path, depending on the educator's role
   def homepage_path_for_role(educator)
-    if educator.districtwide_access?
-      educators_districtwide_url
-    elsif educator.schoolwide_access? || educator.has_access_to_grade_levels?
-      school_url(educator.school)
-    elsif educator.school.school_type == 'HS'
-      default_section_path(educator)
-    else
-      default_homeroom_path(educator)
-    end
-  end
-
-  def homepage_path_for_current_educator
-    homepage_path_for_role(current_educator)
-  end
-
-  def default_homeroom_path(educator)
-    homeroom_path(educator.default_homeroom)
-  rescue Exceptions::NoAssignedHomeroom   # Thrown by educator without default homeroom
-    no_homeroom_path
-  rescue Exceptions::NoHomerooms
-    no_homerooms_path
-  end
-
-  def default_section_path(educator)
-    section_path(educator.default_section)
-  rescue Exceptions::NoAssignedSections   # Thrown by educator without any sections
-    no_section_path
-  rescue Exceptions::NoSections
-    no_sections_path
+    PathsForEducator.new(educator).homepage_path
   end
 
   # Wrap all database queries with this to enforce authorization

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,18 +1,14 @@
 class PagesController < ApplicationController
 
-  skip_before_action :authenticate_educator!, only: [:about, :lets_encrypt_endpoint]  # Inherited from ApplicationController.
+  skip_before_action :authenticate_educator!, only: [:about, :lets_encrypt_endpoint]  # Inherited from ApplicationController
 
-  def about
+  def no_default_page
   end
 
-  def no_homeroom
-  end
-
-  def no_section
+  def not_authorized
   end
 
   def lets_encrypt_endpoint
     render text: ENV['LETS_ENCRYPT_STRING']
   end
-
 end

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -98,7 +98,7 @@ class SchoolsController < ApplicationController
 
   def authorize_for_school
     unless current_educator.is_authorized_for_school(@school)
-      redirect_to(homepage_path_for_current_educator)
+      redirect_to homepage_path_for_role(current_educator)
     end
 
     if current_educator.has_access_to_grade_levels?

--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -27,7 +27,7 @@
 #
 class Authorizer
   # These fields are required on the `Student` model for
-  # authorization checks
+  # authorization checks.
   def self.student_fields_for_authorization
     [
       :id,
@@ -35,6 +35,20 @@ class Authorizer
       :limited_english_proficiency,
       :school_id,
       :grade
+    ]
+  end
+
+  # These fields are required on the `Educator` model for
+  # authorization checks.
+  def self.educator_fields_for_authorization
+    [
+      :schoolwide_access,
+      :grade_level_access,
+      :restricted_to_sped_students,
+      :restricted_to_english_language_learners,
+      :districtwide_access,
+      :school_id,
+      :admin
     ]
   end
 
@@ -69,7 +83,8 @@ class Authorizer
       # to optimize a query.  The authorization layer could only recover by making more
       # queries, so instead we raise and force the developer to figure out how to resolve.
       #
-      # See `Authorizer.student_fields_for_authorization`
+      # See `Authorizer.student_fields_for_authorization` and `Authorizer.educator_field_for_authorization`
+      # to see what fields are required on each model.
       raise err
     end
     false
@@ -96,6 +111,20 @@ class Authorizer
     return false unless is_authorized_for_student?(event_note.student)
     return false if event_note.is_restricted && !@educator.can_view_restricted_notes
     true
+  end
+
+  # There are five types of entry experiences, depending on levels
+  # of access.
+  def homepage_type
+    begin
+      return :districtwide if @educator.districtwide_access?
+      return :school if @educator.schoolwide_access? || @educator.has_access_to_grade_levels?
+      return :section if @educator.school.school_type == 'HS' && @educator.default_section
+      return :homeroom if @educator.school.school_type != 'HS' && @educator.default_homeroom
+      return :nothing
+    rescue Exceptions::NoAssignedHomeroom, Exceptions::NoAssignedSections => err
+      :nothing
+    end
   end
 
   # TODO(kr) remove implementation

--- a/app/lib/exceptions.rb
+++ b/app/lib/exceptions.rb
@@ -1,7 +1,5 @@
 module Exceptions
   class NoAssignedHomeroom < StandardError; end
-  class NoHomerooms < StandardError; end
   class NoAssignedSections < StandardError; end
-  class NoSections < StandardError; end
   class EducatorNotAuthorized < StandardError; end
 end

--- a/app/lib/paths_for_educator.rb
+++ b/app/lib/paths_for_educator.rb
@@ -1,0 +1,29 @@
+# Determine paths for educators, based on what they have authorization to access.
+class PathsForEducator
+  def initialize(educator)
+    @educator = educator
+  end
+
+  # Return the homepage path, depending on the educator's role
+  def homepage_path
+    type = Authorizer.new(@educator).homepage_type
+    if type == :districtwide
+      url_helpers.educators_districtwide_path
+    elsif type == :school
+      url_helpers.school_path(@educator.school)
+    elsif type == :section
+      url_helpers.section_path(@educator.default_section)
+    elsif type == :homeroom
+      url_helpers.homeroom_path(@educator.default_homeroom)
+    elsif type == :nothing
+      url_helpers.no_default_page_path
+    else
+      url_helpers.no_default_page_path
+    end
+  end
+
+  private
+  def url_helpers
+    Rails.application.routes.url_helpers
+  end
+end

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -60,15 +60,13 @@ class Educator < ActiveRecord::Base
   end
 
   def default_homeroom
-    raise Exceptions::NoHomerooms if Homeroom.count == 0    # <= We can't show any homerooms if there are none
-    return homeroom if homeroom.present?                    # <= Logged-in educator has an assigned homeroom
-    raise Exceptions::NoAssignedHomeroom                    # <= Logged-in educator has no assigned homeroom
+    return homeroom if homeroom.present?
+    raise Exceptions::NoAssignedHomeroom
   end
 
   def default_section
-    raise Exceptions::NoSections if Section.count == 0    # <= We can't show any sectionss if there are none
-    return sections[0] if sections.present?                      # <= Logged-in educator has at least one assigned section
-    raise Exceptions::NoAssignedSections                    # <= Logged-in educator has no assigned section
+    return sections[0] if sections.present?
+    raise Exceptions::NoAssignedSections
   end
 
   def has_access_to_grade_levels?

--- a/app/views/admin/educators/_permissions_links.html.erb
+++ b/app/views/admin/educators/_permissions_links.html.erb
@@ -1,0 +1,9 @@
+<div style="padding: 10px">
+  <b>Educator permissions: </b>
+  <%= link_to 'Overview', admin_authorization_url, {
+    class: 'prominent-link'
+  } %>  
+  <%= link_to 'Adjust', admin_root_url, {
+    class: 'prominent-link'
+  } %>
+</div>

--- a/app/views/admin/educators/authorization.html.erb
+++ b/app/views/admin/educators/authorization.html.erb
@@ -1,0 +1,67 @@
+<%= render 'permissions_links' %>
+
+<h2>Sensitive access</h2>
+<div style="padding: 20px">
+  <div>
+    <div>Can set access: <%= @can_set_educators.size %></div>
+    <div>Admin: <%= @admin_educators.size %></div>
+    <div>Restricted notes: <%= @restricted_notes_educators.size %></div>
+    <div>Districtwide: <%= @districtwide_educators.size %></div>
+  </div>
+  <table style="margin-top: 40px; text-align: left;">
+    <thead>
+      <tr>
+        <th>Email</th>
+        <th>Name</th>
+        <th>Can set access</th>
+        <th>Admin</th>
+        <th>Restricted notes</th>
+        <th>Districtwide</th>
+        <th>School</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% educators = (@can_set_educators + @admin_educators + @districtwide_educators).uniq %>
+      <% educators.map do |educator| %>
+        <tr>
+          <td><%= educator.email %></td>
+          <td><%= educator.full_name %></td>
+          <td><%= educator.can_set_districtwide_access %></td>
+          <td><%= educator.admin %></td>
+          <td><%= educator.can_view_restricted_notes %></td>
+          <td><%= educator.districtwide_access %></td>
+          <td><%= educator.school.name %></td>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<h2>Educator homepages</h2>
+<div style="padding: 20px">
+  <pre><%=
+    hash = Hash.new(0);
+    homepage_types = @all_educators.map {|e| Authorizer.new(e).homepage_type }
+    homepage_types.each {|value| hash[value] += 1};
+    JSON.pretty_generate(hash)
+  %>
+  </pre>
+
+  <table style="margin-top: 40px; text-align: left;">
+      <thead>
+        <tr>
+          <th>Email</th>
+          <th>Name</th>
+          <th>Homepage</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @all_educators.map do |educator| %>
+          <% path = PathsForEducator.new(educator).homepage_path %>
+          <tr>
+            <td><%= educator.email %></td>
+            <td><%= educator.full_name %></td>
+            <td><%= link_to path, path %></td>
+        <% end %>
+      </tbody>
+    </table>
+</div>

--- a/app/views/admin/educators/index.html.erb
+++ b/app/views/admin/educators/index.html.erb
@@ -23,6 +23,8 @@ It renders the `_table` partial to display details about the resources.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
 %>
 
+<%= render 'permissions_links' %>
+
 <% content_for(:title) do %>
   <%= display_resource_name(page.resource_name) %>
 <% end %>

--- a/app/views/educators/districtwide_admin_homepage.html.erb
+++ b/app/views/educators/districtwide_admin_homepage.html.erb
@@ -38,6 +38,11 @@
           </h3>
           <ul>
             <li>
+              <%= link_to 'Educator permissions overview', admin_authorization_url, {
+                class: 'prominent-link'
+              } %>
+            </li>
+            <li>
               <%= link_to 'Adjust educator permissions', admin_root_url, {
                 class: 'prominent-link'
               } %>

--- a/app/views/pages/no_default_page.erb
+++ b/app/views/pages/no_default_page.erb
@@ -1,5 +1,5 @@
-<div class="info-area">
-  You don't have the correct authorization for this page.
+<div class="no_default_page info-area">
+  It looks like there's a problem with your account.
   <br/>
   Please check with the principal or school secretary if you feel this is incorrect.
   <br/>

--- a/app/views/pages/no_homeroom.html.erb
+++ b/app/views/pages/no_homeroom.html.erb
@@ -1,3 +1,0 @@
-<div class="info-area">
-  Looks like there's no homeroom assigned to you.
-</div>

--- a/app/views/pages/no_homerooms.html.erb
+++ b/app/views/pages/no_homerooms.html.erb
@@ -1,3 +1,0 @@
-<div class="info-area">
-  Looks like there are no homerooms.
-</div>

--- a/app/views/pages/no_section.html.erb
+++ b/app/views/pages/no_section.html.erb
@@ -1,3 +1,0 @@
-<div class="info-area">
-  Looks like there's no section assigned to you.
-</div>

--- a/app/views/pages/no_sections.html.erb
+++ b/app/views/pages/no_sections.html.erb
@@ -1,3 +1,0 @@
-<div class="info-area">
-  Looks like there are no sections.
-</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,10 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :educators
+    get '/authorization' => 'educators#authorization'
     root to: "educators#index"
   end
+  
 
   devise_for :educators
   authenticated :educator do
@@ -17,12 +19,7 @@ Rails.application.routes.draw do
     root to: "devise/sessions#new"
   end
 
-  get 'no_homeroom' => 'pages#no_homeroom'
-  get 'no_homerooms' => 'pages#no_homerooms'
-
-  get 'no_section' => 'pages#no_section'
-  get 'no_sections' => 'pages#no_sections'
-
+  get 'no_default_page' => 'pages#no_default_page'
   get 'not_authorized' => 'pages#not_authorized'
 
   if ENV['LETS_ENCRYPT_ENDPOINT']

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,25 @@
+require "#{Rails.root}/db/seeds/database_constants"
+require "#{Rails.root}/spec/support/test_pals"
+
+
+def sample_numeric_grade_from_letter(grade_letter)
+  case grade_letter
+    when "A"
+      grade_numeric = rand(90..100)
+    when "B"
+      grade_numeric = rand(80..89)
+    when "C"
+      grade_numeric = rand(70..79)
+    when "D"
+      grade_numeric = rand(60..69)
+    when "F"
+      grade_numeric = rand(50..59)
+  end
+end
+
+
+puts 'Starting seeds.rb...'
+
 # This forces updating schema.rb before seeding.  This is necessary
 # to allow `bundle exec rake db:migrate db:seed`, which otherwise would
 # not update the schema until all rake tasks are completed, and the seed task
@@ -8,161 +30,61 @@ ActiveRecord::Base.descendants.each do |klass|
   klass.reset_column_information
 end
 
-require "#{Rails.root}/db/seeds/database_constants"
-
-puts "Creating demo schools, homerooms, interventions..."
-
-raise "empty yer db" if School.count > 0 ||
-                        Student.count > 0 ||
-                        EventNote.count > 0 ||
-                        Service.count > 0
+puts "Checking for existing data in the database..."
+[School, Student, EventNote, Service].each do |klass|
+  raise "empty yer db for: #{klass}" if klass.count > 0
+end
 
 # The local demo data setup uses the Somerville database constants
 # (eg., the set of `ServiceType`s) for generating local demo data and
 # for tests.
 puts 'Seeding database constants for Somerville...'
-
 DatabaseConstants.new.seed!
-School.seed_somerville_schools
 
-healey = School.find_by_name("Arthur D Healey")
-wsns = School.find_by_name("West Somerville Neighborhood")
-shs = School.find_by_name("Somerville High")
-
-puts "Creating demo educators..."
+puts 'Destroying all educators...'
 Educator.destroy_all
 
-Educator.create!([{
-  email: "demo@example.com",
-  full_name: 'Principal, Laura',
-  password: "demo-password",
-  local_id: '350',
-  school: healey,
-  admin: true,
-  schoolwide_access: true,
-  can_view_restricted_notes: true
-}, {
-  email: "demo-admin@example.com",
-  password: "demo-password",
-  districtwide_access: true,
-  admin: true,
-}, {
-  email: "fake-fifth-grade@example.com",
-  full_name: 'Teacher, Sarah',
-  password: "demo-password",
-  local_id: '450',
-  school: healey,
-  admin: false,
-  schoolwide_access: false,
-}, {
-  email: "wsns@example.com",
-  full_name: 'Teacher, Mari',
-  password: 'demo-password',
-  local_id: '550',
-  school: wsns,
-  admin: false,
-  schoolwide_access: false,
-}, {
-  email: "shs_art@example.com",
-  full_name: 'Teacher, Hugo',
-  password: 'demo-password',
-  local_id: '650',
-  school: shs,
-  admin: false,
-  schoolwide_access: false,
-}, {
-  email: "shs_science@example.com",
-  full_name: 'Teacher, Fatima',
-  password: 'demo-password',
-  local_id: '750',
-  school: shs,
-  admin: false,
-  schoolwide_access: false,
-}])
+puts 'Creating TestPals...'
+pals = TestPals.create!
 
-puts 'Creating homerooms..'
-
-homerooms = [
-  Homeroom.create(name: "HEA 500", grade: "5", school: healey),
-  Homeroom.create(name: "WSNS 500", grade: "5", school: wsns),
-]
-
-puts 'Creating course and sections..'
-
-art_course = Course.create(course_number: "ART-302", course_description: "Ceramic Art 3", school: shs)
-science_course = Course.create(course_number: "SCI-201", course_description: "Physics 2", school: shs)
-
-sections = [
-  Section.create(section_number: "ART-302A", term_local_id: "FY", schedule: "2(M,R)", room_number: "201", course: art_course),
-  Section.create(section_number: "ART-302B", term_local_id: "FY", schedule: "4(M,R)", room_number: "234", course: art_course),
-  Section.create(section_number: "SCI-201A", term_local_id: "S1", schedule: "3(M,W,F)", room_number: "306W", course: science_course),
-  Section.create(section_number: "SCI-201B", term_local_id: "S1", schedule: "4(M,W,F)", room_number: "306W", course: science_course),
-]
-
-ServiceUpload.create([
+puts 'Uploading services...'
+ServiceUpload.create!([
   { file_name: "ReadingIntervention-2016.csv" },
   { file_name: "ATP-2016.csv" },
   { file_name: "SPELL-2016.csv" },
   { file_name: "SomerSession-2016.csv" },
 ])
 
-fifth_grade_educator = Educator.find_by_email('fake-fifth-grade@example.com')
-wsns_fifth_grade_educator = Educator.find_by_email('wsns@example.com')
-shs_art_educator = Educator.find_by_email('shs_art@example.com')
-shs_science_educator = Educator.find_by_email('shs_science@example.com')
-
-Homeroom.find_by_name("HEA 500").update_attribute(:educator, fifth_grade_educator)
-Homeroom.find_by_name("WSNS 500").update_attribute(:educator, wsns_fifth_grade_educator)
-
-art_course.sections.each do |section|
-  EducatorSectionAssignment.create(educator: shs_art_educator, section: section)
+puts 'Creating more students for each homeroom...'
+Homeroom.all.each do |homeroom|
+  puts "  Creating for homeroom: #{homeroom.name}..."
+  10.times { FakeStudent.new(homeroom.school, homeroom) }
 end
 
-science_course.sections.each do |section|
-  EducatorSectionAssignment.create(educator: shs_science_educator, section: section)
-end
+puts 'Creating additional students for the Healey with no homeroom...'
+10.times { FakeStudent.new(pals.healey, nil) }
 
-homerooms.each do |homeroom|
-  puts "Creating students for homeroom #{homeroom.name}..."
-  school = homeroom.school
-  10.times do
-    FakeStudent.new(school, homeroom)
-  end
-end
-
-shs_homeroom = Homeroom.create(name: "SHS ALL", grade: "10", school: shs)
-
-sections.each do |section|
-  puts "Creating students for section #{section.section_number}..."
+puts 'Creating more sophomore students...'
+Section.all.each do |section|
+  puts "  Creating students for section #{section.section_number}..."
   school = section.course.school
   10.times do
     grade_letter = ['A','B','C','D','F'].sample
-    case grade_letter
-      when "A"
-        grade_numeric = rand(90..100)
-      when "B"
-        grade_numeric = rand(80..89)
-      when "C"
-        grade_numeric = rand(70..79)
-      when "D"
-        grade_numeric = rand(60..69)
-      when "F"
-        grade_numeric = rand(50..59)
-    end
-
-    fake_student = FakeStudent.new(school, shs_homeroom)
-    StudentSectionAssignment.create(student: fake_student.student,
-                                    section: section,
-                                    grade_numeric: grade_numeric,
-                                    grade_letter: grade_letter)
+    grade_numeric = sample_numeric_grade_from_letter(grade_letter)
+    fake_student = FakeStudent.new(school, pals.shs_sophomore_homeroom)
+    StudentSectionAssignment.create!({
+      student: fake_student.student,
+      section: section,
+      grade_numeric: grade_numeric,
+      grade_letter: grade_letter
+    })
   end
 end
 
-10.times do
-  FakeStudent.new(healey, nil)
-end
 
+puts 'Updating indexes...'
 Student.update_risk_levels!
 Student.update_recent_student_assessments
-
 PrecomputeStudentHashesJob.new(STDOUT).precompute_all!(Time.now)
+
+puts 'Done seeds.rb.'

--- a/spec/controllers/admin_educators_controller_spec.rb
+++ b/spec/controllers/admin_educators_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Admin::EducatorsController do
+  let!(:pals) { TestPals.create! }
+
   describe '#index' do
     def make_request
       request.env['HTTPS'] = 'on'
@@ -15,7 +17,7 @@ describe Admin::EducatorsController do
     end
 
     context 'not admin' do
-      let(:educator) { FactoryGirl.create(:educator) }
+      let(:educator) { pals.healey_sarah_teacher }
       it 'fails' do
         sign_in(educator)
         make_request
@@ -24,18 +26,17 @@ describe Admin::EducatorsController do
     end
 
     context 'admin' do
-      let(:educator) { FactoryGirl.create(:educator, :admin) }
+      let(:educator) { pals.uri }
       it 'succeeds' do
         sign_in(educator)
         make_request
         expect(response.status).to eq 200
       end
     end
-
   end
 
   describe '#update' do
-    let(:admin) { FactoryGirl.create(:educator, :admin) }
+    let(:admin) { pals.uri }
 
     def make_request(params)
       request.env['HTTPS'] = 'on'
@@ -92,7 +93,37 @@ describe Admin::EducatorsController do
         expect(educator.grade_level_access).to eq([])
       end
     end
-
   end
 
+  describe '#authorization' do
+    def make_request
+      request.env['HTTPS'] = 'on'
+      get :authorization
+    end
+
+    context 'not logged in' do
+      it 'fails' do
+        make_request
+        expect(response.status).to eq 302
+      end
+    end
+
+    context 'teacher' do
+      let(:educator) { pals.healey_sarah_teacher }
+      it 'fails' do
+        sign_in(educator)
+        make_request
+        expect(response.status).to eq 302
+      end
+    end
+
+    context 'can set access' do
+      let(:educator) { pals.uri }
+      it 'succeeds' do
+        sign_in(educator)
+        make_request
+        expect(response.status).to eq 200
+      end
+    end
+  end
 end

--- a/spec/controllers/educators_controller_spec.rb
+++ b/spec/controllers/educators_controller_spec.rb
@@ -15,7 +15,7 @@ describe EducatorsController, :type => :controller do
         let!(:educator) { FactoryGirl.create(:educator_with_homeroom) }
         it 'redirects to default homeroom' do
           make_request
-          expect(response).to redirect_to(homeroom_url(educator.homeroom))
+          expect(response).to redirect_to(homeroom_path(educator.homeroom))
         end
       end
 
@@ -24,7 +24,7 @@ describe EducatorsController, :type => :controller do
         let!(:homeroom) { FactoryGirl.create(:homeroom) }   # Not associated with educator
         it 'redirects to no homeroom assigned page' do
           make_request
-          expect(response).to redirect_to(no_homeroom_url)
+          expect(response).to redirect_to(no_default_page_path)
         end
       end
     end

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -184,7 +184,7 @@ describe HomeroomsController, :type => :controller do
         let!(:homeroom) { FactoryGirl.create(:homeroom) }
         it 'redirects to no-homeroom error page' do
           make_request(homeroom.slug)
-          expect(response).to redirect_to(no_homeroom_url)
+          expect(response).to redirect_to(no_default_page_url)
         end
       end
     end

--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
   sequence(:staff_local_id) { |n| "000#{n}" }
 
   factory :educator do
-    password "PairShareCompare"
+    password 'demo-password' # All the same for local development and the demo site
     email { FactoryGirl.generate(:email) }
     local_id { FactoryGirl.generate(:staff_local_id) }
     association :school

--- a/spec/features/sign_in_feature_spec.rb
+++ b/spec/features/sign_in_feature_spec.rb
@@ -2,39 +2,25 @@ require 'rails_helper'
 require 'capybara/rspec'
 
 describe 'educator sign in', type: :feature do
+  let!(:pals) { TestPals.create! }
 
-  context 'educator with LDAP authorization signs in' do
-
-    context 'with homeroom' do
-      let(:school) { FactoryGirl.create(:school) }
-      let(:homeroom) { FactoryGirl.create(:homeroom, school: school) }
-      let(:educator) { FactoryGirl.create(:educator, homeroom: homeroom, school: school) }
-
-      it 'signs in' do
-        mock_ldap_authorization
-        educator_sign_in(educator)
-        expect(page).to have_content 'Signed in successfully.'
-      end
+  context 'teacher signs in' do
+    def expect_successful_sign_in_for(educator)
+      mock_ldap_authorization
+      educator_sign_in(educator)
+      expect(page).to have_content 'Signed in successfully.'
     end
 
-    context 'without homeroom' do
-      let(:educator) { FactoryGirl.create(:educator) }
+    it { expect_successful_sign_in_for(pals.healey_sarah_teacher) }
+    it { expect_successful_sign_in_for(pals.uri) }
+    it { expect_successful_sign_in_for(pals.west_marcus_teacher) }
 
-      context 'homerooms exist' do
-        let!(:homeroom) { FactoryGirl.create(:homeroom) }
-        it 'redirects to no-homeroom error page' do
-          mock_ldap_authorization
-          educator_sign_in(educator)
-          expect(page).to have_content 'Looks like there\'s no homeroom assigned to you.'
-        end
-      end
-
-      context 'no homerooms exist' do
-        it 'redirects to no homerooms page' do
-          mock_ldap_authorization
-          educator_sign_in(educator)
-          expect(page).to have_content 'Looks like there are no homerooms.'
-        end
+    context 'without default page' do
+      let(:educator) { pals.shs_jodi }
+      it 'redirects to no default page' do
+        mock_ldap_authorization
+        educator_sign_in(educator)
+        expect(page).to have_content 'problem with your account'
       end
     end
   end
@@ -46,5 +32,4 @@ describe 'educator sign in', type: :feature do
       expect(page).to have_content 'Invalid Email or password.'
     end
   end
-
 end

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe Authorizer do
 
   it 'sets up test context correctly' do
     expect(School.all.size).to eq 13
-    expect(Homeroom.all.size).to eq 3
+    expect(Homeroom.all.size).to eq 6
     expect(Student.all.size).to eq 2
-    expect(Educator.all.size).to eq 7
-    expect(Course.all.size).to eq 1
-    expect(Section.all.size).to eq 2
+    expect(Educator.all.size).to eq 12
+    expect(Course.all.size).to eq 3
+    expect(Section.all.size).to eq 6
   end
 
   describe '.student_fields_for_authorization' do
@@ -34,7 +34,7 @@ RSpec.describe Authorizer do
         pals.healey_kindergarten_student,
         pals.shs_freshman_mari
       ]
-      expect(authorized(pals.healey_teacher) { students }).to eq [pals.healey_kindergarten_student]
+      expect(authorized(pals.healey_vivian_teacher) { students }).to eq [pals.healey_kindergarten_student]
       expect(authorized(pals.shs_bill_nye) { students }).to eq [pals.shs_freshman_mari]
     end
 
@@ -52,11 +52,36 @@ RSpec.describe Authorizer do
         # attribute.
         expect do
           authorized(pals.uri) { students }
-          authorized(pals.healey_teacher) { students }
+          authorized(pals.healey_vivian_teacher) { students }
           authorized(pals.healey_ell_teacher) { students }
           authorized(pals.healey_sped_teacher) { students }
           authorized(pals.shs_bill_nye) { students }
           authorized(pals.shs_ninth_grade_counselor) { students }
+        end.to raise_error(ActiveModel::MissingAttributeError)
+      end
+    end
+  end
+
+  describe '.educator_field_for_authorization' do
+    it 'does not work when fields are missing' do
+      test_fields = Authorizer.educator_fields_for_authorization - [:id]
+
+      # Test each of the required fields individually
+      test_fields.each do |missing_field|
+        students = Student.all
+        some_fields = test_fields - [missing_field]
+
+        # Different educator permissions check different field.
+        # When this particular required field is missing, the check for
+        # one of these educators should raise an error about a missing
+        # attribute.
+        expect do
+          authorized(Educator.select(*some_fields).find(pals.uri.id)) { students }
+          authorized(Educator.select(*some_fields).find(pals.healey_vivian_teacher.id)) { students }
+          authorized(Educator.select(*some_fields).find(pals.healey_ell_teacher.id)) { students }
+          authorized(Educator.select(*some_fields).find(pals.healey_sped_teacher.id)) { students }
+          authorized(Educator.select(*some_fields).find(pals.shs_bill_nye.id)) { students }
+          authorized(Educator.select(*some_fields).find(pals.shs_ninth_grade_counselor.id)) { students }
         end.to raise_error(ActiveModel::MissingAttributeError)
       end
     end
@@ -69,7 +94,7 @@ RSpec.describe Authorizer do
           pals.healey_kindergarten_student,
           pals.shs_freshman_mari
         ]
-        expect(authorized(pals.healey_teacher) { Student.all }).to eq [
+        expect(authorized(pals.healey_vivian_teacher) { Student.all }).to eq [
           pals.healey_kindergarten_student
         ]
         expect(authorized(pals.shs_jodi) { Student.all }).to eq [
@@ -81,11 +106,11 @@ RSpec.describe Authorizer do
       end
 
       it 'limits access for Student.find' do
-        expect(authorized(pals.healey_teacher) { Student.find(pals.shs_freshman_mari.id) }).to eq nil
+        expect(authorized(pals.healey_vivian_teacher) { Student.find(pals.shs_freshman_mari.id) }).to eq nil
       end
 
       it 'limits access for arrays' do
-        expect(authorized(pals.healey_teacher) { [pals.shs_freshman_mari, pals.healey_kindergarten_student] }).to eq [pals.healey_kindergarten_student]
+        expect(authorized(pals.healey_vivian_teacher) { [pals.shs_freshman_mari, pals.healey_kindergarten_student] }).to eq [pals.healey_kindergarten_student]
       end
 
       it 'raises if given a Student model with `#select` filtering out fields needed for authorization' do
@@ -94,7 +119,7 @@ RSpec.describe Authorizer do
           'id' => pals.shs_freshman_mari.id,
           'local_id' => pals.shs_freshman_mari.local_id
         })
-        expect { authorized(pals.healey_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
+        expect { authorized(pals.healey_vivian_teacher) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
         expect { authorized(pals.shs_bill_nye) { thin_student } }.to raise_error(ActiveModel::MissingAttributeError)
       end
 
@@ -104,7 +129,7 @@ RSpec.describe Authorizer do
           pals.healey_kindergarten_student.id,
           pals.shs_freshman_mari.id
         ])
-        expect((authorized(pals.healey_teacher) { thin_relation }).map(&:id)).to eq([
+        expect((authorized(pals.healey_vivian_teacher) { thin_relation }).map(&:id)).to eq([
           pals.healey_kindergarten_student.id
         ])
         expect((authorized(pals.shs_bill_nye) { thin_relation }).map(&:id)).to eq([
@@ -126,7 +151,7 @@ RSpec.describe Authorizer do
           shs_public_note,
           shs_restricted_note
         ]
-        expect(authorized(pals.healey_teacher) { EventNote.all }).to eq [
+        expect(authorized(pals.healey_vivian_teacher) { EventNote.all }).to eq [
           healey_public_note
         ]
         expect(authorized(pals.shs_bill_nye) { EventNote.all }).to eq [
@@ -147,7 +172,7 @@ RSpec.describe Authorizer do
           shs_public_note,
           shs_restricted_note
         ]
-        expect(authorized(pals.healey_teacher) { all_notes }).to eq [
+        expect(authorized(pals.healey_vivian_teacher) { all_notes }).to eq [
           healey_public_note
         ]
         expect(authorized(pals.shs_bill_nye) { all_notes }).to eq [
@@ -164,10 +189,10 @@ RSpec.describe Authorizer do
         expect(is_authorized(pals.uri, healey_restricted_note)).to eq true
         expect(is_authorized(pals.uri, shs_public_note)).to eq true
         expect(is_authorized(pals.uri, shs_restricted_note)).to eq true
-        expect(is_authorized(pals.healey_teacher, healey_public_note)).to eq true
-        expect(is_authorized(pals.healey_teacher, healey_restricted_note)).to eq false
-        expect(is_authorized(pals.healey_teacher, shs_public_note)).to eq false
-        expect(is_authorized(pals.healey_teacher, shs_restricted_note)).to eq false
+        expect(is_authorized(pals.healey_vivian_teacher, healey_public_note)).to eq true
+        expect(is_authorized(pals.healey_vivian_teacher, healey_restricted_note)).to eq false
+        expect(is_authorized(pals.healey_vivian_teacher, shs_public_note)).to eq false
+        expect(is_authorized(pals.healey_vivian_teacher, shs_restricted_note)).to eq false
         expect(is_authorized(pals.shs_bill_nye, healey_public_note)).to eq false
         expect(is_authorized(pals.shs_bill_nye, healey_restricted_note)).to eq false
         expect(is_authorized(pals.shs_bill_nye, shs_public_note)).to eq true
@@ -186,7 +211,7 @@ RSpec.describe Authorizer do
     it 'raises if `#select` was used on the `student` argument, and fields needed for authorization are missing' do
       thin_student = Student.select(:id, :local_id).find(pals.shs_freshman_mari.id)
       expect(Authorizer.new(pals.uri).is_authorized_for_student?(thin_student)).to eq true
-      expect { Authorizer.new(pals.healey_teacher).is_authorized_for_student?(thin_student) }.to raise_error(ActiveModel::MissingAttributeError)
+      expect { Authorizer.new(pals.healey_vivian_teacher).is_authorized_for_student?(thin_student) }.to raise_error(ActiveModel::MissingAttributeError)
       expect { Authorizer.new(pals.shs_bill_nye).is_authorized_for_student?(thin_student) }.to raise_error(ActiveModel::MissingAttributeError)
     end
   end

--- a/spec/lib/paths_for_educator_spec.rb
+++ b/spec/lib/paths_for_educator_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe PathsForEducator do
+  let!(:pals) { TestPals.create! }
+
+  it '#homepage_path' do
+    expect(PathsForEducator.new(pals.uri).homepage_path).to eq '/educators/districtwide'
+
+    # healey
+    expect(PathsForEducator.new(pals.healey_laura_principal).homepage_path).to eq '/schools/hea'
+    expect(PathsForEducator.new(pals.healey_ell_teacher).homepage_path).to eq '/no_default_page'
+    expect(PathsForEducator.new(pals.healey_sped_teacher).homepage_path).to eq '/no_default_page'
+    expect(PathsForEducator.new(pals.healey_vivian_teacher).homepage_path).to eq "/homerooms/#{pals.healey_kindergarten_homeroom.slug}"
+    expect(PathsForEducator.new(pals.healey_sarah_teacher).homepage_path).to eq "/homerooms/#{pals.healey_fifth_homeroom.slug}"
+
+    # west
+    expect(PathsForEducator.new(pals.west_marcus_teacher).homepage_path).to eq "/homerooms/#{pals.west_fifth_homeroom.slug}"
+
+    # high school
+    expect(PathsForEducator.new(pals.shs_jodi).homepage_path).to eq '/no_default_page'
+    expect(PathsForEducator.new(pals.shs_ninth_grade_counselor).homepage_path).to eq '/schools/shs'
+    expect(PathsForEducator.new(pals.shs_bill_nye).homepage_path).to eq "/sections/#{pals.shs_tuesday_biology_section.id}"
+    expect(PathsForEducator.new(pals.shs_hugo_art_teacher).homepage_path).to eq "/sections/#{pals.shs_second_period_ceramics.id}"
+    expect(PathsForEducator.new(pals.shs_fatima_science_teacher).homepage_path).to eq "/sections/#{pals.shs_third_period_physics.id}"
+  end
+end

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -157,15 +157,6 @@ RSpec.describe Educator do
   end
 
   describe '#default_homeroom' do
-
-    context 'no homerooms' do
-      let(:educator) { FactoryGirl.create(:educator) }
-
-      it 'raises an error' do
-        expect { educator.default_homeroom }.to raise_error Exceptions::NoHomerooms
-      end
-    end
-
     context 'educator assigned a homeroom' do
       let(:educator) { FactoryGirl.create(:educator) }
       let!(:homeroom) { FactoryGirl.create(:homeroom, educator: educator) }

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -11,22 +11,48 @@ class TestPals
     pals
   end
 
-  attr_reader :uri
+  # schools
   attr_reader :healey
+  attr_reader :shs
+  attr_reader :west
+
+  # students
   attr_reader :healey_kindergarten_student
-  attr_reader :healey_teacher
+  attr_reader :shs_freshman_mari
+
+  # educators
+  attr_reader :uri
+  attr_reader :healey_vivian_teacher
   attr_reader :healey_ell_teacher
   attr_reader :healey_sped_teacher
-  attr_reader :healey_kindergarten_homeroom
-  attr_reader :shs
-  attr_reader :shs_freshman_mari
+  attr_reader :healey_laura_principal
+  attr_reader :healey_sarah_teacher
+  attr_reader :west_marcus_teacher
   attr_reader :shs_jodi
   attr_reader :shs_bill_nye
   attr_reader :shs_ninth_grade_counselor
+  attr_reader :shs_hugo_art_teacher
+  attr_reader :shs_fatima_science_teacher
+
+  # homerooms
+  attr_reader :healey_kindergarten_homeroom
+  attr_reader :healey_fifth_homeroom
+  attr_reader :west_fifth_homeroom
   attr_reader :shs_jodi_homeroom
+  attr_reader :shs_sophomore_homeroom
+
+  # courses
   attr_reader :shs_biology_course
+  attr_reader :shs_ceramics_course
+  attr_reader :shs_physics_course
+
+  # sections
   attr_reader :shs_tuesday_biology_section
   attr_reader :shs_thursday_biology_section
+  attr_reader :shs_second_period_ceramics
+  attr_reader :shs_fourth_period_ceramics
+  attr_reader :shs_third_period_physics
+  attr_reader :shs_fifth_period_physics
 
   def create!
     School.seed_somerville_schools
@@ -34,7 +60,9 @@ class TestPals
     # Uri works in the central office, and is the admin for the entire
     # project at the district.
     @uri = FactoryGirl.create(:educator, {
-      email: 'uri@studentinsights.org',
+      email: 'uri@demo.studentinsights.org',
+      full_name: 'Disney, Uri',
+      can_set_districtwide_access: true,
       districtwide_access: true,
       admin: true,
       schoolwide_access: true,
@@ -47,56 +75,146 @@ class TestPals
 
     # Healey is a K8 school.
     @healey = School.find_by_local_id('HEA')
-    @healey_kindergarten_homeroom = FactoryGirl.create(:homeroom, school: healey)
-    @healey_kindergarten_student = FactoryGirl.create(:student, {
-      school: @healey,
-      homeroom: @healey_kindergarten_homeroom,
-      grade: 'KF'
+    @healey_kindergarten_homeroom = FactoryGirl.create(:homeroom, {
+      name: 'HEA 003',
+      grade: 'KF',
+      school: @healey
     })
-    @healey_teacher = FactoryGirl.create(:educator, {
+    @healey_fifth_homeroom = FactoryGirl.create(:homeroom, {
+      name: 'HEA 500',
+      grade: '5',
+      school: @healey,
+    })
+
+    @healey_vivian_teacher = FactoryGirl.create(:educator, {
+      email: 'vivian@demo.studentinsights.org',
+      full_name: 'Teacher, Vivian',
       school: @healey,
       homeroom: @healey_kindergarten_homeroom
     })
     @healey_ell_teacher = FactoryGirl.create(:educator, {
+      email: 'alonso@demo.studentinsights.org',
+      full_name: 'Teacher, Alonso',
       restricted_to_english_language_learners: true,
       school: @healey
     })
     @healey_sped_teacher = FactoryGirl.create(:educator, {
+      email: 'silva@demo.studentinsights.org',
+      full_name: 'Teacher, Silva',
       restricted_to_sped_students: true,
       school: @healey
+    })
+    @healey_laura_principal = FactoryGirl.create(:educator, {
+      email: 'laura@demo.studentinsights.org',
+      full_name: 'Principal, Laura',
+      school: @healey,
+      admin: true,
+      schoolwide_access: true,
+      can_view_restricted_notes: true,
+      local_id: '350'
+    })
+    @healey_sarah_teacher = FactoryGirl.create(:educator, {
+      email: "sarah@demo.studentinsights.org",
+      full_name: 'Teacher, Sarah',
+      homeroom: @healey_fifth_homeroom,
+      school: @healey,
+      local_id: '450'
+    })
+    @healey_kindergarten_student = FactoryGirl.create(:student, {
+      first_name: 'Garfield',
+      last_name: 'Skywalker',
+      school: @healey,
+      homeroom: @healey_kindergarten_homeroom,
+      grade: 'KF'
+    })
+
+    # West is a K8 school
+    @west = School.find_by_local_id('WSNS')
+    @west_fifth_homeroom = FactoryGirl.create(:homeroom, {
+      name: 'WSNS 501',
+      grade: '5',
+      school: @west
+    })
+    @west_marcus_teacher = FactoryGirl.create(:educator, {
+      email: "marcus@demo.studentinsights.org",
+      full_name: 'Teacher, Marcus',
+      local_id: '550',
+      homeroom: @west_fifth_homeroom,
+      school: @west
     })
 
     # high school
     @shs = School.find_by_local_id('SHS')
     @shs_ninth_grade_counselor = FactoryGirl.create(:educator, {
+      email: 'sofia@demo.studentinsights.org',
+      full_name: 'Counselor, Sofia',
       school: @shs,
       grade_level_access: ['9']
     })
+    @shs_sophomore_homeroom = Homeroom.create(name: "SHS ALL", grade: "10", school: @shs)
 
     # Jodi has a homeroom period at the high school.
-    @shs_jodi_homeroom = FactoryGirl.create(:homeroom, school: @shs)
+    @shs_jodi_homeroom = FactoryGirl.create(:homeroom, {
+      name: 'SHS 942',
+      grade: '9',
+      school: @shs
+    })
     @shs_jodi = FactoryGirl.create(:educator, {
-      email: 'jodi@studentinsights.org',
+      email: 'jodi@demo.studentinsights.org',
+      full_name: 'Teacher, Jodi',
       school: @shs,
       homeroom: @shs_jodi_homeroom
     })
 
     # Bill Nye is a biology teacher at Somerville High School.  He teaches sections
     # on Tuesday and Thursday and has a homeroom period.
-    @shs_bill_nye_homeroom = FactoryGirl.create(:homeroom, school: @shs)
+    @shs_bill_nye_homeroom = FactoryGirl.create(:homeroom, {
+      name: 'SHS 917',
+      grade: '9',
+      school: @shs
+    })
     @shs_bill_nye = FactoryGirl.create(:educator, {
-      email: 'billnye@studentinsights.org',
+      email: 'bill@demo.studentinsights.org',
+      full_name: 'Teacher, Bill',
       school: @shs,
       homeroom: @shs_bill_nye_homeroom
     })
     @shs_biology_course = FactoryGirl.create(:course, school: @shs)
-    @shs_tuesday_biology_section = FactoryGirl.create(:section, course: @shs_biology_course)
-    @shs_thursday_biology_section = FactoryGirl.create(:section, course: @shs_biology_course)
-    FactoryGirl.create(:educator_section_assignment, educator: @shs_bill_nye, section: @shs_tuesday_biology_section)
-    FactoryGirl.create(:educator_section_assignment, educator: @shs_bill_nye, section: @shs_thursday_biology_section)
+    create_section_assignment(@shs_bill_nye, [
+      @shs_tuesday_biology_section = FactoryGirl.create(:section, course: @shs_biology_course),
+      @shs_thursday_biology_section = FactoryGirl.create(:section, course: @shs_biology_course)
+    ])
+
+    # Hugo teachers two sections of ceramics at the high school.
+    @shs_hugo_art_teacher = FactoryGirl.create(:educator, {
+      email: "hugo@demo.studentinsights.org",
+      full_name: 'Teacher, Hugo',
+      local_id: '650',
+      school: @shs
+    })
+    @shs_ceramics_course = Course.create(course_number: "ART-302", course_description: "Ceramic Art 3", school: @shs)
+    create_section_assignment(@shs_hugo_art_teacher, [
+      @shs_second_period_ceramics = Section.create(section_number: "ART-302A", term_local_id: "FY", schedule: "2(M,R)", room_number: "201", course: @shs_ceramics_course),
+      @shs_fourth_period_ceramics = Section.create(section_number: "ART-302B", term_local_id: "FY", schedule: "4(M,R)", room_number: "234", course: @shs_ceramics_course)
+    ])
+
+    # Fatima teaches two sections of physics at the high school.
+    @shs_fatima_science_teacher = FactoryGirl.create(:educator, {
+      email: "fatima@demo.studentinsights.org",
+      full_name: 'Teacher, Fatima',
+      local_id: '750',
+      school: @shs
+    })
+    @shs_physics_course = Course.create(course_number: "SCI-201", course_description: "Physics 2", school: @shs)
+    create_section_assignment(@shs_fatima_science_teacher, [
+      @shs_third_period_physics = Section.create(section_number: "SCI-201A", term_local_id: "S1", schedule: "3(M,W,F)", room_number: "306W", course: @shs_physics_course),
+      @shs_fifth_period_physics = Section.create(section_number: "SCI-201B", term_local_id: "S1", schedule: "5(M,W,F)", room_number: "306W", course: @shs_physics_course)
+    ])
 
     # Mari is a freshman at the high school, enrolled in biology and in Jodi's homeroom.
     @shs_freshman_mari = FactoryGirl.create(:student, {
+      first_name: 'Mari',
+      last_name: 'Kenobi',
       school: @shs,
       homeroom: @shs_jodi_homeroom,
       grade: '9'
@@ -104,5 +222,12 @@ class TestPals
     FactoryGirl.create(:student_section_assignment, student: @shs_freshman_mari, section: @shs_tuesday_biology_section)
 
     self
+  end
+
+  private
+  def create_section_assignment(educator, sections)
+    sections.each do |section|
+      EducatorSectionAssignment.create(educator: educator, section: section)
+    end
   end
 end


### PR DESCRIPTION
❗️ **This updates the local development process - see the updated README for how to login in development mode** ❗️ 

# Who is this PR for?
Developers and project admin

# What problem does this PR fix?
This updates the local development data to use `TestPals` so that the development data allows manually testing the set of educator roles that are also tested in automated tests.  These should have semantically correct relationships so that authorization rules all make sense.

It also adds an `/admin/authorization` page to audit which users have sensitive access, and to see the homeroom pages for each educator.

# What does this PR do?
It reworks `seeds.rb` to merge it into `TestPals`.

It moves the homepage code out of `ApplicationController` and into `Authorizer` for determining what kind of homepage to show, and `PathsForEducator` for computing the actual path for standalone testing.  In the process, this removes some unnecessary code and pages that were handling cases when the database had no `Section` or `Homeroom` models, and collapses that into a `no_default_page` view.

It adds `/admin/authorization`.

# Screenshot (if adding a client-side feature)
Seeding:
```

Starting seeds.rb...
Checking for existing data in the database...
Seeding database constants for Somerville...
Destroying all educators...
Creating TestPals...
Uploading services...
Creating more students for each homeroom...
  Creating for homeroom: HEA 500...
  Creating for homeroom: HEA 003...
  Creating for homeroom: WSNS 501...
  Creating for homeroom: SHS ALL...
  Creating for homeroom: SHS 917...
  Creating for homeroom: SHS 942...
Creating additional students for the Healey with no homeroom...
Creating more sophomore students...
  Creating students for section SECTION-1...
  Creating students for section SECTION-2...
  Creating students for section ART-302A...
  Creating students for section ART-302B...
  Creating students for section SCI-201A...
  Creating students for section SCI-201B...
Updating indexes...
Querying for jobs...
Found 5 jobs.
Starting precomputing...
Wrote document 1...
Wrote document 2...
Wrote document 3...
Wrote document 4...
Wrote document 5...
Done.
Done seeds.rb.
```

Authorization overview admin page (showing new development data created from `TestPals`):
<img width="838" alt="screen shot 2017-12-10 at 1 53 23 pm" src="https://user-images.githubusercontent.com/1056957/33808275-974ac8d2-ddb1-11e7-980c-51297b6c6123.png">
<img width="606" alt="screen shot 2017-12-10 at 2 02 26 pm" src="https://user-images.githubusercontent.com/1056957/33808353-cae0c60a-ddb2-11e7-862e-934f87da84d1.png">
