### PR TITLE
Remove ELEM shortcode option for import process

### DIFF
--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -21,10 +21,6 @@ class Import
       'SHS',
     ]
 
-    SCHOOL_SHORTCODE_EXPANSIONS = {
-      "ELEM" => %w[BRN HEA KDY AFAS ESCS WSNS WHCS]
-    }
-
     X2_IMPORTERS = [
       StudentsImporter,
       X2AssessmentImporter,
@@ -76,7 +72,7 @@ class Import
       type: :array,
       default: DEFAULT_SCHOOLS,
       aliases: "-s",
-      desc: "Scope by school local IDs; use ELEM to import all elementary schools"
+      desc: "Scope by school local IDs"
     class_option :first_time,
       type: :boolean,
       desc: "Fill up an empty database"
@@ -130,10 +126,6 @@ class Import
           [PRIORITY.fetch(import_class, 100), import_class.to_s]
         end
       end
-
-      def school_local_ids(schools = options["school"])
-        schools.flat_map { |s| SCHOOL_SHORTCODE_EXPANSIONS.fetch(s, s) }.uniq
-      end
     end
 
     def load_rails
@@ -150,7 +142,7 @@ class Import
 
     def validate_schools
       School.seed_somerville_schools if School.count == 0
-      school_local_ids.each { |id| School.find_by!(local_id: id) }
+      options["school"].each { |id| School.find_by!(local_id: id) }
     end
 
     def connect_transform_import

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -138,33 +138,4 @@ RSpec.describe Import do
     end
   end
 
-  describe '#schools' do
-    context 'when passed a valid school local ID' do
-      it 'returns the school local ID' do
-        expect(task.school_local_ids(['HEA'])).to eq ["HEA"]
-      end
-    end
-    context 'when passed the ELEM shorthand id' do
-      it 'returns all elementary school IDs' do
-        expect(task.school_local_ids(['ELEM'])).to eq %w[
-          BRN HEA KDY AFAS ESCS WSNS WHCS
-        ]
-      end
-    end
-    context 'when passed the ELEM shorthand and a valid school local id in the ELEM list' do
-      it 'returns all elementary school IDs' do
-        expect(task.school_local_ids(['ELEM', 'HEA'])).to eq %w[
-          BRN HEA KDY AFAS ESCS WSNS WHCS
-        ]
-      end
-    end
-    context 'when passed the ELEM shorthand and another valid school local id' do
-      it 'returns all elementary school IDs and the other id' do
-        expect(task.school_local_ids(['ELEM', 'SHS'])).to eq %w[
-          BRN HEA KDY AFAS ESCS WSNS WHCS SHS
-        ]
-      end
-    end
-  end
-
 end


### PR DESCRIPTION
# Why?

+ It adds complexity that makes `import.thor` harder to read, but is rarely if ever used.
  + In my next couple of PRs, I'll be changing `import.thor` to clear a path for importing New Bedford data and this will be a stumbling block. The ELEM code creates another set of configuration for each new district we add. 
  + I can't remember the last time I used the ELEM shortcut for Somerville, if ever.
  + It doesn't look like it would even work: the `school_local_ids` method that calls is is only used in `#validate_schools`, but not in the code that runs the import itself.