### PR TITLE
Convert Educator.js to ES6 module

### DIFF
--- a/app/assets/javascripts/student_profile/Educator.js
+++ b/app/assets/javascripts/student_profile/Educator.js
@@ -1,31 +1,35 @@
+import React from 'react';
+
 /*
 Canonical display of an educator, showing their name as a link to email them.
 */
-
-export default React.createClass({
-  displayName: 'Educator',
-
-  propTypes: {
-    educator: React.PropTypes.shape({
-      full_name: React.PropTypes.string, // or null
-      email: React.PropTypes.string.isRequired
-    }).isRequired
-  },
+class Educator extends React.Component {
 
   // Turns SIS format (Watson, Joe) -> Joe Watson
-  educatorName: function(educator) {
+  educatorName(educator) {
     if (educator.full_name === null) return educator.email.split('@')[0] + '@';
     const parts = educator.full_name.split(', ');
     return parts[1] + ' ' + parts[0];
-  },
+  }
 
-  render: function() {
+  render() {
     const educator = this.props.educator;
     const educatorName = this.educatorName(educator);
+
     return (
       <a className="Educator" href={'mailto:' + educator.email}>
         {educatorName}
       </a>
     );
   }
-});
+
+}
+
+Educator.propTypes = {
+  educator: React.PropTypes.shape({
+    full_name: React.PropTypes.string, // or null
+    email: React.PropTypes.string.isRequired
+  }).isRequired
+};
+
+export default Educator;

--- a/app/assets/javascripts/student_profile/note_card.jsx
+++ b/app/assets/javascripts/student_profile/note_card.jsx
@@ -1,6 +1,5 @@
-import Educator from './educator.jsx';
+import Educator from '../student_profile/Educator.js';
 import moment from 'moment';
-
 
 (function() {
   window.shared || (window.shared = {});

--- a/ui/legacy.js
+++ b/ui/legacy.js
@@ -13,7 +13,6 @@ import '../app/assets/javascripts/student_profile/risk_bubble.jsx';
 import '../app/assets/javascripts/student_profile/service_color.jsx';
 import '../app/assets/javascripts/student_profile/provided_by_educator_dropdown.jsx';
 import '../app/assets/javascripts/student_profile/profile_chart_settings.jsx';
-import '../app/assets/javascripts/student_profile/educator.jsx';
 import '../app/assets/javascripts/student_profile/datepicker.jsx';
 import '../app/assets/javascripts/student_profile/highcharts_wrapper.jsx';
 import '../app/assets/javascripts/student_profile/bar_chart_sparkline.jsx';


### PR DESCRIPTION
# Who is this PR for?

Developers who want to contribute to the codebase by adding or improving client-side features. 

# What problem does this PR fix?

Not all our JS files use ES6 modules, which can be confusing for new JS devs coming on to the project.

# What does this PR do?

Converts `Educator.js` to ES6. 

# Checklist 

+ [x] Student Profile teacher notes  — tested latest commit in Internet Explorer

# Screenshot 

![notes](https://user-images.githubusercontent.com/3209501/34269466-4523985a-e639-11e7-8bd2-441618ab7250.png)
