### PR TITLE
Api.js doesn't extend React.Component because it doesn't touch the DOM

### DIFF
--- a/app/assets/javascripts/student_profile/Api.js
+++ b/app/assets/javascripts/student_profile/Api.js
@@ -1,9 +1,4 @@
-import React from 'react';
-
-class Api extends React.Component {
-  constructor(props) {
-    super(props);
-  }
+class Api {
 
   saveNotes(studentId, eventNoteParams) {
     if (eventNoteParams.id) {


### PR DESCRIPTION
# Who is this PR for?

+ Developers who write JS.

# What problem does this PR fix?

+ Fixes the class inheritance of `Api.js`.

# What does this PR do?

+ Removes `extends React.Component` from `Api.js` since `Api.js` is not a React component; does not touch the DOM.

# Checklist 

+ [x] Student Profile educator notes Create/Edit note — tested latest commit in Internet Explorer 

# Screenshots

## Created note

![created note](https://user-images.githubusercontent.com/3209501/34269965-4ff2a724-e63b-11e7-91a5-74131ffaacdc.png)

## Edited note

![edited note](https://user-images.githubusercontent.com/3209501/34269966-500c9382-e63b-11e7-845d-dcbbf488a30e.png)
