### PR TITLE
Improve loading and parsing of district config YAML 

### DIFF
--- a/app/config_objects/district_config.rb
+++ b/app/config_objects/district_config.rb
@@ -1,3 +1,6 @@
+# This class exposes an API for district config that runs validation or other
+# logic on the parsed YAML config.
+
 class DistrictConfig
 
   def remote_filenames
@@ -5,9 +8,7 @@ class DistrictConfig
 
     remote_filenames = yml_config.fetch("remote_filenames")
 
-    if Rails.env.production?
-      validate_remote_filenames(remote_filenames)
-    end
+    validate_remote_filenames(remote_filenames) if Rails.env.production?
 
     return remote_filenames
   end

--- a/app/config_objects/district_config.rb
+++ b/app/config_objects/district_config.rb
@@ -1,7 +1,9 @@
 class DistrictConfig
 
   def remote_filenames
-    remote_filenames = load_remote_filenames_from_yml
+    yml_config = LoadDistrictConfig.new.load
+
+    remote_filenames = yml_config.fetch("remote_filenames")
 
     if Rails.env.production?
       validate_remote_filenames(remote_filenames)
@@ -11,25 +13,6 @@ class DistrictConfig
   end
 
   private
-
-  def district_key
-    ENV.fetch('DISTRICT_KEY')
-  end
-
-  def district_key_to_config_file
-    {
-      'somerville' => 'config/district_somerville.yml',
-      'new_bedford' => 'config/district_new_bedford.yml',
-    }
-  end
-
-  def config_file_path
-    district_key_to_config_file.fetch(district_key)
-  end
-
-  def load_remote_filenames_from_yml
-    YAML.load(File.open(config_file_path)).fetch("remote_filenames")
-  end
 
   def expected_keys
     [

--- a/app/config_objects/district_config.rb
+++ b/app/config_objects/district_config.rb
@@ -28,9 +28,7 @@ class DistrictConfig
   end
 
   def load_remote_filenames_from_yml
-    YAML.load(File.open(config_file_path))
-        .fetch("config")
-        .fetch("remote_filenames")
+    YAML.load(File.open(config_file_path)).fetch("remote_filenames")
   end
 
   def expected_keys

--- a/app/config_objects/load_district_config.rb
+++ b/app/config_objects/load_district_config.rb
@@ -1,3 +1,9 @@
+# This class is responsible for pulling YAML district config out of the
+# filesystem and parsing it into a Ruby hash.
+
+# This class can be used directly when raw config values are acceptable.
+# When validation or server-side logic is needed, use DistrictConfig class.
+
 class LoadDistrictConfig
 
   def initialize(district_key = ENV['DISTRICT_KEY'])

--- a/app/config_objects/load_district_config.rb
+++ b/app/config_objects/load_district_config.rb
@@ -1,0 +1,24 @@
+class LoadDistrictConfig
+
+  def initialize(district_key = ENV['DISTRICT_KEY'])
+    @district_key = district_key
+  end
+
+  def load
+    YAML.load(File.open(config_file_path))
+  end
+
+  private
+
+  def district_key_to_config_file
+    {
+      'somerville' => 'config/district_somerville.yml',
+      'new_bedford' => 'config/district_new_bedford.yml',
+    }
+  end
+
+  def config_file_path
+    district_key_to_config_file.fetch(@district_key)
+  end
+
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -17,16 +17,20 @@ class School < ActiveRecord::Base
     educators_without_test_account.pluck(:full_name)
   end
 
-  def self.fetch_school_data_for_district(district_key)
-    YAML.load(File.open("config/district_#{district_key}.yml")).fetch("schools")
-  end
-
-  def self.seed_somerville_schools
-    district_key = ENV.fetch('DISTRICT_KEY')
-
+  def self.seed_schools_for_district(district_key = ENV['DISTRICT_KEY'])
     schools = School.fetch_school_data_for_district(district_key)
 
     School.create!(schools)
+  end
+
+  def self.fetch_school_data_for_district(district_key)
+    yml_config = LoadDistrictConfig.new(district_key).load
+
+    return yml_config.fetch("schools")
+  end
+
+  def self.seed_somerville_schools
+    School.seed_schools_for_district('somerville')
   end
 
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -18,9 +18,7 @@ class School < ActiveRecord::Base
   end
 
   def self.fetch_school_data_for_district(district_key)
-    YAML.load(File.open("config/district_#{district_key}.yml"))
-        .fetch("config")
-        .fetch("schools")
+    YAML.load(File.open("config/district_#{district_key}.yml")).fetch("schools")
   end
 
   def self.seed_somerville_schools

--- a/config/district_new_bedford.yml
+++ b/config/district_new_bedford.yml
@@ -1,77 +1,76 @@
-config:
-  schools:
-    -
-      name: Charles S. Ashley
-      local_id: '010'
-    -
-      name: Elizabeth Carter Brooks
-      local_id: '015'
-    -
-      name: Elwyn G. Campbell
-      local_id: '020'
-    -
-      name: Sgt. William Carney Memorial Academy
-      local_id: '045'
-    -
-      name: James B. Congdon
-      local_id: '040'
-    -
-      name: John B. DeValles
-      local_id: '050'
-    -
-      name: Alfred J. Gomes
-      local_id: '063'
-    -
-      name: Irwin M. Jacobs
-      local_id: '070'
-    -
-      name: Ellen R. Hathaway
-      local_id: '075'
-    -
-      name: Hayden-McFadden
-      local_id: '078'
-    -
-      name: Abraham Lincoln
-      local_id: '095'
-    -
-      name: Carlos Pacheco
-      local_id: '105'
-    -
-      name: John A. Parker
-      local_id: '115'
-    -
-      name: Casimir Pulaski
-      local_id: '105'
-    -
-      name: Renaissance
-      local_id: '124'
-    -
-      name: Thomas R. Rodman
-      local_id: '125'
-    -
-      name: Jireh Swift
-      local_id: '130'
-    -
-      name: William H. Taylor
-      local_id: '135'
-    -
-      name: Betsey B. Winslow
-      local_id: '140'
-    -
-      name: Keith Middle
-      local_id: '405'
-    -
-      name: Normandin Middle
-      local_id: '410'
-    -
-      name: Roosevelt Middle
-      local_id: '415'
-    -
-      name: New Bedford High
-      local_id: '505'
-    -
-      name: Trinity Day Academy
-      local_id: '510'
-    -
-      name: Whaling City Jr./Sr. High
-      local_id: '515'
+schools:
+  -
+    name: Charles S. Ashley
+    local_id: '010'
+  -
+    name: Elizabeth Carter Brooks
+    local_id: '015'
+  -
+    name: Elwyn G. Campbell
+    local_id: '020'
+  -
+    name: Sgt. William Carney Memorial Academy
+    local_id: '045'
+  -
+    name: James B. Congdon
+    local_id: '040'
+  -
+    name: John B. DeValles
+    local_id: '050'
+  -
+    name: Alfred J. Gomes
+    local_id: '063'
+  -
+    name: Irwin M. Jacobs
+    local_id: '070'
+  -
+    name: Ellen R. Hathaway
+    local_id: '075'
+  -
+    name: Hayden-McFadden
+    local_id: '078'
+  -
+    name: Abraham Lincoln
+    local_id: '095'
+  -
+    name: Carlos Pacheco
+    local_id: '105'
+  -
+    name: John A. Parker
+    local_id: '115'
+  -
+    name: Casimir Pulaski
+    local_id: '105'
+  -
+    name: Renaissance
+    local_id: '124'
+  -
+    name: Thomas R. Rodman
+    local_id: '125'
+  -
+    name: Jireh Swift
+    local_id: '130'
+  -
+    name: William H. Taylor
+    local_id: '135'
+  -
+    name: Betsey B. Winslow
+    local_id: '140'
+  -
+    name: Keith Middle
+    local_id: '405'
+  -
+    name: Normandin Middle
+    local_id: '410'
+  -
+    name: Roosevelt Middle
+    local_id: '415'
+  -
+    name: New Bedford High
+    local_id: '505'
+  -
+    name: Trinity Day Academy
+    local_id: '510'
+  -
+    name: Whaling City Jr./Sr. High
+    local_id: '515'

--- a/config/district_somerville.yml
+++ b/config/district_somerville.yml
@@ -1,74 +1,73 @@
-config:
-  remote_filenames:
-    FILENAME_FOR_STUDENTS_IMPORT: >-
-      students_export.txt
-    FILENAME_FOR_EDUCATORS_IMPORT: >-
-      educators_export.txt
-    FILENAME_FOR_BEHAVIOR_IMPORT: >-
-      behavior_export.txt
-    FILENAME_FOR_ASSESSMENT_IMPORT: >-
-      assessment_export.txt
-    FILENAME_FOR_ATTENDANCE_IMPORT: >-
-      attendance_export.txt
-    FILENAME_FOR_STUDENT_AVERAGES_IMPORT: >-
-      student_averages_export.txt
-    FILENAME_FOR_COURSE_SECTION_IMPORT: >-
-      courses_sections_export.txt
-    FILENAME_FOR_STUDENTS_SECTION_ASSIGNMENT_IMPORT: >-
-      student_section_assignment_export.txt
-    FILENAME_FOR_EDUCATOR_SECTION_ASSIGNMENT_IMPORT: >-
-      educator_section_assignment_export.txt
-    FILENAME_FOR_STAR_READING_IMPORT: >-
-      SomervillePublicSchools\ -\ Generic\ SR\ Pipeline\ Extract\ -\ Active.csv
-    FILENAME_FOR_STAR_MATH_IMPORT: >-
-      SomervillePublicSchools\ -\ Generic\ SM\ Pipeline\ Extract\ -\ Active.csv
-  schools:
-    -
-      local_id: BRN
-      name: Benjamin G Brown
-      school_type: ES
-    -
-      local_id: HEA
-      name: Arthur D Healey
-      school_type: ESMS
-    -
-      local_id: KDY
-      name: John F Kennedy
-      school_type: ESMS
-    -
-      local_id: AFAS
-      name: Albert F. Argenziano School
-      school_type: ESMS
-    -
-      local_id: ESCS
-      name: E Somerville Community
-      school_type: ESMS
-    -
-      local_id: WSNS
-      name: West Somerville Neighborhood
-      school_type: ESMS
-    -
-      local_id: WHCS
-      name: Winter Hill Community
-      school_type: ESMS
-    -
-      local_id: NW
-      name: Next Wave Junior High
-      school_type: MS
-    -
-      local_id: SHS
-      name: Somerville High
-      school_type: HS
-    -
-      local_id: FC
-      name: Full Circle High School
-      school_type: HS
-    -
-      local_id: CAP
-      name: Capuano Early Childhood Center
-    -
-      local_id: PIC
-      name: Parent Information Center
-    -
-      local_id: SPED
-      name: Special Education
+remote_filenames:
+  FILENAME_FOR_STUDENTS_IMPORT: >-
+    students_export.txt
+  FILENAME_FOR_EDUCATORS_IMPORT: >-
+    educators_export.txt
+  FILENAME_FOR_BEHAVIOR_IMPORT: >-
+    behavior_export.txt
+  FILENAME_FOR_ASSESSMENT_IMPORT: >-
+    assessment_export.txt
+  FILENAME_FOR_ATTENDANCE_IMPORT: >-
+    attendance_export.txt
+  FILENAME_FOR_STUDENT_AVERAGES_IMPORT: >-
+    student_averages_export.txt
+  FILENAME_FOR_COURSE_SECTION_IMPORT: >-
+    courses_sections_export.txt
+  FILENAME_FOR_STUDENTS_SECTION_ASSIGNMENT_IMPORT: >-
+    student_section_assignment_export.txt
+  FILENAME_FOR_EDUCATOR_SECTION_ASSIGNMENT_IMPORT: >-
+    educator_section_assignment_export.txt
+  FILENAME_FOR_STAR_READING_IMPORT: >-
+    SomervillePublicSchools\ -\ Generic\ SR\ Pipeline\ Extract\ -\ Active.csv
+  FILENAME_FOR_STAR_MATH_IMPORT: >-
+    SomervillePublicSchools\ -\ Generic\ SM\ Pipeline\ Extract\ -\ Active.csv
+schools:
+  -
+    local_id: BRN
+    name: Benjamin G Brown
+    school_type: ES
+  -
+    local_id: HEA
+    name: Arthur D Healey
+    school_type: ESMS
+  -
+    local_id: KDY
+    name: John F Kennedy
+    school_type: ESMS
+  -
+    local_id: AFAS
+    name: Albert F. Argenziano School
+    school_type: ESMS
+  -
+    local_id: ESCS
+    name: E Somerville Community
+    school_type: ESMS
+  -
+    local_id: WSNS
+    name: West Somerville Neighborhood
+    school_type: ESMS
+  -
+    local_id: WHCS
+    name: Winter Hill Community
+    school_type: ESMS
+  -
+    local_id: NW
+    name: Next Wave Junior High
+    school_type: MS
+  -
+    local_id: SHS
+    name: Somerville High
+    school_type: HS
+  -
+    local_id: FC
+    name: Full Circle High School
+    school_type: HS
+  -
+    local_id: CAP
+    name: Capuano Early Childhood Center
+  -
+    local_id: PIC
+    name: Parent Information Center
+  -
+    local_id: SPED
+    name: Special Education


### PR DESCRIPTION
# Who is this PR for?

Developers who need to read districtwide configuration from YAML.

# What problem does this PR fix?

A couple of inconsistent methods and code style practices. After I merged in #1322 I realized I was unsatisfied with a couple of things: 

+ The method `School.seed_somerville_schools` was a lie. This method read from `ENV` to determine district, so if ENV told it to seed New Bedford schools, it would do that. 
+ The `School` class used an ENV variable to read a path in the filesystem, which isn't a good practice.
+ The YAML config files I wrote had an unnecessary `"config"` key at the top level which added extra lines of code to unwrap. 

# What does this PR do?

+ Fixes the `School.seed_somerville_schools` method by making it pass in a fixed string as district key, so that it always does what it says it will.
+ Creates two separate classes, `LoadDistrictConfig` and `DistrictConfig`. `LoadDistrictConfig` uses district keys to select the right config files from the filesystem and parses them from YAML;  `DistrictConfig` applies validation and other logic. 
  + I separated them out because searching for YAML on the filesystem seemed a like a very different concern from exposing validated config information to the rest of the app. 
  + `School` also asks for a consistent way to find school config, but doesn't need any validation or other logic once it gets the config it needs.
+ Removes the unnecessary top-level key from the district config YAML files.

# Checklist 

+ [x] Test data import process locally before deploying

![screen shot 2017-12-26 at 11 10 43 am](https://user-images.githubusercontent.com/3209501/34363056-753bc7f4-ea2d-11e7-8f35-d6de106fe00c.png)

+ [x] Verify school seeding process by re-creating a demo site on this branch 

![screen shot 2017-12-26 at 11 06 12 am](https://user-images.githubusercontent.com/3209501/34362965-dcc9241c-ea2c-11e7-8f26-97c55e6fc8ff.png)
