### PR TITLE
Add New Bedford remote filenames to config

### DIFF
--- a/config/district_new_bedford.yml
+++ b/config/district_new_bedford.yml
@@ -1,3 +1,15 @@
+remote_filenames:
+  FILENAME_FOR_STUDENTS_IMPORT: istudent.csv
+  FILENAME_FOR_EDUCATORS_IMPORT: istaff.csv
+  FILENAME_FOR_BEHAVIOR_IMPORT: iconduct.csv
+  FILENAME_FOR_ASSESSMENT_IMPORT: iassessments.csv
+  FILENAME_FOR_ATTENDANCE_IMPORT: iattendance.csv
+
+  # iperson.csv -- looks like this is based off of persons_export.sql, but
+  #   we're not importing a persons
+
+  # istudentschedule.csv -- looks like this is based off of student_schedule_export.sql,
+  #   but that isn't a data source we're using
 schools:
   -
     name: Charles S. Ashley


### PR DESCRIPTION
# Who is this PR for?

New Bedford Public Schools.

# What problem does this PR fix?

Student Insights doesn't know where to read in data from New Bedford's SFTP site. 

# What does this PR do?

Adds filenames of remote New Bedford data files so the nightly import process knows where to read them. 

This also made me take a closer look at New Bedford's files. That in turn made me realize that some of the files were unnecessary or unused. This is on me, since I pointed New Bedford IT to our `/x2_exports` SQL files for reference. I didn't realize that some of those files were out of date or unused. That's probably because the SQL files stored there aren't being deployed directly by our app, they're being referenced/deployed by John Breslin against the Somerville X2 SIS. So there's less pressure to keep them up to date. 

tl;dr — Time to clean up the `/x2_exports` directory! 

# A note about security 

I'm treating these filenames as public, not as secret. That's because they're essentially variable names. The files could be named whatever, it's the data within that needs to be guarded and protected. 