### PR TITLE
Make Dashboard compatible with es6 highcharts wrapper

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_bar_chart.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_bar_chart.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import _ from 'lodash';
 
+import HighchartsWrapper from '../student_profile/HighchartsWrapper.js';
+
 const styles = {
   title: {
     color: 'black',
@@ -58,7 +60,6 @@ export default React.createClass({
   },
 
   render: function() {
-    const {HighchartsWrapper} = window.shared;
     return (
       <div id={this.props.id} style={styles.container}>
         <HighchartsWrapper


### PR DESCRIPTION
# Who is this PR for?
Dashboard users
# What problem does this PR fix?
The dashboard uses the student profile highcharts wrapper and stopped working when it was converted to es6
# What does this PR do?
imports highchartswrapper - very simple fix

# Checklists


+ [x] Author checked latest in IE - School Admin Dashboard
+ [ ] Reviewer checked latest in IE - School Admin Dashboard
