### PR TITLE
Fix broken "onCancelNotes" function

### DIFF
--- a/app/assets/javascripts/student_profile/NotesDetails.js
+++ b/app/assets/javascripts/student_profile/NotesDetails.js
@@ -31,6 +31,7 @@ class NotesDetails extends React.Component {
 
     this.onClickTakeNotes = this.onClickTakeNotes.bind(this);
     this.onClickSaveNotes = this.onClickSaveNotes.bind(this);
+    this.onCancelNotes = this.onCancelNotes.bind(this);
   }
 
   onClickTakeNotes(event) {


### PR DESCRIPTION
# Notes 

+ We've been getting a few live errors on this in production via Rollbar
+ Simple missing function binding error

# GIF (`master`, demo student)

![cancel-not-workin](https://user-images.githubusercontent.com/3209501/34489435-f8e7a2d4-efa1-11e7-8818-ec6af8579340.gif)

# GIF (this branch, demo student)

![cancel-working](https://user-images.githubusercontent.com/3209501/34489622-ac69aa6e-efa2-11e7-9860-10cb548fbd47.gif)


