### PR TITLE
Load past Service Uploads async

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,8 @@
     "React": true,
     "ReactDOM": true,
     "d3": true,
-    "spyOn": true
+    "spyOn": true,
+    "global": true
   },
   "parserOptions": {
     "ecmaVersion": 6,

--- a/app/assets/javascripts/service_uploads/PastServiceUploads.js
+++ b/app/assets/javascripts/service_uploads/PastServiceUploads.js
@@ -3,7 +3,17 @@ import React from 'react';
 class PastServiceUploads extends React.Component {
 
   render() {
+    const { serviceUploads } = this.props;
+
+    if (serviceUploads === null) return this.renderSpinner();
+
     return null;
+  }
+
+  renderSpinner() {
+    return (
+      <div className="loader">Loading...</div>
+    );
   }
 
 }

--- a/app/assets/javascripts/service_uploads/PastServiceUploads.js
+++ b/app/assets/javascripts/service_uploads/PastServiceUploads.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+class PastServiceUploads extends React.Component {
+
+  render() {
+    return null;
+  }
+
+}
+
+PastServiceUploads.propTypes = {
+  serviceUploads: React.PropTypes.array.isRequired,
+  onClickDeleteServiceUpload: React.PropTypes.func.isRequired,
+};
+
+export default PastServiceUploads;

--- a/app/assets/javascripts/service_uploads/PastServiceUploads.js
+++ b/app/assets/javascripts/service_uploads/PastServiceUploads.js
@@ -1,3 +1,6 @@
+window.shared || (window.shared = {});
+const ServiceUploadDetail = window.shared.ServiceUploadDetail;
+
 import React from 'react';
 
 class PastServiceUploads extends React.Component {
@@ -7,7 +10,24 @@ class PastServiceUploads extends React.Component {
 
     if (serviceUploads === null) return this.renderSpinner();
 
-    return null;
+    return this.renderUploads();
+  }
+
+  renderUploads() {
+    const { serviceUploads, onClickDeleteServiceUpload } = this.props;
+
+    return (
+      <div>
+        {serviceUploads.map((serviceUpload) => {
+          return (
+            <ServiceUploadDetail
+              data={serviceUpload}
+              onClickDeleteServiceUpload={onClickDeleteServiceUpload}
+              key={String(serviceUpload.id)} />
+          );
+        }, this)}
+      </div>
+    );
   }
 
   renderSpinner() {
@@ -19,7 +39,7 @@ class PastServiceUploads extends React.Component {
 }
 
 PastServiceUploads.propTypes = {
-  serviceUploads: React.PropTypes.array.isRequired,
+  serviceUploads: React.PropTypes.array,  /* show loading spinner if null */
   onClickDeleteServiceUpload: React.PropTypes.func.isRequired,
 };
 

--- a/app/assets/javascripts/service_uploads/service_uploads_page.jsx
+++ b/app/assets/javascripts/service_uploads/service_uploads_page.jsx
@@ -229,7 +229,7 @@ import PastServiceUploads from '../service_uploads/PastServiceUploads.js';
 
       return (
         <PastServiceUploads
-          serviceUploads={serviceUploads}
+          serviceUploads={null}
           onClickDeleteServiceUpload={this.onClickDeleteServiceUpload}
         />
       );

--- a/app/assets/javascripts/service_uploads/service_uploads_page.jsx
+++ b/app/assets/javascripts/service_uploads/service_uploads_page.jsx
@@ -29,6 +29,16 @@ import PastServiceUploads from '../service_uploads/PastServiceUploads.js';
       };
     },
 
+    componentDidMount: function () {
+      fetch('/service_uploads/past', { credentials: 'include' })
+        .then(response => response.json())
+        .then(json => {
+          this.setState({
+            serviceUploads: json
+          });
+        });
+    },
+
     isMissingRequiredFields: function () {
       const formData = this.state.formData;
 
@@ -96,16 +106,6 @@ import PastServiceUploads from '../service_uploads/PastServiceUploads.js';
           }
         }.bind(this)
       });
-    },
-
-    componentDidMount: function () {
-      fetch('/service_uploads/past', { credentials: 'include' })
-        .then(response => response.json())
-        .then(json => {
-          this.setState({
-            serviceUploads: json
-          });
-        });
     },
 
     onClickDeleteServiceUpload: function (id) {

--- a/app/assets/javascripts/service_uploads/service_uploads_page.jsx
+++ b/app/assets/javascripts/service_uploads/service_uploads_page.jsx
@@ -14,8 +14,8 @@ import PastServiceUploads from '../service_uploads/PastServiceUploads.js';
 
     getInitialState: function () {
       return {
-        serviceUploads: this.props.serializedData.serviceUploads, // Existing service uploads
-        formData: {},                                             // New service upload form data
+        serviceUploads: null,
+        formData: {},
 
         // Student LASID validation
         studentLasidsReceivedFromBackend: false,
@@ -99,7 +99,13 @@ import PastServiceUploads from '../service_uploads/PastServiceUploads.js';
     },
 
     componentDidMount: function () {
-
+      fetch('/service_uploads/past', { credentials: 'include' })
+        .then(response => response.json())
+        .then(json => {
+          this.setState({
+            serviceUploads: json
+          });
+        });
     },
 
     onClickDeleteServiceUpload: function (id) {
@@ -229,7 +235,7 @@ import PastServiceUploads from '../service_uploads/PastServiceUploads.js';
 
       return (
         <PastServiceUploads
-          serviceUploads={null}
+          serviceUploads={serviceUploads}
           onClickDeleteServiceUpload={this.onClickDeleteServiceUpload}
         />
       );

--- a/app/assets/javascripts/service_uploads/service_uploads_page.jsx
+++ b/app/assets/javascripts/service_uploads/service_uploads_page.jsx
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import {merge} from '../helpers/react_helpers.jsx';
+import PastServiceUploads from '../service_uploads/PastServiceUploads.js';
 
 (function() {
   window.shared || (window.shared = {});
-  const ServiceUploadDetail = window.shared.ServiceUploadDetail;
   const NewServiceUpload = window.shared.NewServiceUpload;
 
   window.shared.ServiceUploadsPage = React.createClass({
@@ -96,6 +96,10 @@ import {merge} from '../helpers/react_helpers.jsx';
           }
         }.bind(this)
       });
+    },
+
+    componentDidMount: function () {
+
     },
 
     onClickDeleteServiceUpload: function (id) {
@@ -221,14 +225,14 @@ import {merge} from '../helpers/react_helpers.jsx';
     },
 
     renderServiceDetails: function () {
-      return this.state.serviceUploads.map(function (serviceUpload) {
-        return (
-          <ServiceUploadDetail
-            data={serviceUpload}
-            onClickDeleteServiceUpload={this.onClickDeleteServiceUpload}
-            key={String(serviceUpload.id)} />
-        );
-      }, this);
+      const { serviceUploads } = this.state;
+
+      return (
+        <PastServiceUploads
+          serviceUploads={serviceUploads}
+          onClickDeleteServiceUpload={this.onClickDeleteServiceUpload}
+        />
+      );
     },
 
   });

--- a/app/assets/stylesheets/loader.scss
+++ b/app/assets/stylesheets/loader.scss
@@ -41,3 +41,26 @@
     transform: rotate(360deg);
   }
 }
+
+/*
+The MIT License (MIT)
+
+Copyright (c) 2014 Luke Haas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/

--- a/app/assets/stylesheets/loader.scss
+++ b/app/assets/stylesheets/loader.scss
@@ -1,3 +1,5 @@
+/* CSS from https://projects.lukehaas.me/css-loaders/. Thank you @lukehaas! */
+
 .loader,
 .loader:after {
   border-radius: 50%;

--- a/app/assets/stylesheets/loader.scss
+++ b/app/assets/stylesheets/loader.scss
@@ -1,0 +1,41 @@
+.loader,
+.loader:after {
+  border-radius: 50%;
+  width: 10em;
+  height: 10em;
+}
+.loader {
+  margin: 60px auto;
+  font-size: 10px;
+  position: relative;
+  text-indent: -9999em;
+  border-top: 1.1em solid rgba(119,119,119, 0.2);
+  border-right: 1.1em solid rgba(119,119,119, 0.2);
+  border-bottom: 1.1em solid rgba(119,119,119, 0.2);
+  border-left: 1.1em solid #777777;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation: load8 1.1s infinite linear;
+  animation: load8 1.1s infinite linear;
+}
+@-webkit-keyframes load8 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@keyframes load8 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -13,6 +13,7 @@
 @import 'components/flexible_roster';
 @import 'components/school_dashboard';
 
+@import 'loader';
 @import 'roster';
 @import 'about';
 @import 'tooltip';

--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -77,8 +77,8 @@ class ServiceUploadsController < ApplicationController
     render 'shared/serialized_data'
   end
 
-  def past_service_uploads
-    render json: ServiceUpload.order(created_at: :desc).as_json(
+  def past
+    return render json: ServiceUpload.order(created_at: :desc).as_json(
       only: [:created_at, :file_name, :id],
       include: {
         services: {

--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -72,25 +72,28 @@ class ServiceUploadsController < ApplicationController
   def index
     @serialized_data = {
       current_educator: current_educator,
-      service_uploads: ServiceUpload.order(created_at: :desc).as_json(
-        only: [:created_at, :file_name, :id],
-        include: {
-          services: {
-            only: [],
-            include: {
-              student: {
-                only: [:first_name, :last_name, :id]
-              },
-              service_type: {
-                only: [:name]
-              }
-            }
-          }
-        }
-      ),
       service_type_names: ServiceType.pluck(:name)
     }
     render 'shared/serialized_data'
+  end
+
+  def past_service_uploads
+    render json: ServiceUpload.order(created_at: :desc).as_json(
+      only: [:created_at, :file_name, :id],
+      include: {
+        services: {
+          only: [],
+          include: {
+            student: {
+              only: [:first_name, :last_name, :id]
+            },
+            service_type: {
+              only: [:name]
+            }
+          }
+        }
+      }
+    )
   end
 
   def destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,11 @@ Rails.application.routes.draw do
   resources :services, only: [:destroy]
   resources :service_types, only: [:index]
   resources :event_note_attachments, only: [:destroy]
-  resources :service_uploads, only: [:create, :index, :destroy]
+  resources :service_uploads, only: [:create, :index, :destroy] do
+    collection do
+      get :past
+    end
+  end
   resources :homerooms, only: [:show]
   resources :sections, only: [:index, :show]
   resources :import_records, only: [:index]

--- a/spec/javascripts/service_uploads/PastServiceUploads.test.js
+++ b/spec/javascripts/service_uploads/PastServiceUploads.test.js
@@ -1,0 +1,32 @@
+import ReactDOM from 'react-dom';
+import PastServiceUploads from '../../../app/assets/javascripts/service_uploads/PastServiceUploads';
+
+describe('null serviceUploads', function () {
+  it('renders without crashing', () => {
+    const div = document.createElement('div');
+
+    ReactDOM.render(
+      <PastServiceUploads
+        serviceUploads={null}
+        onClickDeleteServiceUpload={jest.fn()}
+      />, div);
+  });
+});
+
+describe('serviceUploads', function () {
+  it('renders without crashing', () => {
+    const div = document.createElement('div');
+
+    ReactDOM.render(
+      <PastServiceUploads
+        serviceUploads={[
+          {
+            file_name: 'test_file.csv',
+            created_at: 'Tue, 02 Jan 2018 15:48:53 UTC +00:00', // Rails created_at
+            services: [],
+          }
+        ]}
+        onClickDeleteServiceUpload={jest.fn()}
+      />, div);
+  });
+});

--- a/spec/javascripts/service_uploads/PastServiceUploads.test.js
+++ b/spec/javascripts/service_uploads/PastServiceUploads.test.js
@@ -1,7 +1,7 @@
 import ReactDOM from 'react-dom';
 import PastServiceUploads from '../../../app/assets/javascripts/service_uploads/PastServiceUploads';
 
-describe('null serviceUploads', function () {
+describe('with null past service upload data', function () {
   it('renders without crashing', () => {
     const div = document.createElement('div');
 
@@ -13,7 +13,7 @@ describe('null serviceUploads', function () {
   });
 });
 
-describe('serviceUploads', function () {
+describe('with valid past service upload data', function () {
   it('renders without crashing', () => {
     const div = document.createElement('div');
 

--- a/spec/javascripts/service_uploads/service_uploads_page_spec.jsx
+++ b/spec/javascripts/service_uploads/service_uploads_page_spec.jsx
@@ -26,7 +26,7 @@ describe('ServiceUploadsPage', function() {
           resolve({
             ok: true,
             json: function() {
-              return []
+              return [];
             }
           });
         });
@@ -52,7 +52,7 @@ describe('ServiceUploadsPage', function() {
           resolve({
             ok: true,
             json: function() {
-              return []
+              return [];
             }
           });
         });

--- a/spec/javascripts/service_uploads/service_uploads_page_spec.jsx
+++ b/spec/javascripts/service_uploads/service_uploads_page_spec.jsx
@@ -12,14 +12,25 @@ describe('ServiceUploadsPage', function() {
   };
 
   SpecSugar.withTestEl('integration tests', function(container) {
-    it('renders the page with no service uploads', function() {
+    it('renders the page', function() {
       const el = container.testEl;
       const props = {
         serializedData: {
-          serviceUploads: [],
           serviceTypeNames: ['Extra Tutoring', 'After-School Art Class'],
         }
       };
+
+      // Mock fetch('/service_uploads/past'):
+      global.fetch = jest.fn().mockImplementation(() => {
+        return new Promise((resolve, reject) => {
+          resolve({
+            ok: true,
+            json: function() {
+              return []
+            }
+          });
+        });
+      });
 
       helpers.renderInto(el, props);
 
@@ -27,40 +38,24 @@ describe('ServiceUploadsPage', function() {
       expect($(el).text()).toContain('Confirm Upload');
     });
 
-    it('renders the page with existing service upload', function() {
-      const el = container.testEl;
-      const props = {
-        serializedData: {
-          serviceUploads: [
-            {
-              created_at: '2017-01-19 18:21:22',
-              file_name: 'bulk_upload.csv',
-              id: 1,
-              services: [
-                {
-                  student: {first_name: 'Steve', last_name: 'V.'},
-                  service_type: { name: 'Extra Tutoring'}
-                }
-              ],
-            }
-          ],
-          serviceTypeNames: ['Extra Tutoring', 'After-School Art Class'],
-        }
-      };
-
-      helpers.renderInto(el, props);
-
-      expect($(el).text()).toContain('bulk_upload.csv'); // Renders the file name
-      expect($(el).text()).toContain('Extra Tutoring');  // Renders the service type name
-    });
-
     it('tolerates cancelling file upload', function() {
       const el = container.testEl;
       const instance = helpers.renderInto(el, {
         serializedData: {
-          serviceUploads: [],
           serviceTypeNames: ['Extra Tutoring', 'After-School Art Class'],
         }
+      });
+
+      // Mock fetch('/service_uploads/past'):
+      global.fetch = jest.fn().mockImplementation(() => {
+        return new Promise((resolve, reject) => {
+          resolve({
+            ok: true,
+            json: function() {
+              return []
+            }
+          });
+        });
       });
 
       const fileInputEl = $(el).find('input[type=file]').get(0);


### PR DESCRIPTION
# Who is this PR for?

District admins who need to upload bulk service data.

# What problem does this PR fix?

Page is getting to heavy to load inline as amount of service upload data grows (should fix #1352).

# What does this PR do?

Moves the service upload data loading to async so that the page can load first and the past service upload data can load after. 

Adds a spinny loader while the past service upload data loads.

# Notes
+ This is the first spinny loader in the project! I chose a CSS approach in order to have the most lightweight code footprint possible; no JS dependencies. CSS from https://projects.lukehaas.me/css-loaders/. Thank you for the great resource @lukehaas!

# GIF (demo data; Internet Explorer VM)

![async-past-services-ie](https://user-images.githubusercontent.com/3209501/34535782-a42ff574-f088-11e7-876b-622f93c06618.gif)

# Checklists

## Javascript QA

+ [x] Author checked latest in IE - Service Upload and Past Service Upload

## Automated Testing

+ [x] Author included specs for `PastServiceUpload.js`
  
  