### PR TITLE
Re-order checks on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ script:
   - bundle exec rake db:create db:migrate DATABASE_URL=postgres://localhost/student_insights_test
   - bundle exec rake immigrant:check_keys
   - ./scripts/ci/detect_package_lock.sh
+  - rubocop
   - bundle exec rspec spec
   - yarn test-cli
-  - rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ install:
   - yarn install
 
 script:
-  - yarn test-cli
-  - rubocop
   - bundle exec rake db:create db:migrate DATABASE_URL=postgres://localhost/student_insights_test
   - bundle exec rake immigrant:check_keys
-  - bundle exec rspec spec
   - ./scripts/ci/detect_package_lock.sh
+  - bundle exec rspec spec
+  - yarn test-cli
+  - rubocop


### PR DESCRIPTION
# Who is this PR for?

Developers who check their PRs on Travis CI.

# What problem does this PR fix?

The database migration on Travis produces a lot of noisy output. If a test fails before the database migration step, the developer has to hunt way back in the test logs to spot it and read it.

# What does this PR do?

Moves all checks that can exit 1 or 0 to the end of the `script` in `.travis.yml`. That way anything that can cause the CI to fail will run after the noisy database migration and won't require the dev to hunt through the CI logs.