### PR TITLE
Make target directory on SFTP site configurable

### DIFF
--- a/app/importers/clients/sftp_client.rb
+++ b/app/importers/clients/sftp_client.rb
@@ -27,11 +27,7 @@ class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password
     local_filename = File.join('tmp/data_download/', remote_file_name)
     local_file = File.open(local_filename, 'w')
 
-    target_file = target_directory
-                  ? "../#{target_directory}/#{remote_file_name}"
-                  : remote_file_name
-
-    sftp_session.download!(target_file, local_file.path)
+    sftp_session.download!(target_file(remote_file_name), local_file.path)
 
     local_file
   end
@@ -41,6 +37,14 @@ class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password
   end
 
   private
+
+  def target_file(remote_file_name)
+    if target_directory.present?
+      "../#{target_directory}/#{remote_file_name}"
+    else
+      remote_file_name
+    end
+  end
 
   # This is the folder on the remote SFTP site where the data files live
   def target_directory

--- a/app/importers/clients/sftp_client.rb
+++ b/app/importers/clients/sftp_client.rb
@@ -26,7 +26,12 @@ class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password
 
     local_filename = File.join('tmp/data_download/', remote_file_name)
     local_file = File.open(local_filename, 'w')
-    sftp_session.download!(remote_file_name, local_file.path)
+
+    target_file = target_directory
+                  ? "../#{target_directory}/#{remote_file_name}"
+                  : remote_file_name
+
+    sftp_session.download!(target_file, local_file.path)
 
     local_file
   end
@@ -36,6 +41,12 @@ class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password
   end
 
   private
+
+  # This is the folder on the remote SFTP site where the data files live
+  def target_directory
+    LoadDistrictConfig.new.load.fetch("target_directory", nil)
+  end
+
   # This returns an object that will reveal secure data if printed
   def sftp_session
     raise "SFTP information missing" unless sftp_info_present?

--- a/config/district_new_bedford.yml
+++ b/config/district_new_bedford.yml
@@ -11,7 +11,7 @@ remote_filenames:
   # istudentschedule.csv -- looks like this is based off of student_schedule_export.sql,
   #   but that isn't a data source we're using
 
-target_directory: new_bedford
+target_directory: newbedford
 
 schools:
   -

--- a/config/district_new_bedford.yml
+++ b/config/district_new_bedford.yml
@@ -10,6 +10,9 @@ remote_filenames:
 
   # istudentschedule.csv -- looks like this is based off of student_schedule_export.sql,
   #   but that isn't a data source we're using
+
+target_directory: new_bedford
+
 schools:
   -
     name: Charles S. Ashley


### PR DESCRIPTION
# Who is this PR for?

School districts who want to set up a Student Insights instance. 

# What problem does this PR fix?

The data files might live in different directories on their remote SFTP sites; this PR makes the directory name configurable. 

# What does this PR do?

Add `target_directory` as a key to the district YML file.

If `target_directory` is unset, read from the home directory.

# Checks

+ [x] Tested locally for New Bedford
+ [x] Tested locally for Somerville