### PR TITLE
Configure Net::SFTP to work with Quotaguard static IPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,12 @@ node_modules
 yarn-debug.log*
 yarn-error.log*
 
-# This holds configuration for testing production import scripts locally, so it shouldn't be checked into
-# source control.
+# This holds configuration for testing production import scripts locally,
+# so it shouldn't be checked into source control.
 config/local_env.yml
+
+# This is for use with `heroku local`.
+.env
 
 ## Environment normalisation:
 /.bundle

--- a/app/importers/clients/sftp_client.rb
+++ b/app/importers/clients/sftp_client.rb
@@ -48,7 +48,7 @@ class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password
   end
 
   def start_sftp_session
-    if ENV.fetch('QUOTAGUARDSTATIC_URL', false)
+    if ENV.fetch('USE_QUOTAGUARD', false)
       start_sftp_session_with_proxy
     else
       start_sftp_session_no_proxy

--- a/app/importers/clients/sftp_client.rb
+++ b/app/importers/clients/sftp_client.rb
@@ -60,7 +60,10 @@ class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password
   def start_sftp_session_with_proxy
     quotaguard = URI(ENV.fetch("QUOTAGUARDSTATIC_URL"))
 
-    proxy = Net::SSH::Proxy::HTTP.new(quotaguard.host, quotaguard.port)
+    proxy = Net::SSH::Proxy::HTTP.new(
+      quotaguard.host, quotaguard.port,
+      user: quotaguard.user, password: quotaguard.password
+    )
 
     @sftp_session = Net::SFTP.start(host, user, auth_mechanism({ proxy: proxy }))
   end

--- a/app/importers/clients/sftp_client.rb
+++ b/app/importers/clients/sftp_client.rb
@@ -62,7 +62,7 @@ class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password
       'quotaguard_proxy_host', ENV.fetch('QUOTAGUARDSTATIC_URL')
     )
 
-    @sftp_session = Net::SFTP.start(host, user, auth_mechanism, proxy: proxy)
+    @sftp_session = Net::SFTP.start(host, user, auth_mechanism({proxy: proxy}))
   end
 
   def start_sftp_session_no_proxy
@@ -74,9 +74,16 @@ class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password
   end
 
   # secrets
-  def auth_mechanism
+  def auth_mechanism(extra_info = {})
+    base_auth_mechanism.merge(extra_info)
+  end
+
+  def base_auth_mechanism
     return { password: password } if password.present?
-    { key_data: key_data } if key_data.present?
+
+    return { key_data: key_data } if key_data.present?
+
+    raise "Need either a password or a key!"
   end
 
   # avoid storing sensitive data from ENV as an instance variable, read it on-demand

--- a/app/importers/clients/sftp_client.rb
+++ b/app/importers/clients/sftp_client.rb
@@ -1,3 +1,5 @@
+require 'net/ssh/proxy/http'
+
 # These are keys into ENV
 class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password, :env_key_data
 

--- a/app/importers/clients/sftp_client.rb
+++ b/app/importers/clients/sftp_client.rb
@@ -41,14 +41,30 @@ class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password
     raise "SFTP information missing" unless sftp_info_present?
 
     if @sftp_session.nil?
-      proxy = Net::SSH::Proxy::HTTP.new(
-        'quotaguard_proxy_host', ENV.fetch('QUOTAGUARDSTATIC_URL')
-      )
-
-      @sftp_session = Net::SFTP.start(host, user, auth_mechanism, proxy: proxy)
+      start_sftp_session
     end
 
     @sftp_session
+  end
+
+  def start_sftp_session
+    if ENV.fetch('QUOTAGUARDSTATIC_URL', false)
+      start_sftp_session_with_proxy
+    else
+      start_sftp_session_no_proxy
+    end
+  end
+
+  def start_sftp_session_with_proxy
+    proxy = Net::SSH::Proxy::HTTP.new(
+      'quotaguard_proxy_host', ENV.fetch('QUOTAGUARDSTATIC_URL')
+    )
+
+    @sftp_session = Net::SFTP.start(host, user, auth_mechanism, proxy: proxy)
+  end
+
+  def start_sftp_session_no_proxy
+    @sftp_session = Net::SFTP.start(host, user, auth_mechanism)
   end
 
   def sftp_info_present?

--- a/app/importers/clients/sftp_client.rb
+++ b/app/importers/clients/sftp_client.rb
@@ -58,11 +58,11 @@ class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password
   end
 
   def start_sftp_session_with_proxy
-    proxy = Net::SSH::Proxy::HTTP.new(
-      'quotaguard_proxy_host', ENV.fetch('QUOTAGUARDSTATIC_URL')
-    )
+    quotaguard = URI(ENV.fetch("QUOTAGUARDSTATIC_URL"))
 
-    @sftp_session = Net::SFTP.start(host, user, auth_mechanism({proxy: proxy}))
+    proxy = Net::SSH::Proxy::HTTP.new(quotaguard.host, quotaguard.port)
+
+    @sftp_session = Net::SFTP.start(host, user, auth_mechanism({ proxy: proxy }))
   end
 
   def start_sftp_session_no_proxy

--- a/app/importers/clients/sftp_client.rb
+++ b/app/importers/clients/sftp_client.rb
@@ -39,9 +39,15 @@ class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password
   # This returns an object that will reveal secure data if printed
   def sftp_session
     raise "SFTP information missing" unless sftp_info_present?
+
     if @sftp_session.nil?
-      @sftp_session = Net::SFTP.start(host, user, auth_mechanism)
+      proxy = Net::SSH::Proxy::HTTP.new(
+        'quotaguard_proxy_host', ENV.fetch('QUOTAGUARDSTATIC_URL')
+      )
+
+      @sftp_session = Net::SFTP.start(host, user, auth_mechanism, proxy: proxy)
     end
+
     @sftp_session
   end
 


### PR DESCRIPTION
# Who is this PR for?

Districts with IP filtering on their Insights SFTP box. 

# What problem does this PR fix?

For IP filtering and whitelisting to work successfully, the nightly data import process needs to run on the static IP provided by Quotaguard.

# What does this PR do?

Sets up Quotaguard as a proxy for the data import process. 
  

# Checklists

+ [x] Tested with Somerville data import process
+ [x] Tested with New Bedford data import process