### PR TITLE
Include full file paths for remote data files in YAML

### DIFF
--- a/app/importers/clients/sftp_client.rb
+++ b/app/importers/clients/sftp_client.rb
@@ -24,7 +24,7 @@ class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password
   def download_file(remote_file_name)
     Dir.mkdir('tmp/data_download/') unless File.exist?('tmp/data_download/')
 
-    local_filename = File.join('tmp/data_download/', remote_file_name)
+    local_filename = File.join('tmp/data_download/', remote_file_name.split("/").last)
     local_file = File.open(local_filename, 'w')
     sftp_session.download!(remote_file_name, local_file.path)
 

--- a/config/district_new_bedford.yml
+++ b/config/district_new_bedford.yml
@@ -1,9 +1,9 @@
 remote_filenames:
-  FILENAME_FOR_STUDENTS_IMPORT: istudent.csv
-  FILENAME_FOR_EDUCATORS_IMPORT: istaff.csv
-  FILENAME_FOR_BEHAVIOR_IMPORT: iconduct.csv
-  FILENAME_FOR_ASSESSMENT_IMPORT: iassessments.csv
-  FILENAME_FOR_ATTENDANCE_IMPORT: iattendance.csv
+  FILENAME_FOR_STUDENTS_IMPORT: ../newbedford/istudent.csv
+  FILENAME_FOR_EDUCATORS_IMPORT: ../newbedford/istaff.csv
+  FILENAME_FOR_BEHAVIOR_IMPORT: ../newbedford/iconduct.csv
+  FILENAME_FOR_ASSESSMENT_IMPORT: ../newbedford/iassessments.csv
+  FILENAME_FOR_ATTENDANCE_IMPORT: ../newbedford/iattendance.csv
 
   # iperson.csv -- looks like this is based off of persons_export.sql, but
   #   we're not importing a persons


### PR DESCRIPTION
# Who is this PR for?

School districts who want to set up a Student Insights instance. 

# What problem does this PR fix?

This PR shows how we'll handle different paths on the SFTP site's folder system: write the full file path directly in the YAML configuration. 

# Thanks! 

Great simplifying suggestion from @kevinrobinson here! 

# Checks

+ [x] Tested locally for New Bedford
+ [x] Tested locally for Somerville
  