### PR TITLE
Add New Bedford grade levels: PPK, TK, 13

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -32,7 +32,7 @@ class Student < ActiveRecord::Base
   validate :registration_date_cannot_be_in_future
 
   VALID_GRADES = [
-    'PK', 'KF', 'SP', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'
+    'PPK', 'PK', 'KF', 'SP', 'TK', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13'
   ].freeze
 
   def valid_grade


### PR DESCRIPTION
# Who is this PR for?

New Bedford Public Schools!

# What problem does this PR fix?

New Bedford has a wider set of grade levels than Somerville. 

# What does this PR do?

Add new grade levels: TK, PPK, 13.

From New Bedford Public Schools:

```
+ PPK – our 4 year old PKs
+ TK – our 3 year old PKs
```
 
Rather than writing special code to map these grade levels into PK, I'd like to import the students as-is for the initial run and then decide if we need to do anything differently. 