### PR TITLE
Fix N+1 bug with past ServiceUpload JSON generation

### DIFF
--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -78,22 +78,7 @@ class ServiceUploadsController < ApplicationController
   end
 
   def past
-    return render json: ServiceUpload.order(created_at: :desc).as_json(
-      only: [:created_at, :file_name, :id],
-      include: {
-        services: {
-          only: [],
-          include: {
-            student: {
-              only: [:first_name, :last_name, :id]
-            },
-            service_type: {
-              only: [:name]
-            }
-          }
-        }
-      }
-    )
+    render json: past_service_upload_json and return
   end
 
   def destroy
@@ -109,6 +94,26 @@ class ServiceUploadsController < ApplicationController
   end
 
   private
+
+    def past_service_upload_json
+      ServiceUpload.includes(services: [:student, :service_type])
+                   .order(created_at: :desc)
+                   .as_json(only: [:created_at, :file_name, :id],
+                     include: {
+                       services: {
+                         only: [],
+                         include: {
+                           student: {
+                             only: [:first_name, :last_name, :id]
+                           },
+                           service_type: {
+                             only: [:name]
+                           }
+                         }
+                       }
+                     }
+                   )
+    end
 
     def recorded_at
       DateTime.current


### PR DESCRIPTION
# Who is this PR for?

District-wide admins who use the "new service upload" page.

# What problem does this PR fix?

Speeds up loading of data on past service uploads (which students, which services).

# What does this PR do?

Fixes an N+1 bug in generating the JSON for the new `#past` endpoint. 

I natively assumed that the `include` clauses in this code would trigger some kind of include statement in the top-level database query or some other eager loading:

```
ServiceUpload.order(created_at: :desc).as_json(
  only: [:created_at, :file_name, :id],
  include: {
    services: {
      only: [],
      include: {
        student: {
          only: [:first_name, :last_name, :id]
        },
        service_type: {
          only: [:name]
        }
      }
    }
  }
)
```

I looked at the Rails source code for `as_json` (which in turn calls `serializable_hash`) and saw that it doesn't do anything like that:

https://github.com/rails/rails/blob/18a2513729ab90b04b1c86963e7d5b9213270c81/activemodel/lib/active_model/serialization.rb#L124

I did some testing with production-sized service upload data and saw that we could speed up the querying/JSON generation by 3x by adding database `includes`: 

```
irb(main):057:0> past_service_upload_json_with_includes
log_timing:start [2018-01-03 20:10:52 +0000]
log_timing:start [2018-01-03 20:10:59 +0000]
Total time: 6.874725349

irb(main):058:0> past_service_upload_json_no_includes
log_timing:start [2018-01-03 20:11:11 +0000]
log_timing:start [2018-01-03 20:11:30 +0000]
Total time: 18.658125956
```

This should reduce the time the districtwide admin has to spend watching a spinny loader circle in production by around 3x.
  
# GIF (demo data, IE VM)

![async-past-services-ie-no-n 1](https://user-images.githubusercontent.com/3209501/34538922-01d0e62e-f094-11e7-8aa7-23fa820612fb.gif)
