### PR TITLE
Updating nokogiri to patch version with fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'jquery-rails'
 gem 'jquery-ui-rails', '~> 5.0.3'
 gem 'net-sftp'
 gem 'net-ssh'
+gem 'nokogiri', '~> 1.8.1' # forcing patching version on transitive dependency
 gem 'probability'
 gem 'rollbar'
 gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,7 +161,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_mime (0.1.3)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.3)
     momentjs-rails (2.17.1)
       railties (>= 3.1)
@@ -171,8 +171,8 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
     nio4r (2.1.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     oj (3.3.4)
     oj_mimic_json (1.0.1)
     orm_adapter (0.5.0)
@@ -345,6 +345,7 @@ DEPENDENCIES
   launchy
   net-sftp
   net-ssh
+  nokogiri (~> 1.8.1)
   oj
   oj_mimic_json
   pg


### PR DESCRIPTION
Fixing a bug in nokogiri 1.8.0.  It's pulled in transitively by a few different dependencies.