### PR TITLE
Fix bug in Student Report date filtering

### DIFF
--- a/app/assets/javascripts/student_profile/profile_details.jsx
+++ b/app/assets/javascripts/student_profile/profile_details.jsx
@@ -9,8 +9,6 @@ import ProfileDetailsStyle from '../helpers/profile_details_style.jsx';
   const QuadConverter = window.shared.QuadConverter;
   const styles = ProfileDetailsStyle;
   const StudentSectionsRoster = window.shared.StudentSectionsRoster;
-  const filterFromDate = QuadConverter.firstDayOfSchool(QuadConverter.toSchoolYear(moment())-1);
-  const filterToDate = moment();
 
   window.shared.ProfileDetails = React.createClass({
     displayName: 'ProfileDetails',
@@ -170,21 +168,41 @@ import ProfileDetailsStyle from '../helpers/profile_details_style.jsx';
       return _.sortBy(events, 'date').reverse();
     },
 
+    filterFromDateForQuery: function() {
+      const {filterFromDate} = this.state;
+
+      return filterFromDate.format('MM/DD/YYYY');
+    },
+
+    filterToDateForQuery: function() {
+      const {filterToDate} = this.state;
+
+      return filterToDate.format('MM/DD/YYYY');
+    },
+
+    studentReportURL: function() {
+      const id = this.props.student.id;
+      const filterFromDateForQuery = this.filterFromDateForQuery();
+      const filterToDateForQuery = this.filterToDateForQuery();
+      const sections = $('#section:checked').map(function() {return this.value;}).get().join(',');
+
+      return `${id}/student_report.pdf?sections=${sections}&from_date=${filterFromDateForQuery}&to_date=${filterToDateForQuery}`;
+    },
+
     onFilterFromDateChanged: function(dateText) {
       const textMoment = moment.utc(dateText, 'MM/DD/YYYY');
       const updatedMoment = (textMoment.isValid()) ? textMoment : null;
-      this.filterFromDate = updatedMoment;
+      this.setState({ filterFromDate: updatedMoment });
     },
 
     onFilterToDateChanged: function(dateText) {
       const textMoment = moment.utc(dateText, 'MM/DD/YYYY');
       const updatedMoment = (textMoment.isValid()) ? textMoment : null;
-      this.filterToDate = updatedMoment;
+      this.setState({ filterToDate: updatedMoment });
     },
 
     onClickGenerateStudentReport: function(event) {
-      const sections = $('#section:checked').map(function() {return this.value;}).get().join(',');
-      window.location = this.props.student.id + '/student_report.pdf?sections=' + sections + '&from_date=' + filterFromDate.format('MM/DD/YYYY') + '&to_date=' + filterToDate.format('MM/DD/YYYY');
+      window.location = this.studentReportURL();
       return null;
     },
 
@@ -319,7 +337,7 @@ import ProfileDetailsStyle from '../helpers/profile_details_style.jsx';
               <label>From date:</label>
               <Datepicker
                 styles={{ input: styles.datepickerInput }}
-                value={filterFromDate.format('MM/DD/YYYY')}
+                value={this.state.filterFromDate.format('MM/DD/YYYY')}
                 onChange={this.onFilterFromDateChanged}
                 datepickerOptions={{
                   showOn: 'both',
@@ -331,7 +349,7 @@ import ProfileDetailsStyle from '../helpers/profile_details_style.jsx';
               <label>To date:</label>
               <Datepicker
                 styles={{ input: styles.datepickerInput }}
-                value={filterToDate.format('MM/DD/YYYY')}
+                value={this.state.filterToDate.format('MM/DD/YYYY')}
                 onChange={this.onFilterToDateChanged}
                 datepickerOptions={{
                   showOn: 'both',

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -191,8 +191,8 @@ class StudentsController < ApplicationController
     @current_educator = current_educator
     @sections = (params[:sections] || "").split(",")
 
-    @filter_from_date = params[:from_date] ? Date.strptime(params[:from_date],  "%m/%d/%Y") : Date.today()
-    @filter_to_date = params[:from_date] ? Date.strptime(params[:to_date],  "%m/%d/%Y") : Date.today()
+    @filter_from_date = params[:from_date] ? Date.strptime(params[:from_date],  "%m/%d/%Y") : Date.today
+    @filter_to_date = params[:from_date] ? Date.strptime(params[:to_date],  "%m/%d/%Y") : Date.today
 
     # Load event notes that are NOT restricted for the student for the filtered dates
     @event_notes = @student.event_notes.where(:is_restricted => false).where(recorded_at: @filter_from_date..@filter_to_date)


### PR DESCRIPTION
# Who is this PR for?

Any educator who wants to create a Student Report PDF.

# What problem does this PR fix?

+ User input that tries to set from date / to date in Student Report is ignored.
+ Fix #1365.

# What does this PR do?
  
Binds `filterFromDate` and `filterToDate` to state so that they can be changed by the user.

# GIF 

![date-customization-working](https://user-images.githubusercontent.com/3209501/34635453-1164c28c-f255-11e7-84cf-0d53ddaad0ce.gif)

  
# Checklists

+ [x] Author checked latest in IE - Student Report generation with custom date range
  