### PR TITLE
Rename and refactor date formatter

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -11,10 +11,6 @@ class StudentsController < ApplicationController
 
   before_action :authorize_for_districtwide_access_admin, only: [:lasids]
 
-  def string_format_date(date)
-    date.strftime("%m/%d/%Y")
-  end
-
   def authorize!
     student = Student.find(params[:id])
     raise Exceptions::EducatorNotAuthorized unless current_educator.is_authorized_for_student(student)
@@ -80,7 +76,7 @@ class StudentsController < ApplicationController
 
     respond_to do |format|
       format.pdf do
-        footer = "Somerville Public Schools Student Report -- Generated #{string_format_date(todays_date)} by #{current_educator.full_name} -- Page [page] of [topage]"
+        footer = "Somerville Public Schools Student Report -- Generated #{format_date_for_student_report(todays_date)} by #{current_educator.full_name} -- Page [page] of [topage]"
         render(wait_for_js.merge({
           pdf: 'student_report',
           title: 'Student Report',

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -11,6 +11,10 @@ class StudentsController < ApplicationController
 
   before_action :authorize_for_districtwide_access_admin, only: [:lasids]
 
+  def string_format_date(date)
+    date.strftime("%m/%d/%Y")
+  end
+
   def authorize!
     student = Student.find(params[:id])
     raise Exceptions::EducatorNotAuthorized unless current_educator.is_authorized_for_student(student)
@@ -76,7 +80,7 @@ class StudentsController < ApplicationController
 
     respond_to do |format|
       format.pdf do
-        footer = "Somerville Public Schools Student Report -- Generated #{format_date(todays_date)} by #{current_educator.full_name} -- Page [page] of [topage]"
+        footer = "Somerville Public Schools Student Report -- Generated #{string_format_date(todays_date)} by #{current_educator.full_name} -- Page [page] of [topage]"
         render(wait_for_js.merge({
           pdf: 'student_report',
           title: 'Student Report',

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,9 @@
 module ApplicationHelper
 
+  def format_date_for_student_report(date)
+    date.strftime("%m/%d/%Y")
+  end
+
   def todays_date
     Time.now.in_time_zone('Eastern Time (US & Canada)').to_date
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,11 +1,5 @@
 module ApplicationHelper
 
-  def format_date(date)
-    return "" unless date.respond_to?(:strftime)
-
-    date.strftime("%m/%d/%Y")
-  end
-
   def todays_date
     Time.now.in_time_zone('Eastern Time (US & Canada)').to_date
   end

--- a/app/views/students/student_report.pdf.erb
+++ b/app/views/students/student_report.pdf.erb
@@ -59,12 +59,12 @@
     <div style="float: left; width: 512px;">
       <div>
         <span style="font-size:24px; font-weight:bold;"><%= "#{@student.first_name} #{@student.last_name}"%></span><br />
-        Report dates: <span><%="#{string_format_date(@filter_from_date)} to #{string_format_date(@filter_to_date)}"%></span>
+        Report dates: <span><%="#{format_date_for_student_report(@filter_from_date)} to #{format_date_for_student_report(@filter_to_date)}"%></span>
         <p />
       </div>
       <div style="float: left; width: 200px;">
         <ul>
-          <li>DOB: <%= string_format_date(@student.date_of_birth) %></li>
+          <li>DOB: <%= format_date_for_student_report(@student.date_of_birth) %></li>
           <li><%= "Grade #{@student.grade}" %></li>
           <li><%= @student.school.try(:name) || "No School Assigned" %></li>
           <li><%= @student.homeroom.try(:name) || "No Homeroom Assigned" %></li>
@@ -94,7 +94,7 @@
         <% @event_notes.each do |event_note| %>
           <div style="float: left; width:370px; padding:5px">
             <ul>
-              <li><span style="font-weight:bold;"><%= string_format_date(event_note.recorded_at) %></span></li>
+              <li><span style="font-weight:bold;"><%= format_date_for_student_report(event_note.recorded_at) %></span></li>
               <li><span style="font-style:italic;"><%= event_note.event_note_type.name %></span></li>
               <li><%= event_note.text %></li>
             </ul>
@@ -122,9 +122,9 @@
             <ul>
               <li>
                 <span style="font-weight:bold;">
-                  <%= string_format_date(service.date_started) %> -
+                  <%= format_date_for_student_report(service.date_started) %> -
                   <% if service.discontinued_at.present? %>
-                    <%= "#{string_format_date(service.discontinued_at)}" %>
+                    <%= "#{format_date_for_student_report(service.discontinued_at)}" %>
                   <% else %>
                     Present
                   <% end %>
@@ -163,14 +163,14 @@
             <td>
               <ul>
               <% year.filtered_absences(@filter_from_date, @filter_to_date).each do |absence| %>
-                <li><%= string_format_date(absence.occurred_at) %></li>
+                <li><%= format_date_for_student_report(absence.occurred_at) %></li>
               <% end %>
               </ul>
             </td>
             <td>
               <ul>
               <% year.filtered_tardies(@filter_from_date, @filter_to_date).each do |tardy| %>
-                <li><%= string_format_date(tardy.occurred_at) %></li>
+                <li><%= format_date_for_student_report(tardy.occurred_at) %></li>
               <% end %>
               </ul>
             </td>
@@ -192,7 +192,7 @@
         <% @discipline_incidents.each do |incident| %>
           <div style="float: left; width:370px; padding:5px">
             <ul>
-              <li><span style="font-weight:bold;"><%= "#{string_format_date(incident.occurred_at)} - #{incident.incident_location} - Code: #{incident.incident_code}"%></span></li>
+              <li><span style="font-weight:bold;"><%= "#{format_date_for_student_report(incident.occurred_at)} - #{incident.incident_location} - Code: #{incident.incident_code}"%></span></li>
               <li><span><%= incident.incident_description %></span></li>
             </ul>
           </div>
@@ -223,7 +223,7 @@
               <li><span style="font-weight:bold;"><%= test_name %></span></li>
               <% if test_scores.any? %>
                 <% test_scores.each do |score| %>
-                  <li><%= "#{string_format_date(score[0])} - #{score[1]}" %></li>
+                  <li><%= "#{format_date_for_student_report(score[0])} - #{score[1]}" %></li>
                 <% end %>
               <% else %>
                 <li>No Scores</li>

--- a/app/views/students/student_report.pdf.erb
+++ b/app/views/students/student_report.pdf.erb
@@ -59,12 +59,12 @@
     <div style="float: left; width: 512px;">
       <div>
         <span style="font-size:24px; font-weight:bold;"><%= "#{@student.first_name} #{@student.last_name}"%></span><br />
-        Report dates: <span><%="#{format_date(@filter_from_date)} to #{format_date(@filter_to_date)}"%></span>
+        Report dates: <span><%="#{string_format_date(@filter_from_date)} to #{string_format_date(@filter_to_date)}"%></span>
         <p />
       </div>
       <div style="float: left; width: 200px;">
         <ul>
-          <li>DOB: <%= format_date(@student.date_of_birth) %></li>
+          <li>DOB: <%= string_format_date(@student.date_of_birth) %></li>
           <li><%= "Grade #{@student.grade}" %></li>
           <li><%= @student.school.try(:name) || "No School Assigned" %></li>
           <li><%= @student.homeroom.try(:name) || "No Homeroom Assigned" %></li>
@@ -94,7 +94,7 @@
         <% @event_notes.each do |event_note| %>
           <div style="float: left; width:370px; padding:5px">
             <ul>
-              <li><span style="font-weight:bold;"><%= format_date(event_note.recorded_at) %></span></li>
+              <li><span style="font-weight:bold;"><%= string_format_date(event_note.recorded_at) %></span></li>
               <li><span style="font-style:italic;"><%= event_note.event_note_type.name %></span></li>
               <li><%= event_note.text %></li>
             </ul>
@@ -122,9 +122,9 @@
             <ul>
               <li>
                 <span style="font-weight:bold;">
-                  <%= format_date(service.date_started) %> -
+                  <%= string_format_date(service.date_started) %> -
                   <% if service.discontinued_at.present? %>
-                    <%= "#{format_date(service.discontinued_at)}" %>
+                    <%= "#{string_format_date(service.discontinued_at)}" %>
                   <% else %>
                     Present
                   <% end %>
@@ -163,14 +163,14 @@
             <td>
               <ul>
               <% year.filtered_absences(@filter_from_date, @filter_to_date).each do |absence| %>
-                <li><%= format_date(absence.occurred_at) %></li>
+                <li><%= string_format_date(absence.occurred_at) %></li>
               <% end %>
               </ul>
             </td>
             <td>
               <ul>
               <% year.filtered_tardies(@filter_from_date, @filter_to_date).each do |tardy| %>
-                <li><%= format_date(tardy.occurred_at) %></li>
+                <li><%= string_format_date(tardy.occurred_at) %></li>
               <% end %>
               </ul>
             </td>
@@ -192,7 +192,7 @@
         <% @discipline_incidents.each do |incident| %>
           <div style="float: left; width:370px; padding:5px">
             <ul>
-              <li><span style="font-weight:bold;"><%= "#{format_date(incident.occurred_at)} - #{incident.incident_location} - Code: #{incident.incident_code}"%></span></li>
+              <li><span style="font-weight:bold;"><%= "#{string_format_date(incident.occurred_at)} - #{incident.incident_location} - Code: #{incident.incident_code}"%></span></li>
               <li><span><%= incident.incident_description %></span></li>
             </ul>
           </div>
@@ -223,7 +223,7 @@
               <li><span style="font-weight:bold;"><%= test_name %></span></li>
               <% if test_scores.any? %>
                 <% test_scores.each do |score| %>
-                  <li><%= "#{format_date(score[0])} - #{score[1]}" %></li>
+                  <li><%= "#{string_format_date(score[0])} - #{score[1]}" %></li>
                 <% end %>
               <% else %>
                 <li>No Scores</li>


### PR DESCRIPTION
# Who is this PR for?
Developers
# What problem does this PR fix?
Code quality
# What does this PR do?
Renames format_date to string_format_date for specificity and moves it into the student controller because it is only used there

# Checklists

## Javascript QA

*If the PR touches Javascript, follow this checklist. If the PR doesn't touch Javascript, you can delete this section.*

*Which features or pages does this PR touch? Make a list here so that you can double-check each affected page in a Internet Explorer before merging.*

*Make one list for the author and another for the reviewer.*

*For more info on how to download and use a Virtual Machine to test in IE, see the README.*

*Example:*

+ [x] Author checked latest in IE - Student Report PDF
+ [x] Reviewer checked latest in IE - Student Report PDF
