### PR TITLE
Comment out educator remote file for New Bedford

### DIFF
--- a/config/district_new_bedford.yml
+++ b/config/district_new_bedford.yml
@@ -1,6 +1,6 @@
 remote_filenames:
   FILENAME_FOR_STUDENTS_IMPORT: ../newbedford/istudent.csv
-  FILENAME_FOR_EDUCATORS_IMPORT: ../newbedford/istaff.csv
+  # FILENAME_FOR_EDUCATORS_IMPORT: ../newbedford/istaff.csv
   FILENAME_FOR_BEHAVIOR_IMPORT: ../newbedford/iconduct.csv
   FILENAME_FOR_ASSESSMENT_IMPORT: ../newbedford/iassessments.csv
   FILENAME_FOR_ATTENDANCE_IMPORT: ../newbedford/iattendance.csv


### PR DESCRIPTION
# Notes 

+ For our initial New Bedford site, we're going to hand-roll user accounts.
+ That means we are going to manually set user roles for authorization, and use database passwords for authentication.
+ . . . instead of importing educator records from Aspen/X2 for authorization and using LDAP for authentication, like we do with Somerville.
