### PR TITLE
Limit seeding data to stay under Heroku demo limit

### DIFF
--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -160,7 +160,7 @@ class FakeStudent
   def add_student_assessments_from_x2
     create_x2_assessment_generators(@student).each do |assessment_generator|
       unless @newstudent
-        5.times do
+        4.times do
           StudentAssessment.new(assessment_generator.next).save
         end
       end
@@ -171,7 +171,7 @@ class FakeStudent
     unless @newstudent
       star_period_days = 90
       # Define semi-realistic date ranges for STAR assessments
-      start_date = DateTime.new(2010, 9, 1)
+      start_date = DateTime.new(2014, 9, 1)
       now = DateTime.now
       assessment_count = (now - start_date).to_i / star_period_days
       options = {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -58,17 +58,17 @@ ServiceUpload.create!([
 puts 'Creating more students for each homeroom...'
 Homeroom.all.each do |homeroom|
   puts "  Creating for homeroom: #{homeroom.name}..."
-  10.times { FakeStudent.new(homeroom.school, homeroom) }
+  9.times { FakeStudent.new(homeroom.school, homeroom) }
 end
 
 puts 'Creating additional students for the Healey with no homeroom...'
-10.times { FakeStudent.new(pals.healey, nil) }
+9.times { FakeStudent.new(pals.healey, nil) }
 
 puts 'Creating more sophomore students...'
 Section.all.each do |section|
   puts "  Creating students for section #{section.section_number}..."
   school = section.course.school
-  10.times do
+  9.times do
     grade_letter = ['A','B','C','D','F'].sample
     grade_numeric = sample_numeric_grade_from_letter(grade_letter)
     fake_student = FakeStudent.new(school, pals.shs_sophomore_homeroom)


### PR DESCRIPTION
# Who is this PR for?
Developers

# What problem does this PR fix?
Heroku's database row limits on the demo site

# What does this PR do?
Reduce the data generated in the database seed task so that it's under 10k.

```
irb(main):012:0> ActiveRecord::Base.subclasses.map {|klass| klass.all.size }.sum
=> 8265
```

We could improve this overall (eg, updating the number of students per section is probably important for developing UI features for that page), but the goal here is just to unblock the demo site after shipping https://github.com/studentinsights/studentinsights/pull/1315.

# Screenshot (if adding a client-side feature)
Charts are fine.  Demo data isn't all entirely semantically meaningful for all schools, students and grade levels anyway.

<img width="1261" alt="screen shot 2018-01-10 at 8 48 54 am" src="https://user-images.githubusercontent.com/1056957/34776005-3a701c30-f5e3-11e7-8317-bc9e93d9c0c3.png">
