### PR TITLE
Add guard in authorization page for educators who aren't assigned a school

### DIFF
--- a/app/views/admin/educators/authorization.html.erb
+++ b/app/views/admin/educators/authorization.html.erb
@@ -30,7 +30,7 @@
           <td><%= educator.admin %></td>
           <td><%= educator.can_view_restricted_notes %></td>
           <td><%= educator.districtwide_access %></td>
-          <td><%= educator.school.name %></td>
+          <td><%= educator.school.try(:name) || "N/A" %></td>
       <% end %>
     </tbody>
   </table>


### PR DESCRIPTION
# Who is this PR for?

Folks who want to look at the "Educator permissions overview" page.

# What problem does this PR fix?

The page breaks if any of the district-wide educator records aren't assigned to a school. (Currently the case on the fledgeling New Bedford Insights app.) 

# What does this PR do?

Adds a `try` clause and prints "N/A" if the educator isn't assigned to a school.