### PR TITLE
Allow districtwide admin with no school assigned to visit homeroom pages

### DIFF
--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -144,9 +144,6 @@ class Authorizer
 
   # TODO(kr) remove implementation
   def homerooms
-    # Educator can visit roster view for these homerooms
-    return [] if @educator.school.nil?
-
     if @educator.districtwide_access?
       Homeroom.all
     elsif @educator.schoolwide_access?


### PR DESCRIPTION
# Who is this PR for?

Folks who want to demo insights on the demo Heroku site (or the fledgeling New Bedford instance).

# What problem does this PR fix?

Admin user can't see homerooms because s/he isn't assigned a school! 

# What does this PR do?

+ Fix #1304 