### PR TITLE
Use canonical domain from ENV to set mailer SMTP settings instead of hardcoding

### DIFF
--- a/app/config_objects/load_district_config.rb
+++ b/app/config_objects/load_district_config.rb
@@ -8,14 +8,18 @@ class LoadDistrictConfig
   end
 
   def remote_filenames
-    load.fetch("remote_filenames")
+    load_yml.fetch("remote_filenames")
   end
 
   def schools
-    load.fetch("schools")
+    load_yml.fetch("schools")
   end
 
-  def load
+  def canonical_domain
+    ENV.fetch('CANONICAL_DOMAIN')
+  end
+
+  def load_yml
     YAML.load(File.open(config_file_path))
   end
 

--- a/app/config_objects/load_district_config.rb
+++ b/app/config_objects/load_district_config.rb
@@ -16,7 +16,7 @@ class LoadDistrictConfig
   end
 
   def canonical_domain
-    ENV.fetch('CANONICAL_DOMAIN')
+    ENV.fetch('CANONICAL_DOMAIN', nil)
   end
 
   def load_yml

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,7 +45,7 @@ class ApplicationController < ActionController::Base
 
   # For redirecting requests directly from the Heroku domain to the canonical domain name
   def redirect_domain!
-    canonical_domain = EnvironmentVariable.value('CANONICAL_DOMAIN')
+    canonical_domain = LoadDistrictConfig.new.canonical_domain
     return if canonical_domain == nil
     return if request.host == canonical_domain
     redirect_to "#{request.protocol}#{canonical_domain}#{request.fullpath}", :status => :moved_permanently

--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -32,7 +32,7 @@ class ImportTask
   def validate_district_option
     # The LoadDistrictConfig class uses `fetch`, which will validate the
     # district option for us
-    LoadDistrictConfig.new.load
+    LoadDistrictConfig.new.load_yml
   end
 
   def seed_schools_if_needed

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -24,7 +24,7 @@ class School < ActiveRecord::Base
   end
 
   def self.fetch_school_data_for_district(district_key)
-    yml_config = LoadDistrictConfig.new(district_key).load
+    yml_config = LoadDistrictConfig.new(district_key).load_yml
 
     return yml_config.fetch("schools")
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,11 +80,13 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-
-
   # ---- Student Insights additions ----
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { host: "https://#{ENV.fetch('CANONICAL_DOMAIN')}/" }
+
+  config.action_mailer.default_url_options = {
+    host: "https://#{LoadDistrictConfig.new.canonical_domain}/"
+  }
+
   ActionMailer::Base.smtp_settings = {
     :port           => ENV['MAILGUN_SMTP_PORT'],
     :address        => ENV['MAILGUN_SMTP_SERVER'],

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,7 +90,7 @@ Rails.application.configure do
     :address        => ENV['MAILGUN_SMTP_SERVER'],
     :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
     :password       => ENV['MAILGUN_SMTP_PASSWORD'],
-    :domain         => "https://#{ENV.fetch('CANONICAL_DOMAIN')}/",
+    :domain         => "https://#{LoadDistrictConfig.new.canonical_domain}/",
     :authentication => :plain,
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -84,13 +84,13 @@ Rails.application.configure do
 
   # ---- Student Insights additions ----
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { host: 'https://homeroom-somerville.herokuapp.com/' }
+  config.action_mailer.default_url_options = { host: "https://#{ENV.fetch('CANONICAL_DOMAIN')}/" }
   ActionMailer::Base.smtp_settings = {
     :port           => ENV['MAILGUN_SMTP_PORT'],
     :address        => ENV['MAILGUN_SMTP_SERVER'],
     :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
     :password       => ENV['MAILGUN_SMTP_PASSWORD'],
-    :domain         => 'http://somerville.studentinsights.org/',
+    :domain         => "https://#{ENV.fetch('CANONICAL_DOMAIN')}/",
     :authentication => :plain,
   }
 


### PR DESCRIPTION
# Who is this PR for?

Folks who want to set up a new Insights instance. 

# What problem does this PR fix?

The Somerville app's URL is hardcoded into the part of the code that enables sending emails from the app.

# What does this PR do?

Un-hardcode Somerville from mailer SMTP settings and use an ENV variable instead. 

# Notes 

I noticed that for Somerville the CANONICAL_DOMAIN variable does not include an "https://" prefix, while the SMTP settings URL does. 

I figure the simplest thing to do is to follow that pattern in future instances and leave the "https://" hardcoded since we'll always be using SSL.