### PR TITLE
Update net-ldap through devise

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,11 @@ gem 'puma'
 gem 'activerecord-import'
 gem 'aws-sdk', '~> 2'
 gem 'devise', '~> 4.3.0'
-gem 'devise_ldap_authenticatable'
+
+# This is forked, waiting on https://github.com/cschiewek/devise_ldap_authenticatable/issues/242 to be merged, at
+# which point we can switch back to the gem upstream.
+gem 'devise_ldap_authenticatable', git: 'https://github.com/studentinsights/devise_ldap_authenticatable'
+
 gem 'activemodel-serializers-xml'
 gem 'administrate', '~> 0.8.1'
 gem 'friendly_id', '~> 5.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/studentinsights/devise_ldap_authenticatable
+  revision: 8eace15d08fb5b5599debe466aa4c68a86379fba
+  specs:
+    devise_ldap_authenticatable (0.8.6)
+      devise (>= 3.4.1)
+      net-ldap (>= 0.16.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -105,9 +113,6 @@ GEM
       railties (>= 4.1.0, < 5.2)
       responders
       warden (~> 1.2.3)
-    devise_ldap_authenticatable (0.8.5)
-      devise (>= 3.4.1)
-      net-ldap (>= 0.6.0, <= 0.11)
     diff-lcs (1.3)
     docile (1.1.5)
     erubi (1.6.1)
@@ -167,7 +172,7 @@ GEM
     momentjs-rails (2.17.1)
       railties (>= 3.1)
     multi_json (1.12.1)
-    net-ldap (0.11)
+    net-ldap (0.16.1)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
@@ -341,7 +346,7 @@ DEPENDENCIES
   database_cleaner
   delayed_job_active_record
   devise (~> 4.3.0)
-  devise_ldap_authenticatable
+  devise_ldap_authenticatable!
   factory_girl_rails
   faker
   friendly_id (~> 5.1.0)
@@ -388,4 +393,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
# Who is this PR for?
everyone!

# What does this PR do?
It update `net-ldap` to a more recent version.  Since the pull request in `devise_ldap_authenticatable`, this forks the project to the studentinsights org to update the dependency.  It also incidentally included a patch version bump to bundler.

This can only be properly tested in production mode, so weekend deploy seems like a good time. :)