### PR TITLE
Add minimal browserconfig.xml for IE

### DIFF
--- a/public/browserconfig.xml
+++ b/public/browserconfig.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<browserconfig>
+  <msapplication>
+  </msapplication>
+</browserconfig>


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Cleaning up false positive 404s in Rollbar

# What does this PR do?
Adds a minimal browserconfig.xml for IE 11.  See https://msdn.microsoft.com/en-us/library/dn455106(v=vs.85).aspx.  We could support tiles or whatever this does, but we haven't ever before and so this is really just trying to provide a minimal file and remove these extra requests (and the 404s too).