### PR TITLE
Improving service date saving in RecordService, factor out toMoment

### DIFF
--- a/app/assets/javascripts/helpers/toMoment.js
+++ b/app/assets/javascripts/helpers/toMoment.js
@@ -1,0 +1,28 @@
+// Allow a few strict formats of dates
+const allowedFormats = [
+  'MM/DD/YYYY',
+  'MM/D/YYYY',
+  'M/DD/YYYY',
+  'M/D/YYYY',
+
+  'MM/DD/YY',
+  'MM/D/YY',
+  'M/DD/YY',
+  'M/D/YY',
+
+  'MM-DD-YYYY',
+  'MM-D-YYYY',
+  'M-DD-YYYY',
+  'M-D-YYYY',
+
+  'MM-DD-YY',
+  'MM-D-YY',
+  'M-DD-YY',
+  'M-D-YY'
+];
+
+// This will always return a `moment` but if`dateText` can't be parsed, that moment will return false
+// when you call `isValid`.
+export function toMoment(dateText) {
+  return moment.utc(dateText, allowedFormats, true); // this does 'strict parsing' on multiple formats
+}

--- a/app/assets/javascripts/helpers/toMoment.test.js
+++ b/app/assets/javascripts/helpers/toMoment.test.js
@@ -1,0 +1,9 @@
+import {toMoment} from './toMoment.js';
+
+it('#toMoment and then back to text', () => {
+  expect(toMoment('12/19/2018').format('YYYY-MM-DD')).toEqual('2018-12-19');
+  expect(toMoment('3/5/2018').format('YYYY-MM-DD')).toEqual('2018-03-05');
+  expect(toMoment('1/15/18').format('YYYY-MM-DD')).toEqual('2018-01-15');
+  expect(toMoment('01/5/18').format('YYYY-MM-DD')).toEqual('2018-01-05');
+  expect(toMoment('01-5-18').format('YYYY-MM-DD')).toEqual('2018-01-05');
+});

--- a/app/assets/javascripts/student_profile/quad_converter.jsx
+++ b/app/assets/javascripts/student_profile/quad_converter.jsx
@@ -61,6 +61,13 @@ import moment from 'moment';
       return QuadConverter.toMoment([year, 8, 15]);
     },
 
+    lastDayOfSchool: function(year){
+      // year: An integer year.
+      // returns: A moment object representing roughly the last day of that school year (which will
+      // be in the following calendar year).
+      return QuadConverter.toMoment([year + 1, 6, 30]);
+    },
+
     toSchoolYear: function(date) {
       // date: A JS date object or Moment object.
       // returns: Integer representing what the calendar year was in the fall of date's school year.

--- a/app/assets/javascripts/student_profile/record_service.jsx
+++ b/app/assets/javascripts/student_profile/record_service.jsx
@@ -6,6 +6,7 @@ import serviceColor from '../student_profile/service_color.js';
 (function() {
   window.shared || (window.shared = {});
   const ProvidedByEducatorDropdown = window.shared.ProvidedByEducatorDropdown;
+  const QuadConverter = window.shared.QuadConverter;
 
   const styles = {
     dialog: {
@@ -65,12 +66,19 @@ import serviceColor from '../student_profile/service_color.js';
 
     getInitialState: function() {
       const {nowMoment} = this.props;
+      
       return {
         serviceTypeId: null,
         providedByEducatorName: ''  ,
         dateStartedText: nowMoment.format('MM/DD/YYYY'),
-        estimatedEndDateText: ''
+        estimatedEndDateText: this.defaultEstimatedEndDate(nowMoment).format('MM/DD/YYYY')
       };
+    },
+
+    // The default is to assume the service will last until the end of the school year.
+    defaultEstimatedEndDate(nowMoment) {
+      const schoolYear = QuadConverter.toSchoolYear(nowMoment);
+      return QuadConverter.lastDayOfSchool(schoolYear);
     },
 
     // Normalize input date text into format Rails expects, tolerating empty string as null.

--- a/app/assets/javascripts/student_profile/record_service.jsx
+++ b/app/assets/javascripts/student_profile/record_service.jsx
@@ -1,4 +1,5 @@
 import Datepicker from '../student_profile/Datepicker.js';
+import {toMoment} from '../helpers/toMoment.js';
 import {merge} from '../helpers/react_helpers.jsx';
 import serviceColor from '../student_profile/service_color.js';
 
@@ -66,20 +67,34 @@ import serviceColor from '../student_profile/service_color.js';
       const {nowMoment} = this.props;
       return {
         serviceTypeId: null,
-        providedByEducatorName: "",
+        providedByEducatorName: ''  ,
         dateStartedText: nowMoment.format('MM/DD/YYYY'),
-        estimatedEndDateText: nowMoment.format('MM/DD/YYYY')
+        estimatedEndDateText: ''
       };
     },
 
-    dateStartedMoment: function() {
-      const {dateStartedText} = this.state;
-      return moment.utc(dateStartedText, 'MM/DD/YYYY', true); // strict parsing
+    // Normalize input date text into format Rails expects, tolerating empty string as null.
+    // If the date is not valid, an error will be raised.
+    formatDateTextForRails(dateText) {
+      if (dateText === '') return null;
+      const moment = toMoment(dateText);
+      if (!moment.isValid()) throw new Error('invalid date: ' + dateText);
+      return moment.format('YYYY-MM-DD');
     },
 
-    estimatedenddateMoment: function() {
-      const {estimatedEndDateText} = this.state;
-      return moment.utc(estimatedEndDateText, 'MM/DD/YYYY', true); // strict parsing
+    isFormComplete() {
+      const {serviceTypeId, providedByEducatorName} = this.state;
+      if (serviceTypeId === null) return false;
+      if (providedByEducatorName === '') return false;
+      return true;
+    },
+
+    // Both dates need to be valid, but an empty end date is allowed.
+    areDatesValid() {
+      const {dateStartedText, estimatedEndDateText} = this.state;
+      if (!toMoment(dateStartedText).isValid()) return false;
+      if (estimatedEndDateText !== '' && !toMoment(estimatedEndDateText).isValid()) return false;
+      return true;
     },
 
     onDateTextChanged: function(dateStartedText) {
@@ -107,17 +122,18 @@ import serviceColor from '../student_profile/service_color.js';
     },
 
     onClickSave: function(event) {
-      const {serviceTypeId, providedByEducatorName} = this.state;
       const {currentEducator} = this.props;
-      const reformattedDateText = this.dateStartedMoment().format('YYYY-MM-DD');
-      const estimatedenddateMoment = this.estimatedenddateMoment().format('YYYY-MM-DD');
+      const {serviceTypeId, providedByEducatorName, dateStartedText, estimatedEndDateText} = this.state;
+      if (!this.isFormComplete()) {
+        console.error('onClickSave when form is not complete, aborting save...'); // eslint-disable-line no-console
+        return;
+      }
 
-      // Get the value of the autocomplete input
       this.props.onSave({
         serviceTypeId,
         providedByEducatorName,
-        dateStartedText: reformattedDateText,
-        estimatedEndDateText: estimatedenddateMoment,
+        dateStartedText: this.formatDateTextForRails(dateStartedText),
+        estimatedEndDateText: this.formatDateTextForRails(estimatedEndDateText),
         recordedByEducatorId: currentEducator.id
       });
     },
@@ -185,8 +201,6 @@ import serviceColor from '../student_profile/service_color.js';
     },
 
     renderWhoAndWhen: function() {
-      const isValidDate = this.dateStartedMoment().isValid();
-
       return (
         <div>
           <div style={{ marginTop: 20 }}>
@@ -229,15 +243,14 @@ import serviceColor from '../student_profile/service_color.js';
               minDate: undefined
             }} />
             <div style={{height: '2em'}}>
-              {!isValidDate && <div style={styles.invalidDate}>Choose a valid date</div>}
+              {!this.areDatesValid() && <div className="RecordService-warning" style={styles.invalidDate}>Choose a valid date (end date is optional)</div>}
             </div>
         </div>
       );
     },
 
     renderButtons: function() {
-      const {serviceTypeId, providedByEducatorName} = this.state;
-      const isFormComplete = (serviceTypeId && providedByEducatorName !== '' && this.dateStartedMoment().isValid());
+      const isFormComplete = this.isFormComplete();
 
       return (
         <div style={{ marginTop: 15 }}>

--- a/spec/javascripts/student_profile/quad_converter_spec.jsx
+++ b/spec/javascripts/student_profile/quad_converter_spec.jsx
@@ -36,6 +36,13 @@ describe('QuadConverter', function() {
     });
   });
 
+  describe('#lastDayOfSchool', function() {
+    it('works', function() {
+      expect(QuadConverter.lastDayOfSchool(2016).isSame(moment.utc("2017-06-30"))).toEqual(true);
+      expect(QuadConverter.lastDayOfSchool(2013).isSame(moment.utc("2014-06-30"))).toEqual(true);
+    });
+  });
+
   describe('#schoolYearStartDates', function(){
     it('works', function() {
       // TODO: Write a Jasmine custom matcher for this?

--- a/spec/javascripts/student_profile/record_service_spec.jsx
+++ b/spec/javascripts/student_profile/record_service_spec.jsx
@@ -103,7 +103,7 @@ describe('RecordService', function() {
       expect($(el).text()).toContain('When did/will they end');
       expect($(el).text()).not.toContain('Invalid date');
       expect(helpers.findStartDateInput(el).value).toContain('02/11/2016');
-      expect(helpers.findEndDateInput(el).value).toEqual('');
+      expect(helpers.findEndDateInput(el).value).toEqual('06/30/2016');
       expect(helpers.findSaveButton(el).length).toEqual(1);
       expect($(el).find('.btn.cancel').length).toEqual(1);
 

--- a/spec/javascripts/student_profile/record_service_spec.jsx
+++ b/spec/javascripts/student_profile/record_service_spec.jsx
@@ -12,8 +12,8 @@ describe('RecordService', function() {
   const RecordService = window.shared.RecordService;
 
   const helpers = {
-    renderInto: function(el, props) {
-      const mergedProps = merge(props || {}, {
+    testProps: function(props) {
+      return merge({
         studentFirstName: 'Tamyra',
         serviceTypesIndex: studentProfile.serviceTypesIndex,
         educatorsIndex: studentProfile.educatorsIndex,
@@ -23,7 +23,11 @@ describe('RecordService', function() {
         onCancel: jest.fn(),
         requestState: null,
         studentId: 1
-      });
+      }, props || {});
+    },
+
+    renderInto: function(el, props) {
+      const mergedProps = helpers.testProps(props);
       ReactDOM.render(<RecordService {...mergedProps} />, el);
     },
 
@@ -37,22 +41,43 @@ describe('RecordService', function() {
       return $(el).find('.btn.save');
     },
 
-    findDateInput: function(el) {
-      return $(el).find('.datepicker');
+    findStartDateInput: function(el) {
+      return $(el).find('.datepicker').get(0);
+    },
+
+    findEndDateInput: function(el) {
+      return $(el).find('.datepicker').get(1);
     },
 
     isSaveButtonEnabled: function(el) {
       return helpers.findSaveButton(el).attr('disabled') !== 'disabled';
     },
 
-    simulateDateChange: function(el, text) {
-      const inputEl = helpers.findDateInput(el).get(0);
+    isWarningMessageShown(el) {
+      return $(el).find('.RecordService-warning').text() === 'Choose a valid date (end date is optional)';
+    },
+
+    simulateStartDateChange: function(el, text) {
+      const inputEl = helpers.findStartDateInput(el);
+      return ReactTestUtils.Simulate.change(inputEl, {target: {value: text}});
+    },
+
+    simulateEndDateChange: function(el, text) {
+      const inputEl = helpers.findEndDateInput(el);
       return ReactTestUtils.Simulate.change(inputEl, {target: {value: text}});
     },
 
     simulateEducatorChange: function(el, text) {
       const inputEl = $(el).find('.ProvidedByEducatorDropdown').get(0);
       ReactTestUtils.Simulate.change(inputEl, {target: {value: text}});
+    },
+
+    submitForm(el, params = {}) {
+      $(el).find('.btn.service-type').click();
+      helpers.simulateEducatorChange(el, params.educatorText || 'kevin');
+      helpers.simulateStartDateChange(el, params.startDateText || '12/19/2018');
+      helpers.simulateEndDateChange(el, params.endDateText);
+      $(el).find('.btn.save').click();
     }
   };
 
@@ -76,43 +101,112 @@ describe('RecordService', function() {
       // TODO (as): test staff dropdown autocomplete async
       expect($(el).text()).toContain('When did they start?');
       expect($(el).text()).toContain('When did/will they end');
-      expect(helpers.findDateInput(el).length).toEqual(2);
       expect($(el).text()).not.toContain('Invalid date');
+      expect(helpers.findStartDateInput(el).value).toContain('02/11/2016');
+      expect(helpers.findEndDateInput(el).value).toEqual('');
       expect(helpers.findSaveButton(el).length).toEqual(1);
-      expect(helpers.isSaveButtonEnabled(el)).toEqual(false);
       expect($(el).find('.btn.cancel').length).toEqual(1);
-    });
 
-    it('shows warning on invalid date', function() {
-      const el = container.testEl;
-      helpers.renderInto(el);
-      helpers.simulateDateChange(el, 'fds 1/2/2/22 not a valid date');
-      expect($(el).text()).toContain('Choose a valid date');
-    });
-
-    it('does not allow save on invalid date', function() {
-      const el = container.testEl;
-      helpers.renderInto(el);
-      helpers.simulateDateChange(el, '1/2/2/22 not a valid date');
+      expect(helpers.isWarningMessageShown(el)).toEqual(false);
       expect(helpers.isSaveButtonEnabled(el)).toEqual(false);
     });
 
-    it('does not allow without educator', function() {
-      const el = container.testEl;
-      helpers.renderInto(el);
-      $(el).find('.btn:first').click();
-      helpers.simulateEducatorChange(el, '');
-      helpers.simulateDateChange(el, '12/19/2018');
-      expect(helpers.isSaveButtonEnabled(el)).toEqual(false);
+    describe('validation', () => {
+      it('shows warning on invalid start date', function() {
+        const el = container.testEl;
+        helpers.renderInto(el);
+        helpers.simulateStartDateChange(el, 'fds 1/2/2/22 not a valid date');
+        expect(helpers.isWarningMessageShown(el)).toEqual(true);
+      });
+
+      it('shows warning on invalid end date', function() {
+        const el = container.testEl;
+        helpers.renderInto(el);
+        helpers.simulateEndDateChange(el, 'fds 1/2/2/22 not a valid date');
+        expect(helpers.isWarningMessageShown(el)).toEqual(true);
+      });
+
+      it('does not allow save on invalid start date', function() {
+        const el = container.testEl;
+        helpers.renderInto(el);
+        helpers.simulateStartDateChange(el, '1/2/2/22 not a valid date');
+        expect(helpers.isSaveButtonEnabled(el)).toEqual(false);
+      });
+
+      it('does not allow save on invalid end date', function() {
+        const el = container.testEl;
+        helpers.renderInto(el);
+        helpers.simulateEndDateChange(el, '1/2/2/22 not a valid date');
+        expect(helpers.isSaveButtonEnabled(el)).toEqual(false);
+      });
+
+      it('does not allow save on end date before start date', function() {
+        const el = container.testEl;
+        helpers.renderInto(el);
+        helpers.simulateStartDateChange(el, '1/20/18');
+        helpers.simulateEndDateChange(el, '1/2/18');
+        expect(helpers.isSaveButtonEnabled(el)).toEqual(false);
+      });
+
+      it('does not allow save without educator', function() {
+        const el = container.testEl;
+        helpers.renderInto(el);
+        $(el).find('.btn.service-type').click();
+        helpers.simulateEducatorChange(el, '');
+        helpers.simulateStartDateChange(el, '12/19/2018');
+        expect(helpers.isSaveButtonEnabled(el)).toEqual(false);
+      });
+
+      it('requires service, educator and valid start date set in order to save and allows blank end date', function() {
+        const el = container.testEl;
+        helpers.renderInto(el);
+        $(el).find('.btn.service-type').click();
+        helpers.simulateEducatorChange(el, 'kevin');
+        helpers.simulateStartDateChange(el, '12/19/2018');
+        helpers.simulateEndDateChange(el, '');
+        expect(helpers.isSaveButtonEnabled(el)).toEqual(true);
+      });
     });
 
-    it('requires service, educator and valid date set in order to save', function() {
+    it('#onSave called as expected', () => {
       const el = container.testEl;
-      helpers.renderInto(el);
-      $(el).find('.btn:first').click();
-      helpers.simulateEducatorChange(el, 'kevin');
-      helpers.simulateDateChange(el, '12/19/2018');
-      expect(helpers.isSaveButtonEnabled(el)).toEqual(true);
+      const props = helpers.testProps();
+      ReactDOM.render(<RecordService {...props} />, el);
+      helpers.submitForm(el, { endDateText: '06/30/2019' });
+
+      expect(props.onSave).toBeCalledWith({
+        serviceTypeId: 507,
+        providedByEducatorName: 'kevin',
+        dateStartedText: '2018-12-19',
+        estimatedEndDateText: '2019-06-30',
+        recordedByEducatorId: 1
+      });
+    });
+
+    it('#onSave called as expected when blank end date', () => {
+      const el = container.testEl;
+      const props = helpers.testProps();
+      ReactDOM.render(<RecordService {...props} />, el);
+      helpers.submitForm(el, { endDateText: '' });
+
+      expect(props.onSave).toBeCalledWith({
+        serviceTypeId: 507,
+        providedByEducatorName: 'kevin',
+        dateStartedText: '2018-12-19',
+        estimatedEndDateText: null,
+        recordedByEducatorId: 1
+      });
+    });
+
+    it('#formatDateTextForRails', () => {
+      const el = container.testEl;
+      const props = helpers.testProps();
+      const instance = ReactDOM.render(<RecordService {...props} />, el); // eslint-disable-line react/no-render-return-value
+      expect(instance.formatDateTextForRails('12/19/2018')).toEqual('2018-12-19');
+      expect(instance.formatDateTextForRails('3/5/2018')).toEqual('2018-03-05');
+      expect(instance.formatDateTextForRails('1/15/18')).toEqual('2018-01-15');
+      expect(instance.formatDateTextForRails('01/5/18')).toEqual('2018-01-05');
+      expect(instance.formatDateTextForRails('01-5-18')).toEqual('2018-01-05');
     });
   });
 });


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
Fixes https://github.com/studentinsights/studentinsights/issues/1307.

# What does this PR do?
- Educators should be able to leave end date blank. We should change the UI to allow this, and send up null instead of the string "Invalid date". This change would fix the immediate bug that came up last week.
- If there is an end date, validates on the client that it is an actual valid date and not allow saving until that's resolved.
- Makes the default "estimated end date" blank.
- Uses another strategy to parse the dates so that educators can write in natural formats and we assume American date ordering and accept 2/20/18 as validly representing Feb. 20th, 2018 without requiring them to type 02/20/2018.  This function is factored out of the component into its own module.

# Screenshot (if adding a client-side feature)
<img width="619" alt="screen shot 2018-01-21 at 1 11 32 pm" src="https://user-images.githubusercontent.com/1056957/35197390-b5b558ca-feac-11e7-9352-7737164335a3.png">
<img width="614" alt="screen shot 2018-01-21 at 1 12 29 pm" src="https://user-images.githubusercontent.com/1056957/35197395-c3a33a10-feac-11e7-9e26-9f38f92cefad.png">

+ [x] Author checked latest in IE - Student Profile
+ [x] Reviewer checked latest in IE - Student Profile

## Automated Testing
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code
