### PR TITLE
Add rake task to show response times from Heroku logs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :development, :test do
   gem 'timecop'
   gem 'rails-controller-testing'
   gem 'bourbon', '~> 4.3.2'
+  gem 'descriptive-statistics'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
     delayed_job_active_record (4.1.2)
       activerecord (>= 3.0, < 5.2)
       delayed_job (>= 3.0, < 5)
+    descriptive-statistics (2.2.0)
     devise (4.3.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -340,6 +341,7 @@ DEPENDENCIES
   capybara
   database_cleaner
   delayed_job_active_record
+  descriptive-statistics
   devise (~> 4.3.0)
   devise_ldap_authenticatable
   factory_girl_rails
@@ -388,4 +390,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/lib/tasks/smallog.rake
+++ b/lib/tasks/smallog.rake
@@ -1,0 +1,85 @@
+# group a path into a string key (eg, representing an endpoint)
+def action(path, options = {})
+  if path.start_with?('/assets')
+    '[assets]'
+  elsif path.start_with?('/build')
+    '[build]'
+  elsif path.start_with?('/wp-content') || path == '/modules/mod_artuploader/upload.php'
+    '[hacking]'
+  elsif path == '/robots.txt' || path == '/favicon.ico' || path == '/browserconfig.xml'
+    '[config]'
+  else
+    begin
+      match = Rails.application.routes.recognize_path(path, options)
+      "#{match[:controller]}##{match[:action]}"
+    rescue => err
+      path
+    end
+  end
+end
+
+# Count how many rows are for a class of status codes (eg, 2xx)
+def percentage_status_code(rows, number)
+  count = rows.select {|row| row[4].start_with?(number.to_s) }.size
+  percentage = count / rows.size.to_f
+  (percentage * 100).round.to_s + '%'
+end
+
+
+namespace :logs do
+  desc 'Convert logs to JSON'
+  task analyze: :environment do
+    # load log and parse raw log files for the values we care about
+    filename = ARGV[1]
+    rows = []
+    bad_lines = []
+    File.readlines(filename).each do |line|
+      regex = /.*(\d\d\d\d-\d\d-\d\d)T.*method=(\w*)\spath="(.*)"\shost=.*service=(\d*)ms status=(\d\d\d).* protocol=.*/
+      matches = regex.match(line)
+      if matches.nil?
+        # debug unparseable lines puts line
+        bad_lines << line
+      else
+        row = [matches[1], matches[2], matches[3], matches[4], matches[5]]
+        rows << row
+      end
+    end
+
+    # group by endpoint
+    file_group = rows.group_by do |row|
+      path = action(row[2], method: row[1])
+    end
+
+    # compute metrics
+    records = []
+    file_group.each do |key, values| 
+      stats = DescriptiveStatistics::Stats.new(values.map {|row| row[3].to_i })
+      records << [
+        values.size,
+        '|',
+        percentage_status_code(values, '2'),
+        percentage_status_code(values, '3'),
+        percentage_status_code(values, '4'),
+        percentage_status_code(values, '5'),
+        '|',
+        "#{stats.value_from_percentile(50).to_i}ms",
+        "#{stats.value_from_percentile(90).to_i}ms",
+        "#{stats.value_from_percentile(95).to_i}ms",
+        '|',
+        key
+      ]
+    end
+
+    # sort and output
+    sorted = records.sort_by {|record| record[7].to_i * -1 }
+    puts ['count', '', '2xx', '3xx', '4xx', '5xx', '', 'p50', 'p90', 'p95', '', 'key'].join("\t")
+    puts ['---', '---', '---', '---', '---', '---', '---', '---', '---', '---', '---', '---'].join("\t")
+    sorted.each {|record| puts record.join("\t") }
+
+    # data range
+    dates = rows.map {|row| Date.parse(row[0].slice(0, 10)) }.sort
+    puts
+    puts "Includes #{rows.size} log lines over #{(dates.last - dates.first).to_i} days (from #{dates.first} to #{dates.last})."
+    puts "Skipped #{bad_lines.size} log lines that could not be parsed."
+  end
+end

--- a/lib/tasks/smallog.rake
+++ b/lib/tasks/smallog.rake
@@ -45,7 +45,6 @@ def parse_csv(filename)
   [rows, bad_lines]
 end
 
-
 namespace :logs do
   desc 'Convert logs to JSON'
   task analyze: :environment do
@@ -56,7 +55,7 @@ namespace :logs do
 
     # compute metrics
     records = []
-    file_group.each do |key, values| 
+    file_group.each do |key, values|
       stats = DescriptiveStatistics::Stats.new(values.map {|row| row[3].to_i })
       records << [
         values.size,


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
visibility into endpoint response times

# What does this PR do?
adds a rake task for analyzing a dump of Heroku logs (eg, from logentries).  This is an initial investigation into https://github.com/studentinsights/studentinsights/issues/1392, just getting aggregate response times over the last week.

# Screenshot (if adding a client-side feature)
This is sorted by p50.

```
$ rake logs:analyze /Users/krobinson/Desktop/somerville-teacher-tool_2018-01-14_192745_2018-01-21_192745.log

count		2xx	3xx	4xx	5xx		p50	p90	p95		key
---	---	---	---	---	---	---	---	---	---	---	---
2	|	50%	0%	50%	0%	|	15051ms	0ms	0ms	|	admin/educators#authorization
7	|	57%	0%	43%	0%	|	10128ms	0ms	0ms	|	students#student_report
3	|	100%	0%	0%	0%	|	9759ms	0ms	0ms	|	service_uploads#past
5	|	80%	0%	20%	0%	|	5332ms	0ms	0ms	|	iep_documents#show
28	|	68%	0%	32%	0%	|	4503ms	20723ms	22956ms	|	students#restricted_notes
179	|	89%	4%	5%	2%	|	3007ms	11081ms	17091ms	|	schools#show
606	|	83%	2%	12%	3%	|	2647ms	11679ms	18803ms	|	students#show
201	|	13%	86%	0%	1%	|	779ms	1624ms	2257ms	|	devise/sessions#create
7	|	100%	0%	0%	0%	|	722ms	0ms	0ms	|	admin/educators#index
2	|	100%	0%	0%	0%	|	394ms	0ms	0ms	|	import_records#index
49	|	84%	16%	0%	0%	|	345ms	1124ms	1821ms	|	sections#show
109	|	58%	42%	0%	0%	|	344ms	1673ms	2447ms	|	homerooms#show
3	|	67%	0%	0%	33%	|	204ms	0ms	0ms	|	students#service
5	|	0%	0%	100%	0%	|	197ms	0ms	0ms	|	[hacking]
34	|	100%	0%	0%	0%	|	116ms	279ms	524ms	|	event_notes#update
3	|	100%	0%	0%	0%	|	100ms	0ms	0ms	|	service_uploads#index
187	|	99%	0%	1%	0%	|	98ms	489ms	810ms	|	event_notes#create
14	|	100%	0%	0%	0%	|	96ms	345ms	0ms	|	educators#names_for_dropdown
2	|	0%	0%	100%	0%	|	88ms	0ms	0ms	|	/educators/planet.png
29	|	0%	100%	0%	0%	|	76ms	614ms	758ms	|	/educators/sign_out
48	|	98%	2%	0%	0%	|	69ms	398ms	750ms	|	educators#districtwide_admin_homepage
196	|	98%	0%	2%	0%	|	55ms	237ms	508ms	|	students#names
47	|	98%	2%	0%	0%	|	53ms	342ms	900ms	|	devise/sessions#new
718	|	47%	53%	0%	0%	|	40ms	257ms	510ms	|	/
5	|	100%	0%	0%	0%	|	37ms	0ms	0ms	|	pages#not_authorized
208	|	82%	18%	0%	0%	|	30ms	174ms	417ms	|	[build]
316	|	54%	3%	42%	0%	|	29ms	471ms	961ms	|	[config]
5	|	100%	0%	0%	0%	|	27ms	0ms	0ms	|	/icon.png
8	|	100%	0%	0%	0%	|	27ms	0ms	0ms	|	pages#no_default_page
1697	|	87%	10%	2%	0%	|	10ms	64ms	135ms	|	[assets]
1	|	100%	0%	0%	0%	|	0ms	0ms	0ms	|	admin/educators#show
1	|	0%	100%	0%	0%	|	0ms	0ms	0ms	|	/admin/educators/436
1	|	100%	0%	0%	0%	|	0ms	0ms	0ms	|	admin/educators#edit

Includes 4726 log lines over 7 days (from 2018-01-14 to 2018-01-21).
Skipped 7 log lines that could not be parsed.
```

This is run by searching logentries for "router service" and downloading that.