### PR TITLE
Validate uniqueness of school local ID

### DIFF
--- a/app/importers/file_importers/student_section_assignments_importer.rb
+++ b/app/importers/file_importers/student_section_assignments_importer.rb
@@ -39,11 +39,12 @@ class StudentSectionAssignmentsImporter
   end
 
   def delete_rows
-    # Delete all stale rows no longer included in the import
-    # For the schools imported during this run of the importer
+    #Delete all stale rows no longer included in the import
+    #For the schools imported during this run of the importer
     StudentSectionAssignment.joins(:section => {:course => :school})
                             .where.not(id: @imported_assignments)
                             .where(:schools => {:local_id => @school_scope}).delete_all
+
   end
 
   def import_row(row)

--- a/app/importers/file_importers/student_section_assignments_importer.rb
+++ b/app/importers/file_importers/student_section_assignments_importer.rb
@@ -39,12 +39,11 @@ class StudentSectionAssignmentsImporter
   end
 
   def delete_rows
-    #Delete all stale rows no longer included in the import
-    #For the schools imported during this run of the importer
+    # Delete all stale rows no longer included in the import
+    # For the schools imported during this run of the importer
     StudentSectionAssignment.joins(:section => {:course => :school})
                             .where.not(id: @imported_assignments)
                             .where(:schools => {:local_id => @school_scope}).delete_all
-
   end
 
   def import_row(row)

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,6 +1,7 @@
 class School < ActiveRecord::Base
   extend FriendlyId
   friendly_id :local_id, use: :slugged
+  validates :local_id, presence: true, uniqueness: true
   has_many :students
   has_many :educators
   has_many :homerooms

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -205,7 +205,7 @@ describe SchoolsController, :type => :controller do
     context 'with school-wide access' do
       before { School.seed_somerville_schools }
       before { FactoryGirl.create(:homeroom) }
-      let!(:school) { FactoryGirl.create(:healey) }
+      let!(:school) { School.find_by_local_id('HEA') }
       let!(:educator) { FactoryGirl.create(:educator, districtwide_access: true) }
 
       it 'succeeds without throwing' do

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
 
   factory :school do
-    sequence(:state_id) {|n| n }
+    sequence(:local_id) {|n| n }
     sequence(:slug) {|n| "slug#{n}" }
   end
 

--- a/spec/importers/file_importers/educator_section_assignments_importer_spec.rb
+++ b/spec/importers/file_importers/educator_section_assignments_importer_spec.rb
@@ -159,4 +159,3 @@ RSpec.describe EducatorSectionAssignmentsImporter do
     end
   end
 end
-

--- a/spec/importers/file_importers/educator_section_assignments_importer_spec.rb
+++ b/spec/importers/file_importers/educator_section_assignments_importer_spec.rb
@@ -14,26 +14,29 @@ RSpec.describe EducatorSectionAssignmentsImporter do
     let!(:educator) { FactoryGirl.create(:educator) }
 
     context 'happy path' do
-      let(:row) { { local_id:educator.local_id,
-                    course_number:section.course.course_number,
-                    school_local_id: 'SHS',
-                    section_number:section.section_number,
-                    term_local_id:'FY'
-                } }
+      let(:row) {
+        {
+          local_id:educator.local_id,
+          course_number:section.course.course_number,
+          school_local_id: 'SHS',
+          section_number:section.section_number,
+          term_local_id:'FY'
+        }
+      }
 
-        before do
-          educator_section_assignments_importer.import_row(row)
-        end
-
-        it 'creates an educator section assignment' do
-          expect(EducatorSectionAssignment.count).to eq(1)
-        end
-
-        it 'assigns the proper student to the proper section' do
-          expect(EducatorSectionAssignment.first.educator).to eq(educator)
-          expect(EducatorSectionAssignment.first.section).to eq(section)
-        end
+      before do
+        educator_section_assignments_importer.import_row(row)
       end
+
+      it 'creates an educator section assignment' do
+        expect(EducatorSectionAssignment.count).to eq(1)
+      end
+
+      it 'assigns the proper student to the proper section' do
+        expect(EducatorSectionAssignment.first.educator).to eq(educator)
+        expect(EducatorSectionAssignment.first.section).to eq(section)
+      end
+    end
 
     context 'educator lasid is missing' do
       let(:row) { { course_number:section.course.course_number,
@@ -42,67 +45,62 @@ RSpec.describe EducatorSectionAssignmentsImporter do
                     term_local_id:'FY'
                 } }
 
-        before do
-          educator_section_assignments_importer.import_row(row)
-        end
-
-        it 'does not create an educator section assignment' do
-          expect(EducatorSectionAssignment.count).to eq(0)
-        end
-
+      before do
+        educator_section_assignments_importer.import_row(row)
       end
 
-      context 'section is missing' do
-        let(:row) { { local_id:educator.local_id,
-                    course_number:section.course.course_number,
-                    school_local_id: 'SHS',
-                    term_local_id:'FY'
-                } }
+      it 'does not create an educator section assignment' do
+        expect(EducatorSectionAssignment.count).to eq(0)
+      end
+    end
 
-        before do
-          educator_section_assignments_importer.import_row(row)
-        end
+    context 'section is missing' do
+      let(:row) { { local_id:educator.local_id,
+                  course_number:section.course.course_number,
+                  school_local_id: 'SHS',
+                  term_local_id:'FY'
+              } }
 
-        it 'does not create an educator section assignment' do
-          expect(EducatorSectionAssignment.count).to eq(0)
-        end
-
+      before do
+        educator_section_assignments_importer.import_row(row)
       end
 
-      context 'educator does not exist' do
-        let(:row) { { local_id: 'NO EXIST',
-                    course_number:section.course.course_number,
-                    school_local_id: 'SHS',
-                    section_number:section.section_number,
-                    term_local_id:'FY'
-                } }
+      it 'does not create an educator section assignment' do
+        expect(EducatorSectionAssignment.count).to eq(0)
+      end
+    end
 
-        before do
-          educator_section_assignments_importer.import_row(row)
-        end
+    context 'educator does not exist' do
+      let(:row) { { local_id: 'NO EXIST',
+                  course_number:section.course.course_number,
+                  school_local_id: 'SHS',
+                  section_number:section.section_number,
+                  term_local_id:'FY'
+              } }
 
-        it 'does not create an educator section assignment' do
-          expect(EducatorSectionAssignment.count).to eq(0)
-        end
-
+      before do
+        educator_section_assignments_importer.import_row(row)
       end
 
-      context 'section does not exist' do
-        let(:row) { { local_id: educator.local_id,
-                    course_number:section.course.course_number,
-                    school_local_id: 'SHS',
-                    section_number:'NO EXIST',
-                    term_local_id:'FY'
-                } }
+      it 'does not create an educator section assignment' do
+        expect(EducatorSectionAssignment.count).to eq(0)
+      end
+    end
 
-        before do
-          educator_section_assignments_importer.import_row(row)
-        end
+    context 'section does not exist' do
+      let(:row) { { local_id: educator.local_id,
+                  course_number:section.course.course_number,
+                  school_local_id: 'SHS',
+                  section_number:'NO EXIST',
+                  term_local_id:'FY'
+              } }
 
-        it 'does not create an educator section assignment' do
-          expect(EducatorSectionAssignment.count).to eq(0)
-        end
+      before do
+        educator_section_assignments_importer.import_row(row)
+      end
 
+      it 'does not create an educator section assignment' do
+        expect(EducatorSectionAssignment.count).to eq(0)
       end
     end
 
@@ -120,6 +118,11 @@ RSpec.describe EducatorSectionAssignmentsImporter do
       } }
 
       context 'happy path' do
+        let(:educator_section_assignments_importer) {
+          described_class.new(options: {
+            school_scope: School.pluck(:local_id), log: log
+          })
+        }
 
         before do
           FactoryGirl.create_list(:educator_section_assignment,20)
@@ -155,3 +158,5 @@ RSpec.describe EducatorSectionAssignmentsImporter do
       end
     end
   end
+end
+

--- a/spec/importers/file_importers/student_section_assignments_importer_spec.rb
+++ b/spec/importers/file_importers/student_section_assignments_importer_spec.rb
@@ -115,6 +115,12 @@ RSpec.describe StudentSectionAssignmentsImporter do
     } }
 
     context 'happy path' do
+      let(:student_section_assignments_importer) {
+        described_class.new(options: {
+          school_scope: School.pluck(:local_id), log: LogHelper::Redirect.instance.file
+        })
+      }
+
       before do
         FactoryGirl.create_list(:student_section_assignment, 20)
         FactoryGirl.create(:student_section_assignment, student_id: student.id, section_id: section.id)


### PR DESCRIPTION
# Who is this PR for?

Developers who set up new school districts in the future.  

# What problem does this PR fix?

The codebase doesn't throw an error when two schools have the same local ID like in #1407. 

# What does this PR do?

Uses Rails validations to validate school local ID and updates the spec.