### PR TITLE
Remove unused activerecord-import gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'rails', '~> 5.1.1'
 gem 'pg'
 gem 'puma'
 
-gem 'activerecord-import'
 gem 'aws-sdk', '~> 2'
 gem 'devise', '~> 4.3.0'
 gem 'devise_ldap_authenticatable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,8 +38,6 @@ GEM
       activemodel (= 5.1.3)
       activesupport (= 5.1.3)
       arel (~> 8.0)
-    activerecord-import (0.19.1)
-      activerecord (>= 3.2)
     activesupport (5.1.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
@@ -332,7 +330,6 @@ PLATFORMS
 
 DEPENDENCIES
   activemodel-serializers-xml
-  activerecord-import
   administrate (~> 0.8.1)
   aws-sdk (~> 2)
   better_errors


### PR DESCRIPTION
# What problem does this PR fix?

Removes an unused gem and reduces our at-boot memory by a small amount. This PR is in the same spirit as #1409.

We experimented with the activerecord-import gem at one point to try to bulk import data from districts, but it wasn't a success and is not used in the current nightly import job.