### PR TITLE
Remove unused OJ gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,6 @@ gem 'probability'
 gem 'rollbar'
 gem 'rails-erd', require: false, group: :development
 gem 'rubocop', require: false
-gem 'oj'
-gem 'oj_mimic_json'
 gem 'rubystats'
 gem 'sass-rails', '~> 5.0'
 gem 'secure_headers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,8 +174,6 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
-    oj (3.3.4)
-    oj_mimic_json (1.0.1)
     orm_adapter (0.5.0)
     parallel (1.12.0)
     parser (2.4.0.0)
@@ -353,8 +351,6 @@ DEPENDENCIES
   net-sftp
   net-ssh
   nokogiri (~> 1.8.1)
-  oj
-  oj_mimic_json
   pg
   pivotal_git_scripts
   probability


### PR DESCRIPTION
# What problem does this PR fix?

Removes an unused gem and reduces our at-boot memory by a small amount. This PR is in the same spirit as #1409.

@kevinrobinson, I believe you experimented with using OJ for JSON serialization at one point, but I don't think we're using the OJ gem anymore. I searched the codebase with Sublime and GitHub (https://github.com/studentinsights/studentinsights/search?utf8=%E2%9C%93&q=oj&type=) and couldn't find any reference to OJ besides installing the gem.