### PR TITLE
Move rubocop to the development group in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'nokogiri', '~> 1.8.1' # forcing patching version on transitive dependency
 gem 'probability'
 gem 'rollbar'
 gem 'rails-erd', require: false, group: :development
-gem 'rubocop', require: false
 gem 'oj'
 gem 'oj_mimic_json'
 gem 'rubystats'
@@ -65,6 +64,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'rubocop', require: false
   gem 'better_errors'
   gem 'pivotal_git_scripts'
   gem 'spring'


### PR DESCRIPTION
# What problem does this PR fix?

My understanding is that gems in the development group aren't installed on Heroku, so this move should reduce our at-boot memory by a small amount. We don't need to run code style rules in production. This PR is in the same spirit as #1409.