### PR TITLE
Remove rubystats dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem 'rails-erd', require: false, group: :development
 gem 'rubocop', require: false
 gem 'oj'
 gem 'oj_mimic_json'
-gem 'rubystats'
 gem 'sass-rails', '~> 5.0'
 gem 'secure_headers'
 gem 'sprockets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,6 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-graphviz (1.2.3)
     ruby-progressbar (1.8.1)
-    rubystats (0.2.6)
     rubyzip (1.2.1)
     sass (3.5.1)
       sass-listen (~> 4.0.0)
@@ -368,7 +367,6 @@ DEPENDENCIES
   rollbar
   rspec-rails
   rubocop
-  rubystats
   sass-rails (~> 5.0)
   scout_apm
   secure_headers

--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -246,7 +246,7 @@ class FakeStudent
   def add_deprecated_interventions
     15.in(100) do
       generator = FakeInterventionGenerator.new(@student)
-      intervention_count = Rubystats::NormalDistribution.new(3, 6).rng.round
+      intervention_count = [3, 6].sample
       intervention_count.times do
         intervention = Intervention.new(generator.next)
         intervention.save!

--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -246,7 +246,7 @@ class FakeStudent
   def add_deprecated_interventions
     15.in(100) do
       generator = FakeInterventionGenerator.new(@student)
-      intervention_count = [3, 6].sample
+      intervention_count = rand > 0.5 ? 0 : (1..6).to_a.sample
       intervention_count.times do
         intervention = Intervention.new(generator.next)
         intervention.save!


### PR DESCRIPTION
# What problem does this PR fix?

Removes a gem that we're only calling in one site, for a very trivial reason, to reduce our at-boot memory by a small amount. This PR is in the same spirit as #1409.

We are only using Rubystats once, to make the shape of the data for a ⭐️ deprecated⭐️  model in our fake database slightly more realistic. Since overall our demo data is highly unrealistic, trying to make a single model more realistic is not a great reason to download an entire gem.

I replaced the `rubystats` implementation with a simple `sample`.