### PR TITLE
Add script that uses Heroku platform API to restart web dynos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'selenium-webdriver'
 gem 'delayed_job_active_record'
 gem 'scout_apm'
 gem 'immigrant'
+gem 'platform-api'
 
 #code for browserstack api usage and storing the png to slack:
 #gem 'slack-ruby-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
     diff-lcs (1.3)
     docile (1.1.5)
     erubi (1.6.1)
+    erubis (2.7.0)
+    excon (0.60.0)
     execjs (2.7.0)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
@@ -117,6 +119,11 @@ GEM
       activerecord (>= 4.0.0)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
+    heroics (0.0.24)
+      erubis (~> 2.0)
+      excon
+      moneta
+      multi_json (>= 1.9.2)
     i18n (0.8.6)
     immigrant (0.3.6)
       activerecord (>= 3.0)
@@ -155,6 +162,7 @@ GEM
     minitest (5.10.3)
     momentjs-rails (2.17.1)
       railties (>= 3.1)
+    moneta (0.8.1)
     multi_json (1.12.1)
     net-ldap (0.11)
     net-sftp (2.1.2)
@@ -171,6 +179,9 @@ GEM
       ast (~> 2.2)
     pg (0.21.0)
     pivotal_git_scripts (1.4.0)
+    platform-api (2.1.0)
+      heroics (~> 0.0.23)
+      moneta (~> 0.8.1)
     powerpack (0.1.1)
     probability (1.0.0)
     pry (0.10.4)
@@ -340,6 +351,7 @@ DEPENDENCIES
   oj_mimic_json
   pg
   pivotal_git_scripts
+  platform-api
   probability
   pry
   puma

--- a/lib/tasks/heroku_platform_api.rake
+++ b/lib/tasks/heroku_platform_api.rake
@@ -15,6 +15,7 @@ namespace :heroku_platform_api do
     now_hour = Time.now.in_time_zone('Eastern Time (US & Canada)').hour
 
     if target_hour == now_hour
+      puts "It feels like a good time to restart our web dynos!"
       heroku = PlatformAPI.connect_oauth(ENV.fetch('HEROKU_OAUTH_TOKEN'))
       dynos = heroku.dyno.list(ENV.fetch('HEROKU_APP_NAME'))
 
@@ -23,13 +24,15 @@ namespace :heroku_platform_api do
           puts "Found web dyno!"; puts
 
           name = dyno.fetch('name')
-          puts "Restaring dyno #{name}..."
+          puts "Restaring dyno #{name}..."; puts
           heroku.dyno.restart(ENV.fetch('HEROKU_APP_NAME'), name)
 
-          puts "Sleeping for 60 seconds so we get a rolling restart ..."
+          puts "Sleeping for 60 seconds so we get a rolling restart ..."; puts
           sleep 60
         end
       end
+    else
+      puts "It doesn't feel like a good time to restart our web dynos right now."
     end
   end
 end

--- a/lib/tasks/heroku_platform_api.rake
+++ b/lib/tasks/heroku_platform_api.rake
@@ -1,0 +1,13 @@
+namespace :heroku_platform_api do
+  desc 'Restart heroku web dyno'
+  task restart_web_dynos: :environment do
+    heroku = PlatformAPI.connect_oauth(ENV.fetch('HEROKU_OAUTH_TOKEN'))
+    dynos = heroku.dyno.list(ENV.fetch('HEROKU_APP_NAME'))
+
+    dynos.each do |dyno|
+      if dyno.fetch("type") == "web"
+        heroku.dyno.restart(ENV.fetch('HEROKU_APP_NAME'), dyno.fetch('name'))
+      end
+    end
+  end
+end

--- a/lib/tasks/heroku_platform_api.rake
+++ b/lib/tasks/heroku_platform_api.rake
@@ -20,7 +20,14 @@ namespace :heroku_platform_api do
 
       dynos.each do |dyno|
         if dyno.fetch("type") == "web"
-          heroku.dyno.restart(ENV.fetch('HEROKU_APP_NAME'), dyno.fetch('name'))
+          puts "Found web dyno!"; puts
+
+          name = dyno.fetch('name')
+          puts "Restaring dyno #{name}..."
+          heroku.dyno.restart(ENV.fetch('HEROKU_APP_NAME'), name)
+
+          puts "Sleeping for 60 seconds so we get a rolling restart ..."
+          sleep 60
         end
       end
     end

--- a/lib/tasks/heroku_platform_api.rake
+++ b/lib/tasks/heroku_platform_api.rake
@@ -1,12 +1,27 @@
 namespace :heroku_platform_api do
   desc 'Restart heroku web dyno'
-  task restart_web_dynos: :environment do
-    heroku = PlatformAPI.connect_oauth(ENV.fetch('HEROKU_OAUTH_TOKEN'))
-    dynos = heroku.dyno.list(ENV.fetch('HEROKU_APP_NAME'))
 
-    dynos.each do |dyno|
-      if dyno.fetch("type") == "web"
-        heroku.dyno.restart(ENV.fetch('HEROKU_APP_NAME'), dyno.fetch('name'))
+  # To schedule automatic restarts at 5AM Eastern Time and 5PM Eastern Time,
+  # set two tasks to run hourly:
+  #
+  # $ rake 'heroku_platform_api:restart_web_dynos[5]'
+  # $ rake 'heroku_platform_api:restart_web_dynos[17]'
+  #
+  # Good blog post on rake tasks with arguments from Thoughtbot:
+  # https://robots.thoughtbot.com/how-to-use-arguments-in-a-rake-task
+
+  task :restart_web_dynos, [:hour] => :environment do |t, args|
+    target_hour = args[:hour].to_i
+    now_hour = Time.now.in_time_zone('Eastern Time (US & Canada)').hour
+
+    if target_hour == now_hour
+      heroku = PlatformAPI.connect_oauth(ENV.fetch('HEROKU_OAUTH_TOKEN'))
+      dynos = heroku.dyno.list(ENV.fetch('HEROKU_APP_NAME'))
+
+      dynos.each do |dyno|
+        if dyno.fetch("type") == "web"
+          heroku.dyno.restart(ENV.fetch('HEROKU_APP_NAME'), dyno.fetch('name'))
+        end
       end
     end
   end


### PR DESCRIPTION
# What problem does this PR fix?

Our Heroku app throws a lot of memory errors. This week those memory errors escalated up to "memory quota vastly exceeded" and the app went down. We can see the memory going up in our metrics dashboard, we think there are memory leaks.

# What does this PR do?

Adds a script that can restart the web dynos of our Heroku apps programmatically, which could mitigate the memory leaks.

Fixes #1418.

# Implementation

We could use the Heroku Scheduler to run this every 1 hour. That would have the same effect as a dev team that shipped code or changed a var every hour, around the clock. 

This approach is soooo much lazier than digging in and trying to fix memory leaks, but part of my lazy developer brain wonders, "if it works, and there are no tradeoffs, why not implement it?"

http://threevirtues.com/

# Tradeoffs?

I wonder if users on the app experience anything when the dyno is being restarted. Heroku automatically restarts dynos whenever we reset ENV vars or ship code, which sometimes happens many times per day, so I can't imagine there's a terribly negative user impact. 

# Improvements to this strategy

This blog post has a write-up that summarizes our situation pretty much exactly: https://stormconsultancy.co.uk/blog/development/ruby-on-rails/automatically-restart-struggling-heroku-dynos-using-logentries/

They offer a more intelligent version of this script that restarts every time they get an R14 memory error. We could ship this first and then consider implementing their version later if needed. I wonder it might trigger too many restarts if we get lots of R14 errors. 

# Checklist

+ [x] Test script locally 
+ [x] Generate OAuth token
+ [ ] Set `HEROKU_OAUTH_TOKEN` and `HEROKU_APP_NAME` env variables
+ [ ] Set up the task in Heroku schedule:

```
rake 'heroku_platform_api:restart_web_dynos[5]'
rake 'heroku_platform_api:restart_web_dynos[17]'
```