### PR TITLE
Fix bug in Rollbar env check

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -4,7 +4,7 @@ Rollbar.configure do |config|
 
   config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
 
-  if Rails.env.test? || Rails.env.development? || (ENV["SHOULD_REPORT_ERRORS"] == false)
+  if Rails.env.test? || Rails.env.development? || !EnvironmentVariable.is_true('SHOULD_REPORT_ERRORS')
     config.enabled = false
   end
 


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
The demo site tries to report errors to Rollbar but doesn't have the API key to do so.

# What does this PR do?
Fixes a bug in reading environment values about reporting errors to Rollbar.

```
irb(main):001:0> ENV["SHOULD_REPORT_ERRORS"]
=> "false"
irb(main):002:0> ENV["SHOULD_REPORT_ERRORS"] == false
=> false
```
