### PR TITLE
Fix the educator_id for the admin user in TestPals

### DIFF
--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -60,7 +60,7 @@ class TestPals
     # Uri works in the central office, and is the admin for the entire
     # project at the district.
     @uri = Educator.create!(
-      id: 1,
+      id: 999999,
       email: 'uri@demo.studentinsights.org',
       full_name: 'Disney, Uri',
       password: 'demo-password',
@@ -95,6 +95,7 @@ class TestPals
       school: @healey,
       homeroom: @healey_kindergarten_homeroom
     )
+
     @healey_ell_teacher = Educator.create!(
       email: 'alonso@demo.studentinsights.org',
       full_name: 'Teacher, Alonso',

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -60,6 +60,7 @@ class TestPals
     # Uri works in the central office, and is the admin for the entire
     # project at the district.
     @uri = Educator.create!(
+      id: 1,
       email: 'uri@demo.studentinsights.org',
       full_name: 'Disney, Uri',
       password: 'demo-password',


### PR DESCRIPTION
# Who is this PR for?
developers using the demo site

# What problem does this PR fix?
The value for `URI_ID` isn't set in the demo environment, and can't be since `TestPals` doesn't give it a stable id.  This came up trying to test the rake task in https://github.com/studentinsights/studentinsights/pull/1286 on the demo site.

# What does this PR do?
Fixes the id in `TestPals` so we can add a stable `URI_ID` to the demo site.
