### PR TITLE
Update foreign keys to be required by default, opt-out in three cases

### DIFF
--- a/app/models/homeroom.rb
+++ b/app/models/homeroom.rb
@@ -6,7 +6,7 @@ class Homeroom < ActiveRecord::Base
   validates :school, presence: true
   has_many :students, after_add: :update_grade
   has_many :student_risk_levels, through: :students
-  belongs_to :educator
+  belongs_to :educator, optional: true
   belongs_to :school
 
   def update_grade(student)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -2,7 +2,7 @@ class Service < ActiveRecord::Base
   belongs_to :student
   belongs_to :recorded_by_educator, class_name: 'Educator'
   belongs_to :service_type
-  belongs_to :service_upload          # For bulk-uploaded services
+  belongs_to :service_upload, optional: true # For bulk-uploaded services only
 
   validates_presence_of :recorded_by_educator_id, :student_id, :service_type_id, :recorded_at, :date_started
   validate :must_be_discontinued_after_service_start_date

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -6,7 +6,7 @@ class Student < ActiveRecord::Base
   # Contrast with student_row.rb, which represents a row imported from X2,
   # (not necessarily in the database yet).
 
-  belongs_to :homeroom, counter_cache: true
+  belongs_to :homeroom, optional: true, counter_cache: true
   belongs_to :school
   has_many :student_assessments, dependent: :destroy
   has_many :assessments, through: :student_assessments

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -15,6 +15,3 @@ Rails.application.config.action_controller.forgery_protection_origin_check = fal
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.
 ActiveSupport.to_time_preserves_timezone = false
-
-# Require `belongs_to` associations by default. Previous versions had false.
-Rails.application.config.active_record.belongs_to_required_by_default = false

--- a/lib/tasks/scan_for_missing_records.rake
+++ b/lib/tasks/scan_for_missing_records.rake
@@ -71,16 +71,6 @@ namespace :missing_foreign_key_relations do
         puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
 
-        puts "Missing Educator IDs on Homeroom"
-        missing = []
-        Homeroom.find_each do |homeroom|
-            if !homeroom.educator
-                missing << homeroom.educator_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
         puts "Missing School IDs on Homeroom"
         missing = []
         Homeroom.find_each do |homeroom|
@@ -171,16 +161,6 @@ namespace :missing_foreign_key_relations do
         puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
         puts ""
 
-        puts "Missing ServiceUploads IDs on Service"
-        missing = []
-        Service.find_each do |service|
-            if !service.service_upload
-                missing << service.service_upload_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
         puts "Missing Student IDs on Service"
         missing = []
         Service.find_each do |service|
@@ -216,16 +196,6 @@ namespace :missing_foreign_key_relations do
         StudentRiskLevel.find_each do |risk_level|
             if !risk_level.student
                 missing << risk_level.student_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing Homeroom IDs on Student"
-        missing = []
-        Student.find_each do |student|
-            if !student.homeroom
-                missing << student.homeroom_id
             end
         end
         puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"

--- a/lib/tasks/scan_for_missing_records.rake
+++ b/lib/tasks/scan_for_missing_records.rake
@@ -1,214 +1,214 @@
 desc 'Scan for missing foreign key records'
 namespace :missing_foreign_key_relations do
-    task scan: :environment do
-        puts "Missing School IDs on Course"
-        missing = []
-        Course.find_each do |course|
-            if !course.school
-                missing << course.school_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing School IDs on Educator"
-        missing = []
-        Educator.find_each do |educator|
-            if !educator.school
-                missing << educator.school_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing EventNote IDs on EventNoteAttachment"
-        missing = []
-        EventNoteAttachment.find_each do |attachment|
-            if !attachment.event_note
-                missing << attachment.event_note_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing EventNote IDs on EventNoteRevision"
-        missing = []
-        EventNoteRevision.find_each do |revision|
-            if !revision.event_note
-                missing << revision.event_note_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing Educator IDs on EventNote"
-        missing = []
-        EventNote.find_each do |note|
-            if !note.educator
-                missing << note.educator_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing EventNoteType IDs on EventNote"
-        missing = []
-        EventNote.find_each do |note|
-            if !note.event_note_type
-                missing << note.event_note_type_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing Student IDs on EventNote"
-        missing = []
-        EventNote.find_each do |note|
-            if !note.student
-                missing << note.student_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing School IDs on Homeroom"
-        missing = []
-        Homeroom.find_each do |homeroom|
-            if !homeroom.school
-                missing << homeroom.school_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing Student IDs on IepDocument"
-        missing = []
-        IepDocument.find_each do |document|
-            if !document.student
-                missing << document.student_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing Educator IDs on Intervention"
-        missing = []
-        Intervention.find_each do |intervention|
-            if !intervention.educator
-                missing << intervention.educator_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing InterventionType IDs on Intervention"
-        missing = []
-        Intervention.find_each do |intervention|
-            if !intervention.intervention_type
-                missing << intervention.intervention_type_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing Student IDs on Intervention"
-        missing = []
-        Intervention.find_each do |intervention|
-            if !intervention.student
-                missing << intervention.student_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing Course IDs on Section"
-        missing = []
-        Section.find_each do |section|
-            if !section.course
-                missing << section.course_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing Educator IDs on ServiceUpload"
-        missing = []
-        ServiceUpload.find_each do |upload|
-            if !upload.uploaded_by_educator
-                missing << upload.uploaded_by_educator_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing Educator IDs on Service"
-        missing = []
-        Service.find_each do |service|
-            if !service.recorded_by_educator
-                missing << service.recorded_by_educator_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing ServiceType IDs on Service"
-        missing = []
-        Service.find_each do |service|
-            if !service.service_type
-                missing << service.service_type_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing Student IDs on Service"
-        missing = []
-        Service.find_each do |service|
-            if !service.student
-                missing << service.student_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing Assessment IDs on StudentAssessment"
-        missing = []
-        StudentAssessment.find_each do |student_assesment|
-            if !student_assesment.assessment
-                missing << student_assesment.assessment_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing Student IDs on StudentAssessment"
-        missing = []
-        StudentAssessment.find_each do |student_assesment|
-            if !student_assesment.student
-                missing << student_assesment.student_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing Student IDs on StudentRiskLevel"
-        missing = []
-        StudentRiskLevel.find_each do |risk_level|
-            if !risk_level.student
-                missing << risk_level.student_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
-
-        puts "Missing School IDs on Student"
-        missing = []
-        Student.find_each do |student|
-            if !student.school
-                missing << student.school_id
-            end
-        end
-        puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
-        puts ""
+  task scan: :environment do
+    puts "Missing School IDs on Course"
+    missing = []
+    Course.find_each do |course|
+      if !course.school
+        missing << course.school_id
+      end
     end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing School IDs on Educator"
+    missing = []
+    Educator.find_each do |educator|
+      if !educator.school
+        missing << educator.school_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing EventNote IDs on EventNoteAttachment"
+    missing = []
+    EventNoteAttachment.find_each do |attachment|
+      if !attachment.event_note
+        missing << attachment.event_note_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing EventNote IDs on EventNoteRevision"
+    missing = []
+    EventNoteRevision.find_each do |revision|
+      if !revision.event_note
+        missing << revision.event_note_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing Educator IDs on EventNote"
+    missing = []
+    EventNote.find_each do |note|
+      if !note.educator
+        missing << note.educator_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing EventNoteType IDs on EventNote"
+    missing = []
+    EventNote.find_each do |note|
+      if !note.event_note_type
+        missing << note.event_note_type_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing Student IDs on EventNote"
+    missing = []
+    EventNote.find_each do |note|
+      if !note.student
+        missing << note.student_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing School IDs on Homeroom"
+    missing = []
+    Homeroom.find_each do |homeroom|
+      if !homeroom.school
+        missing << homeroom.school_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing Student IDs on IepDocument"
+    missing = []
+    IepDocument.find_each do |document|
+      if !document.student
+        missing << document.student_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing Educator IDs on Intervention"
+    missing = []
+    Intervention.find_each do |intervention|
+      if !intervention.educator
+        missing << intervention.educator_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing InterventionType IDs on Intervention"
+    missing = []
+    Intervention.find_each do |intervention|
+      if !intervention.intervention_type
+        missing << intervention.intervention_type_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing Student IDs on Intervention"
+    missing = []
+    Intervention.find_each do |intervention|
+      if !intervention.student
+        missing << intervention.student_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing Course IDs on Section"
+    missing = []
+    Section.find_each do |section|
+      if !section.course
+        missing << section.course_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing Educator IDs on ServiceUpload"
+    missing = []
+    ServiceUpload.find_each do |upload|
+      if !upload.uploaded_by_educator
+        missing << upload.uploaded_by_educator_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing Educator IDs on Service"
+    missing = []
+    Service.find_each do |service|
+      if !service.recorded_by_educator
+        missing << service.recorded_by_educator_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing ServiceType IDs on Service"
+    missing = []
+    Service.find_each do |service|
+      if !service.service_type
+        missing << service.service_type_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing Student IDs on Service"
+    missing = []
+    Service.find_each do |service|
+      if !service.student
+        missing << service.student_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing Assessment IDs on StudentAssessment"
+    missing = []
+    StudentAssessment.find_each do |student_assesment|
+      if !student_assesment.assessment
+        missing << student_assesment.assessment_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing Student IDs on StudentAssessment"
+    missing = []
+    StudentAssessment.find_each do |student_assesment|
+      if !student_assesment.student
+        missing << student_assesment.student_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing Student IDs on StudentRiskLevel"
+    missing = []
+    StudentRiskLevel.find_each do |risk_level|
+      if !risk_level.student
+        missing << risk_level.student_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+
+    puts "Missing School IDs on Student"
+    missing = []
+    Student.find_each do |student|
+      if !student.school
+        missing << student.school_id
+      end
+    end
+    puts "#{missing.length} records missing an object. Missing IDs: #{missing.uniq}"
+    puts ""
+  end
 end


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
We made an awesome rake task for looking at nil associations when increasing the strictness for foreign keys (not allowing orphans or nils).  Without that historical context, this task implies that we don't want these nil records, but we do as discussed here: https://github.com/studentinsights/studentinsights/pull/1275#issuecomment-347276598.

Also, Rails 5 changed `belongs_to` relations to be "non-nil" by default but we're opted-out because of those three associations where we want to allow nil values.  So there's nowhere in the code right now that expresses what we want.

# What does this PR do?
Updates the rake task to remove the three associations for which `nil` values are normal and expected.  Updates the default `belongs_to` behavior to be stricter and disallow `nil` values by default, and update the three associations where we intentionally allow `nils` with the `optional: true` flag so this is expressed in code and enforced.

