### PR TITLE
Update developer users in Mixpanel filters

### DIFF
--- a/app/reports/mixpanel_report.rb
+++ b/app/reports/mixpanel_report.rb
@@ -167,7 +167,7 @@ class MixpanelReport
   # Filter out developer users
   def where_no_developers
     [[:educator_id, '!=', 12],
-     [:educator_id, '!=', 509]]
+     [:educator_id, '!=', 1054]]
   end
 
   def where_string(where_clauses)


### PR DESCRIPTION
# Who is this PR for?
admin and product

# What problem does this PR fix?
Filter out developer users from usage reports; we rotated these ids.  We'll have to rework how we do this for the second district, but this fixes up for now.