### PR TITLE
Bind this on failure path when saving restricted notes

### DIFF
--- a/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
+++ b/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
@@ -41,6 +41,7 @@ class RestrictedNotesPageContainer extends React.Component {
 
     this.onClickSaveNotes = this.onClickSaveNotes.bind(this);
     this.onSaveNotesDone = this.onSaveNotesDone.bind(this);
+    this.onSaveNotesFail = this.onSaveNotesFail.bind(this);
   }
 
   componentWillMount(props, state) {


### PR DESCRIPTION
# Who is this PR for?
admin educators

# What problem does this PR fix?
Server errors saving restricted notes aren't handled in the UI code correctly, giving the user no feedback.  See https://rollbar.com/somerville-teacher-tool/somerville-teacher-tool/items/86/occurrences/36284246425/.

# What does this PR do?
Fix the bug by binding `this` on the method like we did for other methods in converting this to use classes [here](https://github.com/studentinsights/studentinsights/commit/8f5326d6f458f76ffb33c03508b4e2d49e0b86ef).

I looked at the server logs, but this was on the demo site and those have rotated away since.  I can't reproduce the server error on the demo site or locally now.