### PR TITLE
Add date to tardies tooltip

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/school_tardies_dashboard.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/school_tardies_dashboard.jsx
@@ -73,6 +73,8 @@ export default React.createClass({
       return [moment(date).format('ddd MM/DD'), this.props.schoolTardyEvents[date].length];
     });
     const monthCategories = this.createMonthCategories(this.props.schoolTardyEvents);
+    let tickPositions = Object.keys(monthCategories).map(Number);
+    tickPositions.splice(0, 1);
 
     return (
         <DashboardBarChart
@@ -81,7 +83,7 @@ export default React.createClass({
             offset: 0,
             linkedTo: 0,
             categories: monthCategories,
-            tickPositions: Object.keys(monthCategories).map(Number),
+            tickPositions: tickPositions,
             tickmarkPlacement: "on"
           }}
           seriesData = {seriesData}

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/school_tardies_dashboard.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/school_tardies_dashboard.jsx
@@ -34,6 +34,17 @@ export default React.createClass({
     return monthCategories;
   },
 
+  getDatesForPastThreeMonths: function() {
+    const today = moment().format('YYYY-MM-DD');
+    let datesForPastThreeMonths = [];
+    let date = moment().subtract(3, 'months').format('YYYY-MM-DD');
+    while (moment(date).isBefore(moment(today))) {
+      datesForPastThreeMonths.push(date);
+      date = moment(date).add(1, 'day').format('YYYY-MM-DD');
+    }
+    return datesForPastThreeMonths;
+  },
+
   setStudentList: function(highchartsEvent) {
     this.setState({selectedHomeroom: highchartsEvent.point.category});
   },
@@ -57,7 +68,8 @@ export default React.createClass({
   },
 
   renderMonthlyTardiesChart: function() {
-    const seriesData = Object.keys(this.props.schoolTardyEvents).sort().map((date) => {
+    const seriesData = this.getDatesForPastThreeMonths().map((date) => {
+      if (this.props.schoolTardyEvents[date] === undefined) this.props.schoolTardyEvents[date] = [];
       return [moment(date).format('ddd MM/DD'), this.props.schoolTardyEvents[date].length];
     });
     const monthCategories = this.createMonthCategories(this.props.schoolTardyEvents);

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/school_tardies_dashboard.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/school_tardies_dashboard.jsx
@@ -58,7 +58,7 @@ export default React.createClass({
 
   renderMonthlyTardiesChart: function() {
     const seriesData = Object.keys(this.props.schoolTardyEvents).sort().map((date) => {
-      return this.props.schoolTardyEvents[date].length;
+      return [moment(date).format('ddd MM/DD'), this.props.schoolTardyEvents[date].length];
     });
     const monthCategories = this.createMonthCategories(this.props.schoolTardyEvents);
 


### PR DESCRIPTION
# Who is this PR for?
School Administrators using the tardies dashboard

# What problem does this PR fix?
From user testing, it's apparent that users will want to know the day of the week for each data point in the schoolwide tardies. 

# What does this PR do?
Adds the date, including day of the week, to the tooltip.

# Screenshot (if adding a client-side feature)

![tardies_tooltip](https://user-images.githubusercontent.com/638809/35475766-d1ec5efc-0371-11e8-978d-0a1f15bd033e.gif)

# Checklists

## Javascript QA

+ [x] Author checked latest in IE - Tardies Dashboard
+ [ ] Reviewer checked latest in IE - Tardies Dashboard