### PR TITLE
Make 'tmp' directory if it doesn't exist locally; use Dir.exist?

### DIFF
--- a/app/importers/clients/sftp_client.rb
+++ b/app/importers/clients/sftp_client.rb
@@ -22,7 +22,8 @@ class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password
   end
 
   def download_file(remote_file_name)
-    Dir.mkdir('tmp/data_download/') unless File.exist?('tmp/data_download/')
+    Dir.mkdir('tmp') unless Dir.exist?('tmp')
+    Dir.mkdir('tmp/data_download/') unless Dir.exist?('tmp/data_download/')
 
     local_filename = File.join('tmp/data_download/', remote_file_name.split("/").last)
     local_file = File.open(local_filename, 'w')


### PR DESCRIPTION
# Who is this PR for?

Developers.

# What problem does this PR fix?

The local development cleanup script deletes the `tmp` directory entirely. The import script expects a `tmp` directory. This PR creates a `tmp` directory if it's missing. It also uses more idiomatic Ruby.