### PR TITLE
Tolerant attendance importer for New Bedford (rebased onto #1439)

### DIFF
--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -18,14 +18,14 @@ class AttendanceImporter
 
     @data.each_with_index do |row, index|
       import_row(row) if filter.include?(row)
-      log.write(
+      @log.write(
         "\r#{@success_count} valid rows imported, #{@error_list.size} invalid rows skipped"
       )
     end
 
     @error_summary = @error_list.inject(Hash.new(0)) { |h, e| h[e] += 1 ; h }
-    log.write("\n\nInvalid attendance rows summary: ")
-    log.write(@error_summary)
+    @log.write("\n\nInvalid attendance rows summary: ")
+    @log.write(@error_summary)
   end
 
   def remote_file_name

--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -13,9 +13,19 @@ class AttendanceImporter
       log: @log, remote_file_name: remote_file_name, client: client, transformer: data_transformer
     ).get_data
 
+    @success_count = 0
+    @error_list = []
+
     @data.each_with_index do |row, index|
       import_row(row) if filter.include?(row)
+      log.write(
+        "\r#{@success_count} valid rows imported, #{@error_list.size} invalid rows skipped"
+      )
     end
+
+    @error_summary = @error_list.inject(Hash.new(0)) { |h, e| h[e] += 1 ; h }
+    log.write("\n\nInvalid attendance rows summary: ")
+    log.write(@error_summary)
   end
 
   def remote_file_name
@@ -45,6 +55,14 @@ class AttendanceImporter
   def import_row(row)
     return if (@only_recent_attendance && old_event?(row))
 
-    AttendanceRow.build(row).save!
+    attendance_event = AttendanceRow.build(row)
+
+    if attendance_event.valid?
+      attendance_event.save!
+      @success_count += 1
+    else
+      @error_list << attendance_event.errors.messages
+    end
   end
+
 end

--- a/app/importers/rows/attendance_row.rb
+++ b/app/importers/rows/attendance_row.rb
@@ -6,13 +6,19 @@ class AttendanceRow < Struct.new(:row)
   # :state_id, :local_id, :absence, :tardy, :event_date, :school_local_id
 
   class NullRelation
-    class NullEvent
-      def save!; end
-
-      def assign_attributes(_); end
+    class NullEventErrors
+      def messages; "Neither absence nor tardy" end
     end
 
-    def find_or_initialize_by(_)
+    class NullEvent
+      def save; end
+
+      def valid?; false end
+
+      def errors; NullEventErrors.new end
+    end
+
+    def self.find_or_initialize_by(_)
       NullEvent.new
     end
   end
@@ -23,7 +29,8 @@ class AttendanceRow < Struct.new(:row)
 
   def build
     attendance_event = attendance_event_class.find_or_initialize_by(
-      occurred_at: row[:event_date]
+      occurred_at: row[:event_date],
+      student_id: student.try(:id),
     )
 
     return attendance_event
@@ -32,13 +39,13 @@ class AttendanceRow < Struct.new(:row)
   private
 
   def attendance_event_class
-    return student.absences if row[:absence].to_i == 1
-    return student.tardies if row[:tardy].to_i == 1
-    NullRelation.new
+    return Absence if row[:absence].to_i == 1
+    return Tardy if row[:tardy].to_i == 1
+    NullRelation
   end
 
   def student
-    Student.find_by_local_id!(row[:local_id])
+    Student.find_by_local_id(row[:local_id])
   end
 
 end

--- a/spec/importers/file_importers/attendance_importer_spec.rb
+++ b/spec/importers/file_importers/attendance_importer_spec.rb
@@ -11,13 +11,8 @@ RSpec.describe AttendanceImporter do
   describe '#import_row' do
 
     context 'recent attendance events' do
-      before do
-        Timecop.freeze('2005-09-16')
-      end
-
-      after do
-        Timecop.return
-      end
+      before { Timecop.freeze('2005-09-16') }
+      after { Timecop.return }
 
       context 'one row for one student on one date' do
         let!(:student) { FactoryGirl.create(:student, local_id: '1') }
@@ -29,6 +24,9 @@ RSpec.describe AttendanceImporter do
           }
 
           it 'creates an absence' do
+            attendance_importer.instance_variable_set(:@success_count, 0)
+            attendance_importer.instance_variable_set(:@error_list, [])
+
             expect {
               attendance_importer.import_row(row)
             }.to change {
@@ -37,6 +35,9 @@ RSpec.describe AttendanceImporter do
           end
 
           it 'creates only 1 absence if run twice' do
+            attendance_importer.instance_variable_set(:@success_count, 0)
+            attendance_importer.instance_variable_set(:@error_list, [])
+
             expect {
               attendance_importer.import_row(row)
               attendance_importer.import_row(row)
@@ -44,6 +45,9 @@ RSpec.describe AttendanceImporter do
           end
 
           it 'increments student absences by 1' do
+            attendance_importer.instance_variable_set(:@success_count, 0)
+            attendance_importer.instance_variable_set(:@error_list, [])
+
             expect {
               attendance_importer.import_row(row)
             }.to change {
@@ -52,6 +56,9 @@ RSpec.describe AttendanceImporter do
           end
 
           it 'does not increment student tardies' do
+            attendance_importer.instance_variable_set(:@success_count, 0)
+            attendance_importer.instance_variable_set(:@error_list, [])
+
             expect {
               attendance_importer.import_row(row)
             }.to change {
@@ -71,6 +78,9 @@ RSpec.describe AttendanceImporter do
         let(:row_for_kristen) { { event_date: date, local_id: '2', absence: '1', tardy: '0' } }
 
         it 'creates an absence for each student' do
+          attendance_importer.instance_variable_set(:@success_count, 0)
+          attendance_importer.instance_variable_set(:@error_list, [])
+
           expect {
             attendance_importer.import_row(row_for_edwin)
             attendance_importer.import_row(row_for_kristen)
@@ -86,6 +96,9 @@ RSpec.describe AttendanceImporter do
         let(:second_row) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
 
         it 'creates an absence' do
+          attendance_importer.instance_variable_set(:@success_count, 0)
+          attendance_importer.instance_variable_set(:@error_list, [])
+
           expect {
             attendance_importer.import_row(first_row)
             attendance_importer.import_row(second_row)
@@ -102,13 +115,16 @@ RSpec.describe AttendanceImporter do
         let(:third_row) { { event_date: '2005-09-18', local_id: '1', absence: '1', tardy: '0' } }
         let(:fourth_row) { { event_date: '2005-09-19', local_id: '1', absence: '1', tardy: '0' } }
 
+
         it 'creates multiple absences' do
-          importer = attendance_importer
+          attendance_importer.instance_variable_set(:@success_count, 0)
+          attendance_importer.instance_variable_set(:@error_list, [])
+
           expect {
-            importer.import_row(first_row)
-            importer.import_row(second_row)
-            importer.import_row(third_row)
-            importer.import_row(fourth_row)
+            attendance_importer.import_row(first_row)
+            attendance_importer.import_row(second_row)
+            attendance_importer.import_row(third_row)
+            attendance_importer.import_row(fourth_row)
           }.to change { Absence.count }.by 4
         end
       end
@@ -155,4 +171,5 @@ RSpec.describe AttendanceImporter do
 
     end
   end
+
 end

--- a/spec/importers/file_importers/attendance_importer_spec.rb
+++ b/spec/importers/file_importers/attendance_importer_spec.rb
@@ -2,10 +2,16 @@ require 'rails_helper'
 
 RSpec.describe AttendanceImporter do
 
-  let(:attendance_importer) {
-    described_class.new(options: {
+  let(:base_attendance_importer) {
+    importer = described_class.new(options: {
       school_scope: nil, log: nil, only_recent_attendance: false
     })
+  }
+
+  let(:attendance_importer) {
+    base_attendance_importer.instance_variable_set(:@success_count, 0)
+    base_attendance_importer.instance_variable_set(:@error_list, [])
+    base_attendance_importer
   }
 
   describe '#import_row' do
@@ -24,8 +30,6 @@ RSpec.describe AttendanceImporter do
           }
 
           it 'creates an absence' do
-            attendance_importer.instance_variable_set(:@success_count, 0)
-            attendance_importer.instance_variable_set(:@error_list, [])
 
             expect {
               attendance_importer.import_row(row)
@@ -35,9 +39,6 @@ RSpec.describe AttendanceImporter do
           end
 
           it 'creates only 1 absence if run twice' do
-            attendance_importer.instance_variable_set(:@success_count, 0)
-            attendance_importer.instance_variable_set(:@error_list, [])
-
             expect {
               attendance_importer.import_row(row)
               attendance_importer.import_row(row)
@@ -45,9 +46,6 @@ RSpec.describe AttendanceImporter do
           end
 
           it 'increments student absences by 1' do
-            attendance_importer.instance_variable_set(:@success_count, 0)
-            attendance_importer.instance_variable_set(:@error_list, [])
-
             expect {
               attendance_importer.import_row(row)
             }.to change {
@@ -56,9 +54,6 @@ RSpec.describe AttendanceImporter do
           end
 
           it 'does not increment student tardies' do
-            attendance_importer.instance_variable_set(:@success_count, 0)
-            attendance_importer.instance_variable_set(:@error_list, [])
-
             expect {
               attendance_importer.import_row(row)
             }.to change {
@@ -78,9 +73,6 @@ RSpec.describe AttendanceImporter do
         let(:row_for_kristen) { { event_date: date, local_id: '2', absence: '1', tardy: '0' } }
 
         it 'creates an absence for each student' do
-          attendance_importer.instance_variable_set(:@success_count, 0)
-          attendance_importer.instance_variable_set(:@error_list, [])
-
           expect {
             attendance_importer.import_row(row_for_edwin)
             attendance_importer.import_row(row_for_kristen)
@@ -96,9 +88,6 @@ RSpec.describe AttendanceImporter do
         let(:second_row) { { event_date: date, local_id: '1', absence: '1', tardy: '0' } }
 
         it 'creates an absence' do
-          attendance_importer.instance_variable_set(:@success_count, 0)
-          attendance_importer.instance_variable_set(:@error_list, [])
-
           expect {
             attendance_importer.import_row(first_row)
             attendance_importer.import_row(second_row)
@@ -117,9 +106,6 @@ RSpec.describe AttendanceImporter do
 
 
         it 'creates multiple absences' do
-          attendance_importer.instance_variable_set(:@success_count, 0)
-          attendance_importer.instance_variable_set(:@error_list, [])
-
           expect {
             attendance_importer.import_row(first_row)
             attendance_importer.import_row(second_row)
@@ -154,7 +140,7 @@ RSpec.describe AttendanceImporter do
       end
 
       context '--only_recent_attendance flag off' do
-        let(:attendance_importer) {
+        let(:base_attendance_importer) {
           described_class.new(options: {
             school_scope: nil, log: nil, only_recent_attendance: false
           })

--- a/spec/importers/rows/attendance_row_spec.rb
+++ b/spec/importers/rows/attendance_row_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe AttendanceRow do
   describe '#build' do
     context 'when the row is an absence' do
       it 'saves an absence' do
-        expect { row.build.save! }.to change(Absence, :count).by(1)
+        expect { row.build.save }.to change(Absence, :count).by(1)
       end
     end
 
@@ -29,7 +29,7 @@ RSpec.describe AttendanceRow do
       let(:tardy) { '1' }
 
       it 'saves a tardy' do
-        expect { row.build.save! }.to change(Tardy, :count).by(1)
+        expect { row.build.save }.to change(Tardy, :count).by(1)
       end
     end
 
@@ -37,11 +37,11 @@ RSpec.describe AttendanceRow do
       let(:absence) { '0' }
 
       it 'does not save an absence' do
-        expect { row.build.save! }.not_to change(Absence, :count)
+        expect { row.build.save }.not_to change(Absence, :count)
       end
 
       it 'does not save a tardy' do
-        expect { row.build.save! }.not_to change(Tardy, :count)
+        expect { row.build.save }.not_to change(Tardy, :count)
       end
     end
   end


### PR DESCRIPTION
# Who is this PR for?

New Bedford Public Schools.

# What does this PR fix?

Blocked attendance import as described in https://github.com/studentinsights/studentinsights/issues/1371#issuecomment-360859776 and https://github.com/studentinsights/studentinsights/issues/1371#issuecomment-360864063.

# What does this PR do?

Makes the attendance importer tolerant of invalid rows. Instead of blowing up when it hits the first invalid row, the attendance importer skips those rows, and keeps a count of invalid rows plus error messages. 

This will also be beneficial to the Somerville app, because it will produce a more detailed report of how the attendance export file is getting parsed and how many invalid rows are in the file.