### PR TITLE
Document expected fields in from X2 Assessment export

### DIFF
--- a/x2_export/assessment_export.sql
+++ b/x2_export/assessment_export.sql
@@ -7,9 +7,9 @@ SELECT
   'assessment_scale_score',
   'assessment_performance_level',
   'assessment_growth',
-  'assessment_name',
-  'assessment_subject',
-  'assessment_test'
+  'assessment_name',      -- Full, unedited assessment name. Example: "MCAS 2013 English Language Arts"
+  'assessment_subject',   -- Assessment subject. Examples: "English Language Arts", "Mathematics"
+  'assessment_test'       -- Assessment family. Examples: "MCAS", "MAP", "DIBELS"
 UNION ALL
 SELECT DISTINCT
   STD_ID_STATE,


### PR DESCRIPTION
# Who is this PR for?

+ External developers who write export scripts for an Insights instance and are using `x2_export/assessment_export.sql` as a model
+ Internal developers who need a reminder of what the different fields in `assessment_export.sql` mean

# What problem does this PR fix?

New Bedford's assessment export had the columns switched around, which means that I didn't properly document/explain them.

# What does this PR do?

Adds code comments to the SQL file to explain what key column names mean and what they should look like. 