### PR TITLE
Reduce school overview memory usage

### DIFF
--- a/app/helpers/students_query_helper.rb
+++ b/app/helpers/students_query_helper.rb
@@ -1,6 +1,15 @@
 require 'digest'
 
 module StudentsQueryHelper
+  INCLUDE_FOR_EVENT_NOTES = [
+    :id,
+    :student_id,
+    :educator_id,
+    :event_note_type_id,
+    :recorded_at,
+    :is_restricted,
+  ]
+
   # Used to serializes a Student into a hash with other fields joined in (that are used to perform
   # filtering and slicing in the UI).
   # This may be slow if you're doing it for many students without eager includes.
@@ -38,7 +47,7 @@ module StudentsQueryHelper
   def mutable_fields_for_slicing(student_ids)
     summer_service_type_ids = ServiceType.where(summer_program: true).pluck(:id)
     {
-      all_event_notes: EventNote.where(student_id: student_ids),
+      all_event_notes: EventNote.where(student_id: student_ids).select(INCLUDE_FOR_EVENT_NOTES),
       all_active_services: Service.where(student_id: student_ids).active,
       all_interventions: Intervention.where(student_id: student_ids),
       all_summer_services: Service.where(student_id: student_ids)


### PR DESCRIPTION
# Who is this PR for?

Users who want a fast Insights experience.

# What problem does this PR fix?

Our automated Heroku restarts have avoided major memory errors and crashes in the past week, but memory is still high. It usually peaks somewhere around 103%-105% of our box size daily which dips into swap memory before restarting. 

# What does this PR do?

Use `#select` to pull fewer event note fields into school overview query, reducing retained memory by ~11% for the School Overview page in the demo data environment. 

To start investigating, I looked at the derailed_benchmarks gem: https://github.com/schneems/derailed_benchmarks/. 

The derailed_benchmarks guide told me to start my app with `RAILS_ENV=production`, which I did on a separate branch. (I didn't want to put that branch up on GitHub because it does bad things like disable SSL in order to make `RAILS_ENV=production` work locally.)

The derailed_benchmarks API proved complicated to work with, because our app needs user authentication to access meaningful controller actions. So I ended up reusing some of @kevinrobinson's `csv_benchmark.rake` code and wrapping it around the controller action for the school overview and student profile pages:

```
# schools_controller.rb

def show
  report = MemoryProfiler.report do
    @serialized_data = json_for_overview(@school)
    render 'shared/serialized_data'
  end

  puts "Printing report..."
  report.pretty_print(to_file: "tmp/memory_profiler_school_overview_#{Time.current}.txt")
end

--

# students_controller.rb

def show
  report = MemoryProfiler.report do
    student = Student.find(params[:id])
    chart_data = StudentProfileChart.new(student).chart_data

    @serialized_data = { ... }
    render 'shared/serialized_data'
  end

  puts "Printing report..."
  report.pretty_print(to_file: "tmp/memory_profiler_student_profile_#{Time.current}.txt")
end

```

The first thing I saw was that the School Overview retained about 3x more memory than the Student Profile action, comparing warm path to warm path (demo data, `RAILS_ENV=production`):

```
student profile warm:
Total allocated: 1740144 bytes (19952 objects)
Total retained:  162096 bytes (1620 objects)

school overview warm:
Total allocated: 3782716 bytes (35091 objects)
Total retained:  442998 bytes (3350 objects)
```

When I looked into "Retained Strings" for the school overview report, I saw strings that we generate as fake event note content:

```
# fake_event_note_generator.rb, #sample_text
"Meredith is setting up a family meeting to discuss absences and tardies, and to follow up on concerns about supporting morning routines at home"
```

Those strings shouldn't be in the school overview  memory allocation! The school overview doesn't surface event note content. So I dove into the code until I found `students_query_helper.rb` loading up EventNotes. I tried adding the select statement in this PR to keep event note content out of the mutable data query, and here are the results I found (warm to warm):

```
master (current app state): 
Total allocated: 3785005 bytes (35109 objects)
Total retained:  443397 bytes (3354 objects)

with event note #select in students_query_helper:
Total allocated: 3249055 bytes (29603 objects)
Total retained:  397374 bytes (2725 objects)
```

Adding the select statement reduced the memory increase by about 46KB, or around 10%, with our demo data setup. I'd predict a bigger impact in the production data environment, because we have many more students and many more event notes in production than in the demo dataset.

## Checklist

+ [x] Manually QA visiting School Overview Page
+ [x] Manually QA running rake school_overview precompute job