### PR TITLE
Reduce school overview memory usage further

### DIFF
--- a/app/helpers/students_query_helper.rb
+++ b/app/helpers/students_query_helper.rb
@@ -1,6 +1,39 @@
 require 'digest'
 
 module StudentsQueryHelper
+  INCLUDE_FOR_STUDENTS = [
+    :id,
+    :grade,
+    :hispanic_latino,
+    :race,
+    :free_reduced_lunch,
+    :homeroom_id,
+    :first_name,
+    :last_name,
+    :home_language,
+    :registration_date,
+    :program_assigned,
+    :sped_placement,
+    :disability,
+    :sped_level_of_need,
+    :plan_504,
+    :limited_english_proficiency,
+    :most_recent_mcas_math_growth,
+    :most_recent_mcas_ela_growth,
+    :most_recent_mcas_math_performance,
+    :most_recent_mcas_ela_performance,
+    :most_recent_mcas_math_scaled,
+    :most_recent_mcas_ela_scaled,
+    :most_recent_star_reading_percentile,
+    :most_recent_star_math_percentile,
+    :enrollment_status,
+    :date_of_birth,
+    :risk_level,
+    :gender,
+    :house,
+    :counselor,
+  ]
+
   INCLUDE_FOR_EVENT_NOTES = [
     :id,
     :student_id,
@@ -14,12 +47,16 @@ module StudentsQueryHelper
   # filtering and slicing in the UI).
   # This may be slow if you're doing it for many students without eager includes.
   def student_hash_for_slicing(student)
-    HashWithIndifferentAccess.new(student.as_json.merge({
-      discipline_incidents_count: student.most_recent_school_year_discipline_incidents_count,
-      absences_count: student.most_recent_school_year_absences_count,
-      tardies_count: student.most_recent_school_year_tardies_count,
-      homeroom_name: student.try(:homeroom).try(:name)
-    }))
+    student_fields = Student.where(id: student.id).select(INCLUDE_FOR_STUDENTS)
+
+    HashWithIndifferentAccess.new(
+      student_fields.first.as_json.merge({
+        discipline_incidents_count: student.most_recent_school_year_discipline_incidents_count,
+        absences_count: student.most_recent_school_year_absences_count,
+        tardies_count: student.most_recent_school_year_tardies_count,
+        homeroom_name: student.try(:homeroom).try(:name)
+      })
+    )
   end
 
   # Queries for Services and EventNotes for each student, and merges the results

--- a/app/helpers/students_query_helper.rb
+++ b/app/helpers/students_query_helper.rb
@@ -1,37 +1,11 @@
 require 'digest'
 
 module StudentsQueryHelper
-  INCLUDE_FOR_STUDENTS = [
-    :id,
-    :grade,
-    :hispanic_latino,
-    :race,
-    :free_reduced_lunch,
-    :homeroom_id,
-    :first_name,
-    :last_name,
-    :home_language,
-    :registration_date,
-    :program_assigned,
-    :sped_placement,
-    :disability,
-    :sped_level_of_need,
-    :plan_504,
-    :limited_english_proficiency,
-    :most_recent_mcas_math_growth,
-    :most_recent_mcas_ela_growth,
-    :most_recent_mcas_math_performance,
-    :most_recent_mcas_ela_performance,
-    :most_recent_mcas_math_scaled,
-    :most_recent_mcas_ela_scaled,
-    :most_recent_star_reading_percentile,
-    :most_recent_star_math_percentile,
+  INCLUDE_FOR_STUDENTS = Student.column_names.map(&:to_sym) - [
     :enrollment_status,
-    :date_of_birth,
-    :risk_level,
-    :gender,
-    :house,
-    :counselor,
+    :primary_phone,
+    :primary_email,
+    :student_address
   ]
 
   INCLUDE_FOR_EVENT_NOTES = [


### PR DESCRIPTION
# Notes

This PR builds on top of #1445 and follows a similar methodology. 

When I looked at the MemoryProfiler output for the school overview page, I found another suspicious thing: among the "Retained String Report" output were strings like "999-999-9999 C-Mom" and "student@example.com". 

These were suspicious because they are fake generated student contact info. The school overview never surfaces contact info!

Using `#select` to pull only the necessary fields for students brought the retained memory down (measuring warm path to warm path):

```
master (current app state): 
Total allocated: 3785005 bytes (35109 objects)
Total retained:  443397 bytes (3354 objects)

with student fields #selected in students_query_helper:
Total allocated: 3168397 bytes (29097 objects)
Total retained:  376418 bytes (2603 objects)
```

Combined with #1445, this change brings retained memory down from the baseline by about 15%.

## Code quality notes

I searched in vain through the Rails API for an "opposite of `#select`" method for ActiveRecord::Association that would let me specify fields to exclude. Since I couldn't find one, I ended up with a big, ugly `INCLUDE_FOR_STUDENTS` constant at the top of the class. Anyone got any good alternatives to this? 😄 

Similarly, I had hope that `#select` would work on an individual record, but it didn't, and neither did `#pluck`. That left me with:

```
student_fields = Student.where(id: student.id).select(INCLUDE_FOR_STUDENTS)
```

... which is ugly but gets the job done.

Finally, we're still querying the un-`#selected` student from the database to get discipline_incidents_count, absences_count, and tardies_count. I think that's the reason we still have some "student@example.com"s showing up in the memory profiling report (but much fewer than in the baseline report).

## Checklist

+ [x] Manually QA visiting School Overview Page
+ [x] Manually QA running rake school_overview precompute job