### PR TITLE
Bug Fix: double counting each student's first absence

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/school_absence_dashboard.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/school_absence_dashboard.jsx
@@ -50,7 +50,7 @@ export default React.createClass({
     let studentAbsenceCounts = {};
     this.state.displayDates.forEach((day) => {
       _.each(this.props.schoolAbsenceEvents[day], (absence) => {
-        studentAbsenceCounts[absence.student_id] = studentAbsenceCounts[absence.student_id] || 1;
+        studentAbsenceCounts[absence.student_id] = studentAbsenceCounts[absence.student_id] || 0;
         studentAbsenceCounts[absence.student_id]++;
       });
     });


### PR DESCRIPTION
# Who is this PR for?
Dashboard Users
# What problem does this PR fix?
The first absence for each student is being counted twice. This is only a problem in the absence dashboard. Tardies shouldn't have this issue. 

# What does this PR do?
Counts each absence once!

# Checklists

## Javascript QA

+ [x] Author checked latest in IE - Absence Dashboard
+ [ ] Reviewer checked latest in IE - Absence Dashboard
