### PR TITLE
Improve Next Gen MCAS detection for school overview slice panels

### DIFF
--- a/app/assets/javascripts/components/SlicePanels.js
+++ b/app/assets/javascripts/components/SlicePanels.js
@@ -97,7 +97,7 @@ class SlicePanels extends React.Component {
       this.createItem('Advanced', Filters.Range(key, [260, 281])),
     ];
 
-    const sortedScores = _.map(this.props.students, key).sort();
+    const sortedScores = _.compact(_.map(this.props.students, key)).sort();
     const medianScore = sortedScores[Math.floor(sortedScores.length / 2)];
 
     if (medianScore > 280) return nullItem.concat(nextGenMCASFilters, oldMCASFilters);


### PR DESCRIPTION
# Who is this PR for?

New Bedford school overview.

# What problem does this PR fix?

The SlicePanel filters are showing "Classic" MCAS performance categories instead of "Next Gen" when most students have Next Gen Results.

# What does this PR do?

If a school has lots of students without MCAS results (for example, because they're younger and haven't taken MCAS yet), those null values drag down the median score unless specifically excluded. 

That can make the Next Gen MCAS detection function in the Slice Panels component misfire and display "Classic" MCAS filters as defaults instead of Next Gen.

This PR excludes null results from that detection function with lodash `_.compact`. 

# Screenshot (if adding a client-side feature)

### This PR: useful filters up top and shown by default
![screen shot 2018-02-05 at 10 57 14 am](https://user-images.githubusercontent.com/3209501/35817664-b1e97466-0a63-11e8-8d89-43a42ab44de1.png)

### `master`: useful filters down below and hidden by default
![screen shot 2018-02-05 at 11 01 17 am](https://user-images.githubusercontent.com/3209501/35817783-f48ad800-0a63-11e8-8844-f162be0f7748.png)

![screen shot 2018-02-05 at 11 01 10 am](https://user-images.githubusercontent.com/3209501/35817782-f35c3c3a-0a63-11e8-8df9-c0b4a24a9c97.png)

# Checklists

## Javascript QA

+ [x] Author checked latest in IE - School Overview Slice Panels