### PR TITLE
Add new summary methods for inspecting exported assessments CSV

### DIFF
--- a/lib/analysis/analyze_assessments_table.rb
+++ b/lib/analysis/analyze_assessments_table.rb
@@ -29,7 +29,7 @@ class AnalyzeAssessmentsTable < Struct.new(:path)
   end
 
   def assessment_subject_summary
-    assessment_subject.each_with_object(Hash.new(0)) { |subj, counts| counts[subj] += 1 }
+    assessment_subject.each_with_object(Hash.new(0)) { |subj, memo| memo[subj] += 1 }
   end
 
   def assessment_test
@@ -37,7 +37,17 @@ class AnalyzeAssessmentsTable < Struct.new(:path)
   end
 
   def assessment_test_summary
-    assessment_test.each_with_object(Hash.new(0)) { |subj, counts| counts[subj] += 1 }
+    assessment_test.each_with_object(Hash.new(0)) { |test, memo| memo[test] += 1 }
+  end
+
+  def assessment_test_subject_crosstabs
+    data.each_with_object(Hash.new(0)) do |row, memo|
+      crosstab = [
+        row.fetch(:assessment_test, 'NIL'), row.fetch(:assessment_subject, 'NIL')
+      ].join('+')
+
+      memo[crosstab] += 1
+    end
   end
 
   def nil_converter(value)

--- a/lib/analysis/analyze_assessments_table.rb
+++ b/lib/analysis/analyze_assessments_table.rb
@@ -24,6 +24,22 @@ class AnalyzeAssessmentsTable < Struct.new(:path)
     @parsed_csv ||= CSV.parse(contents, csv_options)
   end
 
+  def assessment_subject
+    data[:assessment_subject]
+  end
+
+  def assessment_subject_summary
+    assessment_subject.each_with_object(Hash.new(0)) { |subj, counts| counts[subj] += 1 }
+  end
+
+  def assessment_test
+    data[:assessment_test]
+  end
+
+  def assessment_test_summary
+    assessment_test.each_with_object(Hash.new(0)) { |subj, counts| counts[subj] += 1 }
+  end
+
   def nil_converter(value)
     value unless value == '\N'
   end


### PR DESCRIPTION
# Who is this PR for?

Insights developers.

# What problem does this PR fix?

No quick access to summary data about assessment export files.

# What does this PR do?

Adds some summary methods to show the subjects and test families in an assessment export file as part of manually reviewing assessment export data for New Bedford (#1371).