### PR TITLE
Allow scheduled import task to take arguments 

### DIFF
--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -7,9 +7,6 @@ class ImportTask
     # options["source"] describes which external data sources to import from
     @source = options.fetch("source", ["x2", "star"])
 
-    # options["test_mode"] is for the test suite and supresses log output
-    @test_mode = options.fetch("test_mode", false)
-
     # options["only_recent_attendance"]
     @only_recent_attendance = options.fetch("only_recent_attendance", false)
   end
@@ -58,7 +55,7 @@ class ImportTask
   ## SET UP COMMAND LINE REPORT AND DATABASE RECORD ##
 
   def log
-    @test_mode ? LogHelper::Redirect.instance.file : STDOUT
+    Rails.env.test? ? LogHelper::Redirect.instance.file : STDOUT
   end
 
   def set_up_record
@@ -68,7 +65,7 @@ class ImportTask
   def set_up_report
     models = [ Student, StudentAssessment, DisciplineIncident, Absence, Tardy, Educator, School, Course, Section, StudentSectionAssignment, EducatorSectionAssignment ]
 
-    log = @test_mode ? LogHelper::Redirect.instance.file : STDOUT
+    log = Rails.env.test? ? LogHelper::Redirect.instance.file : STDOUT
 
     @report = ImportTaskReport.new(
       models_for_report: models,

--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -1,7 +1,11 @@
 class ImportJob
+
+  def initialize(options:)
+    @options = options
+  end
+
   def perform
-    load File.expand_path("#{Rails.root}/lib/tasks/import.thor", __FILE__)
-    Import::Start.new.invoke_all
+    ImportTask.new(options: @options).connect_transform_import
   end
 
   def max_attempts

--- a/lib/tasks/chores.rake
+++ b/lib/tasks/chores.rake
@@ -24,14 +24,4 @@ namespace :chores do
   task update_searchbar_data_for_educators_who_log_in: :environment do
     Educator.save_student_searchbar_json_for_folks_who_log_in
   end
-
-  desc 'Kick off background worker for data import'
-  task import_data_in_background: :environment do
-    Delayed::Job.enqueue ImportJob.new
-  end
-
-  desc 'Kick off console output for fun'
-  task console_output_in_background: :environment do
-    Delayed::Job.enqueue ConsoleJob.new
-  end
 end

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -1,7 +1,5 @@
 require 'thor'
-require_relative '../../app/importers/constants/x2_importers'
-require_relative '../../app/importers/constants/star_importers'
-require_relative '../../app/importers/constants/file_importer_options'
+require File.expand_path("../../../config/environment.rb", __FILE__)
 
 class Import
   class Start < Thor::Group
@@ -14,23 +12,21 @@ class Import
       type: :array,
       default: ['x2', 'star'],  # This runs all X2 and STAR importers
       desc: "Import data from one of #{FileImporterOptions.keys}"
-    class_option :test_mode,
-      type: :boolean,
-      default: false,
-      desc: "Redirect log output away from STDOUT; do not load Rails during import"
     class_option :only_recent_attendance,
       type: :boolean,
       default: false,
       desc: "Only import attendance rows from the past 90 days for faster attendance import"
+    class_option :background,
+      type: :boolean,
+      default: true,
+      desc: "Import data in a background job"
 
-    def load_rails
-      unless options["test_mode"]
-        require File.expand_path("../../../config/environment.rb", __FILE__)
+    def import
+      if options.fetch(:background)
+        Delayed::Job.enqueue ImportJob.new(options: options)
+      else
+        ImportTask.new(options: options).connect_transform_import
       end
-    end
-
-    def connect_transform_import
-      ImportTask.new(options: options).connect_transform_import
     end
   end
 end


### PR DESCRIPTION
# Who is this PR for?

Developers who want to configure data import job.

# What problem does this PR fix?

Currently the only way to schedule an import job in the background is to set:

```
rake chores:import_data_in_background
```

The problem with this is that it's not configured to accept any arguments, so you can't pass in flags like `--only-recent-attendance` to the scheduled job.

# What does this PR do?

This PR removes the `chores:import_data_in_background` rake tasks, which don't accept command line arguments very elegantly, and uses thor instead as the top level API for starting background jobs, because thor has all great command-line interface tooling. 

The thor CLI accepts a `--background` flag that can be used to run the process on a worker (i.e. in production), and can also be run `--no-background` (i.e. in local development).

This PR also removes the `--test-mode` flag, which is better implemented by calling `Rails.env.test?` directly instead of asking the developer who calls thor to supply an argument. 

# QA Checklist 

+ [x] Test the `--background` import path
+ [x] Test the `--no-background` import path

# Post-Deploy Checklist

+ [ ] Update Somerville task to `thor import:start --background --only-recent-attendance`
+ [ ] Update New Bedford task to `thor import:start --background --school '123' '115'`*

*Once we have historical attendance data in the app for every New Bedford school we can add the `--only-recent-attendance` flag