### PR TITLE
Tolerant behavior importer [unblock behavior import for New Bedford]

### DIFF
--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -23,8 +23,10 @@ class AttendanceImporter
       )
     end
 
-    @error_summary = @error_list.inject(Hash.new(0)) { |h, e| h[e] += 1 ; h }
-    @log.write("\n\nInvalid attendance rows summary: ")
+    @error_summary = @error_list.each_with_object(Hash.new(0)) do |error, memo|
+      memo[error] += 1
+    end
+    @log.write("\n\nInvalid behavior rows summary: ")
     @log.write(@error_summary)
   end
 

--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -102,6 +102,7 @@ class ImportTask
         file_importer.import
       rescue => error
         log.write("🚨  🚨  🚨  🚨  🚨  Error! #{error}")
+        log.write(error.backtrace)
 
         extra_info =  { "importer" => file_importer.class.name }
         ErrorMailer.error_report(error, extra_info).deliver_now if Rails.env.production?

--- a/app/importers/rows/behavior_row.rb
+++ b/app/importers/rows/behavior_row.rb
@@ -11,8 +11,9 @@ class BehaviorRow < Struct.new(:row)
   end
 
   def build
-    discipline_incident = student.discipline_incidents.find_or_initialize_by(
+    discipline_incident = DisciplineIncident.find_or_initialize_by(
       occurred_at: occurred_at,
+      student_id: student.try(:id),
       incident_code: row[:incident_code]
     )
 
@@ -42,6 +43,6 @@ class BehaviorRow < Struct.new(:row)
   end
 
   def student
-    Student.find_by_local_id!(row[:local_id])
+    Student.find_by_local_id(row[:local_id])
   end
 end

--- a/spec/importers/file_importers/behavior_importer_spec.rb
+++ b/spec/importers/file_importers/behavior_importer_spec.rb
@@ -2,10 +2,16 @@ require 'rails_helper'
 
 RSpec.describe BehaviorImporter do
 
-  let(:behavior_importer) {
+  let(:base_behavior_importer) {
     described_class.new(options: {
-      school_scope: nil, log: nil
+      school_scope: nil, log: nil, only_recent_attendance: false
     })
+  }
+
+  let(:behavior_importer) {
+    base_behavior_importer.instance_variable_set(:@success_count, 0)
+    base_behavior_importer.instance_variable_set(:@error_list, [])
+    base_behavior_importer
   }
 
   describe '#import_row' do


### PR DESCRIPTION
# Who is this PR for?

New Bedford Public Schools.

# What does this PR fix?

Blocked New Bedford behavior import as described in https://github.com/studentinsights/studentinsights/issues/1371#issuecomment-360859776 and https://github.com/studentinsights/studentinsights/issues/1371#issuecomment-360864063.

# What does this PR do?

Makes the behavior importer tolerant of invalid rows. Instead of blowing up when it hits the first invalid row, the behavior importer skips those rows, and keeps a count of invalid rows plus error messages. 

This will also be beneficial to the Somerville app, because it will produce a more detailed report of how the behavior export file is getting parsed and how many invalid rows are in the file.

# Checklist 

+ [x] QA attendance import process for Somerville Public Schools
+ [x] QA attendance import process for New Bedford Public Schools