### PR TITLE
Show tardies for entire school year on dashboard

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/dashboard_helpers.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/dashboard_helpers.jsx
@@ -43,7 +43,8 @@ export default {
   },
 
   schoolYearStart: function() {
-    return moment().month() < 8 ? moment().subtract(1, 'year').year() + "-08-10" : moment().year() + "-08-10";
+    const today = moment();
+    return today.month() < 8 ? today.subtract(1, 'year').year() + "-08-10" : today.year() + "-08-10";
   },
 
   //slightly faster than Array.filter for getting a new date range

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/dashboard_helpers.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/dashboard_helpers.jsx
@@ -42,6 +42,10 @@ export default {
     });
   },
 
+  schoolYearStart: function() {
+    return moment().month() < 8 ? moment().subtract(1, 'year').year() + "-08-10" : moment().year() + "-08-10";
+  },
+
   //slightly faster than Array.filter for getting a new date range
   filterDates: function(dates, start_date, end_date) {
     return dates.sort().slice(this.getFirstDateIndex(dates, start_date), this.getLastDateIndex(dates, end_date));

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/students_table.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/students_table.jsx
@@ -8,7 +8,8 @@ export default React.createClass({
 
   propTypes: {
     rows: React.PropTypes.array.isRequired,
-    selectedHomeroom: React.PropTypes.string
+    selectedHomeroom: React.PropTypes.string,
+    schoolYearFlag: React.PropTypes.bool
   },
 
   getInitialState () {
@@ -16,7 +17,8 @@ export default React.createClass({
       sortBy: 'events',
       sortType: 'number',
       sortDesc: true,
-      slectedHomeroom: null
+      slectedHomeroom: null,
+      schoolYearFlag: false
     };
   },
 
@@ -112,7 +114,8 @@ export default React.createClass({
   },
 
   renderCaption () {
-    return this.props.selectedHomeroom ? this.props.selectedHomeroom : "All Students";
+    const schoolYearCaption = this.props.schoolYearFlag? " (School Year)" : "";
+    return this.props.selectedHomeroom ? this.props.selectedHomeroom + schoolYearCaption : "All Students" + schoolYearCaption;
   }
 
 });

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/school_tardies_dashboard.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/school_tardies_dashboard.jsx
@@ -23,12 +23,13 @@ export default React.createClass({
   createMonthCategories: function(eventsByDay) {
     let monthCategories = {};
     let lastStoredMonth;
+    const startMonth = moment().subtract(3, 'months');
 
     Object.keys(eventsByDay).sort().forEach((day, dayIndex) => {
-      const month = moment(day).date(1).format("MMM 'YY");
-      if (lastStoredMonth != month) {
-        monthCategories[dayIndex] = month;
-        lastStoredMonth = month;
+      const month = moment(day);
+      if (lastStoredMonth != month.date(1).format("MMM 'YY") && month.isSameOrAfter(startMonth, 'month')) {
+        lastStoredMonth = month.date(1).format("MMM 'YY");
+        monthCategories[dayIndex] = lastStoredMonth;
       }
     });
     return monthCategories;
@@ -87,7 +88,7 @@ export default React.createClass({
             tickmarkPlacement: "on"
           }}
           seriesData = {seriesData}
-          titleText = {'Schoolwide Tardies'}
+          titleText = {'Schoolwide Tardies (Last three months)'}
           measureText = {'Number of Tardies'}
           tooltip = {{
             pointFormat: 'Total tardies: <b>{point.y}</b>'}}
@@ -106,7 +107,7 @@ export default React.createClass({
           id = {'string'}
           categories = {{categories: homerooms}}
           seriesData = {homeroomSeries}
-          titleText = {'Tardies By Homeroom'}
+          titleText = {'Tardies By Homeroom (School Year)'}
           measureText = {'Number of Tardies'}
           tooltip = {{
             pointFormat: 'Total tardies: <b>{point.y}</b>'}}

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/school_tardies_dashboard.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/school_tardies_dashboard.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 
 import DashboardHelpers from '../dashboard_helpers.jsx';
 import StudentsTable from '../students_table.jsx';
@@ -44,6 +45,22 @@ export default React.createClass({
       date = moment(date).add(1, 'day').format('YYYY-MM-DD');
     }
     return datesForPastThreeMonths;
+  },
+
+  studentTardyCounts: function(tardiesArray) {
+    let studentTardyCounts = {};
+    const daysWithTardies = Object.keys(this.props.schoolTardyEvents);
+    const startDate = DashboardHelpers.schoolYearStart();
+    const endDate = moment().format("YYYY-MM-DD");
+    const schoolYearTardies = DashboardHelpers.filterDates(daysWithTardies.sort(), startDate, endDate);
+
+    schoolYearTardies.forEach((day) => {
+      _.each(this.props.schoolTardyEvents[day], (tardy) => {
+        studentTardyCounts[tardy.student_id] = studentTardyCounts[tardy.student_id] || 0;
+        studentTardyCounts[tardy.student_id]++;
+      });
+    });
+    return studentTardyCounts;
   },
 
   setStudentList: function(highchartsEvent) {
@@ -117,6 +134,7 @@ export default React.createClass({
   },
 
   renderStudentTardiesTable: function () {
+    const studentTardyCounts = this.studentTardyCounts();
     const studentsByHomeroom = DashboardHelpers.groupByHomeroom(this.props.dashboardStudents);
     const students = studentsByHomeroom[this.state.selectedHomeroom] || this.props.dashboardStudents;
     let rows =[];
@@ -125,7 +143,7 @@ export default React.createClass({
         id: student.id,
         first_name: student.first_name,
         last_name: student.last_name,
-        events: student.tardies.length || 0
+        events: studentTardyCounts[student.id] || 0
       });
     });
 

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/school_tardies_dashboard.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/school_tardies_dashboard.jsx
@@ -150,7 +150,8 @@ export default React.createClass({
     return (
       <StudentsTable
         rows = {rows}
-        selectedHomeroom = {this.state.selectedHomeroom}/>
+        selectedHomeroom = {this.state.selectedHomeroom}
+        schoolYearFlag ={true}/>
     );
   }
 });

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/schoolwide_tardies.jsx
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/schoolwide_tardies.jsx
@@ -20,10 +20,15 @@ export default React.createClass({
     let homeroomTardyEvents = {};
     const studentRecords = this.props.dashboardStudents;
     const studentsByHomeroom = DashboardHelpers.groupByHomeroom(studentRecords);
+    const schoolYearStart = DashboardHelpers.schoolYearStart();
     Object.keys(studentsByHomeroom).forEach((homeroom) => {
       homeroomTardyEvents[homeroom] = 0;
       _.each(studentsByHomeroom[homeroom], (student) => {
-        homeroomTardyEvents[homeroom] += student.tardies.length;
+        student.tardies.forEach((tardy) => {
+          if (moment(tardy.occurred_at).isSameOrAfter(schoolYearStart)) {
+            homeroomTardyEvents[homeroom]++;
+          }
+        });
       });
     });
     return homeroomTardyEvents;

--- a/app/assets/stylesheets/components/school_dashboard.scss
+++ b/app/assets/stylesheets/components/school_dashboard.scss
@@ -40,7 +40,8 @@
 }
 
 .StudentsList {
-  height : 450px;
+  margin-top: 200px;
+  height: 450px;
   overflow:hidden;
 }
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -14,7 +14,7 @@ class Student < ActiveRecord::Base
   has_many :event_notes, dependent: :destroy
   has_many :services, dependent: :destroy
   has_many :tardies, dependent: :destroy
-  has_many :dashboard_tardies, -> { where('occurred_at >= ?', 3.months.ago) },
+  has_many :dashboard_tardies, -> { where('occurred_at >= ?', 1.year.ago) },
     class_name: "Tardy"
   has_many :absences, dependent: :destroy
   has_many :dashboard_absences, -> { where('occurred_at >= ?', 1.year.ago) },


### PR DESCRIPTION
# Who is this PR for?
Dashboard users

# What problem does this PR fix?
The students table and homeroom chart were restricting tardy data to the previous 3 months, only the schoolwide tardies chart should do that. Everything else should be based on the school year.

# What does this PR do?
Increases the tardy data to the entire current school year.

![screen shot 2018-02-13 at 11 04 13 am](https://user-images.githubusercontent.com/638809/36159801-ab7f8368-10ad-11e8-8eb3-953a278b9e73.png)

## Javascript QA

+ [x] Author checked latest in IE - Tardies Dashboard
+ [ ] Reviewer checked latest in IE - Tardies Dashboard
