### PR TITLE
Remove rails_12factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,10 +35,6 @@ gem 'uglifier', '>= 1.3.0'
 gem 'wicked_pdf'
 gem 'wkhtmltopdf-binary'
 
-group :production do
-  gem 'rails_12factor'
-end
-
 group :development, :test do
   gem 'bourbon', '~> 4.3.2'
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,11 +222,6 @@ GEM
       ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.1.3)
       actionpack (= 5.1.3)
       activesupport (= 5.1.3)
@@ -364,7 +359,6 @@ DEPENDENCIES
   rails (~> 5.1.1)
   rails-controller-testing
   rails-erd
-  rails_12factor
   rollbar
   rspec-rails
   rubocop


### PR DESCRIPTION
# What problem does this PR fix?

Extra gem in Gemfile that can be removed.

The `rails_12factor` gem was required to launch our app on Heroku when we were at Rails 4.x. Now that we're at Rails 5.1.1, we don't need the gem anymore.

Our app already has the required `production.rb` setup described in the "Migrating to Rails 5" section of the 12_factor docs: https://github.com/heroku/rails_12factor#rails-5

+ [x] `config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?`
+ [x] `if ENV["RAILS_LOG_TO_STDOUT"].present? . . .`
 
# What does this PR do?

Removes the `rails_12factor` gem from the production group.
