### PR TITLE
 Remove commented-out code in SchoolOverviewPage.js

### DIFF
--- a/app/assets/javascripts/school_overview/SchoolOverviewPage.js
+++ b/app/assets/javascripts/school_overview/SchoolOverviewPage.js
@@ -173,10 +173,6 @@ class SchoolOverviewPage extends React.Component {
   onResetClicked(e) {
     this.clearFilters();
   }
-  // key code 27 is the ESC key
-  //onKeyDown: function(e) {
-  //  if (e.keyCode === 27) this.clearFilters();
-  //},
 
   render() {
     this.setFilteredStudents(this.filteredStudents());


### PR DESCRIPTION
# What problem does this PR fix?

I noticed some commented-out code in SchoolOverviewPage.js. Looks like this functionality was moved to SliceButtons.js, but the commented-out bit wasn't deleted. This PR deletes the comments to keep our code base tidy and easy to read.