### PR TITLE
Move service types to district config

### DIFF
--- a/app/config_objects/load_district_config.rb
+++ b/app/config_objects/load_district_config.rb
@@ -15,6 +15,10 @@ class LoadDistrictConfig
     load_yml.fetch("schools")
   end
 
+  def service_types
+    load_yml.fetch("service_types")
+  end
+
   def canonical_domain
     ENV.fetch('CANONICAL_DOMAIN', nil)
   end

--- a/app/models/service_type.rb
+++ b/app/models/service_type.rb
@@ -1,29 +1,11 @@
 class ServiceType < ActiveRecord::Base
   has_many :services
 
-  def self.seed_somerville_service_types
+  def self.seed_service_types
     ServiceType.destroy_all
-    ServiceType.create([
-      { id: 502, name: 'Attendance Officer'},
-      { id: 503, name: 'Attendance Contract'},
-      { id: 504, name: 'Behavior Contract'},
-      { id: 505, name: 'Counseling, in-house'},
-      { id: 506, name: 'Counseling, outside'},
-      { id: 507, name: 'Reading intervention'},
-      { id: 508, name: 'Math intervention'},
-      { id: 509, name: 'SomerSession' },
-      { id: 510, name: 'Summer Program for English Language Learners' },
-      { id: 511, name: 'Afterschool Tutoring' },
-      { id: 512, name: 'Freedom School' },
-      { id: 513, name: 'Community Schools' },
-      { id: 514, name: 'X-Block' },
-    ])
-  end
 
-  def self.add_summer_program_status_to_service_types
-    [509, 510, 512].each do |id|
-      ServiceType.find(id).update!({ summer_program: true })
-    end
-  end
+    service_types = LoadDistrictConfig.new.service_types
 
+    ServiceType.create!(service_types)
+  end
 end

--- a/config/district_new_bedford.yml
+++ b/config/district_new_bedford.yml
@@ -82,3 +82,32 @@ schools:
   -
     name: Whaling City Jr./Sr. High
     local_id: '515'
+service_types:
+  -
+    name: Behavior Plan
+    id: 1
+  -
+    name: Safety Plan
+    id: 2
+  -
+    name: Counseling – Individual
+    id: 3
+  -
+    name: Group Counseling
+    id: 4
+  -
+    name: Social Skills Group
+    id: 5
+  -
+    name: Afterschool Teacher Help
+    id: 6
+  -
+    name: Reading Interventionist
+    id: 7
+  -
+    name: Lexia Core 5
+    id: 8
+  -
+    name: MySidewalks Intervention
+    id: 9
+

--- a/config/district_somerville.yml
+++ b/config/district_somerville.yml
@@ -61,3 +61,47 @@ schools:
   -
     local_id: SPED
     name: Special Education
+service_types:
+  -
+    name: Attendance Officer
+    id: 502
+  -
+    name: Attendance Contract
+    id: 503
+  -
+    name: Behavior Contract
+    id: 504
+  -
+    name: Counseling, in-house
+    id: 505
+  -
+    name: Counseling, outside
+    id: 506
+  -
+    name: Reading intervention
+    id: 507
+  -
+    name: Math intervention
+    id: 508
+  -
+    name: SomerSession
+    id: 509
+    summer_program: true
+  -
+    name: Summer Program for English Language Learners
+    id: 510
+    summer_program: true
+  -
+    name: Afterschool Tutoring
+    id: 511
+  -
+    name: Freedom School
+    id: 512
+    summer_program: true
+  -
+    name: Community Schools
+    id: 513
+  -
+    name: X-Block
+    id: 514
+

--- a/db/seeds/database_constants.rb
+++ b/db/seeds/database_constants.rb
@@ -9,7 +9,7 @@ class DatabaseConstants
     Assessment.seed_somerville_assessments
     InterventionType.seed_somerville_intervention_types
     EventNoteType.seed_somerville_event_note_types
-    ServiceType.seed_somerville_service_types
+    ServiceType.seed_service_types
     ServiceType.add_summer_program_status_to_service_types
     nil
   end


### PR DESCRIPTION
# Who is this PR for?

New Bedford insights.

# What problem does this PR fix?

Service types are currently stored as constants and are all hard-coded to Somerville service types. 

# What does this PR do?

Pulls service types to district config YAML.

# Screenshot (if adding a client-side feature)

TK 

# Checklists

## Javascript QA

+ [ ] Author checked latest in IE - Student Profile

## Automated Testing

+ [ ] Author included specs for new code
