### PR TITLE
Fix overzealous prop in ServiceUploadDetail.js

### DIFF
--- a/app/assets/javascripts/service_uploads/ServiceUploadDetail.js
+++ b/app/assets/javascripts/service_uploads/ServiceUploadDetail.js
@@ -172,7 +172,6 @@ ServiceUploadDetail.propTypes = {
     created_at: React.PropTypes.string.isRequired,
     services: React.PropTypes.arrayOf(
       React.PropTypes.shape({
-        id: React.PropTypes.number.isRequired,
         service_type: React.PropTypes.shape({
           name: React.PropTypes.string.isRequired,
         }).isRequired,


### PR DESCRIPTION
# Notes 

+ The id of each service associated with a ServiceUpload shouldn't be required by `ServiceUploadDetail.js`, and isn't used in the component. 
+ You can see this by looking at the structure of the JSON object created by `ServiceUploadsController#index`:

```
def past_service_upload_json
  ServiceUpload.includes(services: [:student, :service_type])
               .order(created_at: :desc)
               .as_json(only: [:created_at, :file_name, :id],
                 include: {
                   services: {
                     only: [],
                     include: {
                       student: {
                         only: [:first_name, :last_name, :id]
                       },
                       service_type: {
                         only: [:name]
                       }
                     }
                   }
                 }
               )
end
```

No ID included for services when serialized down for this view!