### PR TITLE
Investigate New Bedford MCAS dates

### DIFF
--- a/lib/analysis/analyze_assessments_table.rb
+++ b/lib/analysis/analyze_assessments_table.rb
@@ -61,4 +61,12 @@ class AnalyzeAssessmentsTable < Struct.new(:path)
         .sort
   end
 
+  def new_bedford_pilot_school_mcas_dates
+    data.select { |row| row[:assessment_test] == 'MCAS' }
+        .select { |row| row[:school_local_id] == '123' || row[:school_local_id] == '115' }
+        .map { |row| row[:assessment_date] }
+        .uniq
+        .sort
+  end
+
 end

--- a/lib/analysis/analyze_assessments_table.rb
+++ b/lib/analysis/analyze_assessments_table.rb
@@ -54,12 +54,11 @@ class AnalyzeAssessmentsTable < Struct.new(:path)
     value unless value == '\N'
   end
 
-  def dibels
-    data.select { |row| row[:asd_name].include?('DIBELS') }
-  end
-
-  def access
-    data.select { |row| row[:asd_name].include?('ACCESS') }
+  def new_bedford_mcas_dates
+    data.select { |row| row[:assessment_test] == 'MCAS' }
+        .map { |row| row[:assessment_date] }
+        .uniq
+        .sort
   end
 
 end


### PR DESCRIPTION
# What problem does this PR fix?

+ Only one MCAS event per student is coming through in the New Bedford MCAS instance

# What does this PR do?

+ Analyzing the raw iassessment.csv export file shows that there are assessment records from multiple test dates in the raw data, which means that it's an issue with the import process:

```

["2010-05-01",
"2011-05-01",
"2012-05-01",
"2012-11-01",
"2013-02-01",
"2013-03-01",
"2013-05-01",
"2013-11-01",
"2014-02-01",
"2014-03-01",
"2014-05-01",
"2014-11-01",
"2015-02-01",
"2015-03-01",
"2015-05-01",
"2015-11-01",
"2016-02-01",
"2016-03-01",
"2016-05-01",
"2017-02-01",
"2017-03-01",
"2017-05-01",
"2017-11-01"]
```