### PR TITLE
Don't show years enrolled on School Overview page unless we have data

### DIFF
--- a/app/assets/javascripts/components/SlicePanels.js
+++ b/app/assets/javascripts/components/SlicePanels.js
@@ -311,12 +311,19 @@ class SlicePanels extends React.Component {
   }
 
   renderYearsEnrolled() {
-    const uniqueValues = _.compact(_.unique(this.props.allStudents.map(function(student) {
-      return Math.floor((new Date() - new Date(student.registration_date)) / (1000 * 60 * 60 * 24 * 365));
-    })));
+    const {allStudents} = this.props;
+    const registrationDates = _.compact(allStudents.map(s => s.registration_date));
+
+    if (registrationDates.length === 0) return null;
+
+    const uniqueValues =_.unique(registrationDates.map((regDate) => {
+      return Math.floor((new Date() - new Date(regDate)) / (1000 * 60 * 60 * 24 * 365));
+    }));
+
     const items = uniqueValues.map(function(value) {
       return this.createItem(value, Filters.YearsEnrolled(value));
     }, this);
+
     const sortedItems = _.sortBy(items, function(item) { return parseFloat(item.caption); });
 
     return this.renderTable({

--- a/spec/javascripts/components/SlicePanels.test.js
+++ b/spec/javascripts/components/SlicePanels.test.js
@@ -68,8 +68,8 @@ SpecSugar.withTestEl('high-level integration tests', (container) => {
        student registration dates`, () => {
     const el = container.testEl;
     const studentsWithRegistration = FixtureStudents.map((student) => {
-      return _.merge(student, {registration_date: '2018-02-13T22:17:30.338Z'})
-    })
+      return _.merge(student, {registration_date: '2018-02-13T22:17:30.338Z'});
+    });
 
     helpers.renderInto(el, {
       students: studentsWithRegistration,

--- a/spec/javascripts/components/SlicePanels.test.js
+++ b/spec/javascripts/components/SlicePanels.test.js
@@ -1,9 +1,9 @@
+import _ from 'lodash';
 import ReactDOM from 'react-dom';
 import SpecSugar from '../support/spec_sugar.jsx';
 import {serviceTypesIndex, eventNoteTypesIndex} from '../fixtures/database_constants.jsx';
 import FixtureStudents from '../fixtures/students.jsx';
 import SlicePanels from '../../../app/assets/javascripts/components/SlicePanels';
-
 
 const helpers = {
   renderInto(el, props = {}) {
@@ -47,9 +47,34 @@ const helpers = {
 };
 
 SpecSugar.withTestEl('high-level integration tests', (container) => {
-  it('renders everything on the happy path', () => {
+  it(`renders everything on the happy path for elementary school with
+      no student registration dates`, () => {
     const el = container.testEl;
     helpers.renderInto(el);
+
+    expect($(el).find('.SlicePanels').length).toEqual(1);
+    expect($(el).find('.column').length).toEqual(6);
+    expect(helpers.columnTitlesMatrix(el)).toEqual([
+      [ 'Disability', 'Low Income', 'LEP', 'Race', 'Hispanic/Latino', 'Gender' ],
+      [ 'Grade', 'Risk level' ],
+      [ 'STAR Reading', 'MCAS ELA Score', 'MCAS ELA SGP' ],
+      [ 'STAR Math', 'MCAS Math Score', 'MCAS Math SGP' ],
+      [ 'Discipline incidents', 'Absences', 'Tardies' ],
+      [ 'Services', 'Summer', 'Notes', 'Program', 'Homeroom' ]
+    ]);
+  });
+
+  it(`renders everything on the happy path for elementary school with
+       student registration dates`, () => {
+    const el = container.testEl;
+    const studentsWithRegistration = FixtureStudents.map((student) => {
+      return _.merge(student, {registration_date: '2018-02-13T22:17:30.338Z'})
+    })
+
+    helpers.renderInto(el, {
+      students: studentsWithRegistration,
+      allStudents: studentsWithRegistration
+    });
 
     expect($(el).find('.SlicePanels').length).toEqual(1);
     expect($(el).find('.column').length).toEqual(6);
@@ -79,7 +104,7 @@ SpecSugar.withTestEl('high-level integration tests', (container) => {
     expect($(el).find('.column').length).toEqual(6);
     expect(helpers.columnTitlesMatrix(el)).toEqual([
       [ 'Disability', 'Low Income', 'LEP', 'Race', 'Hispanic/Latino', 'Gender' ],
-      [ 'Grade', 'House', 'Counselor', 'Years enrolled', 'Risk level' ],
+      [ 'Grade', 'House', 'Counselor', 'Risk level' ],
       [ 'STAR Reading', 'MCAS ELA Score', 'MCAS ELA SGP' ],
       [ 'STAR Math', 'MCAS Math Score', 'MCAS Math SGP' ],
       [ 'Discipline incidents', 'Absences', 'Tardies' ],


### PR DESCRIPTION
# Who is this PR for?

New Bedford Public Schools users of the School Overview page.

# What problem does this PR fix?

Right now they see all students as having "Years Enrolled" equal 48, because we don't have any registration data for New Bedford in our Insights instance yet. 

# What does this PR do?

Removes the "Years Enrolled" slice panel if we don't have any registration data. There are many slice panels, and showing one more or one fewer doesn't have a huge effect on the functionality of the page, especially "Years Enrolled" which shows a similar kind of data to "Grade." My theory here is that it's better to show a user one less data category than show an obvious data issue.  