### PR TITLE
Live dashboard link for principals

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,7 @@
               &nbsp; &nbsp; &nbsp;
             <% end %>
             <% if current_educator.admin? %>
-              <%= link_to 'School Administrator Dashboard', school_administrator_dashboard_school_path(current_educator.school) %>
+              <%= link_to 'Administrator Dashboard', school_administrator_dashboard_school_path(current_educator.school) %>
               &nbsp; &nbsp; &nbsp;
             <% end %>
             <p class="search-label">Search for student:</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,10 @@
               <%= link_to 'School Overview', school_path(current_educator.school) %>
               &nbsp; &nbsp; &nbsp;
             <% end %>
+            <% if current_educator.admin? %>
+              <%= link_to 'School Administrator Dashboard', school_administrator_dashboard_school_path(current_educator.school) %>
+              &nbsp; &nbsp; &nbsp;
+            <% end %>
             <p class="search-label">Search for student:</p>
             <input class="student-searchbar" />
             &nbsp; &nbsp; &nbsp;


### PR DESCRIPTION
# Who is this PR for?
Principals and Assistant Principals

# What problem does this PR fix?
If a principal wants to see the dashboard for their school, they have to manually type the URL

# What does this PR do?
Adds a link to their School Overview which takes them to their dashboard

# Screenshot (if adding a client-side feature)
![screen shot 2018-02-28 at 8 39 37 am](https://user-images.githubusercontent.com/638809/36790496-fd77048c-1c62-11e8-8900-02e221d20749.png)


# Checklists

## Javascript QA

+ [x] Author checked latest in IE - Dashboard link with principal (school admin)
+ [x] Author checked latest in IE - Dashboard link with non-admin with schoolwide access
+ [ ] Reviewer checked latest in IE - Dashboard link with principal (school admin)
+ [ ] Reviewer checked latest in IE - Dashboard link with non-admin with schoolwide access
