### PR TITLE
WIP – Make overlapping services invalid

### DIFF
--- a/app/assets/javascripts/service_uploads/NewServiceUpload.js
+++ b/app/assets/javascripts/service_uploads/NewServiceUpload.js
@@ -261,13 +261,9 @@ class NewServiceUpload extends React.Component {
           <br />
           <br />
           <ul>
-            {this.props.incorrectLasids.map(function(lasid) {
-              return (
-                <li>
-                  {lasid}
-                </li>
-              );
-            }.bind(this))}
+            {this.props.incorrectLasids.map((lasid, index) => {
+              return (<li key={index}>{lasid}</li>);
+            })}
           </ul>
         </div>
       );

--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -30,9 +30,11 @@ class ServiceUploadsController < ApplicationController
       services: services
     )
 
-    render_successful_upload_json(service_upload) and return if service_upload.valid?
-
-    render_failed_upload_json(service_upload) and return if service_upload.invalid?
+    if service_upload.valid?
+      service_upload.save! && render_successful_upload_json(service_upload)
+    else
+      render_failed_upload_json(service_upload)
+    end
   end
 
   def index

--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -12,7 +12,7 @@ class ServiceUploadsController < ApplicationController
   def create
     service_type_id = ServiceType.find_by_name(params['service_type_name']).id
 
-    services_to_save = params['student_lasids'].map do |student_lasid|
+    services = params['student_lasids'].map do |student_lasid|
       Service.new(
         student: Student.find_by_local_id(student_lasid),
         recorded_by_educator: current_educator,
@@ -27,7 +27,7 @@ class ServiceUploadsController < ApplicationController
     service_upload = ServiceUpload.new(
       file_name: params['file_name'],
       uploaded_by_educator_id: current_educator.id,
-      services: services_to_save
+      services: services
     )
 
     render_successful_upload_json(service_upload) and return if service_upload.valid?

--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -1,4 +1,5 @@
 class ServiceUploadsController < ApplicationController
+  include ApplicationHelper
   # Authentication by default inherited from ApplicationController.
 
   before_action :authorize_for_districtwide_access_admin # Extra authentication layer
@@ -82,30 +83,14 @@ class ServiceUploadsController < ApplicationController
       )}
     end
 
-    def errors_to_string(errors)
-      errors.messages.to_a.each { |pair| "#{pair[0]}: #{pair[1]}" }.join(' ')
-    end
-
-    def service_to_pretty_error_string(service)
-      return unless service.errors.present?
-
-      student = service.student
-
-      return errors_to_string(service.errors) if student.nil?
-
-      "#{student.first_name} #{student.last_name}: #{errors_to_string(service.errors)}"
-    end
-
     def render_failed_upload_json(service_upload)
       service_errors = service_upload.services.map do |service|
-        service_to_pretty_error_string(service)
+        service.to_pretty_error_string
       end.compact
 
-      upload_errors = "Upload: #{errors_to_string(service_upload.errors)}"
+      upload_errors = ["Upload: #{error_messages_to_string(service_upload.errors)}"]
 
-      errors = service_errors.present? ? service_errors : [upload_errors]
-
-      render json: { errors: errors }
+      render json: { errors: service_errors.present? ? service_errors : upload_errors }
     end
 
     def past_service_upload_json

--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -36,8 +36,10 @@ class ServiceUploadsController < ApplicationController
 
     invalid_services = services_to_save.any? { |service| service.invalid? }
 
-    service_errors = services_to_save.map do |service_to_save|
-      service_to_save.errors.messages
+    service_errors = services_to_save.map do |service|
+      messages = service.errors.messages
+      student = service.student
+      "#{student.first_name} #{student.last_name}: #{messages.values.join(', ')}"
     end.compact
 
     render_errors_as_json(service_errors) and return if invalid_services

--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -89,7 +89,7 @@ class ServiceUploadsController < ApplicationController
         "#{student.first_name} #{student.last_name}: #{messages.values.join(', ')}"
       end.compact
 
-      upload_errors = "Upload: #{service_upload.errors.messages.values.join(', ')}\n"
+      upload_errors = "Upload: #{service_upload.errors.messages.values.join(', ')}"
 
       errors = [upload_errors].concat(service_errors).compact
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,10 @@ module ApplicationHelper
     date.strftime("%m/%d/%Y")
   end
 
+  def error_messages_to_string(errors)
+    errors.messages.to_a.each { |pair| "#{pair[0]}: #{pair[1]}" }.join(' ')
+  end
+
   def todays_date
     Time.now.in_time_zone('Eastern Time (US & Canada)').to_date
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -4,7 +4,7 @@ class Service < ActiveRecord::Base
   belongs_to :service_type
   belongs_to :service_upload, optional: true # For bulk-uploaded services only
 
-  validates_presence_of :recorded_by_educator_id, :student_id, :service_type_id,
+  validates_presence_of :recorded_by_educator_id, :student, :service_type_id,
     :recorded_at, :date_started
   validate :must_be_discontinued_after_service_start_date
   validate :no_overlap
@@ -18,6 +18,8 @@ class Service < ActiveRecord::Base
   end
 
   def no_overlap
+    errors.add(:student) && return if student.nil?
+
     same_service_type = student.services.where(service_type_id: service_type_id)
 
     if same_service_type.detect { |service| service.active? }

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -35,6 +35,14 @@ class Service < ActiveRecord::Base
     end
   end
 
+  def to_pretty_error_string
+    return unless errors.present?
+
+    return error_messages_to_string(errors) if student.nil?
+
+    return "#{student.first_name} #{student.last_name}: #{error_messages_to_string(errors)}"
+  end
+
   def self.active
     future_discontinue + never_discontinued
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -18,7 +18,7 @@ class Service < ActiveRecord::Base
   end
 
   def no_overlap
-    errors.add(:student) && return if student.nil?
+    errors.add(:student, "does not exist") && return if student.nil?
 
     same_service_type = student.services.where(service_type_id: service_type_id)
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -18,7 +18,7 @@ class Service < ActiveRecord::Base
   end
 
   def no_overlap
-    errors.add(:student, "does not exist") && return if student.nil?
+    return if student.nil?
 
     same_service_type = student.services.where(service_type_id: service_type_id)
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -21,7 +21,7 @@ class Service < ActiveRecord::Base
     same_service_type = student.services.where(service_type_id: service_type_id)
 
     if same_service_type.detect { |service| service.active? }
-      errors.add(:student, "already has an active service")
+      errors.add(:student_id, "already has an active service")
     end
   end
 

--- a/spec/controllers/service_uploads_controller_spec.rb
+++ b/spec/controllers/service_uploads_controller_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe ServiceUploadsController, type: :controller do
 
       it 'returns the correct JSON' do
         make_post_request(params)
-        expect(response_json['errors']).to eq(["student can't be blank does not exist"])
+        expect(response_json['errors']).to eq(["student can't be blank"])
       end
     end
 

--- a/spec/controllers/service_uploads_controller_spec.rb
+++ b/spec/controllers/service_uploads_controller_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe ServiceUploadsController, type: :controller do
 
       it 'returns the correct JSON' do
         make_post_request(params)
-        expect(response_json['errors']).to eq(["student can't be blank is invalid"])
+        expect(response_json['errors']).to eq(["student can't be blank does not exist"])
       end
     end
 

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -345,6 +345,7 @@ describe StudentsController, :type => :controller do
           expect(response_body).to eq({
             "errors" => [
               "Student can't be blank",
+              "Student does not exist",
               "Service type can't be blank",
               "Date started can't be blank"
             ]

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -345,7 +345,6 @@ describe StudentsController, :type => :controller do
           expect(response_body).to eq({
             "errors" => [
               "Student can't be blank",
-              "Student does not exist",
               "Service type can't be blank",
               "Date started can't be blank"
             ]

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -303,9 +303,9 @@ describe StudentsController, :type => :controller do
         end
 
         it 'responds with JSON' do
-          make_post_request(student, post_params)
+          make_post_request(student, post_params.merge({service_type_id: 504}))
           expect(response.status).to eq 200
-          make_post_request(student, post_params)
+          make_post_request(student, post_params.merge({service_type_id: 505}))
           expect(response.headers["Content-Type"]).to eq 'application/json; charset=utf-8'
           expect(JSON.parse(response.body).keys).to contain_exactly(
             'id',


### PR DESCRIPTION
# Who is this PR for?

Educators who record services in Insights.

# What problem does this PR fix?

Right now it's possible for two educators to create two services of the same type for the same student at the same time. This situation can lead to duplicate, confusing Student Profile data. I've verified there at 10 duplicates in the Somerville Insights database already. Goal of shipping this is to make sure that number shrinks over time and doesn't grow!

# What does this PR do?

+ Adds Rails validation logic so that adding an overlapping active service is invalid.
+ Refactor the service upload controller to surface Rails error messages for the end user.
  + This makes error message display more useful (show more specific data about the error) and more flexible (handle a wider range of errors).

# GIF (service upload: overlapping service)

TK

# GIF (service upload: happy path)

TK

# GIF (service upload: invalid LASIDs)

TK

# GIF (service upload: educator tries recording overlapping service in Student Profile)

TK