### PR TITLE
Use more general variable names for LDAP config

### DIFF
--- a/config/ldap.yml
+++ b/config/ldap.yml
@@ -22,9 +22,9 @@ authorizations: &AUTHORIZATIONS
 ## Environment
 
 production:
-  host: <%= ENV['SOMERVILLE_LDAP_HOST'] %>
-  port: <%= ENV['SOMERVILLE_LDAP_PORT'] %>
+  host: <%= ENV['DISTRICT_LDAP_HOST'] %>
+  port: <%= ENV['DISTRICT_LDAP_PORT'] %>
   attribute: mail
-  base: <%= ENV['SOMERVILLE_LDAP_BASE'] %>
+  base: <%= ENV['DISTRICT_LDAP_BASE'] %>
   ssl: true
   <<: *AUTHORIZATIONS


### PR DESCRIPTION
# Notes 

+ Right now the LDAP-related ENV config keys are hardcoded with a "SOMERVILLE_" prefix, doesn't make much sense for us to use when setting up New Bedford's LDAP integration
