### PR TITLE
Add "has_many" relation between educators and event notes

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -14,6 +14,7 @@ class Educator < ActiveRecord::Base
   has_many    :sections, through: :educator_section_assignments
   has_many    :section_students, source: :students, through: :sections
   has_many    :interventions
+  has_many    :event_notes
 
   validates :email, presence: true, uniqueness: true
 


### PR DESCRIPTION
# Notes

In the schema, the `event_notes` table has an `educator_id` column and a foreign key relationship:

```
add_foreign_key "event_notes", "educators", name: "event_notes_educator_id_fk"
```

But the relationship is missing from our Educator class model.

Discovered this while writing up some queries on the relationship between educators and event notes to inform the UI @gabivoicu is building in #1443.