### PR TITLE
Send :enrollment_status down to homeroom view

### DIFF
--- a/app/helpers/students_query_helper.rb
+++ b/app/helpers/students_query_helper.rb
@@ -2,7 +2,6 @@ require 'digest'
 
 module StudentsQueryHelper
   INCLUDE_FOR_STUDENTS = Student.column_names.map(&:to_sym) - [
-    :enrollment_status,
     :primary_phone,
     :primary_email,
     :student_address


### PR DESCRIPTION
# Who is this PR for?

Educators.

# What problem does this PR fix?

Broken homeroom page described by @kevinrobinson in #1479.

# What does this PR do?

Sends `:enrollment_status` down to Homeroom roster view.