### PR TITLE
Revise the layout for taking notes in small-width projectors

### DIFF
--- a/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
+++ b/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
@@ -77,7 +77,7 @@ class RestrictedNotesPageContainer extends React.Component {
   render() {
     return (
       <div className="RestrictedNotesPageContainer">
-        <div className="RestrictedNotesDetails" style={{display: 'flex'}}>
+        <div className="RestrictedNotesDetails" style={{display: 'flex', width: '50%', padding: 10}}>
           <NotesDetails
             {...merge(_.pick(this.state,
               'currentEducator',

--- a/app/assets/javascripts/student_profile/NotesDetails.js
+++ b/app/assets/javascripts/student_profile/NotesDetails.js
@@ -55,7 +55,7 @@ class NotesDetails extends React.Component {
       <div className="NotesDetails" style={styles.notesContainer}>
         <div style={{borderBottom: '1px solid #333', padding: 10}}>
           <h4 style={{display: 'inline', color: 'black'}}>
-            {title} for {student.first_name} {student.last_name}
+            {title} for {student.first_name}
           </h4>
           <HelpBubble
             title={this.props.helpTitle}
@@ -107,7 +107,7 @@ class NotesDetails extends React.Component {
           className="btn btn-warning"
           style={styles.restrictedNotesButton}
           href={'/students/' + this.props.student.id + '/restricted_notes'}>
-          {'Restricted Notes (' + this.props.student.restricted_notes_count + ')'}
+          {'Restricted (' + this.props.student.restricted_notes_count + ')'}
         </a>
       );
     } else {

--- a/app/assets/javascripts/student_profile/take_notes.jsx
+++ b/app/assets/javascripts/student_profile/take_notes.jsx
@@ -157,12 +157,10 @@ export default React.createClass({
           <div style={{ flex: 1 }}>
             {this.renderNoteButton(300)}
             {this.renderNoteButton(301)}
-          </div>
-          <div style={{ flex: 1 }}>
             {this.renderNoteButton(305)}
-            {this.renderNoteButton(306)}
           </div>
           <div style={{ flex: 1 }}>
+            {this.renderNoteButton(306)}
             {this.renderNoteButton(302)}
             {this.renderNoteButton(304)}
           </div>

--- a/spec/javascripts/student_profile/NotesDetails.test.js
+++ b/spec/javascripts/student_profile/NotesDetails.test.js
@@ -44,7 +44,7 @@ describe('NotesDetails', function() {
           student: { restricted_notes_count: 0 },
         });
 
-        expect(el.innerHTML).toContain('Restricted Notes (0)');
+        expect(el.innerHTML).toContain('Restricted (0)');
       });
 
       it('renders restricted notes button with 7 notes', function() {
@@ -54,7 +54,7 @@ describe('NotesDetails', function() {
           student: { restricted_notes_count: 7 },
         });
 
-        expect(el.innerHTML).toContain('Restricted Notes (7)');
+        expect(el.innerHTML).toContain('Restricted (7)');
       });
     });
 
@@ -66,7 +66,7 @@ describe('NotesDetails', function() {
           student: { restricted_notes_count: 0 },
         });
 
-        expect(el.innerHTML).not.toContain('Restricted Notes (0)');
+        expect(el.innerHTML).not.toContain('Restricted (0)');
       });
     });
   });


### PR DESCRIPTION
# Who is this PR for?
educators in MTSS/SST meetings with projectors, came up with CG@WH today

# What problem does this PR fix?
Layout doesn't look right in 1024px width on projectors in IE

# What does this PR do?
Fixes that!  Changes layout in restricted notes page to match, just so we have less UI complexity.

# Screenshot (if adding a client-side feature)
Before, restricted notes doesn't fit, buttons overlap and overflow:
<img width="988" alt="screen shot 2018-03-01 at 2 37 05 pm" src="https://user-images.githubusercontent.com/1056957/36866070-4b4cd0e0-1d5f-11e8-9f58-583a0075a963.png">

After, with copy change on red button and remove student last name, change button rows:
<img width="493" alt="screen shot 2018-03-01 at 2 44 18 pm" src="https://user-images.githubusercontent.com/1056957/36866105-5d85d522-1d5f-11e8-8d53-97c13bf2f44f.png">

Restricted notes before:
<img width="1044" alt="screen shot 2018-03-01 at 2 48 12 pm" src="https://user-images.githubusercontent.com/1056957/36866219-b4c22a2a-1d5f-11e8-9f61-50e50a33e71c.png">

Restricted notes after:
<img width="777" alt="screen shot 2018-03-01 at 2 48 01 pm" src="https://user-images.githubusercontent.com/1056957/36866225-b999ed6c-1d5f-11e8-8066-ea9dc0d34aea.png">



# Checklists
## Javascript QA
+ [x] Author checked latest in IE - Student Profile
+ [x] Author checked latest in IE - Restricted notes
