### PR TITLE
Factor out IncidentCard from AttendanceDetails as a component

### DIFF
--- a/app/assets/javascripts/components/IncidentCard.js
+++ b/app/assets/javascripts/components/IncidentCard.js
@@ -50,6 +50,14 @@ class IncidentCard extends React.Component {
     );
   }
 }
+IncidentCard.propTypes = {
+  incident: React.PropTypes.shape({
+    id: React.PropTypes.number.isRequired,
+    incident_code: React.PropTypes.string.isRequired,
+    incident_location: React.PropTypes.string.isRequired,
+    incident_description: React.PropTypes.string.isRequired
+  })
+};
 
 const styles = {
   box: {

--- a/app/assets/javascripts/components/IncidentCard.js
+++ b/app/assets/javascripts/components/IncidentCard.js
@@ -1,0 +1,86 @@
+import React from 'react';
+
+
+/*
+Shows a "card" of an incident that happened with a student.
+Note that this might contain sensitive data.
+*/
+class IncidentCard extends React.Component {
+  render() {
+    const {incident} = this.props;
+    return (
+      <div style={{paddingTop: 60}}>
+        <div style={styles.box} key={incident.id}>
+          <div style={styles.header}>
+            <div style={styles.item}>
+              <span style={styles.itemHead}>
+                {'Date: '}
+              </span>
+              <span>
+                {moment.utc(incident.occurred_at).format('MMM D, YYYY')}
+              </span>
+            </div>
+            <div style={styles.centerItem}>
+              <span style={styles.itemHead}>
+                {'Code: '}
+              </span>
+              <span>
+                {incident.incident_code}
+              </span>
+            </div>
+            <div style={styles.item}>
+              <span style={styles.itemHead}>
+                {'Location: '}
+              </span>
+              <span>
+                {incident.incident_location}
+              </span>
+            </div>
+          </div>
+          <div>
+            <span style={styles.desc}>
+              {'Description: '}
+            </span>
+          </div>
+          <div>
+            {incident.incident_description}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+const styles = {
+  box: {
+    border: '1px solid #ccc',
+    padding:15,
+    marginTop: 10,
+    marginBottom: 10,
+    width: '100%',
+    backgroundColor: '#f2f2f2'
+  },
+  item: {
+    paddingBottom: 10,
+    width: 160
+  },
+  itemHead: {
+    fontWeight: 'bold',
+  },
+  header: {
+    display: 'flex',
+    flexFlow: 'row',
+    justifyContent: 'space-between'
+  },
+  desc: {
+    fontWeight: 'bold',
+    paddingTop: 30
+  },
+  centerItem: {
+    paddingBottom: 10,
+    textAlign: 'center',
+    width: 75
+  }
+};
+
+export default IncidentCard;

--- a/app/assets/javascripts/student_profile/AttendanceDetails.js
+++ b/app/assets/javascripts/student_profile/AttendanceDetails.js
@@ -140,7 +140,7 @@ class AttendanceDetails extends React.Component {
     return (
       <div style={{paddingTop: 60}}>
         {this.props.disciplineIncidents.map(incident => {
-          return <IncidentCard incident={incident} />;
+          return <IncidentCard key={incident.id} incident={incident} />;
         })}
       </div>
     );

--- a/app/assets/javascripts/student_profile/AttendanceDetails.js
+++ b/app/assets/javascripts/student_profile/AttendanceDetails.js
@@ -1,31 +1,8 @@
-import ProfileBarChart from './ProfileBarChart.js';
+import ProfileBarChart from './ProfileBarChart';
+import IncidentCard from '../components/IncidentCard';
 import PropTypes from '../helpers/prop_types.jsx';
 
 const styles = {
-  box: {
-    border: '1px solid #ccc',
-    padding:15,
-    marginTop: 10,
-    marginBottom: 10,
-    width: '100%',
-    backgroundColor: '#f2f2f2'
-  },
-  item: {
-    paddingBottom: 10,
-    width: 160
-  },
-  itemHead: {
-    fontWeight: 'bold',
-  },
-  header: {
-    display: 'flex',
-    flexFlow: 'row',
-    justifyContent: 'space-between'
-  },
-  desc: {
-    fontWeight: 'bold',
-    paddingTop: 30
-  },
   title: {
     color: 'black',
     paddingBottom: 20,
@@ -39,11 +16,6 @@ const styles = {
     border: '1px solid #ccc',
     padding: '30px 30px 30px 30px',
     position: 'relative'
-  },
-  centerItem: {
-    paddingBottom: 10,
-    textAlign: 'center',
-    width: 75
   },
   secHead: {
     display: 'flex',
@@ -59,6 +31,7 @@ const styles = {
     verticalAlign: 'text-top'
   }
 };
+
 
 class AttendanceDetails extends React.Component {
 
@@ -166,46 +139,8 @@ class AttendanceDetails extends React.Component {
   renderIncidents() {
     return (
       <div style={{paddingTop: 60}}>
-        {this.props.disciplineIncidents.map(function(incident) {
-          return (
-            <div style={styles.box} key={incident.id}>
-              <div style={styles.header}>
-                <div style={styles.item}>
-                  <span style={styles.itemHead}>
-                    {'Date: '}
-                  </span>
-                  <span>
-                    {moment.utc(incident.occurred_at).format('MMM D, YYYY')}
-                  </span>
-                </div>
-                <div style={styles.centerItem}>
-                  <span style={styles.itemHead}>
-                    {'Code: '}
-                  </span>
-                  <span>
-                    {incident.incident_code}
-                  </span>
-                </div>
-                <div style={styles.item}>
-                  <span style={styles.itemHead}>
-                    {'Location: '}
-                  </span>
-                  <span>
-                    {incident.incident_location}
-                  </span>
-                </div>
-              </div>
-              <div>
-                <span style={styles.desc}>
-                  {'Description: '}
-                </span>
-              </div>
-              <div>
-                {incident.incident_description}
-              </div>
-            </div>
-          );
-
+        {this.props.disciplineIncidents.map(incident => {
+          return <IncidentCard incident={incident} />;
         })}
       </div>
     );

--- a/spec/javascripts/components/IncidentCard.test.js
+++ b/spec/javascripts/components/IncidentCard.test.js
@@ -1,0 +1,9 @@
+import ReactDOM from 'react-dom';
+import IncidentCard from '../../../app/assets/javascripts/components/IncidentCard';
+import incidentFixture from '../fixtures/incident';
+
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<IncidentCard incident={incidentFixture} />, div);
+});

--- a/spec/javascripts/fixtures/incident.js
+++ b/spec/javascripts/fixtures/incident.js
@@ -1,0 +1,1 @@
+export default {"id":36,"incident_code":"C","created_at":"2018-03-01T21:31:56.677Z","updated_at":"2018-03-01T21:31:56.677Z","incident_location":"Lunchroom","incident_description":"Lacus posuere non, nec a. Maecenas egestas class. Diam augue, vel nam.","occurred_at":"2014-01-18T06:26:34.277Z","has_exact_time":null,"student_id":61};


### PR DESCRIPTION
# Who is this PR for?
developers and designers

# What problem does this PR fix?
This is moving towards a home page with a feed of what's happening for students, building on https://github.com/studentinsights/studentinsights/pull/1486.  One piece of information that isn't included now is discipline incidents, which are some of the highest impact events for students.  We have a feed-style UI for this now buried at the bottom of the attendance and behavior tab in the student profile, so this factors it out so we can elevate this kind of "card" as a first-class component.  I'm assuming we'll soon change the layout and visual presentation, but that this element will be useful to have as a design element.

# What does this PR do?
Straight refactor.

# Screenshot (if adding a client-side feature)
<img width="1364" alt="screen shot 2018-03-01 at 4 32 04 pm" src="https://user-images.githubusercontent.com/1056957/36871144-3a480d90-1d6f-11e8-949a-6b554129c1f0.png">

# Checklists
+ [x] Author checked latest in IE - Student Profile
+ [x] Author included specs for new code