### PR TITLE
 Add last SST to absences dashboard

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
@@ -40,6 +40,8 @@ class StudentsTable extends React.Component {
       return rows.sort((a, b) => SortHelpers.sortByString(a, b, sortBy));
     case 'number':
       return rows.sort((a, b) => SortHelpers.sortByNumber(a, b, sortBy));
+    case 'date':
+      return rows.sort((a, b) => SortHelpers.sortByDate(a, b, sortBy));
     default:
       return rows;
     }
@@ -76,30 +78,35 @@ class StudentsTable extends React.Component {
           <caption>{this.renderCaption()}</caption>
           <thead>
             <tr>
-              <th width="66.66%"
+              <th
                   onClick={this.onClickHeader.bind(null, 'last_name', 'string')}
                   className={this.headerClassName('last_name')}>Name</th>
-              <th width="33.33"
+              <th
                   onClick={this.onClickHeader.bind(null, 'events', 'number')}
                   className={this.headerClassName('events')}>Incidents</th>
+              <th
+                  onClick={this.onClickHeader.bind(null, 'last_sst_date_text', 'date')}
+                  className={this.headerClassName('last_sst_date_text')}>Last SST</th>
             </tr>
           </thead>
           <tfoot>
             <tr>
-              <td width="66.66%">{'Total: '}</td>
-              <td width="33.33%">{this.totalEvents()}</td>
+              <td>{'Total: '}</td>
+              <td>{this.totalEvents()}</td>
+              <td></td>
             </tr>
           </tfoot>
           <tbody>
             {this.orderedRows().map(student => {
               return (
                 <tr key={student.id}>
-                  <td width="66.66%">
+                  <td>
                     <a href={Routes.studentProfile(student.id)}>
-                      {student.last_name}, {student.first_name}
+                      {student.first_name} {student.last_name}
                     </a>
                   </td>
-                  <td width="33.33%">{student.events}</td>
+                  <td>{student.events}</td>
+                  <td>{student.last_sst_date_text}</td>
                 </tr>
               );
             })}

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
@@ -6,6 +6,7 @@ import DashboardHelpers from '../DashboardHelpers';
 import StudentsTable from '../StudentsTable';
 import DashboardBarChart from '../DashboardBarChart';
 import DateSlider from '../DateSlider';
+import {latestNoteDateText} from '../../../helpers/latestNoteDateText';
 
 
 class SchoolAbsenceDashboard extends React.Component {
@@ -137,6 +138,7 @@ class SchoolAbsenceDashboard extends React.Component {
         id: student.id,
         first_name: student.first_name,
         last_name: student.last_name,
+        last_sst_date_text: latestNoteDateText(300, student.event_notes),
         events: studentAbsenceCounts[student.id] || 0
       });
     });

--- a/app/assets/stylesheets/components/school_dashboard.scss
+++ b/app/assets/stylesheets/components/school_dashboard.scss
@@ -48,9 +48,7 @@
 table.students-list {
   margin: auto;
   border: 1px solid #ccc;
-  width: 80%;
-
-  thead, tbody, tr, td, th { box-sizing: border-box; display: block; }
+  width: 100%;
 
   thead th, tfoot td {
     height: 30px;
@@ -64,7 +62,6 @@ table.students-list {
   }
 
   tbody td, thead th, tfoot td {
-    float: left;
   }
 
   tbody {

--- a/app/assets/stylesheets/components/school_dashboard.scss
+++ b/app/assets/stylesheets/components/school_dashboard.scss
@@ -41,8 +41,6 @@
 
 .StudentsList {
   margin-top: 200px;
-  height: 450px;
-  overflow:hidden;
 }
 
 table.students-list {
@@ -65,9 +63,6 @@ table.students-list {
   }
 
   tbody {
-    height: 335px;
-    overflow-y: auto;
-    overflow-x: hidden;
     border-top: 1px solid #ccc;
     border-bottom: 1px solid #ccc;
   }

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -32,7 +32,7 @@ class SchoolsController < ApplicationController
       redirect_to not_authorized_path and return #TodDo: determine whether there's a more appropriate action here
     end
 
-    dashboard_students = students_for_dashboard(@school).includes(:homeroom, :dashboard_absences, :dashboard_tardies)
+    dashboard_students = students_for_dashboard(@school).includes(:homeroom, :dashboard_absences, :event_notes, :dashboard_tardies)
                                                         .map { |student| individual_student_dashboard_data(student) }
 
     @serialized_data = {students: dashboard_students.to_json}
@@ -133,9 +133,9 @@ class SchoolsController < ApplicationController
       id: student.id,
       homeroom: student.try(:homeroom).try(:name),
       absences: student.dashboard_absences,
-      tardies: student.dashboard_tardies
-      }
-    )
+      tardies: student.dashboard_tardies,
+      event_notes: student.event_notes
+    })
   end
 
   def students_for_dashboard(school)

--- a/spec/javascripts/school_administrator_dashboard/DashboardTestData.js
+++ b/spec/javascripts/school_administrator_dashboard/DashboardTestData.js
@@ -38,7 +38,8 @@ export const Students = [
     id: 1,
     absences: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo, testEvents.threeMonthsAgo],
     tardies: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo, testEvents.threeMonthsAgo],
-    events: 3
+    events: 3,
+    last_sst_date_text: moment.utc(testEvents.threeMonthsAgo.occurred_at).format('M/D/YY')
   },
   {
     first_name: 'Pierrette',

--- a/spec/javascripts/school_administrator_dashboard/StudentsTable.test.js
+++ b/spec/javascripts/school_administrator_dashboard/StudentsTable.test.js
@@ -11,6 +11,20 @@ describe('Dashboard Students Table', () => {
     expect(table.find("div").hasClass("StudentsList")).toEqual(true);
   });
 
+  it('renders headers for name, incident count and last SST', () => {
+    const headerTexts = table.find('thead th').map(node => node.text());
+    expect(headerTexts).toEqual(['Name', 'Incidents', 'Last SST']);
+  });
+
+  it('renders the first row', () => {
+    const cellTexts = table.find('tbody tr').first().find('td').map(node => node.text());
+    expect(cellTexts).toEqual([
+      "Pierrot Zanni",
+      "3",
+      moment.utc().subtract(3, 'months').format('M/D/YY'),
+    ]);
+  });
+
   it('tallies the total events', () => {
     expect(table.instance().totalEvents()).toEqual(12);
   });
@@ -22,18 +36,23 @@ describe('Dashboard Students Table', () => {
   it('orders students by name when Name is clicked', () => {
     table.find('.sort-header').first().simulate('click');
     expect(table.state().sortBy).toEqual("last_name");
-    expect(table.find('tbody').find('tr').first().find('td').first().text()).toEqual('Avecchi, Scaramuccia');
+    expect(table.find('tbody').find('tr').first().find('td').first().text()).toEqual('Scaramuccia Avecchi');
   });
 
   it('reorders in reverse alphabetical order', () => {
     table.find('.sort-header').first().simulate('click');
     expect(table.state().sortBy).toEqual("last_name");
-    expect(table.find('tbody').find('tr').first().find('td').first().text()).toEqual('ZZanni, Arlecchino');
+    expect(table.find('tbody').find('tr').first().find('td').first().text()).toEqual('Arlecchino ZZanni');
   });
 
   it('orders students by events when Incidents is clicked', () => {
-    table.find('.sort-header').last().simulate('click');
-    table.find('.sort-header').last().simulate('click');
+    table.find('.sort-header').at(1).simulate('click');
     expect(table.state().sortBy).toEqual("events");
   });
+
+  it('orders students by events when Incidents is clicked', () => {
+    table.find('.sort-header').at(2).simulate('click');
+    expect(table.state().sortBy).toEqual("last_sst_date_text");
+  });
+
 });


### PR DESCRIPTION
# Who is this PR for?
SST facilitators and school leaders

# What problem does this PR fix?
The prototype absences dashboard shows kids with absences, but folks have to "join" that manually in their head with who isn't already in SST in order to take action.  This does that work for them.

# What does this PR do?
Adds a "Last SST" column to the table in the prototype absences dashboard.  It also simplifies some styling on the table.

# Screenshot (if adding a client-side feature)
<img width="761" alt="screen shot 2018-03-02 at 7 56 02 am" src="https://user-images.githubusercontent.com/1056957/36900508-8e4ddb54-1df1-11e8-81d8-88c0e4ed3020.png">

# Checklists
+ [x] Author checked latest in IE - Absences Dashboard
+ [x] Author included specs for new code