### PR TITLE
Guard against missing educator name in Research Matters exporter

### DIFF
--- a/app/reports/research_matters_exporter.rb
+++ b/app/reports/research_matters_exporter.rb
@@ -77,8 +77,8 @@ class ResearchMattersExporter
   def teacher_rows
     @educators.map do |educator|
       full_name = educator.full_name
-      last_name = full_name.split(", ")[0]
-      first_name = full_name.split(", ")[1]
+      last_name = full_name.present? ? full_name.split(", ")[0] : nil
+      first_name = full_name.present? ? full_name.split(", ")[1] : nil
 
       [
         educator.id,

--- a/spec/reports/research_matters_exporter_spec.rb
+++ b/spec/reports/research_matters_exporter_spec.rb
@@ -81,13 +81,30 @@ RSpec.describe ResearchMattersExporter do
   end
 
   describe '#teacher_file' do
-    it 'outputs the right file' do
-      exporter = ResearchMattersExporter.new
+    context 'teacher name present' do
+      it 'outputs the right file' do
+        exporter = ResearchMattersExporter.new
 
-      expect(exporter.teacher_file).to eq([
-        "educator_id,email,first_name,last_name,school_id",
-        "#{educator.id},matsay@demo.studentinsights.org,Matsay,Khamar,HEA"
-      ])
+        expect(exporter.teacher_file).to eq([
+          "educator_id,email,first_name,last_name,school_id",
+          "#{educator.id},matsay@demo.studentinsights.org,Matsay,Khamar,HEA"
+        ])
+      end
+    end
+
+    context 'teacher name missing' do
+      let!(:another_educator) {
+        FactoryGirl.create(:educator,
+          :admin, school: school, email: 'noname@demo.studentinsights.org')
+      }
+      it 'outputs the right file' do
+        exporter = ResearchMattersExporter.new
+
+        expect(exporter.teacher_file).to eq([
+          "educator_id,email,first_name,last_name,school_id",
+          "#{educator.id},matsay@demo.studentinsights.org,Matsay,Khamar,HEA"
+        ])
+      end
     end
   end
 end

--- a/spec/reports/research_matters_exporter_spec.rb
+++ b/spec/reports/research_matters_exporter_spec.rb
@@ -102,7 +102,8 @@ RSpec.describe ResearchMattersExporter do
 
         expect(exporter.teacher_file).to eq([
           "educator_id,email,first_name,last_name,school_id",
-          "#{educator.id},matsay@demo.studentinsights.org,Matsay,Khamar,HEA"
+          "#{educator.id},matsay@demo.studentinsights.org,Matsay,Khamar,HEA",
+          "#{another_educator.id},noname@demo.studentinsights.org,,,HEA",
         ])
       end
     end


### PR DESCRIPTION
# Who is this PR for?

Research Matter.

# What problem does this PR fix?

Test test accounts don't have full names associated with them and are assigned to a school, make the script guard against missing educator name when outputting `teacher_file`.