### PR TITLE
Add minimal test coverage

### DIFF
--- a/app/assets/javascripts/section/SectionPage.js
+++ b/app/assets/javascripts/section/SectionPage.js
@@ -62,7 +62,7 @@ class SectionPage extends React.Component {
       // Supports
       {label: 'Last SST', group: 'Supports', key: 'latestSstDateText', sortFunc: SortHelpers.sortByDate},
       {label: 'Last NGE', group: 'Supports', key: 'latestNgeDateText', sortFunc: SortHelpers.sortByDate},
-      {label: 'Last 10GE', group: 'Supports', key: 'latest10GeDateText', sortFunc: SortHelpers.sortByDate},
+      {label: 'Last 10GE', group: 'Supports', key: 'latest10geDateText', sortFunc: SortHelpers.sortByDate},
 
       {label: 'Program Assigned', key: 'program_assigned', sortFunc: this.programSorter},
       

--- a/spec/javascripts/section/SectionPage.test.js
+++ b/spec/javascripts/section/SectionPage.test.js
@@ -10,8 +10,8 @@ const helpers = {
 
 const props = {
   students: [
-    { id: 1, first_name: 'Minnie', last_name: 'Mouse', program_assigned: 'Regular Ed', disability:'', plan_504: '', limited_english_proficiency: 'FLEP', home_language: 'Spanish', free_reduced_lunch: 'Free Lunch', most_recent_school_year_absences_count: 3, most_recent_school_year_tardies_count: 5, most_recent_school_year_discipline_incidents_count: 0},
-    { id: 2, first_name: 'Donald', last_name: 'Duck', program_assigned: 'Special Ed', disability:'Motor', plan_504: '504 Plan', limited_english_proficiency: 'ELL', home_language: 'English', free_reduced_lunch: 'Reduced Lunch', most_recent_school_year_absences_count: 1, most_recent_school_year_tardies_count: 0, most_recent_school_year_discipline_incidents_count: 0},
+    { id: 1, first_name: 'Minnie', last_name: 'Mouse', program_assigned: 'Regular Ed', disability:'', plan_504: '', limited_english_proficiency: 'FLEP', home_language: 'Spanish', free_reduced_lunch: 'Free Lunch', most_recent_school_year_absences_count: 3, most_recent_school_year_tardies_count: 5, most_recent_school_year_discipline_incidents_count: 0, event_notes: []},
+    { id: 2, first_name: 'Donald', last_name: 'Duck', program_assigned: 'Special Ed', disability:'Motor', plan_504: '504 Plan', limited_english_proficiency: 'ELL', home_language: 'English', free_reduced_lunch: 'Reduced Lunch', most_recent_school_year_absences_count: 1, most_recent_school_year_tardies_count: 0, most_recent_school_year_discipline_incidents_count: 0, event_notes: []},
   ],
   educators: [
     { }
@@ -59,21 +59,39 @@ SpecSugar.withTestEl('', function(container) {
     const el = container.testEl;
     helpers.renderInto(el, props);
 
-    const headers = $(el).find('#roster-header th');
+    const headers = $(el).find('#roster-header th').toArray().map(el => $(el).text());
 
     expect(headers.length).toEqual(19);
-    expect(headers[0].innerHTML).toEqual('Name');
+    expect(headers).toEqual([
+      'Name',
+      'Last SST',
+      'Last NGE',
+      'Last 10GE',
+      'Program Assigned',
+      'Disability',
+      '504 Plan',
+      'Fluency',
+      'Home Language',
+      'Grade',
+      'Absences',
+      'Tardies',
+      'Discipline Incidents',
+      'Percentile',
+      'Percentile',
+      'Performance',
+      'Score',
+      'Performance',
+      'Score'
+    ]);
   });
 
   it('renders the correct roster data', function() {
     const el = container.testEl;
-
     helpers.renderInto(el, props);
-    const dataElements = $(el).find('#roster-data tr');
-
-    expect(dataElements.length).toEqual(2);
-
-    const firstDataRows = dataElements.eq(0).find('td');
-    expect(firstDataRows[0].innerHTML).toEqual('<a href="/students/2">Duck, Donald</a>');
+    
+    const $rowEls = $(el).find('#roster-data tr');
+    expect($rowEls.length).toEqual(2);
+    const firstRowCells = $($rowEls.get(0)).find('td').toArray().map(el => $(el).html());
+    expect(firstRowCells[0]).toEqual('<a href="/students/2">Duck, Donald</a>');
   });
 });


### PR DESCRIPTION
# Who is this PR for?
10th grade teachers, JR reported it at 10:20am

# What problem does this PR fix?
Bug in https://github.com/studentinsights/studentinsights/pull/1482/files#diff-96bf4e67678b02ec5509a39708970e95R65, 10GE data didn't show in section page.  Screenshots on PR even show that and I missed it.

# What does this PR do?
Fixes the bug, adds only a tiny bit more test coverage.

# Screenshot (if adding a client-side feature)
<img width="448" alt="screen shot 2018-03-02 at 11 24 33 am" src="https://user-images.githubusercontent.com/1056957/36909555-4dc1157c-1e0c-11e8-93b3-b9b722f2a22f.png">

## Javascript QA
+ [x] Author checked latest in IE - Section page
I didn't really improve the specs now.  Going to get this out before lunch and then look at that.