### PR TITLE
Factor out SectionHeading as visual UI component 

### DIFF
--- a/app/assets/javascripts/components/SectionHeading.js
+++ b/app/assets/javascripts/components/SectionHeading.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+
+// The heading for a primary section on a page
+class SectionHeading extends React.Component {
+  render() {
+    const {children} = this.props;
+    return (
+      <div style={{borderBottom: '1px solid #333', padding: 10}}>
+        <h4 style={{display: 'inline', color: 'black'}}>
+          {children}
+        </h4>
+      </div>
+    );
+  }
+}
+SectionHeading.propTypes = {
+  children: React.PropTypes.node.isRequired
+};
+
+export default SectionHeading;

--- a/app/assets/javascripts/student_profile/NotesDetails.js
+++ b/app/assets/javascripts/student_profile/NotesDetails.js
@@ -2,6 +2,8 @@ import TakeNotes from './take_notes.jsx';
 import PropTypes from '../helpers/prop_types.jsx';
 import React from 'react';
 import HelpBubble from './HelpBubble.js';
+import SectionHeading from '../components/SectionHeading';
+
 
 const styles = {
   notesContainer: {
@@ -53,16 +55,14 @@ class NotesDetails extends React.Component {
 
     return (
       <div className="NotesDetails" style={styles.notesContainer}>
-        <div style={{borderBottom: '1px solid #333', padding: 10}}>
-          <h4 style={{display: 'inline', color: 'black'}}>
-            {title} for {student.first_name}
-          </h4>
+        <SectionHeading>
+          <span>{title} for {student.first_name}</span>
           <HelpBubble
             title={this.props.helpTitle}
             teaserText="(what is this?)"
             content={this.props.helpContent} />
           {this.renderRestrictedNotesButtonIfAppropriate()}
-        </div>
+        </SectionHeading>
         {this.renderTakeNotesSection()}
         <NotesList
           feed={this.props.feed}

--- a/app/assets/javascripts/student_profile/services_details.jsx
+++ b/app/assets/javascripts/student_profile/services_details.jsx
@@ -1,5 +1,6 @@
 import PropTypes from '../helpers/prop_types.jsx';
 import HelpBubble from './HelpBubble.js';
+import SectionHeading from '../components/SectionHeading';
 
 (function() {
   window.shared || (window.shared = {});
@@ -58,15 +59,13 @@ import HelpBubble from './HelpBubble.js';
     render: function() {
       return (
         <div className="ServicesDetails" style={styles.servicesContainer}>
-          <div style={{borderBottom: '1px solid #333', padding: 10}}>
-            <h4 style={{display: 'inline', color: 'black'}}>
-              Services
-            </h4>
+          <SectionHeading>
+            <span>Services</span>
             <HelpBubble
               title="What is a Service?"
               teaserText="(what is this?)"
               content={this.renderServicesHelpContent()} />
-          </div>
+          </SectionHeading>
           <div style={styles.addServiceContainer}>
             {this.renderRecordServiceSection()}
           </div>

--- a/spec/javascripts/components/SectionHeading.test.js
+++ b/spec/javascripts/components/SectionHeading.test.js
@@ -1,0 +1,13 @@
+import ReactDOM from 'react-dom';
+import SpecSugar from '../support/spec_sugar.jsx';
+import SectionHeading from '../../../app/assets/javascripts/components/SectionHeading';
+
+
+SpecSugar.withTestEl('high-level integration tests', function(container) {
+  it('renders everything on the happy path', function() {
+    const el = container.testEl;
+    ReactDOM.render(<SectionHeading>foo</SectionHeading>, el);
+    expect($(el).find('h4').length).toEqual(1);
+    expect(el.innerHTML).toContain('foo');
+  });
+});


### PR DESCRIPTION
# Who is this PR for?
developers and designers

# What problem does this PR fix?
Factor out a visual style as a component that we can reuse and modify.  This came out of work on https://github.com/studentinsights/studentinsights/issues/1497 where we'll want to reuse this style.

# What does this PR do?
Straight refactor.

# Screenshot (if adding a client-side feature)

<img width="1288" alt="screen shot 2018-03-02 at 12 52 18 pm" src="https://user-images.githubusercontent.com/1056957/36913663-ac976f18-1e18-11e8-80ee-0c47a161d8da.png">

<img width="716" alt="screen shot 2018-03-02 at 12 52 47 pm" src="https://user-images.githubusercontent.com/1056957/36913822-1f9fc794-1e19-11e8-875c-826c64ded12b.png">

# Checklists

## Javascript QA
+ [x] Author checked latest in IE - Student Profile
+ [x] Author checked latest in IE - Restricted Notes
+ [x] Author included specs for new code
