### PR TITLE
fixing analytics error in dashboard

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -35,7 +35,9 @@ class SchoolsController < ApplicationController
     dashboard_students = students_for_dashboard(@school).includes(:homeroom, :dashboard_absences, :event_notes, :dashboard_tardies)
                                                         .map { |student| individual_student_dashboard_data(student) }
 
-    @serialized_data = {students: dashboard_students.to_json}
+    @serialized_data = {
+      students: dashboard_students.to_json,
+      current_educator: current_educator}
     render 'shared/serialized_data'
   end
 

--- a/spec/javascripts/school_administrator_dashboard/DashboardTestData.js
+++ b/spec/javascripts/school_administrator_dashboard/DashboardTestData.js
@@ -2,27 +2,27 @@
 //stubbed events for dashboard specs
 export const testEvents = {
   oneMonthAgo: {
-    occurred_at: moment().subtract(1, 'months').format("YYYY-MM-DD HH:mm:sss Z"),
+    occurred_at: moment().subtract(1, 'months').format(),
     student_id: 1,
   },
   twoMonthsAgo: {
-    occurred_at: moment().subtract(2, 'months').format("YYYY-MM-DD HH:mm:sss Z"),
+    occurred_at: moment().subtract(2, 'months').format(),
     student_id: 1,
   },
   threeMonthsAgo: {
-    occurred_at: moment().subtract(3, 'months').format("YYYY-MM-DD HH:mm:sss Z"),
+    occurred_at: moment().subtract(3, 'months').format(),
     student_id: 1,
   },
   fourMonthsAgo: {
-    occurred_at: moment().subtract(4, 'months').format("YYYY-MM-DD HH:mm:sss Z"),
+    occurred_at: moment().subtract(4, 'months').format(),
     student_id: 1,
   },
   oneYearAgo: {
-    occurred_at: moment().subtract(1, 'year').format("YYYY-MM-DD HH:mm:sss Z"),
+    occurred_at: moment().subtract(1, 'year').format(),
     student_id: 1,
   },
   thisMonth: {
-    occurred_at: moment().format("YYYY-MM-DD HH:mm:sss Z"),
+    occurred_at: moment().format(),
     student_id: 1
   }
 };

--- a/spec/javascripts/school_administrator_dashboard/StudentsTable.test.js
+++ b/spec/javascripts/school_administrator_dashboard/StudentsTable.test.js
@@ -21,7 +21,7 @@ describe('Dashboard Students Table', () => {
     expect(cellTexts).toEqual([
       "Pierrot Zanni",
       "3",
-      moment().subtract(3, 'months').format('M/D/YY'),
+      moment.utc().subtract(3, 'months').format('M/D/YY'),
     ]);
   });
 

--- a/spec/javascripts/school_administrator_dashboard/StudentsTable.test.js
+++ b/spec/javascripts/school_administrator_dashboard/StudentsTable.test.js
@@ -21,7 +21,7 @@ describe('Dashboard Students Table', () => {
     expect(cellTexts).toEqual([
       "Pierrot Zanni",
       "3",
-      moment.utc().subtract(3, 'months').format('M/D/YY'),
+      moment().subtract(3, 'months').format('M/D/YY'),
     ]);
   });
 


### PR DESCRIPTION
# Who is this PR for?
Anyone making use of analytics
# What problem does this PR fix?
currentEducator isn't being set in the dashboard, throwing a js error and preventing us from tracking visits cf #1500 
# What does this PR do?
sets the currentEducator

# Checklists

+ [ ] Author checked latest in IE - School Dashboard
+ [ ] Reviewer checked latest in IE - School Dashboard

