### PR TITLE
Changing homeroom name to teacher name in dashboard

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashboardHelpers.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashboardHelpers.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 export default {
 
   groupByHomeroom: function(studentRecords) {
-    const studentsByHomeroom = _.groupBy(studentRecords, 'homeroom');
+    const studentsByHomeroom = _.groupBy(studentRecords, 'homeroom_label');
     if (studentsByHomeroom[null]) {
       studentsByHomeroom["No Homeroom"] = studentsByHomeroom[null];
       delete studentsByHomeroom[null];

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -131,7 +131,7 @@ class SchoolsController < ApplicationController
       first_name: student.first_name,
       last_name: student.last_name,
       id: student.id,
-      homeroom: student.try(:homeroom).try(:educator).try(:full_name),
+      homeroom_label: student.try(:homeroom).try(:educator).try(:full_name),
       absences: student.dashboard_absences,
       tardies: student.dashboard_tardies,
       event_notes: student.event_notes

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -32,7 +32,7 @@ class SchoolsController < ApplicationController
       redirect_to not_authorized_path and return #TodDo: determine whether there's a more appropriate action here
     end
 
-    dashboard_students = students_for_dashboard(@school).includes(:homeroom, :dashboard_absences, :event_notes, :dashboard_tardies)
+    dashboard_students = students_for_dashboard(@school).includes([homeroom: :educator], :dashboard_absences, :event_notes, :dashboard_tardies)
                                                         .map { |student| individual_student_dashboard_data(student) }
 
     @serialized_data = {students: dashboard_students.to_json}
@@ -131,7 +131,7 @@ class SchoolsController < ApplicationController
       first_name: student.first_name,
       last_name: student.last_name,
       id: student.id,
-      homeroom: student.try(:homeroom).try(:name),
+      homeroom: student.try(:homeroom).try(:educator).try(:full_name),
       absences: student.dashboard_absences,
       tardies: student.dashboard_tardies,
       event_notes: student.event_notes

--- a/spec/javascripts/school_administrator_dashboard/DashboardTestData.js
+++ b/spec/javascripts/school_administrator_dashboard/DashboardTestData.js
@@ -34,7 +34,7 @@ export const Students = [
   {
     first_name: 'Pierrot',
     last_name: 'Zanni',
-    homeroom: 'Test 1',
+    homeroom_label: 'Test 1',
     id: 1,
     absences: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo, testEvents.threeMonthsAgo],
     tardies: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo, testEvents.threeMonthsAgo],
@@ -44,7 +44,7 @@ export const Students = [
   {
     first_name: 'Pierrette',
     last_name: 'Zanni',
-    homeroom: 'Test 1',
+    homeroom_label: 'Test 1',
     id: 2,
     absences: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo],
     tardies: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo],
@@ -53,7 +53,7 @@ export const Students = [
   {
     first_name: 'Arlecchino',
     last_name: 'ZZanni',
-    homeroom: 'Test 1',
+    homeroom_label: 'Test 1',
     id: 3,
     absences: [],
     tardies: [],
@@ -62,7 +62,7 @@ export const Students = [
   {
     first_name: 'Colombina',
     last_name: 'Zanni',
-    homeroom: 'Test 2',
+    homeroom_label: 'Test 2',
     id: 4,
     absences: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo, testEvents.oneYearAgo],
     tardies: [testEvents.thisMonth],
@@ -71,7 +71,7 @@ export const Students = [
   {
     first_name: 'Scaramuccia',
     last_name: 'Avecchi',
-    homeroom: 'Test 2',
+    homeroom_label: 'Test 2',
     id: 5,
     absences: [testEvents.twoMonthsAgo, testEvents.threeMonthsAgo],
     tardies: [testEvents.oneYearAgo],
@@ -81,7 +81,7 @@ export const Students = [
   {
     first_name: 'Pulcinella',
     last_name: 'Vecchi',
-    homeroom: null,
+    homeroom_label: null,
     id: 6,
     absences: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo],
     tardies: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo],


### PR DESCRIPTION
# Who is this PR for?
Principals and APs

# What problem does this PR fix?
Per MTSS meeting, it's more useful to have teacher names than Homeroom names in the dashboard

# What does this PR do?
Swaps homeroom names for teacher names in dashboard

# Screenshot (if adding a client-side feature)
![screen shot 2018-03-07 at 10 21 29 am](https://user-images.githubusercontent.com/638809/37100780-d3a4233a-21f1-11e8-8285-01b5ff7cc364.png)

# Checklists

## Javascript QA

+ [x] Author checked latest in IE - Absence Dashboard
+ [x] Author checked latest in IE - Tardies Dashboard

+ [ ] Reviewer checked latest in IE - Absence Dashboard
+ [ ] Reviewer checked latest in IE - Tardies Dashboard
