### PR TITLE
By default deploy from origin/master not local master

### DIFF
--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -5,7 +5,8 @@
 for remote in "$@"
 do
     echo "🚢  🚢  🚢  Deploying code to $remote.";
-    git push $remote master
+    git fetch origin
+    git push $remote origin/master
     echo;
     echo "⚙  ⚙  ⚙  Migrating the database for $remote.";
     heroku run rake db:migrate --remote $remote


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
merging a PR, running the deploy scripts, and then realizing nothing deployed because the scripts are running off local master not GitHub master

# What does this PR do?
Updates the deploy script to fetch and then deploy from origin/master instead of leaving it to developer to do this beforehand.  My mental model for this script is "when I run deploy it deploys the latest code from GitHub, just like if I clicked deploy in the Heroku UI."
