### PR TITLE
Restrict dashboard date range to school year

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashboardHelpers.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashboardHelpers.js
@@ -44,7 +44,7 @@ export default {
 
   schoolYearStart: function() {
     const today = moment();
-    return today.month() < 8 ? today.subtract(1, 'year').year() + "-08-10" : today.year() + "-08-10";
+    return today.month() < 8 ? today.subtract(1, 'year').year() + "-08-10" : today.year() + "-08-15";
   },
 
   //slightly faster than Array.filter for getting a new date range

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashboardHelpers.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashboardHelpers.js
@@ -44,7 +44,7 @@ export default {
 
   schoolYearStart: function() {
     const today = moment();
-    return today.month() < 8 ? today.subtract(1, 'year').year() + "-08-10" : today.year() + "-08-15";
+    return today.month() < 8 ? today.subtract(1, 'year').year() + "-08-15" : today.year() + "-08-15";
   },
 
   //slightly faster than Array.filter for getting a new date range

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
@@ -14,9 +14,7 @@ class SchoolAbsenceDashboard extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      displayDates: DashboardHelpers.filterDates(this.props.dateRange,
-                                                 DashboardHelpers.schoolYearStart(),
-                                                 moment().format("YYYY-MM-DD")),
+      displayDates: this.props.dateRange,
       selectedHomeroom: null
     };
     this.setDate = (range) => {

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
@@ -14,7 +14,9 @@ class SchoolAbsenceDashboard extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      displayDates: this.props.dateRange,
+      displayDates: DashboardHelpers.filterDates(this.props.dateRange,
+                                                 DashboardHelpers.schoolYearStart(),
+                                                 moment().format("YYYY-MM-DD")),
       selectedHomeroom: null
     };
     this.setDate = (range) => {

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
@@ -151,7 +151,7 @@ class SchoolAbsenceDashboard extends React.Component {
   }
 
   renderDateRangeSlider() {
-    const firstDate = this.props.dateRange[0];
+    const firstDate = DashboardHelpers.schoolYearStart();
     const lastDate = this.props.dateRange[this.props.dateRange.length - 1];
     return (
       <DateSlider

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolwideAttendance.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolwideAttendance.js
@@ -45,6 +45,13 @@ class SchoolwideAttendance extends React.Component {
     return Object.keys(this.props.schoolAbsenceEvents);
   }
 
+  schoolYearDateRange() {
+    //change this to change the maximum date range available for the dashboard
+    const fullYearDateRange = Object.keys(this.schoolAverageDailyAttendance()).sort();
+    const today = moment();
+    return DashboardHelpers.filterDates(fullYearDateRange, DashboardHelpers.schoolYearStart(), today);
+  }
+
   render() {
     return (
         <SchoolAbsenceDashboard
@@ -52,7 +59,7 @@ class SchoolwideAttendance extends React.Component {
           homeroomAverageDailyAttendance = {this.homeroomAverageDailyAttendance()}
           schoolAbsenceEvents = {this.props.schoolAbsenceEvents}
           dashboardStudents = {this.props.dashboardStudents}
-          dateRange = {Object.keys(this.schoolAverageDailyAttendance()).sort()}/>);
+          dateRange = {this.schoolYearDateRange()}/>);
   }
 }
 


### PR DESCRIPTION
# Who is this PR for?
Dashboard users

# What problem does this PR fix?
The absence dashboard shows all absences for the past calendar year, but school year is more useful to users

# What does this PR do?
Restricts the absence dashboard to the current school year

## Javascript QA

+ [x] Author checked latest in IE - Absence Dashboard
+ [x] Reviewer checked latest in IE - Absence Dashboard
