### PR TITLE
Performance improvements for home page insight box around low grades

### DIFF
--- a/app/assets/javascripts/home/HomeInsights.js
+++ b/app/assets/javascripts/home/HomeInsights.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import qs from 'query-string';
 import Card from '../components/Card';
 import Educator from '../components/Educator';
 import GenericLoader from '../components/GenericLoader';
@@ -12,9 +13,10 @@ class HomeInsights extends React.Component {
   }
 
   fetchAssignments() {
-    return fetch('/home/unsupported_low_grades_json', { credentials: 'include' })
-      .then(response => response.json())
-      .then(json => json.assignments);
+    const limit = 100; // limit the data returned, not the query itself
+    const url = `/home/unsupported_low_grades_json?${qs.stringify({limit})}`;
+    return fetch(url, { credentials: 'include' })
+      .then(response => response.json());
   }
 
   render() {
@@ -29,8 +31,13 @@ class HomeInsights extends React.Component {
     );
   }
 
-  renderAssignments(assignments) {
-    return <UnsupportedStudentsPure assignments={assignments} />;
+  renderAssignments(json) {
+    const props = {
+      limit: json.limit,
+      totalCount: json.total_count,
+      assignments: json.assignments
+    };
+    return <UnsupportedStudentsPure {...props} />;
   }
 
   renderPlaceholder() {
@@ -87,15 +94,30 @@ export class UnsupportedStudentsPure extends React.Component {
               );
             })}
           </div>
-          {truncatedAssignments.length !== assignments.length &&
-            <div><a href="#" onClick={this.onMoreAssignments}>See more</a></div>
-          }
+          {this.renderMore(truncatedAssignments)}
         </Card>
       </div>
     );
   }
+
+  renderMore(truncatedAssignments) {
+    const {totalCount, limit, assignments} = this.props;
+
+    if (truncatedAssignments.length !== assignments.length) {
+      return <div><a href="#" onClick={this.onMoreAssignments}>See more</a></div>;
+    }
+
+    if (assignments.length < totalCount) {
+      return <div>There are {totalCount} students total.  Start with checking in on these first {limit} students.</div>;
+    }
+
+    return null;
+  }
 }
+
 UnsupportedStudentsPure.propTypes = {
+  totalCount: React.PropTypes.number.isRequired,
+  limit: React.PropTypes.number.isRequired,
   assignments: React.PropTypes.arrayOf(React.PropTypes.shape({
     id: React.PropTypes.number.isRequired,
     student: React.PropTypes.shape({

--- a/app/assets/javascripts/home/HomeInsights.test.js
+++ b/app/assets/javascripts/home/HomeInsights.test.js
@@ -9,7 +9,7 @@ import unsupportedLowGradesJson from '../../../../spec/javascripts/fixtures/home
 
 beforeEach(() => {
   fetchMock.restore();
-  fetchMock.get('/home/unsupported_low_grades_json', unsupportedLowGradesJson);
+  fetchMock.get('/home/unsupported_low_grades_json?limit=100', unsupportedLowGradesJson);
 });
 
 it('renders without crashing', () => {
@@ -30,8 +30,13 @@ SpecSugar.withTestEl('integration tests', container => {
 });
 
 it('pure component matches snapshot', () => {
+  const props = {
+    limit: unsupportedLowGradesJson.limit,
+    totalCount: unsupportedLowGradesJson.total_count,
+    assignments: unsupportedLowGradesJson.assignments
+  };
   const tree = renderer
-    .create(<UnsupportedStudentsPure assignments={unsupportedLowGradesJson.assignments} />)
+    .create(<UnsupportedStudentsPure {...props} />)
     .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/assets/javascripts/home/HomePage.test.js
+++ b/app/assets/javascripts/home/HomePage.test.js
@@ -10,7 +10,7 @@ import unsupportedLowGradesJson from '../../../../spec/javascripts/fixtures/home
 beforeEach(() => {
   fetchMock.restore();
   fetchMock.get('/home/feed_json?limit=20', homeFeedJson);
-  fetchMock.get('/home/unsupported_low_grades_json', unsupportedLowGradesJson);
+  fetchMock.get('/home/unsupported_low_grades_json?limit=100', unsupportedLowGradesJson);
 });
 
 it('renders without crashing', () => {

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -33,14 +33,17 @@ class HomeController < ApplicationController
   # Response should include everything UI needs.
   def unsupported_low_grades_json
     time_now = time_now_or_param(params[:time_now])
+    limit = params[:limit].to_i
     time_threshold = time_now - 30.days
     grade_threshold = 69
 
     insight = InsightUnsupportedLowGrades.new(current_educator)
     assignments = insight.assignments(time_now, time_threshold, grade_threshold)
-    assignments_json = insight.as_json(assignments)
+    truncated_assignments_json = insight.as_json(assignments.first(limit))
     render json: {
-      assignments: assignments_json
+      limit: limit,
+      total_count: assignments.size,
+      assignments: truncated_assignments_json
     }
   end
 

--- a/app/lib/insight_unsupported_low_grades.rb
+++ b/app/lib/insight_unsupported_low_grades.rb
@@ -11,12 +11,15 @@ class InsightUnsupportedLowGrades
     students = @authorizer.authorized do
       School.select(&:is_high_school?).flat_map(&:students)
     end
-    low_assignments = assignments_below_threshold(students.map(&:id), grade_threshold)
+    student_ids = students.map(&:id)
 
-    # Remove assignments if NGE or 10GE team has commented on
-    # that student recently.
+    # Query for low grades and uncommented students, then join both
+    # This query structure came to be after some optimizations to reduce
+    # latency for HS dept. heads who have access to many students.
+    low_assignments = assignments_below_threshold(student_ids, grade_threshold)
+    commented_student_ids = recently_commented_student_ids(student_ids, time_threshold)
     low_assignments.select do |assignment|
-      !has_experience_team_commented?(assignment, time_threshold)
+      !commented_student_ids.include?(assignment.student_id)
     end
   end
 
@@ -27,20 +30,23 @@ class InsightUnsupportedLowGrades
 
   private
   # Section assignments where a student is struggling.
+  # Does not respect authorization.
   def assignments_below_threshold(student_ids, grade_threshold)
     StudentSectionAssignment
       .includes(:student)
+      .where(student: student_ids)
       .where('grade_numeric < ?', grade_threshold)
-      .where(student_id: student_ids)
       .order(grade_numeric: :asc)
   end
 
-  def has_experience_team_commented?(assignment, time_threshold)
-    assignment.student.event_notes
+  # Students who've commented recently
+  def recently_commented_student_ids(student_ids, time_threshold)
+    recent_notes = EventNote
       .where(is_restricted: false)
+      .where(student_id: student_ids)
       .where('recorded_at > ?', time_threshold)
       .where(event_note_type_id: [305, 306])
-      .count > 0
+    recent_notes.map(&:student_id).uniq
   end
 
   def serialize_assignment(assignment)

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -68,9 +68,14 @@ describe HomeController, :type => :controller do
   describe '#unsupported_low_grades_json' do
     it 'works end-to-end' do
       sign_in(pals.shs_jodi)
-      get :unsupported_low_grades_json, params: { time_now: time_now.to_i.to_s }
+      get :unsupported_low_grades_json, params: {
+        limit: 100,
+        time_now: time_now.to_i.to_s
+      }
       expect(response.code).to eq '200'
       expect(JSON.parse(response.body)).to eq({
+        "limit"=>100,
+        "total_count"=>1,
         "assignments"=>[{
           "id"=>pals.shs_freshman_mari.student_section_assignments.first.id,
           "grade_numeric"=>"67.0",

--- a/spec/javascripts/fixtures/home_unsupported_low_grades_json.js
+++ b/spec/javascripts/fixtures/home_unsupported_low_grades_json.js
@@ -1,4 +1,6 @@
 export default {
+  "limit": 100,
+  "total_count": 22,
   "assignments": [
     {
       "id": 3,

--- a/spec/lib/insight_unsupported_low_grades_spec.rb
+++ b/spec/lib/insight_unsupported_low_grades_spec.rb
@@ -14,19 +14,18 @@ RSpec.describe InsightUnsupportedLowGrades do
     end
   end
 
-  describe '#has_experience_team_commented?' do
+  describe '#recently_commented_student_ids' do
     let!(:time_threshold) { time_now - 30.days }
     let!(:nge_event_note_type) { EventNoteType.find(305) }
     let!(:tenge_event_note_type) { EventNoteType.find(305) }
+    let!(:student_ids) { [pals.shs_freshman_mari] }
+    let!(:assignment) { pals.shs_freshman_mari.student_section_assignments.first }
 
     it 'with no comment' do
-      assignment = pals.shs_freshman_mari.student_section_assignments.first
-      has_commented = insight.send(:has_experience_team_commented?, assignment, time_threshold)
-      expect(has_commented).to eq false
+      expect(insight.send(:recently_commented_student_ids, student_ids, time_threshold)).to eq []
     end
 
     it 'with NGE comment' do
-      assignment = pals.shs_freshman_mari.student_section_assignments.first
       EventNote.create!(
         student: pals.shs_freshman_mari,
         educator: pals.uri,
@@ -34,12 +33,12 @@ RSpec.describe InsightUnsupportedLowGrades do
         text: 'blah',
         recorded_at: time_now
       )
-      has_commented = insight.send(:has_experience_team_commented?, assignment, time_threshold)
-      expect(has_commented).to eq true
+      expect(insight.send(:recently_commented_student_ids, student_ids, time_threshold)).to eq [
+        pals.shs_freshman_mari.id
+      ]
     end
 
     it 'with 10GE comment' do
-      assignment = pals.shs_freshman_mari.student_section_assignments.first
       EventNote.create!(
         student: pals.shs_freshman_mari,
         educator: pals.uri,
@@ -47,12 +46,12 @@ RSpec.describe InsightUnsupportedLowGrades do
         text: 'blah',
         recorded_at: time_now
       )
-      has_commented = insight.send(:has_experience_team_commented?, assignment, time_threshold)
-      expect(has_commented).to eq true
+      expect(insight.send(:recently_commented_student_ids, student_ids, time_threshold)).to eq [
+        pals.shs_freshman_mari.id
+      ]
     end
 
     it 'respects time_threshold' do
-      assignment = pals.shs_freshman_mari.student_section_assignments.first
       EventNote.create!(
         student: pals.shs_freshman_mari,
         educator: pals.uri,
@@ -60,8 +59,7 @@ RSpec.describe InsightUnsupportedLowGrades do
         text: 'blah',
         recorded_at: time_now - 40.days
       )
-      has_commented = insight.send(:has_experience_team_commented?, assignment, time_threshold)
-      expect(has_commented).to eq false
+      expect(insight.send(:recently_commented_student_ids, student_ids, time_threshold)).to eq []
     end
   end
 


### PR DESCRIPTION
this builds on https://github.com/studentinsights/studentinsights/pull/1505

# Who is this PR for?
HS educators, particularly dept. heads or counselors who have access to many students

# What problem does this PR fix?
~25 second load time for the insight box about low grades, for dept. heads

# What does this PR do?
It optimizes the query for students with low grades but who haven't been discussed recently in NGE or 10GE.

# Screenshot (if adding a client-side feature)
No changes:
<img width="1016" alt="screen shot 2018-03-09 at 8 14 27 am" src="https://user-images.githubusercontent.com/1056957/37209104-e7346438-2371-11e8-9ec3-020c4be25b39.png">

# Checklists
+ [x] Author checked latest in IE - Home page
+ [x] Author included specs for new code