### PR TITLE
Update copy for birthday card on current day

### DIFF
--- a/app/assets/javascripts/home/BirthdayCard.js
+++ b/app/assets/javascripts/home/BirthdayCard.js
@@ -6,7 +6,7 @@ import {toMomentFromTime} from '../helpers/toMoment';
 // Render a card in the feed for an EventNote
 function BirthdayCard({studentBirthdayCard, style = {}}) {
   const thisYearBirthdateMoment = toMomentFromTime(studentBirthdayCard.date_of_birth).year(moment.utc().year());
-  const isWas = (thisYearBirthdateMoment.isBefore(moment.utc())) ? 'was' : 'is';
+  const isWas = (thisYearBirthdateMoment.isAfter(moment.utc())) ? 'is' : 'was';
   return (
     <Card key={studentBirthdayCard.id} className="BirthdayCard" style={style}>
       🎉<a style={styles.person} href={`/students/${studentBirthdayCard.id}`}>{studentBirthdayCard.first_name} {studentBirthdayCard.last_name}</a>

--- a/app/assets/javascripts/home/BirthdayCard.js
+++ b/app/assets/javascripts/home/BirthdayCard.js
@@ -4,18 +4,24 @@ import {toMomentFromTime} from '../helpers/toMoment';
 
 
 // Render a card in the feed for an EventNote
-function BirthdayCard({studentBirthdayCard, style = {}}) {
-  const thisYearBirthdateMoment = toMomentFromTime(studentBirthdayCard.date_of_birth).year(moment.utc().year());
-  const isWas = (thisYearBirthdateMoment.isAfter(moment.utc())) ? 'is' : 'was';
-  return (
-    <Card key={studentBirthdayCard.id} className="BirthdayCard" style={style}>
-      🎉<a style={styles.person} href={`/students/${studentBirthdayCard.id}`}>{studentBirthdayCard.first_name} {studentBirthdayCard.last_name}</a>
-      <span>'s birthday {isWas} on </span>
-      <span>{thisYearBirthdateMoment.format('dddd M/D')}!</span>
-    </Card>
-  );
+class BirthdayCard extends React.Component {
+  render() {
+    const {nowFn} = this.context;
+    const {studentBirthdayCard, style = {}} = this.props;
+    const thisYearBirthdateMoment = toMomentFromTime(studentBirthdayCard.date_of_birth).year(moment.utc().year());
+    const isWas = (thisYearBirthdateMoment.isSameOrAfter(nowFn())) ? 'is' : 'was';
+    return (
+      <Card key={studentBirthdayCard.id} className="BirthdayCard" style={style}>
+        🎉<a style={styles.person} href={`/students/${studentBirthdayCard.id}`}>{studentBirthdayCard.first_name} {studentBirthdayCard.last_name}</a>
+        <span>'s birthday {isWas} on </span>
+        <span>{thisYearBirthdateMoment.format('dddd M/D')}!</span>
+      </Card>
+    );
+  }
 }
-
+BirthdayCard.contextTypes = {
+  nowFn: React.PropTypes.func.isRequired
+};
 BirthdayCard.propTypes = {
   studentBirthdayCard: React.PropTypes.shape({
     id: React.PropTypes.number.isRequired,

--- a/app/assets/javascripts/home/BirthdayCard.js
+++ b/app/assets/javascripts/home/BirthdayCard.js
@@ -6,10 +6,10 @@ import {toMomentFromTime} from '../helpers/toMoment';
 // Render a card in the feed for an EventNote
 class BirthdayCard extends React.Component {
   render() {
-    const {nowFn} = this.context;
+    const now = this.context.nowFn();
     const {studentBirthdayCard, style = {}} = this.props;
-    const thisYearBirthdateMoment = toMomentFromTime(studentBirthdayCard.date_of_birth).year(moment.utc().year());
-    const isWas = (thisYearBirthdateMoment.isSameOrAfter(nowFn())) ? 'is' : 'was';
+    const thisYearBirthdateMoment = toMomentFromTime(studentBirthdayCard.date_of_birth).year(now.year());
+    const isWas = (thisYearBirthdateMoment.isBefore(now.clone().startOf('day'))) ? 'was' : 'is';
     return (
       <Card key={studentBirthdayCard.id} className="BirthdayCard" style={style}>
         🎉<a style={styles.person} href={`/students/${studentBirthdayCard.id}`}>{studentBirthdayCard.first_name} {studentBirthdayCard.last_name}</a>

--- a/app/assets/javascripts/home/BirthdayCard.test.js
+++ b/app/assets/javascripts/home/BirthdayCard.test.js
@@ -23,7 +23,7 @@ it('renders without crashing', () => {
   expect($(el).find('a').attr('href')).toEqual('/students/4');
 });
 
-it('renders copy for birthday today', () => {
+it('renders `is` for birthday today', () => {
   const studentBirthdayCard = {
     id: 4,
     first_name: 'Luke',
@@ -32,10 +32,9 @@ it('renders copy for birthday today', () => {
   };
   const el = document.createElement('div');
   ReactDOM.render(
-    withNowContext('2004-03-05T09:23:14.000Z', 
+    withNowContext('2012-03-05T09:23:14.000Z', 
       <BirthdayCard studentBirthdayCard={studentBirthdayCard} />
     )
   , el);
   expect($(el).text()).toContain("🎉Luke Kenobi's birthday is on Monday 3/5!");
-  expect($(el).find('a').attr('href')).toEqual('/students/4');
 });

--- a/app/assets/javascripts/home/BirthdayCard.test.js
+++ b/app/assets/javascripts/home/BirthdayCard.test.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import BirthdayCard from './BirthdayCard';
+import {
+  withNowContext,
+  withDefaultNowContext
+} from '../../../../spec/javascripts/support/NowContainer';
 
 it('renders without crashing', () => {
   const studentBirthdayCard = {
@@ -10,7 +14,28 @@ it('renders without crashing', () => {
     date_of_birth: '2004-03-05T00:00:00.000Z'
   };
   const el = document.createElement('div');
-  ReactDOM.render(<BirthdayCard studentBirthdayCard={studentBirthdayCard} />, el);
+  ReactDOM.render(
+    withDefaultNowContext(
+      <BirthdayCard studentBirthdayCard={studentBirthdayCard} />
+    )
+  , el);
   expect($(el).text()).toContain("🎉Luke Kenobi's birthday was on Monday 3/5!");
+  expect($(el).find('a').attr('href')).toEqual('/students/4');
+});
+
+it('renders copy for birthday today', () => {
+  const studentBirthdayCard = {
+    id: 4,
+    first_name: 'Luke',
+    last_name: 'Kenobi',
+    date_of_birth: '2004-03-05T00:00:00.000Z'
+  };
+  const el = document.createElement('div');
+  ReactDOM.render(
+    withNowContext('2004-03-05T09:23:14.000Z', 
+      <BirthdayCard studentBirthdayCard={studentBirthdayCard} />
+    )
+  , el);
+  expect($(el).text()).toContain("🎉Luke Kenobi's birthday is on Monday 3/5!");
   expect($(el).find('a').attr('href')).toEqual('/students/4');
 });

--- a/spec/javascripts/support/NowContainer.js
+++ b/spec/javascripts/support/NowContainer.js
@@ -28,8 +28,11 @@ NowContainer.propTypes = {
 
 // Helper to freeze the clock during tests
 export function withNowContext(timeString, children) {
-  const frozenNow = toMomentFromTime(timeString);
-  return <NowContainer nowFn={() => frozenNow}>{children}</NowContainer>;
+  return (
+    <NowContainer nowFn={() => toMomentFromTime(timeString)}>
+      {children}
+    </NowContainer>
+  );
 }
 
 // Keep generic "now" value during most tests


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
for students who's birthday is today, it says their birthday "was" on today.
<img width="191" alt="screen shot 2018-03-09 at 8 23 45 am" src="https://user-images.githubusercontent.com/1056957/37209410-355998e4-2373-11e8-81ec-8b76776900ec.png">

This also updates `BirthdayCard` to use the `nowFn` in context, and updates the `withDefaultNow` test helper to return a new `now` each time to prevent accidental test pollution with moment's mutable methods (eg, `now.startOf('day')`).
+ [x] Author included specs for new code