### PR TITLE
Fix bug in deploy script

### DIFF
--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -6,7 +6,7 @@ for remote in "$@"
 do
     echo "🚢  🚢  🚢  Deploying code to $remote.";
     git fetch origin
-    git push $remote origin/master
+    git push $remote origin/master master
     echo;
     echo "⚙  ⚙  ⚙  Migrating the database for $remote.";
     heroku run rake db:migrate --remote $remote


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
deploy script not deploying :)
from a bug in https://github.com/studentinsights/studentinsights/pull/1509
problem is `remote: Pushed to non-master branch, skipping build.`:
```
$ scripts/deploy/deploy.sh demo
🚢  🚢  🚢  Deploying code to demo.
Counting objects: 58, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (58/58), done.
Writing objects: 100% (58/58), 8.15 KiB | 0 bytes/s, done.
Total 58 (delta 46), reused 0 (delta 0)
remote: Pushed to non-master branch, skipping build.
To https://git.heroku.com/somerville-teacher-tool-demo.git
   970f33f..be7a924  origin/master -> origin/master
```

# What does this PR do?
explicitly push to `master`
