### PR TITLE
Fix insight copy to show all student count, not limit

### DIFF
--- a/app/assets/javascripts/home/HomeInsights.js
+++ b/app/assets/javascripts/home/HomeInsights.js
@@ -70,14 +70,14 @@ export class UnsupportedStudentsPure extends React.Component {
   }
 
   render() {
-    const {assignments} = this.props;
+    const {assignments, totalCount} = this.props;
     const {assignmentLimit} = this.state;
     const truncatedAssignments = assignments.slice(0, assignmentLimit);
     return (
       <div className="UnsupportedStudentsPure">
         <div style={styles.cardTitle}>Students to check on</div>
         <Card style={{border: 'none'}}>
-          <div>There are <b>{assignments.length} students</b> you work with who have a D or an F right now but haven't been mentioned in NGE or 10GE for the last month.</div>
+          <div>There are <b>{totalCount} students</b> you work with who have a D or an F right now but haven't been mentioned in NGE or 10GE for the last month.</div>
           <div style={{paddingTop: 10, paddingBottom: 10}}>
             {truncatedAssignments.map(assignment => {
               const {student, section} = assignment;

--- a/app/assets/javascripts/home/HomeInsights.test.js
+++ b/app/assets/javascripts/home/HomeInsights.test.js
@@ -40,3 +40,16 @@ it('pure component matches snapshot', () => {
     .toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+
+it('handles when limit reached', () => {
+  const props = {
+    limit: 3,
+    totalCount: 129,
+    assignments: unsupportedLowGradesJson.assignments.slice(0, 3)
+  };
+  const tree = renderer
+    .create(<UnsupportedStudentsPure {...props} />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/assets/javascripts/home/__snapshots__/HomeInsights.test.js.snap
+++ b/app/assets/javascripts/home/__snapshots__/HomeInsights.test.js.snap
@@ -29,7 +29,7 @@ exports[`handles when limit reached 1`] = `
     <div>
       There are 
       <b>
-        29
+        129
          students
       </b>
        you work with who have a D or an F right now but haven't been mentioned in NGE or 10GE for the last month.
@@ -189,7 +189,7 @@ exports[`handles when limit reached 1`] = `
     </div>
     <div>
       There are 
-      29
+      129
        students total.  Start with checking in on these first 
       3
        students.
@@ -227,7 +227,7 @@ exports[`pure component matches snapshot 1`] = `
     <div>
       There are 
       <b>
-        14
+        129
          students
       </b>
        you work with who have a D or an F right now but haven't been mentioned in NGE or 10GE for the last month.

--- a/app/assets/javascripts/home/__snapshots__/HomeInsights.test.js.snap
+++ b/app/assets/javascripts/home/__snapshots__/HomeInsights.test.js.snap
@@ -1,5 +1,203 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`handles when limit reached 1`] = `
+<div
+  className="UnsupportedStudentsPure"
+>
+  <div
+    style={
+      Object {
+        "backgroundColor": "#eee",
+        "borderBottom": "1px solid #ccc",
+        "color": "black",
+        "padding": 10,
+      }
+    }
+  >
+    Students to check on
+  </div>
+  <div
+    className="Card "
+    style={
+      Object {
+        "border": "none",
+        "borderRadius": 3,
+        "padding": 10,
+      }
+    }
+  >
+    <div>
+      There are 
+      <b>
+        29
+         students
+      </b>
+       you work with who have a D or an F right now but haven't been mentioned in NGE or 10GE for the last month.
+    </div>
+    <div
+      style={
+        Object {
+          "paddingBottom": 10,
+          "paddingTop": 10,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "paddingLeft": 10,
+          }
+        }
+      >
+        <div>
+          <span>
+            <a
+              href="/students/67"
+              style={
+                Object {
+                  "fontWeight": "bold",
+                }
+              }
+            >
+              Pocahontas
+               
+              Skywalker
+            </a>
+          </span>
+          <span>
+             has a 
+            50
+             in 
+            <a
+              href="/sections/1"
+            >
+              SHS-BIO-TUES
+            </a>
+          </span>
+          <span>
+             with 
+            <a
+              className="Educator"
+              href="mailto:bill@demo.studentinsights.org"
+              style={
+                Object {
+                  "fontWeight": "bold",
+                }
+              }
+            >
+              Bill Teacher
+            </a>
+          </span>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "paddingLeft": 10,
+          }
+        }
+      >
+        <div>
+          <span>
+            <a
+              href="/students/115"
+              style={
+                Object {
+                  "fontWeight": "bold",
+                }
+              }
+            >
+              Minnie
+               
+              Pan
+            </a>
+          </span>
+          <span>
+             has a 
+            50
+             in 
+            <a
+              href="/sections/6"
+            >
+              SCI-201B
+            </a>
+          </span>
+          <span>
+             with 
+            <a
+              className="Educator"
+              href="mailto:fatima@demo.studentinsights.org"
+              style={
+                Object {
+                  "fontWeight": "bold",
+                }
+              }
+            >
+              Fatima Teacher
+            </a>
+          </span>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "paddingLeft": 10,
+          }
+        }
+      >
+        <div>
+          <span>
+            <a
+              href="/students/73"
+              style={
+                Object {
+                  "fontWeight": "bold",
+                }
+              }
+            >
+              Pocahontas
+               
+              Kenobi
+            </a>
+          </span>
+          <span>
+             has a 
+            52
+             in 
+            <a
+              href="/sections/1"
+            >
+              SHS-BIO-TUES
+            </a>
+          </span>
+          <span>
+             with 
+            <a
+              className="Educator"
+              href="mailto:bill@demo.studentinsights.org"
+              style={
+                Object {
+                  "fontWeight": "bold",
+                }
+              }
+            >
+              Bill Teacher
+            </a>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div>
+      There are 
+      29
+       students total.  Start with checking in on these first 
+      3
+       students.
+    </div>
+  </div>
+</div>
+`;
+
 exports[`pure component matches snapshot 1`] = `
 <div
   className="UnsupportedStudentsPure"

--- a/spec/javascripts/fixtures/home_unsupported_low_grades_json.js
+++ b/spec/javascripts/fixtures/home_unsupported_low_grades_json.js
@@ -1,6 +1,6 @@
 export default {
   "limit": 100,
-  "total_count": 22,
+  "total_count": 129,
   "assignments": [
     {
       "id": 3,


### PR DESCRIPTION
# Who is this PR for?
HS educators

# What problem does this PR fix?
insight box copy would show the limit of how many students were returned, not actual real number of students
<img width="363" alt="screen shot 2018-03-09 at 9 01 16 am" src="https://user-images.githubusercontent.com/1056957/37211002-89c102fa-2378-11e8-8865-dea6453e9d62.png">

# What does this PR do?
fixes that!

# Checklists
+ [x] Author included specs for new code
