### PR TITLE
Fix JS bug in loading homeroom page

### DIFF
--- a/app/assets/javascripts/homeroom_table/main.jsx
+++ b/app/assets/javascripts/homeroom_table/main.jsx
@@ -31,6 +31,6 @@ export default function homeroomMain() {
       rows={serializedData.rows}
       school={serializedData.school}
     />,
-    document.getElementById('homeroom-table')
+    document.getElementById('main')
   );
 }

--- a/app/views/homerooms/show.html.erb
+++ b/app/views/homerooms/show.html.erb
@@ -16,7 +16,8 @@
   <div id="student-searchbar-wrapper" class="dropdown"></div>
 </div>
 
-<div id="homeroom-table"></div>
+
+<div id="main"></div>
 
 <%= json_div(id: "homeroom-data", data: { homeroom: @homeroom}) %>
 <%= json_div(id: "current-educator-data", data: { current_educator: current_educator}) %>


### PR DESCRIPTION
bug fix from https://github.com/studentinsights/studentinsights/pull/1505

# Who is this PR for?
K8 teachers primarily

# What problem does this PR fix?
Homeroom page doesn't load.  This doesn't produce any JS errors so monitoring didn't catch it.  It's hard to write automated tests for this, since it's a seam between the Rails HTML and the JS bootstrapping.  We could add production tests for this if we wanted.

# What does this PR do?
fixes a bug introduced in https://github.com/studentinsights/studentinsights/pull/1505 with what HTML the JS code expects to be present

# Screenshot (if adding a client-side feature)
before:
<img width="764" alt="screen shot 2018-03-09 at 12 21 31 pm" src="https://user-images.githubusercontent.com/1056957/37220453-b4d70022-2394-11e8-8cdb-ef9f6affb57f.png">

after:
<img width="769" alt="screen shot 2018-03-09 at 12 21 39 pm" src="https://user-images.githubusercontent.com/1056957/37220455-b7e3d1a0-2394-11e8-8cc9-53d8922edca3.png">

# Checklists
+ [x] Author checked latest in IE - K8 homeroom
