### PR TITLE
Add event note counts to teacher file export for Research Matters

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -15,6 +15,7 @@ class Educator < ActiveRecord::Base
   has_many    :section_students, source: :students, through: :sections
   has_many    :interventions
   has_many    :event_notes
+  has_many    :event_note_revisions
 
   validates :email, presence: true, uniqueness: true
 

--- a/app/models/event_note_revision.rb
+++ b/app/models/event_note_revision.rb
@@ -1,3 +1,4 @@
 class EventNoteRevision < ActiveRecord::Base
   belongs_to :event_note
+  belongs_to :educator
 end

--- a/app/reports/research_matters_exporter.rb
+++ b/app/reports/research_matters_exporter.rb
@@ -57,6 +57,9 @@ class ResearchMattersExporter
       first_name
       last_name
       school_id
+      notes_added
+      notes_revised
+      notes_total
     ].join(',')
   end
 
@@ -94,13 +97,19 @@ class ResearchMattersExporter
       full_name = educator.full_name
       last_name = full_name.present? ? full_name.split(", ")[0] : nil
       first_name = full_name.present? ? full_name.split(", ")[1] : nil
+      notes_added = educator.event_notes.count
+      notes_revised = educator.event_note_revisions.count
+      notes_total = notes_added + notes_revised
 
       [
         educator.id,
         educator.email,
         first_name,
         last_name,
-        'HEA'
+        'HEA',
+        notes_added,
+        notes_revised,
+        notes_total,
       ].join(',')
     end
   end

--- a/db/migrate/20180309210903_add_event_note_revision_key.rb
+++ b/db/migrate/20180309210903_add_event_note_revision_key.rb
@@ -1,0 +1,5 @@
+class AddEventNoteRevisionKey < ActiveRecord::Migration[5.1]
+  def change
+    add_foreign_key "event_note_revisions", "educators", name: "event_note_revisions_educator_id_fk"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171126024254) do
+ActiveRecord::Schema.define(version: 20180309210903) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -356,6 +356,7 @@ ActiveRecord::Schema.define(version: 20171126024254) do
   add_foreign_key "educator_section_assignments", "sections"
   add_foreign_key "educators", "schools", name: "educators_school_id_fk"
   add_foreign_key "event_note_attachments", "event_notes", name: "event_note_attachments_event_note_id_fk"
+  add_foreign_key "event_note_revisions", "educators", name: "event_note_revisions_educator_id_fk"
   add_foreign_key "event_note_revisions", "event_notes", name: "event_note_revisions_event_note_id_fk"
   add_foreign_key "event_notes", "educators", name: "event_notes_educator_id_fk"
   add_foreign_key "event_notes", "event_note_types", name: "event_notes_event_note_type_id_fk"

--- a/spec/factories/event_note_revisions.rb
+++ b/spec/factories/event_note_revisions.rb
@@ -1,12 +1,12 @@
 FactoryGirl.define do
   factory :event_note_revision do
+    association :event_note
+    association :educator
     student_id 1
-    educator_id 1
     event_note_type_id 1
     text "MyText"
     created_at "2016-04-11 01:41:48"
     updated_at "2016-04-11 01:41:48"
-    association :event_note
     version 1
   end
 end

--- a/spec/reports/research_matters_exporter_spec.rb
+++ b/spec/reports/research_matters_exporter_spec.rb
@@ -163,8 +163,8 @@ RSpec.describe ResearchMattersExporter do
     context 'teacher name present' do
       it 'outputs the right file' do
         expect(exporter.teacher_file).to eq([
-          "educator_id,email,first_name,last_name,school_id",
-          "#{educator.id},matsay@demo.studentinsights.org,Matsay,Khamar,HEA"
+          "educator_id,email,first_name,last_name,school_id,notes_added,notes_revised,notes_total",
+          "#{educator.id},matsay@demo.studentinsights.org,Matsay,Khamar,HEA,0,0,0"
         ])
       end
     end
@@ -176,9 +176,9 @@ RSpec.describe ResearchMattersExporter do
       }
       it 'outputs the right file' do
         expect(exporter.teacher_file).to eq([
-          "educator_id,email,first_name,last_name,school_id",
-          "#{educator.id},matsay@demo.studentinsights.org,Matsay,Khamar,HEA",
-          "#{another_educator.id},noname@demo.studentinsights.org,,,HEA",
+          "educator_id,email,first_name,last_name,school_id,notes_added,notes_revised,notes_total",
+          "#{educator.id},matsay@demo.studentinsights.org,Matsay,Khamar,HEA,0,0,0",
+          "#{another_educator.id},noname@demo.studentinsights.org,,,HEA,0,0,0",
         ])
       end
     end

--- a/spec/reports/research_matters_exporter_spec.rb
+++ b/spec/reports/research_matters_exporter_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe ResearchMattersExporter do
           FactoryGirl.create(:event_note, student: student, recorded_at: DateTime.new(2017, 12, 20), event_note_type_id: 300)
         }
         let!(:event_note_revision) {
-          FactoryGirl.create(:event_note_revision, event_note: event_note, student_id: student.id, created_at: DateTime.new(2017, 12, 21), event_note_type_id: 300)
+          FactoryGirl.create(:event_note_revision, event_note: event_note, student_id: student.id, created_at: DateTime.new(2017, 12, 21), event_note_type_id: 300, educator: educator)
         }
 
         it 'outputs the right file' do
@@ -161,11 +161,26 @@ RSpec.describe ResearchMattersExporter do
     let(:event_data) { [] }
 
     context 'teacher name present' do
-      it 'outputs the right file' do
-        expect(exporter.teacher_file).to eq([
-          "educator_id,email,first_name,last_name,school_id,notes_added,notes_revised,notes_total",
-          "#{educator.id},matsay@demo.studentinsights.org,Matsay,Khamar,HEA,0,0,0"
-        ])
+      context 'no teacher event notes' do
+        it 'outputs the right file' do
+          expect(exporter.teacher_file).to eq([
+            "educator_id,email,first_name,last_name,school_id,notes_added,notes_revised,notes_total",
+            "#{educator.id},matsay@demo.studentinsights.org,Matsay,Khamar,HEA,0,0,0"
+          ])
+        end
+      end
+
+      context 'teacher has event notes' do
+        let!(:educator_event_note) {
+          FactoryGirl.create(:event_note, educator: educator)
+        }
+
+        it 'outputs the right file' do
+          expect(exporter.teacher_file).to eq([
+            "educator_id,email,first_name,last_name,school_id,notes_added,notes_revised,notes_total",
+            "#{educator.id},matsay@demo.studentinsights.org,Matsay,Khamar,HEA,1,0,1"
+          ])
+        end
       end
     end
 


### PR DESCRIPTION
# Who is this PR for?

Research Matters

# Notes

This added an association between the event_note_revisions table and the educators table in order to pull in the associated event_note_revisions of each educator for Research Matters. That caused our `immigrant` gem to want us to add a foreign key, which I did, which then required a few small updates in the specs. Overall I think this is a reasonable change — we don't want to add event note revisions to the database without knowing which educator revised them. 