### PR TITLE
Add note to README about rubocop linter, remove node_modules from it

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - 'db/**/*'
     - 'docs/**/*'
     - 'log/**/*'
+    - 'node_modules/**/*'
     - 'public/**/*'
     - 'scripts/**/*'
     - 'sketch/**/*'

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ rubocop
 yarn lint
 ```
 
+Or add them into Sublime with [SublimeLinter-eslint](https://github.com/SublimeLinter/SublimeLinter-eslint) and [SublimeLinter-rubocop](https://github.com/SublimeLinter/SublimeLinter-rubocop).
+
 If you miss something, tests will run on any pull request you submit, and after merging to master as well.
 
 ## 5. Write code!


### PR DESCRIPTION
addresses https://github.com/studentinsights/studentinsights/issues/1092

# Who is this PR for?
developers

# What problem does this PR fix?
don't run rubocop on `node_modules`, and add a note for adding Rubocop linting in Sublime
