### PR TITLE
Add links to navbar for absences and tardies

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,13 +36,21 @@
               <%= link_to 'Admin', educators_districtwide_url %>
               &nbsp; &nbsp; &nbsp;
             <% elsif current_educator.schoolwide_access? || current_educator.has_access_to_grade_levels? %>
-              <%= link_to 'School Overview', school_path(current_educator.school) %>
+              <%= link_to 'Roster', school_path(current_educator.school) %>
+              &nbsp;
+            <% end %>
+            <% if current_educator.schoolwide_access? && !current_educator.districtwide_access? %>
+              <%= link_to "Absences", school_administrator_dashboard_school_path + '#/absences_dashboard' %>
+              &nbsp;
+              <%= link_to "Tardies", school_administrator_dashboard_school_path + '#/tardies_dashboard' %>
+              &nbsp;
               &nbsp; &nbsp; &nbsp;
             <% end %>
             <%= link_to "My notes", educators_notes_feed_path %>
-            &nbsp; &nbsp; &nbsp;
+            &nbsp;
             <%= link_to "Home", home_path %>
-            &nbsp; &nbsp; &nbsp;
+            &nbsp;
+            &nbsp; &nbsp;
             <p class="search-label">Search for student:</p>
             <input class="student-searchbar" />
             &nbsp; &nbsp; &nbsp;


### PR DESCRIPTION
# Who is this PR for?
K8 principals and asst. principals

# What problem does this PR fix?
Let folks see the absences and tardies dashboards on their own.

# What does this PR do?
Updates navbar links.

# Screenshot (if adding a client-side feature)
#### school leader
<img width="1019" alt="screen shot 2018-03-15 at 7 08 54 am" src="https://user-images.githubusercontent.com/1056957/37460015-5586b23a-2820-11e8-81fe-1042712c2d49.png">

#### classroom teacher
<img width="1019" alt="screen shot 2018-03-15 at 7 11 12 am" src="https://user-images.githubusercontent.com/1056957/37460016-559452aa-2820-11e8-8129-460fe783964a.png">

#### districtwide (access for school through admin page)
<img width="1024" alt="screen shot 2018-03-15 at 7 12 23 am" src="https://user-images.githubusercontent.com/1056957/37460017-55a03b9c-2820-11e8-86bf-ee1cb5554b9a.png">
