### PR TITLE
Fix bug with last SST on tardies dashboard, add `nullableWithKey` propType

### DIFF
--- a/app/assets/javascripts/helpers/prop_types.jsx
+++ b/app/assets/javascripts/helpers/prop_types.jsx
@@ -32,7 +32,21 @@ const PropTypes = {
   history: React.PropTypes.shape({
     pushState: React.PropTypes.func.isRequired,
     replaceState: React.PropTypes.func.isRequired
-  })
+  }),
+
+  // Return a propType for us in `PropTypes.shape`
+  // that requires a key to be passed, but allows
+  // null values (which `.isRequired` doesn't allow).
+  nullableWithKey(propType) {
+    return (props, propName, componentName) => {
+      if (!props.hasOwnProperty(propName)) {
+        return new Error(
+          'Missing prop `' + propName + '` in ' +
+          ' `' + componentName + '`. Nulls are allowed, but must be passed explicitly.'
+        );
+      }
+    };
+  }
 };
 
 export default PropTypes;

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import SortHelpers from '../../helpers/sort_helpers.jsx';
 import * as Routes from '../../helpers/Routes';
+import SharedPropTypes from '../../helpers/prop_types.jsx';
+
 
 class StudentsTable extends React.Component {
 
@@ -123,7 +125,13 @@ class StudentsTable extends React.Component {
 }
 
 StudentsTable.propTypes = {
-  rows: PropTypes.array.isRequired,
+  rows: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    first_name: PropTypes.string.isRequired,
+    last_name: PropTypes.string.isRequired,
+    events: PropTypes.number.isRequired,
+    last_sst_date_text: SharedPropTypes.nullableWithKey(PropTypes.string)
+  })).isRequired,
   selectedHomeroom: PropTypes.string,
   schoolYearFlag: PropTypes.bool
 };

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolTardiesDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolTardiesDashboard.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import DashboardHelpers from '../DashboardHelpers';
 import StudentsTable from '../StudentsTable';
 import DashboardBarChart from '../DashboardBarChart';
+import {latestNoteDateText} from '../../../helpers/latestNoteDateText';
 
 
 class SchoolTardiesDashboard extends React.Component {
@@ -135,6 +136,7 @@ class SchoolTardiesDashboard extends React.Component {
         id: student.id,
         first_name: student.first_name,
         last_name: student.last_name,
+        last_sst_date_text: latestNoteDateText(300, student.event_notes),
         events: studentTardyCounts[student.id] || 0
       });
     });

--- a/spec/javascripts/school_administrator_dashboard/DashboardTestData.js
+++ b/spec/javascripts/school_administrator_dashboard/DashboardTestData.js
@@ -48,7 +48,8 @@ export const Students = [
     id: 2,
     absences: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo],
     tardies: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo],
-    events: 2
+    events: 2,
+    last_sst_date_text: null
   },
   {
     first_name: 'Arlecchino',
@@ -57,7 +58,8 @@ export const Students = [
     id: 3,
     absences: [],
     tardies: [],
-    events: 0
+    events: 0,
+    last_sst_date_text: null
   },
   {
     first_name: 'Colombina',
@@ -66,7 +68,8 @@ export const Students = [
     id: 4,
     absences: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo, testEvents.oneYearAgo],
     tardies: [testEvents.thisMonth],
-    events: 3
+    events: 3,
+    last_sst_date_text: null
   },
   {
     first_name: 'Scaramuccia',
@@ -75,7 +78,8 @@ export const Students = [
     id: 5,
     absences: [testEvents.twoMonthsAgo, testEvents.threeMonthsAgo],
     tardies: [testEvents.oneYearAgo],
-    events: 2
+    events: 2,
+    last_sst_date_text: null
   },
 
   {
@@ -85,7 +89,8 @@ export const Students = [
     id: 6,
     absences: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo],
     tardies: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo],
-    events: 2
+    events: 2,
+    last_sst_date_text: null
   }
 ];
 


### PR DESCRIPTION
# Who is this PR for?
K8 principals and asst. principals

# What problem does this PR fix?
Tardies dashboard last SST column is missing data

# What does this PR do?
Fixes that, adds propTypes to the `StudentsTable` component in the dashboards to catch this.

# Screenshot (if adding a client-side feature)
After fix:
<img width="339" alt="screen shot 2018-03-15 at 8 15 18 am" src="https://user-images.githubusercontent.com/1056957/37463248-04433e1a-282b-11e8-9bef-b1ed14575e42.png">

`nullableWithKey` propType failure messages:
<img width="783" alt="screen shot 2018-03-15 at 8 26 51 am" src="https://user-images.githubusercontent.com/1056957/37463265-0e7bc08c-282b-11e8-952a-4fcba083f738.png">
<img width="1339" alt="screen shot 2018-03-15 at 8 27 05 am" src="https://user-images.githubusercontent.com/1056957/37463266-0ea2ba02-282b-11e8-9b73-a6c8d68da0ee.png">


# Checklists
## Javascript QA
+ [x] Author checked latest in IE - Absence dashboard
+ [x] Author checked latest in IE - Tardies dashboard
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code
