### PR TITLE
Fix bug with navbar routes for absences dashboards

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,10 +39,10 @@
               <%= link_to 'Roster', school_path(current_educator.school) %>
               &nbsp;
             <% end %>
-            <% if current_educator.schoolwide_access? && !current_educator.districtwide_access? %>
-              <%= link_to "Absences", school_administrator_dashboard_school_path + '#/absences_dashboard' %>
+            <% if current_educator.school.present? && current_educator.schoolwide_access? && !current_educator.districtwide_access? %>
+              <%= link_to "Absences", school_administrator_dashboard_school_path(current_educator.school) + '#/absences_dashboard' %>
               &nbsp;
-              <%= link_to "Tardies", school_administrator_dashboard_school_path + '#/tardies_dashboard' %>
+              <%= link_to "Tardies", school_administrator_dashboard_school_path(current_educator.school) + '#/tardies_dashboard' %>
               &nbsp;
               &nbsp; &nbsp; &nbsp;
             <% end %>


### PR DESCRIPTION
# Who is this PR for?
K8 principals, asst. principals

# What problem does this PR fix?
Bug in https://github.com/studentinsights/studentinsights/pull/1523 with how navbar links are rendered on different pages across roles.

# What does this PR do?
Fixes the bug by explicitly passing the school to these links.

In https://github.com/studentinsights/studentinsights/compare/patch/navbar-across-roles, I also spiked on pulling out the navbar from Rails and rendering in JS so we could add it into https://github.com/studentinsights/studentinsights/pull/1522 and be able to see these easily in production across roles (right now we can't), but this is more involved that I can do this morning and we have other things to ship for tomorrow.