### PR TITLE
Fix deploy script again

### DIFF
--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -6,7 +6,7 @@ for remote in "$@"
 do
     echo "🚢  🚢  🚢  Deploying code to $remote.";
     git fetch origin
-    git push $remote origin/master master
+    git push $remote origin/master:master
     echo;
     echo "⚙  ⚙  ⚙  Migrating the database for $remote.";
     heroku run rake db:migrate --remote $remote


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
The deploy script doesn't always deploy.  Sometimes it does this:

```
$ scripts/deploy/deploy.sh demo
🚢  🚢  🚢  Deploying code to demo.
Counting objects: 109, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (109/109), done.
Writing objects: 100% (109/109), 15.78 KiB | 0 bytes/s, done.
Total 109 (delta 88), reused 0 (delta 0)
remote: Pushed to non-master branch, skipping build.
To https://git.heroku.com/somerville-teacher-tool-demo.git
   5deaeab..1d9f8be  origin/master -> origin/master
```
and then doesn't deploy.  The syntax here was actually just pushing both branches, not pushing origin/master to the remote master.

# What does this PR do?
makes explicit that we're fetching from origin, then pushing origin/master to the remote master


