### PR TITLE
Update filter for NGE and 10GE students

### DIFF
--- a/app/lib/insight_students_with_low_grades.rb
+++ b/app/lib/insight_students_with_low_grades.rb
@@ -1,4 +1,6 @@
 class InsightStudentsWithLowGrades
+  EXPERIENCE_TEAM_GRADES = ['9', '10']
+
   def initialize(educator)
     @educator = educator
     @authorizer = Authorizer.new(@educator)
@@ -92,6 +94,6 @@ class InsightStudentsWithLowGrades
   # list of teachers, and then the list of students who are in their
   # sections and also in NGE and 10GE.
   def included_in_experience_team?(student)
-    student.grade
+    EXPERIENCE_TEAM_GRADES.include?(student.grade)
   end
 end

--- a/spec/lib/insight_students_with_low_grades_spec.rb
+++ b/spec/lib/insight_students_with_low_grades_spec.rb
@@ -115,4 +115,12 @@ RSpec.describe InsightStudentsWithLowGrades do
       expect(json['section']['educators'].first.keys).to eq(['id', 'email', 'full_name'])
     end
   end
+
+  describe '#included_in_experience_team?' do
+    let!(:insight) { InsightStudentsWithLowGrades.new(pals.shs_bill_nye) }
+    it 'filters out students by grade' do
+      expect(insight.send(:included_in_experience_team?, pals.shs_freshman_mari)).to eq true
+      expect(insight.send(:included_in_experience_team?, pals.healey_kindergarten_student)).to eq false
+    end
+  end
 end


### PR DESCRIPTION
# Who is this PR for?
HS classroom teachers

# What problem does this PR fix?
bug in https://github.com/studentinsights/studentinsights/pull/1526, which didn't properly filter down to 9th and 10th grade students

# What does this PR do?
fixes it!

# Checklists
+ [x] Author checked latest in IE - Home page
+ [x] Author included specs for new code

This came up because we don't have enough students and courses generated in local development for this to be visible.  We should fix this but I don't have time to do it now ahead of tomorrow morning.