### PR TITLE
Tune down initial fetch for home feed as short-term performance optimization

### DIFF
--- a/app/assets/javascripts/home/HomeFeed.js
+++ b/app/assets/javascripts/home/HomeFeed.js
@@ -109,7 +109,7 @@ HomeFeed.propTypes = {
   limit: React.PropTypes.number
 };
 HomeFeed.defaultProps = {
-  limit: 20
+  limit: 10
 };
 
 

--- a/app/assets/javascripts/home/HomeFeed.test.js
+++ b/app/assets/javascripts/home/HomeFeed.test.js
@@ -63,8 +63,8 @@ function expectRenderedFeed(el, options = {}) {
 describe('HomeFeed', () => {
   beforeEach(() => {
     fetchMock.restore();
-    fetchMock.get('/home/feed_json?educator_id=9999&limit=20&time_now=1520938986', homeFeedJson);
-    fetchMock.get('/home/feed_json?educator_id=9999&limit=20&time_now=1315440000', moreCardsJson());
+    fetchMock.get('/home/feed_json?educator_id=9999&limit=10&time_now=1520938986', homeFeedJson);
+    fetchMock.get('/home/feed_json?educator_id=9999&limit=10&time_now=1315440000', moreCardsJson());
   });
 
   it('renders without crashing', () => {


### PR DESCRIPTION
# Who is this PR for?
HS classroom teachers

# What problem does this PR fix?
Short-term change to reduce latency loading home page feed

# What does this PR do?
Tunes down initial fetch from 20 (more than fits on screen) to 10.
