### PR TITLE
Fix bug with experience team filter in home page insight box

### DIFF
--- a/spec/lib/insight_students_with_low_grades_spec.rb
+++ b/spec/lib/insight_students_with_low_grades_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe InsightStudentsWithLowGrades do
     let!(:insight) { InsightStudentsWithLowGrades.new(pals.shs_bill_nye) }
     it "finds Mari in Bill's Biology class" do
       grade_threshold = 69
-      assignments = insight.send(:assignments_below_threshold, grade_threshold)
+      student_ids = Student.all.map(&:id)
+      assignments = insight.send(:assignments_below_threshold, student_ids, grade_threshold)
       expect(assignments.size).to eq 1
       expect(assignments.all? {|a| a.grade_numeric < grade_threshold }).to eq true
     end


### PR DESCRIPTION
Fixes bug in https://github.com/studentinsights/studentinsights/pull/1528

# Who is this PR for?
HS classroom teachers

# What problem does this PR fix?
Filtering by NGE/10GE students didn't work correctly in https://github.com/studentinsights/studentinsights/pull/1528, because we filtered by this on one part of the query but not the other part when joining. 

# What does this PR do?
fixes it!

Tested in production console for 2 sample teachers.