### PR TITLE
Revise dashboard JS tests to explicitly pass through current time

### DIFF
--- a/spec/javascripts/school_administrator_dashboard/DashboardHelpers.test.js
+++ b/spec/javascripts/school_administrator_dashboard/DashboardHelpers.test.js
@@ -1,11 +1,12 @@
 import DashboardHelpers from '../../../app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashboardHelpers.js';
 
-import * as Data from './DashboardTestData.js';
+import {createStudents} from './DashboardTestData.js';
+
 
 describe('DashboardHelpers', () => {
   describe('GroupByHomeroom', () => {
     it('returns a hash with homerooms as keys', () => {
-      const students = Data.Students;
+      const students = createStudents(moment.utc());
       const groupedStudents = DashboardHelpers.groupByHomeroom(students);
       expect(groupedStudents).toEqual({
         'Test 1': [students[0], students[1], students[2]],
@@ -17,22 +18,26 @@ describe('DashboardHelpers', () => {
 
   describe('absenceEventsByDay', () => {
     it('returns a hash with distinct days as keys', () =>{
-      const events = DashboardHelpers.absenceEventsByDay(Data.Students);
+      const students = createStudents(moment.utc());
+      const events = DashboardHelpers.absenceEventsByDay(students);
       expect(Object.keys(events).length).toEqual(4);
     });
   });
 
   describe('tardyEventsByDay', () => {
     it('returns a hash with distinct days as keys', () =>{
-      const events = DashboardHelpers.tardyEventsByDay(Data.Students);
+      const students = createStudents(moment.utc());
+      const events = DashboardHelpers.tardyEventsByDay(students);
       expect(Object.keys(events).length).toEqual(5);
     });
   });
 
   describe('averageDailyAttendance', () => {
     it('returns the average number of events for each day', () => {
-      const events = DashboardHelpers.absenceEventsByDay(Data.Students);
-      const averageDailyAttendance = DashboardHelpers.averageDailyAttendance(events, Data.Students.length);
+      const nowMoment = moment.utc();
+      const students = createStudents(nowMoment);
+      const events = DashboardHelpers.absenceEventsByDay(students);
+      const averageDailyAttendance = DashboardHelpers.averageDailyAttendance(events, students.length);
       const result = Object.keys(averageDailyAttendance).map(x => averageDailyAttendance[x]);
       expect(result.sort()).toEqual([16.7,33.3,66.7,83.3]);
     });
@@ -40,8 +45,10 @@ describe('DashboardHelpers', () => {
 
   describe('filterDates', () => {
     it('removes dates outside the date range', () => {
-      const events = DashboardHelpers.absenceEventsByDay(Data.Students);
-      const averageDailyAttendance = DashboardHelpers.averageDailyAttendance(events, Data.Students.length);
+      const nowMoment = moment.utc();
+      const students = createStudents(nowMoment);
+      const events = DashboardHelpers.absenceEventsByDay(students);
+      const averageDailyAttendance = DashboardHelpers.averageDailyAttendance(events, students.length);
       const range = Object.keys(averageDailyAttendance);
       const result = DashboardHelpers.filterDates(range, moment().subtract(4, 'months'), moment());
       expect(result.length).toEqual(3);

--- a/spec/javascripts/school_administrator_dashboard/DashboardTestData.js
+++ b/spec/javascripts/school_administrator_dashboard/DashboardTestData.js
@@ -2,27 +2,27 @@
 //stubbed events for dashboard specs
 export const testEvents = {
   oneMonthAgo: {
-    occurred_at: moment().subtract(1, 'months').format(),
+    occurred_at: moment.utc().subtract(1, 'months').format(),
     student_id: 1,
   },
   twoMonthsAgo: {
-    occurred_at: moment().subtract(2, 'months').format(),
+    occurred_at: moment.utc().subtract(2, 'months').format(),
     student_id: 1,
   },
   threeMonthsAgo: {
-    occurred_at: moment().subtract(3, 'months').format(),
+    occurred_at: moment.utc().subtract(3, 'months').format(),
     student_id: 1,
   },
   fourMonthsAgo: {
-    occurred_at: moment().subtract(4, 'months').format(),
+    occurred_at: moment.utc().subtract(4, 'months').format(),
     student_id: 1,
   },
   oneYearAgo: {
-    occurred_at: moment().subtract(1, 'year').format(),
+    occurred_at: moment.utc().subtract(1, 'year').format(),
     student_id: 1,
   },
   thisMonth: {
-    occurred_at: moment().format(),
+    occurred_at: moment.utc().format(),
     student_id: 1
   }
 };
@@ -96,10 +96,10 @@ export const Students = [
 
 
 export function schoolTardyEvents () {
-  const oneMonthAgo = moment().subtract(1, 'months').format('YYYY-MM-DD');
-  const threeMonthsAgo = moment().subtract(3, 'months').format('YYYY-MM-DD');
-  const fourMonthsAgo = moment().subtract(4, 'months').format('YYYY-MM-DD');
-  const oneYearAgo = moment().subtract(1, 'year').format('YYYY-MM-DD');
+  const oneMonthAgo = moment.utc().subtract(1, 'months').format('YYYY-MM-DD');
+  const threeMonthsAgo = moment.utc().subtract(3, 'months').format('YYYY-MM-DD');
+  const fourMonthsAgo = moment.utc().subtract(4, 'months').format('YYYY-MM-DD');
+  const oneYearAgo = moment.utc().subtract(1, 'year').format('YYYY-MM-DD');
   let schoolTardyEvents = {};
 
   schoolTardyEvents[oneMonthAgo] = [testEvents.oneMonthAgo];

--- a/spec/javascripts/school_administrator_dashboard/DashboardTestData.js
+++ b/spec/javascripts/school_administrator_dashboard/DashboardTestData.js
@@ -1,37 +1,39 @@
 
 //stubbed events for dashboard specs
-export const testEvents = {
-  oneMonthAgo: {
-    occurred_at: moment.utc().subtract(1, 'months').format(),
-    student_id: 1,
-  },
-  twoMonthsAgo: {
-    occurred_at: moment.utc().subtract(2, 'months').format(),
-    student_id: 1,
-  },
-  threeMonthsAgo: {
-    occurred_at: moment.utc().subtract(3, 'months').format(),
-    student_id: 1,
-  },
-  fourMonthsAgo: {
-    occurred_at: moment.utc().subtract(4, 'months').format(),
-    student_id: 1,
-  },
-  oneYearAgo: {
-    occurred_at: moment.utc().subtract(1, 'year').format(),
-    student_id: 1,
-  },
-  thisMonth: {
-    occurred_at: moment.utc().format(),
-    student_id: 1
-  }
-};
+export function createTestEvents(nowMoment) {
+  return {
+    oneMonthAgo: {
+      occurred_at: nowMoment.clone().subtract(1, 'months').format(),
+      student_id: 1,
+    },
+    twoMonthsAgo: {
+      occurred_at: nowMoment.clone().subtract(2, 'months').format(),
+      student_id: 1,
+    },
+    threeMonthsAgo: {
+      occurred_at: nowMoment.clone().subtract(3, 'months').format(),
+      student_id: 1,
+    },
+    fourMonthsAgo: {
+      occurred_at: nowMoment.clone().subtract(4, 'months').format(),
+      student_id: 1,
+    },
+    oneYearAgo: {
+      occurred_at: nowMoment.clone().subtract(1, 'year').format(),
+      student_id: 1,
+    },
+    thisMonth: {
+      occurred_at: nowMoment.clone().format(),
+      student_id: 1
+    }
+  };
+}
 
 
 //stubbed students for dashboard specs
-
-export const Students = [
-  {
+export function createStudents(nowMoment) {
+  const testEvents = createTestEvents(nowMoment);
+  return [{
     first_name: 'Pierrot',
     last_name: 'Zanni',
     homeroom_label: 'Test 1',
@@ -91,15 +93,17 @@ export const Students = [
     tardies: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo],
     events: 2,
     last_sst_date_text: null
-  }
-];
+  }];
+}
 
 
-export function schoolTardyEvents () {
-  const oneMonthAgo = moment.utc().subtract(1, 'months').format('YYYY-MM-DD');
-  const threeMonthsAgo = moment.utc().subtract(3, 'months').format('YYYY-MM-DD');
-  const fourMonthsAgo = moment.utc().subtract(4, 'months').format('YYYY-MM-DD');
-  const oneYearAgo = moment.utc().subtract(1, 'year').format('YYYY-MM-DD');
+export function createSchoolTardyEvents(nowMoment) {
+  const testEvents = createTestEvents(nowMoment);
+  
+  const oneMonthAgo = nowMoment.clone().subtract(1, 'months').format('YYYY-MM-DD');
+  const threeMonthsAgo = nowMoment.clone().subtract(3, 'months').format('YYYY-MM-DD');
+  const fourMonthsAgo = nowMoment.clone().subtract(4, 'months').format('YYYY-MM-DD');
+  const oneYearAgo = nowMoment.clone().subtract(1, 'year').format('YYYY-MM-DD');
   let schoolTardyEvents = {};
 
   schoolTardyEvents[oneMonthAgo] = [testEvents.oneMonthAgo];

--- a/spec/javascripts/school_administrator_dashboard/SchoolAbsenceDashboard.test.js
+++ b/spec/javascripts/school_administrator_dashboard/SchoolAbsenceDashboard.test.js
@@ -2,13 +2,15 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import SchoolAbsenceDashboard from '../../../app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js';
-import * as Data from './DashboardTestData.js';
+import {createStudents, createTestEvents} from './DashboardTestData.js';
+
 
 describe('SchoolAbsenceDashboard', () => {
+  const nowMoment = moment.utc();
   const attendance = {'2001-01-01': 50, '2001-01-02': 25, '2001-01-03': 75, '2001-01-04': 100, '2001-02-01': 10};
   const homeroom = {'HR1': attendance, 'No Homeroom': {'2001-01-01': 50, '2001-01-02': 100, '2001-01-03': 100, '2001-01-04': 100, '2001-02-01': 50}};
-  const students = Data.Students;
-  const events = Data.testEvents;
+  const students = createStudents(nowMoment);
+  const events = createTestEvents(nowMoment);
   const dateRange = ['2001-01-01', '2001-01-02', '2001-01-03', '2001-01-04', '2001-02-01'];
   const dash = shallow(<SchoolAbsenceDashboard
                        schoolAverageDailyAttendance={attendance}

--- a/spec/javascripts/school_administrator_dashboard/SchoolTardiesDashboard.test.js
+++ b/spec/javascripts/school_administrator_dashboard/SchoolTardiesDashboard.test.js
@@ -2,12 +2,22 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import SchoolTardiesDashboard from '../../../app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolTardiesDashboard.js';
-import * as Data from './DashboardTestData.js';
+import {
+  createTestEvents,
+  createStudents,
+  createSchoolTardyEvents
+} from './DashboardTestData.js';
 
 describe('SchoolTardiesDashboard', () => {
-  const schoolTardyEvents = Data.schoolTardyEvents();
-  const homeroomTardyEvents = {'Test 1': [Data.testEvents.oneMonthAgo, Data.testEvents.fourMonthsAgo], 'No Homeroom': [Data.testEvents.oneMonthAgo, Data.testEvents.oneYearAgo]};
-  const students = Data.Students;
+  const nowMoment = moment.utc();
+  const students = createStudents(nowMoment);
+  const testEvents = createTestEvents(nowMoment);
+  const schoolTardyEvents = createSchoolTardyEvents(nowMoment);
+  const homeroomTardyEvents = {
+    'Test 1': [testEvents.oneMonthAgo, testEvents.fourMonthsAgo],
+    'No Homeroom': [testEvents.oneMonthAgo, testEvents.oneYearAgo]
+  };
+  
   const dash = shallow(<SchoolTardiesDashboard
                        schoolTardyEvents={schoolTardyEvents}
                        homeroomTardyEvents={homeroomTardyEvents}
@@ -24,7 +34,7 @@ describe('SchoolTardiesDashboard', () => {
 
   it('displays only the past 3 months of total school data', () => {
     const seriesData = dash.find('DashboardBarChart').first().props().seriesData;
-    expect(seriesData[0][0]).toEqual(moment(Data.testEvents.threeMonthsAgo.occurred_at).format('ddd MM/DD'));
+    expect(seriesData[0][0]).toEqual(moment(testEvents.threeMonthsAgo.occurred_at).format('ddd MM/DD'));
   });
 
 });

--- a/spec/javascripts/school_administrator_dashboard/SchoolwideTardies.test.js
+++ b/spec/javascripts/school_administrator_dashboard/SchoolwideTardies.test.js
@@ -2,10 +2,10 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import SchoolwideTardies from '../../../app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolwideTardies.js';
-import * as Data from './DashboardTestData.js';
+import {createStudents} from './DashboardTestData.js';
 
 describe('SchoolwideTardies', () => {
-  const tardies = shallow(<SchoolwideTardies dashboardStudents={Data.Students} />);
+  const tardies = shallow(<SchoolwideTardies dashboardStudents={createStudents(moment.utc())} />);
 
   it('renders the school tardies dashboard', () => {
     expect(tardies.find('SchoolTardiesDashboard').length).toEqual(1);

--- a/spec/javascripts/school_administrator_dashboard/StudentsTable.test.js
+++ b/spec/javascripts/school_administrator_dashboard/StudentsTable.test.js
@@ -2,10 +2,11 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import StudentsTable from '../../../app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js';
-import * as Data from './DashboardTestData.js';
+import {createStudents} from './DashboardTestData.js';
 
 describe('Dashboard Students Table', () => {
-  const table = shallow(<StudentsTable rows={Data.Students}/>);
+  const nowMoment = moment.utc();
+  const table = shallow(<StudentsTable rows={createStudents(nowMoment)}/>);
 
   it('renders the students list', () => {
     expect(table.find("div").hasClass("StudentsList")).toEqual(true);
@@ -21,7 +22,7 @@ describe('Dashboard Students Table', () => {
     expect(cellTexts).toEqual([
       "Pierrot Zanni",
       "3",
-      moment.utc().subtract(3, 'months').format('M/D/YY'),
+      nowMoment.clone().subtract(3, 'months').format('M/D/YY'),
     ]);
   });
 


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Test failures depending on the timezone and time of day, eg: https://travis-ci.org/studentinsights/studentinsights/builds/354091918.  This was blocking https://github.com/studentinsights/studentinsights/pull/1530 and https://github.com/studentinsights/studentinsights/pull/1529, so just resolving the short-term issue now.

# What does this PR do?
Revises the absence/tardies dashboard specs to explicitly pass through all times.


# Checklists
+ [x] Author improved specs for code in need of better test coverage

There's two deeper underlying issues here, one is that we're parsing times into the incorrect timezone in `toMoment` (unused here) and in other places we're taking dates and converting them to timestamps in UTC days on the server.  The other is that I keep misinterpreting `moment`'s API even after using it for years (eg, functions mutate the date, `moment.utc(text).format()` tells it to tag formatting as in UTC rather than parse it as UTC).  https://date-fns.org/ might be our jam in a separate piece of work.