### PR TITLE
Handle different cases for number of students in low grades box

### DIFF
--- a/app/assets/javascripts/home/HomeInsights.js
+++ b/app/assets/javascripts/home/HomeInsights.js
@@ -85,24 +85,38 @@ export class CheckStudentWithLowGradesView extends React.Component {
     const {studentsWithLowGrades, totalCount} = this.props;
     const {uiLimit} = this.state;
     const truncatedStudentsWithLowGrades = studentsWithLowGrades.slice(0, uiLimit);
+
     return (
       <div className="CheckStudentWithLowGrades">
         <div style={styles.cardTitle}>NGE and 10GE students to check in on</div>
         <Card style={{border: 'none'}}>
-          <div>There are <b>{totalCount} students</b> in your classes who have a D or an F right now but no one has mentioned in NGE or 10GE for the last month.</div>
-          <div style={{paddingTop: 10, paddingBottom: 10}}>
-            {truncatedStudentsWithLowGrades.map(studentWithLowGrades => {
-              const {student, assignments} = studentWithLowGrades;
-              return (
-                <div key={student.id} style={styles.line}>
-                  <span><a style={styles.person} href={`/students/${student.id}`}>{student.first_name} {student.last_name}</a></span>
-                  {this.renderCourseGrades(assignments)}
-                </div>
-              );
-            })}
-          </div>
+           <div>There {this.renderAreHowManyStudents(totalCount)} in your classes who have a D or an F right now but no one has mentioned in NGE or 10GE for the last month.</div>
+          {this.renderList(truncatedStudentsWithLowGrades)}
           {this.renderMore(truncatedStudentsWithLowGrades)}
         </Card>
+      </div>
+    );
+  }
+
+  renderAreHowManyStudents(totalCount) {
+    if (totalCount === 0) return <span>are <b>no students</b></span>;
+    if (totalCount === 1) return <span>is <b>one student</b></span>;
+    return <span>are <b>{totalCount} students</b></span>;
+  }
+
+  renderList(truncatedStudentsWithLowGrades) {
+    if (truncatedStudentsWithLowGrades.length === 0) return null;
+    return (
+      <div style={{paddingTop: 10, paddingBottom: 10}}>
+        {truncatedStudentsWithLowGrades.map(studentWithLowGrades => {
+          const {student, assignments} = studentWithLowGrades;
+          return (
+            <div key={student.id} style={styles.line}>
+              <span><a style={styles.person} href={`/students/${student.id}`}>{student.first_name} {student.last_name}</a></span>
+              {this.renderCourseGrades(assignments)}
+            </div>
+          );
+        })}
       </div>
     );
   }

--- a/app/assets/javascripts/home/HomeInsights.test.js
+++ b/app/assets/javascripts/home/HomeInsights.test.js
@@ -6,9 +6,23 @@ import HomeInsights, {CheckStudentWithLowGradesView} from './HomeInsights';
 import SpecSugar from '../../../../spec/javascripts/support/spec_sugar.jsx';
 import studentsWithLowGradesJson from '../../../../spec/javascripts/fixtures/home_students_with_low_grades_json';
 
+function renderIntoEl(element) {
+  const el = document.createElement('div');
+  ReactDOM.render(element, el);
+  return el;
+}
+
 function testProps() {
   return {
     educatorId: 9999
+  };
+}
+
+function pureTestPropsForN(n) {
+  return {
+    limit: 10,
+    totalCount: n,
+    studentsWithLowGrades: studentsWithLowGradesJson.students_with_low_grades.slice(0, n)
   };
 }
 
@@ -39,6 +53,12 @@ describe('HomeInsights', () => {
 });
 
 describe('CheckStudentWithLowGradesView', () => {
+  it('renders zero, singular and plural states', () => {
+    expect($(renderIntoEl(<CheckStudentWithLowGradesView {...pureTestPropsForN(0)} />)).text()).toContain('There are no students');
+    expect($(renderIntoEl(<CheckStudentWithLowGradesView {...pureTestPropsForN(1)} />)).text()).toContain('There is one student');
+    expect($(renderIntoEl(<CheckStudentWithLowGradesView {...pureTestPropsForN(4)} />)).text()).toContain('There are 4 students');
+  });
+
   it('pure component matches snapshot', () => {
     const props = {
       limit: studentsWithLowGradesJson.limit,

--- a/app/assets/javascripts/home/__snapshots__/HomeInsights.test.js.snap
+++ b/app/assets/javascripts/home/__snapshots__/HomeInsights.test.js.snap
@@ -27,11 +27,14 @@ exports[`CheckStudentWithLowGradesView handles when limit reached 1`] = `
     }
   >
     <div>
-      There are 
-      <b>
-        129
-         students
-      </b>
+      There 
+      <span>
+        are 
+        <b>
+          129
+           students
+        </b>
+      </span>
        in your classes who have a D or an F right now but no one has mentioned in NGE or 10GE for the last month.
     </div>
     <div
@@ -243,11 +246,14 @@ exports[`CheckStudentWithLowGradesView pure component matches snapshot 1`] = `
     }
   >
     <div>
-      There are 
-      <b>
-        7
-         students
-      </b>
+      There 
+      <span>
+        are 
+        <b>
+          7
+           students
+        </b>
+      </span>
        in your classes who have a D or an F right now but no one has mentioned in NGE or 10GE for the last month.
     </div>
     <div


### PR DESCRIPTION
# Who is this PR for?
HS educators

# What problem does this PR fix?
small case bug in text, follow-on to https://github.com/studentinsights/studentinsights/pull/1528

# What does this PR do?
fixes it, nothing fancier or more nudge-y

# Screenshot (if adding a client-side feature)
<img width="516" alt="screen shot 2018-03-15 at 8 39 36 pm" src="https://user-images.githubusercontent.com/1056957/37497838-36b6a48e-2891-11e8-8d5b-0ed0888d3493.png">
<img width="514" alt="screen shot 2018-03-15 at 8 39 51 pm" src="https://user-images.githubusercontent.com/1056957/37497839-36c4951c-2891-11e8-8815-1b65bfe1b842.png">

# Checklists
+ [x] Author checked latest in IE - Home page
+ [x] Author included specs for new code