### PR TITLE
Temporary workaround for NB homeroom names in analysis pages

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -129,11 +129,13 @@ class SchoolsController < ApplicationController
   end
 
   def individual_student_dashboard_data(student)
+    # This is a temporary workaround for New Bedford
+    homeroom_label = student.try(:homeroom).try(:educator).try(:full_name) || student.try(:homeroom).try(:name)
     HashWithIndifferentAccess.new({
       first_name: student.first_name,
       last_name: student.last_name,
       id: student.id,
-      homeroom_label: student.try(:homeroom).try(:educator).try(:full_name),
+      homeroom_label: homeroom_label,
       absences: student.dashboard_absences,
       tardies: student.dashboard_tardies,
       event_notes: student.event_notes


### PR DESCRIPTION
# Who is this PR for?
NB K8 educators

# What problem does this PR fix?
Absence and tardy dashboards don't show homeroom breakdowns, since there aren't any homeroom/educator relationships being imported.

# What does this PR do?
I didn't look further yet, this just works around the immediate problem so the breakdown is meaningful.
