### PR TITLE
Show different disability filters by district

### DIFF
--- a/app/assets/javascripts/components/SlicePanels.js
+++ b/app/assets/javascripts/components/SlicePanels.js
@@ -5,6 +5,8 @@ import FixedTable from './FixedTable';
 import {styles} from '../helpers/Theme';
 import * as Filters from '../helpers/Filters';
 import {shouldDisplay} from '../helpers/customization_helpers.js';
+import {renderSlicePanelsDisabilityTable} from '../helpers/districts';
+
 
 // For showing a set of panels that let users see an overview
 // of distributions, and click to filter a set of data in different
@@ -146,14 +148,13 @@ class SlicePanels extends React.Component {
     );
   }
 
+  // This is different based on the values in the data storage system within
+  // the district.
   renderDisabilityTable() {
-    const key = 'sped_level_of_need';
-    const items = ['Low < 2', 'Low >= 2', 'Moderate', 'High'].map(function(value) {
-      return this.createItem(value, Filters.Equal(key, value));
-    }, this);
-    return this.renderTable({
-      title: 'Disability',
-      items: [this.createItem('None', Filters.Null(key))].concat(items)
+    const {districtKey} = this.props;
+    return renderSlicePanelsDisabilityTable(districtKey, {
+      createItemFn: this.createItem.bind(this),
+      renderTableFn: this.renderTable.bind(this)
     });
   }
 
@@ -346,6 +347,7 @@ class SlicePanels extends React.Component {
   }
 }
 SlicePanels.propTypes = {
+  districtKey: React.PropTypes.string.isRequired,
   filters: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
   students: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
   allStudents: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,

--- a/app/assets/javascripts/env.js.erb
+++ b/app/assets/javascripts/env.js.erb
@@ -4,6 +4,7 @@
   // Describe server-side environment and configuration to the JS UI code.
   window.shared.Env = {
     railsEnvironment: '<%= Rails.env %>',
+    districtKey: '<%= EnvironmentVariable.value('DISTRICT_KEY') %>',
     deploymentKey: '<%= EnvironmentVariable.value('DEPLOYMENT_KEY') %>',
     shouldReportAnalytics: <%= if EnvironmentVariable.is_true('SHOULD_REPORT_ANALYTICS') then 'true' else 'false' end %>,
     shouldReportErrors: <%= if EnvironmentVariable.is_true('SHOULD_REPORT_ERRORS') then 'true' else 'false' end %>,

--- a/app/assets/javascripts/helpers/districts.js
+++ b/app/assets/javascripts/helpers/districts.js
@@ -1,0 +1,43 @@
+import * as Filters from './Filters';
+
+
+const ORDERED_DISABILITY_VALUES_MAP = {
+  'new_bedford': [
+    "Does Not Apply",
+    "Low-Less Than 2hrs/week",
+    "Low-2+ hrs/week",
+    "Moderate",
+    "High"
+  ],
+  'somerville': [
+    // also include null
+    'Low < 2',
+    'Low >= 2',
+    'Moderate',
+    'High'
+  ]
+};
+
+export function orderedDisabilityValues(districtKey) {
+  return ORDERED_DISABILITY_VALUES_MAP[districtKey] || [];
+}
+
+// Renders a table for `SlicePanels` that works differently for different
+// districts.
+export function renderSlicePanelsDisabilityTable(districtKey, options = {}) {
+  const {createItemFn, renderTableFn} = options;
+
+  const key = 'sped_level_of_need';
+  const itemsFromValues = orderedDisabilityValues(districtKey).map(value => {
+    return createItemFn(value, Filters.Equal(key, value));
+  }, this);
+
+  // Somerville uses a null value for no disability, while New Bedford
+  // uses a separate value to describe that explicitly.
+  const items = (districtKey === 'somerville')
+    ? [createItemFn('None', Filters.Null(key))].concat(itemsFromValues)
+    : itemsFromValues;
+  return renderTableFn({items, title: 'Disability'});
+}
+
+

--- a/app/assets/javascripts/school_overview/SchoolOverviewPage.js
+++ b/app/assets/javascripts/school_overview/SchoolOverviewPage.js
@@ -181,6 +181,7 @@ class SchoolOverviewPage extends React.Component {
       <div className="school-overview" style={{ fontSize: styles.fontSize }}>
         <div className="header" style={styles.header}>
           <SlicePanels
+            districtKey={this.props.districtKey}
             allStudents={this.props.allStudents}
             students={this.getFilteredStudents()}
             school={this.props.school}
@@ -210,6 +211,7 @@ class SchoolOverviewPage extends React.Component {
 }
 
 SchoolOverviewPage.propTypes = {
+  districtKey: React.PropTypes.string.isRequired,
   school: React.PropTypes.object.isRequired,
   allStudents: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
   serviceTypesIndex: React.PropTypes.object.isRequired,

--- a/app/assets/javascripts/school_overview/main.jsx
+++ b/app/assets/javascripts/school_overview/main.jsx
@@ -25,7 +25,9 @@ export default function renderSchoolOverviewMain(el, options = {}) {
 function render(el, json) {
   MixpanelUtils.registerUser(json.current_educator);
   MixpanelUtils.track('PAGE_VISIT', { page_key: 'SCHOOL_OVERVIEW_DASHBOARD' });
+  const {districtKey} = window.shared.Env;
   window.ReactDOM.render(<SchoolOverviewPage
+    districtKey={districtKey}
     allStudents={json.students}
     school={json.school}
     serviceTypesIndex={json.constant_indexes.service_types_index}

--- a/spec/javascripts/components/SlicePanels.test.js
+++ b/spec/javascripts/components/SlicePanels.test.js
@@ -8,6 +8,7 @@ import SlicePanels from '../../../app/assets/javascripts/components/SlicePanels'
 const helpers = {
   renderInto(el, props = {}) {
     const mergedProps = {
+      districtKey: 'somerville',
       filters: [],
       serviceTypesIndex,
       eventNoteTypesIndex,
@@ -43,6 +44,12 @@ const helpers = {
         return $(tableEl).find('tbody tr').length;
       });
     });
+  },
+
+  // Returns an array of text values the users can filter by for student
+  // Disability
+  disabilityFilters(el) {
+    return $(el).find('table:first td.caption-cell').toArray().map(el => $(el).text());
   }
 };
 
@@ -102,5 +109,39 @@ SpecSugar.withTestEl('high-level integration tests', (container) => {
       [ 5, 5, 5 ],
       [ 4, 1, 4, 2, 1 ]
     ]);
+  });
+
+  describe('disability values vary by district', () => {
+    it('renders values with None for Somerville', () => {
+      const el = container.testEl;
+      helpers.renderInto(el, {
+        districtKey: 'somerville',
+        students: FixtureStudents,
+        allStudents: FixtureStudents
+      });
+      expect(helpers.disabilityFilters(el)).toEqual([
+        "None",
+        "Low < 2",
+        "Low >= 2",
+        "Moderate",
+        "High"
+      ]);
+    });
+
+    it('renders explicit values only for New Bedford', () => {
+      const el = container.testEl;
+      helpers.renderInto(el, {
+        districtKey: 'new_bedford',
+        students: FixtureStudents,
+        allStudents: FixtureStudents
+      });
+      expect(helpers.disabilityFilters(el)).toEqual([
+        "Does Not Apply",
+        "Low-Less Than 2hrs/week",
+        "Low-2+ hrs/week",
+        "Moderate",
+        "High"
+      ]);
+    });
   });
 });


### PR DESCRIPTION
# Who is this PR for?
NB K8 educators

# What problem does this PR fix?
New Bedford uses different values than Somerville to describe levels of disability in special education.  This makes the summary values in the overview page inaccurate, and the filter values are not all meaningful.

# What does this PR do?
Threads the server env value down to `window.shared.Env.districtKey` and then branches on it in the `SlicePanels` UI to show different filters for each district.

# Screenshot (if adding a client-side feature)
before, showing wrong filters:
<img width="242" alt="screen shot 2018-03-15 at 9 56 16 pm" src="https://user-images.githubusercontent.com/1056957/37499747-ddc802ea-289b-11e8-97c3-7ad6e5aabf3c.png">

after, showing correct filters (but for demo data using Somerville disability values):
<img width="212" alt="screen shot 2018-03-15 at 9 57 04 pm" src="https://user-images.githubusercontent.com/1056957/37499746-ddb8eb84-289b-11e8-9c48-e8a1058a80b3.png">


# Checklists
+ [x] Author checked latest in IE - School Overview
+ [x] Author included specs for new code
