### PR TITLE
Add PerDistrict, render admin home page schools differently in New Bedford

### DIFF
--- a/app/config_objects/load_district_config.rb
+++ b/app/config_objects/load_district_config.rb
@@ -1,6 +1,7 @@
 # This class is responsible for pulling YAML district config out of the
 # filesystem and parsing it into a Ruby hash.
 
+# Deprecated, see PerDistrict
 class LoadDistrictConfig
 
   def initialize(district_key = ENV['DISTRICT_KEY'])

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -1,0 +1,24 @@
+# Server code that's different per-district.  Centralize here
+# whereever possible rather than leaking out to different places in
+# the codebase.
+#
+# If this gets too big we can refactor :)
+class PerDistrict
+  NEW_BEDFORD = 'new_bedford'
+  SOMERVILLE = 'somerville'
+
+  def initialize(options = {})
+    @district_key = options[:district_key] || ENV['DISTRICT_KEY']
+    raise "PerDistrict#initialize couldn't find a value for district_key" if @district_key.nil?
+  end
+
+  # The schools shown on the admin page are in different orders,
+  # with pilot schools in New Bedford shown first.
+  def ordered_schools_for_admin_page
+    if @district_key == NEW_BEDFORD
+      School.where(local_id: ['115', '123']) # parker and pulaski, the first pilot schools
+    else
+      School.all
+    end
+  end
+end

--- a/app/controllers/educators_controller.rb
+++ b/app/controllers/educators_controller.rb
@@ -38,7 +38,7 @@ class EducatorsController < ApplicationController
   end
 
   def districtwide_admin_homepage
-    @schools = School.all
+    @schools = PerDistrict.new.ordered_schools_for_admin_page
   end
 
   def names_for_dropdown


### PR DESCRIPTION
# Who is this PR for?
New Bedford districtwide admin

# What problem does this PR fix?
We're only importing data for pilot schools, but the districtwide admin pages shows all schools and there are a lot, with the two pilot schools buried way below the fold.

# What does this PR do?
Adds a `PerDistrict` class Rails code like this and tags `LoadDistrictConfig` as deprecated.  We'll need to distinguish between what the purpose of these two classes are, and my intent here is to tag `PerDistrict` as "the place to put Ruby code that branches on ENV['DISTRICT_KEY']" rather than "the class that reads yml config."  I think we can revise `LoadDistrictConfig` to just do that, and have `PerDistrict` be the Ruby-facing API for "I need to do something different based on the district."

# Screenshot (if adding a client-side feature)
None.  We don't have a good way to work with Rails code that works for features across districts right now, either in development mode or in RSpec tests, and we need to work on this.  I'll deploy and verify manually for now.
