### PR TITLE
Add lower grade ordering for SlicePanels on overview page

### DIFF
--- a/app/assets/javascripts/components/SlicePanels.js
+++ b/app/assets/javascripts/components/SlicePanels.js
@@ -272,6 +272,8 @@ class SlicePanels extends React.Component {
       return this.createItem(value, Filters.Equal(key, value));
     }, this);
     const sortedItems = _.sortBy(items, function(item) {
+      if (item.caption === 'TK') return -40;
+      if (item.caption === 'PPK') return -30;
       if (item.caption === 'PK') return -20;
       if (item.caption === 'KF') return -10;
       return parseFloat(item.caption);


### PR DESCRIPTION
# Who is this PR for?
New Bedford educators

# What problem does this PR fix?
lower grades aren't sorted correctly on overview page
