### PR TITLE
Include discipline incidents in the home page feed

### DIFF
--- a/app/assets/javascripts/components/Badge.js
+++ b/app/assets/javascripts/components/Badge.js
@@ -1,0 +1,28 @@
+import React from 'react';
+
+
+// A visual UI element for a badge indicating a particular 
+// type of data (eg, in the home page feed).
+function Badge({text, backgroundColor, style}) {
+  const mergedStyle = {
+    ...styles.badge,
+    backgroundColor,
+    ...style
+  };
+  return <span className="Badge" style={mergedStyle}>{text}</span>;
+}
+Badge.propTypes = {
+  text: React.PropTypes.string.isRequired,
+  backgroundColor: React.PropTypes.string.isRequired,
+  style: React.PropTypes.object
+};
+
+const styles = {
+  badge: {
+    padding: 5,
+    color: 'white',
+    opacity: 0.5
+  }
+};
+
+export default Badge;

--- a/app/assets/javascripts/components/Badge.test.js
+++ b/app/assets/javascripts/components/Badge.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Badge from './Badge';
+
+it('renders without crashing', () => {
+  const el = document.createElement('div');
+  ReactDOM.render(<Badge backgroundColor="black" text="hello" />, el);
+  expect(el.innerHTML).toContain('hello');
+});

--- a/app/assets/javascripts/components/IncidentCard.js
+++ b/app/assets/javascripts/components/IncidentCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 
 /*
+DEPRECATED
 Shows a "card" of an incident that happened with a student.
 Note that this might contain sensitive data.
 */

--- a/app/assets/javascripts/components/NoteBadge.js
+++ b/app/assets/javascripts/components/NoteBadge.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Badge from './Badge';
 import {
   eventNoteTypeText,
   eventNoteTypeColor
@@ -9,25 +10,12 @@ import {
 // event note type.
 function NoteBadge({eventNoteTypeId, style}) {
   const text = eventNoteTypeText(eventNoteTypeId);
-  const color = eventNoteTypeColor(eventNoteTypeId);
-  const mergedStyle = {
-    ...styles.noteBadge,
-    backgroundColor: color,
-    color: 'white',
-    opacity: 0.5,
-    ...style
-  };
-  return <span className="NoteBadge" style={mergedStyle}>{text}</span>;
+  const backgroundColor = eventNoteTypeColor(eventNoteTypeId);
+  return Badge({text, backgroundColor, style});
 }
 NoteBadge.propTypes = {
   eventNoteTypeId: React.PropTypes.number.isRequired,
   style: React.PropTypes.object
-};
-
-const styles = {
-  noteBadge: {
-    padding: 5
-  }
 };
 
 export default NoteBadge;

--- a/app/assets/javascripts/home/EventNoteCard.js
+++ b/app/assets/javascripts/home/EventNoteCard.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import Card from '../components/Card';
+import FeedCardFrame from './FeedCardFrame';
 import Educator from '../components/Educator';
-import Homeroom from '../components/Homeroom';
 import HouseBadge from '../components/HouseBadge';
 import NoteBadge from '../components/NoteBadge';
 import {toMomentFromTime} from '../helpers/toMoment';
-import {gradeText} from '../helpers/gradeText';
 import {eventNoteTypeText} from '../components/eventNoteType';
 
 
@@ -16,44 +14,30 @@ class EventNoteCard extends React.Component {
     const now = nowFn();
     const {eventNoteCardJson, style} = this.props;
     const {student, educator} = eventNoteCardJson;
-    const {homeroom} = student;
 
     return (
-      <Card className="EventNoteCard" style={style}>
-        <div style={styles.header}>
-          <div style={styles.studentHeader}>
-            <div>
-              <div>
-                <a style={styles.person} href={`/students/${student.id}`}>{student.first_name} {student.last_name}</a>
-              </div>
-              <div>{gradeText(student.grade)}</div>
-              <div>
-                {homeroom && <Homeroom
-                  id={homeroom.id}
-                  name={homeroom.name}
-                  educator={homeroom.educator} />}
-              </div>
-            </div>
-          </div>
-          <div style={styles.by}>
+      <div className="EventNoteCard">
+        <FeedCardFrame
+          style={style}
+          student={student}
+          byEl={
             <div>
               <span>by </span>
               <Educator
                 style={styles.person}
                 educator={educator} />
             </div>
-            <div>in {eventNoteTypeText(eventNoteCardJson.event_note_type_id)}</div>
-            <div>{toMomentFromTime(eventNoteCardJson.recorded_at).from(now)} on {toMomentFromTime(eventNoteCardJson.recorded_at).format('M/D')}</div>
-          </div>
-        </div>
-        <div style={styles.body}>
+          }
+          whereEl={<div>in {eventNoteTypeText(eventNoteCardJson.event_note_type_id)}</div>}
+          whenEl={<div>{toMomentFromTime(eventNoteCardJson.recorded_at).from(now)} on {toMomentFromTime(eventNoteCardJson.recorded_at).format('M/D')}</div>}
+          badgesEl={<div>
+            {student.house && <HouseBadge style={styles.footerBadge} house={student.house} />}
+            <NoteBadge style={styles.footerBadge} eventNoteTypeId={eventNoteCardJson.event_note_type_id} />
+          </div>}
+        >
           <div>{eventNoteCardJson.text}</div>
-        </div>
-        <div style={styles.footer}>
-          {student.house && <HouseBadge style={styles.footerBadge} house={student.house} />}
-          <NoteBadge style={styles.footerBadge} eventNoteTypeId={eventNoteCardJson.event_note_type_id} />
-        </div>
-      </Card>
+        </FeedCardFrame>
+      </div>
     );
   }
 }
@@ -84,30 +68,6 @@ EventNoteCard.propTypes = {
 
 
 const styles = {
-  header: {
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center'
-  },
-  studentHeader: {
-    display: 'flex',
-    alignItems: 'center'
-  },
-  body: {
-    marginBottom: 20,
-    marginTop: 20
-  },
-  by: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'flex-end'
-  },
-  footer: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    marginBottom: 5
-  },
   footerBadge: {
     marginLeft: 5
   },

--- a/app/assets/javascripts/home/FeedCardFrame.js
+++ b/app/assets/javascripts/home/FeedCardFrame.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import Card from '../components/Card';
+import Homeroom from '../components/Homeroom';
+import {gradeText} from '../helpers/gradeText';
+
+
+// Render a card in the feed for an EventNote
+class FeedCardFrame extends React.Component {
+  render() {
+    const {style, student, byEl, whereEl, whenEl, children, badgesEl} = this.props;
+    const {homeroom} = student;
+    
+    return (
+      <Card className="FeedCardFrame" style={style}>
+        <div style={styles.header}>
+          <div style={styles.studentHeader}>
+            <div>
+              <div>
+                <a style={styles.person} href={`/students/${student.id}`}>{student.first_name} {student.last_name}</a>
+              </div>
+              <div>{gradeText(student.grade)}</div>
+              <div>
+                {homeroom && <Homeroom
+                  id={homeroom.id}
+                  name={homeroom.name}
+                  educator={homeroom.educator} />}
+              </div>
+            </div>
+          </div>
+          <div style={styles.by}>
+            <div>{byEl}</div>
+            <div>{whereEl}</div>
+            <div>{whenEl}</div>
+          </div>
+        </div>
+        <div style={styles.body}>
+          {children}
+        </div>
+        <div style={styles.footer}>
+          {badgesEl}
+        </div>
+      </Card>
+    );
+  }
+}
+FeedCardFrame.contextTypes = {
+  nowFn: React.PropTypes.func.isRequired
+};
+FeedCardFrame.propTypes = {
+  student: React.PropTypes.shape({
+    id: React.PropTypes.number.isRequired,
+    first_name: React.PropTypes.string.isRequired,
+    last_name: React.PropTypes.string.isRequired,
+    grade: React.PropTypes.string.isRequired,
+    house: React.PropTypes.string,
+    homeroom: React.PropTypes.shape({
+      id: React.PropTypes.number.isRequired,
+      name: React.PropTypes.string.isRequired,
+      educator: React.PropTypes.object
+    })
+  }).isRequired,
+  children: React.PropTypes.node.isRequired,
+  byEl: React.PropTypes.node,
+  whereEl: React.PropTypes.node,
+  whenEl: React.PropTypes.node,
+  badgesEl: React.PropTypes.node,
+  style: React.PropTypes.object
+};
+
+
+const styles = {
+  header: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  studentHeader: {
+    display: 'flex',
+    alignItems: 'center'
+  },
+  body: {
+    marginBottom: 20,
+    marginTop: 20
+  },
+  by: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-end'
+  },
+  footer: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    marginBottom: 5
+  },
+  person: {
+    fontWeight: 'bold'
+  }
+};
+
+export default FeedCardFrame;

--- a/app/assets/javascripts/home/FeedCardFrame.test.js
+++ b/app/assets/javascripts/home/FeedCardFrame.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import FeedCardFrame from './FeedCardFrame';
+import {withDefaultNowContext} from '../../../../spec/javascripts/support/NowContainer';
+
+function testStudent() {
+  return {
+    id: 55,
+    first_name: 'Mari',
+    last_name: 'Skywalker',
+    grade: '9',
+    house: 'Beacon',
+    homeroom: {
+      id: 13,
+      name: 'SHS-052',
+      educator: {
+        id: 5,
+        email: 'lt@demo.studentinsights.org',
+        full_name: 'Teacher, Lois',
+      }
+    }
+  };
+}
+
+it('renders without crashing', () => {
+  const el = document.createElement('div');
+  ReactDOM.render(withDefaultNowContext(
+    <FeedCardFrame
+      student={testStudent()}
+      byEl={<div>by</div>}
+      whereEl={<div>where</div>}
+      whenEl={<div>when</div>}
+      badgesEl={<div>badges</div>}>
+      kids
+    </FeedCardFrame>
+  ), el);
+  expect($(el).text()).toContain('Mari Skywalker');
+  expect($(el).text()).toContain('9th grade');
+  expect($(el).text()).toContain('SHS-052');
+  expect($(el).text()).toContain('with Lois Teacher');
+  expect($(el).text()).toContain('by');
+  expect($(el).text()).toContain('where');
+  expect($(el).text()).toContain('when');
+  expect($(el).text()).toContain('badges');
+  expect($(el).text()).toContain('kids');
+});

--- a/app/assets/javascripts/home/HomeFeed.js
+++ b/app/assets/javascripts/home/HomeFeed.js
@@ -3,6 +3,7 @@ import qs from 'query-string';
 import _ from 'lodash';
 import EventNoteCard from './EventNoteCard';
 import BirthdayCard from './BirthdayCard';
+import IncidentCard from './IncidentCard';
 import {apiFetchJson} from '../helpers/apiFetchJson';
 import {toMomentFromTime} from '../helpers/toMoment';
 
@@ -123,6 +124,7 @@ export class HomeFeedPure extends React.Component {
           const {type, json} = feedCard;
           if (type === 'event_note_card') return this.renderEventNoteCard(json);
           if (type === 'birthday_card') return this.renderBirthdayCard(json);
+          if (type === 'incident_card') return this.renderIncidenCard(json);
           console.warn('Unexpected card type: ', type); // eslint-disable-line no-console
         })}
       </div>
@@ -142,6 +144,13 @@ export class HomeFeedPure extends React.Component {
       style={styles.card}
       studentBirthdayCard={json} />;
   }
+
+  renderIncidenCard(json) {
+    return <IncidentCard
+      key={json.id}
+      style={styles.card}
+      incidentCard={json} />;
+  }    
 }
 HomeFeedPure.propTypes = {
   feedCards: React.PropTypes.arrayOf(React.PropTypes.shape({

--- a/app/assets/javascripts/home/IncidentCard.js
+++ b/app/assets/javascripts/home/IncidentCard.js
@@ -1,9 +1,6 @@
 import React from 'react';
-import Card from '../components/Card';
 import {toMomentFromTime} from '../helpers/toMoment';
 import FeedCardFrame from './FeedCardFrame';
-import {gradeText} from '../helpers/gradeText';
-import Homeroom from '../components/Homeroom';
 import HouseBadge from '../components/HouseBadge';
 import Badge from '../components/Badge';
 

--- a/app/assets/javascripts/home/IncidentCard.js
+++ b/app/assets/javascripts/home/IncidentCard.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import Card from '../components/Card';
+import {toMomentFromTime} from '../helpers/toMoment';
+import FeedCardFrame from './FeedCardFrame';
+import {gradeText} from '../helpers/gradeText';
+import Homeroom from '../components/Homeroom';
+import HouseBadge from '../components/HouseBadge';
+import Badge from '../components/Badge';
+
+
+// Render a card in the feed for a discipline incident
+class IncidentCard extends React.Component {
+  render() {
+    const {nowFn} = this.context;
+    const now = nowFn();
+    const {style, incidentCard} = this.props;
+    const {student} = incidentCard;
+
+    return (
+      <div className="IncidentCard" >
+        <FeedCardFrame
+          style={style}
+          student={student}
+          whereEl={<div>in {incidentCard.incident_location}</div>}
+          whenEl={<div>{toMomentFromTime(incidentCard.occurred_at).from(now)} on {toMomentFromTime(incidentCard.occurred_at).format('M/D')}</div>}
+          badgesEl={<div>
+            {student.house && <HouseBadge style={styles.footerBadge} house={student.house} />}
+            <Badge style={styles.footerBadge} text="Incident" backgroundColor="rgb(255, 140, 0)" />
+          </div>}
+        >
+          <div>{incidentCard.incident_description} (code: {incidentCard.incident_code})</div>
+        </FeedCardFrame>
+      </div>
+    );
+  }
+}
+IncidentCard.contextTypes = {
+  nowFn: React.PropTypes.func.isRequired
+};
+IncidentCard.propTypes = {
+  incidentCard: React.PropTypes.shape({
+    id: React.PropTypes.number.isRequired,
+    incident_code: React.PropTypes.string.isRequired,
+    incident_location: React.PropTypes.string.isRequired,
+    incident_description: React.PropTypes.string.isRequired,
+    occurred_at: React.PropTypes.string.isRequired,
+    has_exact_time: React.PropTypes.bool.isRequired,
+    student: React.PropTypes.shape({
+      id: React.PropTypes.number.isRequired,
+      first_name: React.PropTypes.string.isRequired,
+      last_name: React.PropTypes.string.isRequired,
+      grade: React.PropTypes.string.isRequired,
+      house: React.PropTypes.string,
+      homeroom: React.PropTypes.shape({
+        id: React.PropTypes.number.isRequired,
+        name: React.PropTypes.string.isRequired,
+        educator: React.PropTypes.object
+      })
+    })
+  }),
+  style: React.PropTypes.object
+};
+
+
+const styles = {
+  footerBadge: {
+    marginLeft: 5
+  }
+};
+
+export default IncidentCard;

--- a/app/assets/javascripts/home/IncidentCard.test.js
+++ b/app/assets/javascripts/home/IncidentCard.test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import renderer from 'react-test-renderer';
+import IncidentCard from './IncidentCard';
+import {withDefaultNowContext} from '../../../../spec/javascripts/support/NowContainer';
+
+
+function testProps(props = {}) {
+  return {
+    incidentCard: {
+      "id": 21,
+      "incident_code": "OT",
+      "incident_location": "Locker room/gym",
+      "incident_description": "Earlier today something happened with the student that was concerning and we did this to de-escalate and support them in the moment, and then took these steps to understand the underlying challenges they're facing, and adapt how we're working with them moving forward.",
+      "occurred_at": "2018-02-28T05:00:00.000Z",
+      "has_exact_time": false,
+      "student": {
+        "id": 100,
+        "grade": "10",
+        "first_name": "Mowgli",
+        "last_name": "Pan",
+        "house": "Beacon",
+        "homeroom": {
+          "id": 4,
+          "name": "SHS ALL"
+        }
+      }
+    },
+    ...props
+  };
+}
+
+it('renders without crashing', () => {
+  const props = testProps();
+  const el = document.createElement('div');
+  ReactDOM.render(withDefaultNowContext(<IncidentCard {...props} />), el);
+});
+
+it('matches snapshot', () => {
+  const props = testProps();
+  const tree = renderer
+    .create(withDefaultNowContext(<IncidentCard {...props} />))
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/assets/javascripts/home/__snapshots__/EventNoteCard.test.js.snap
+++ b/app/assets/javascripts/home/__snapshots__/EventNoteCard.test.js.snap
@@ -2,22 +2,15 @@
 
 exports[`matches snapshot 1`] = `
 <div
-  className="Card EventNoteCard"
-  style={
-    Object {
-      "border": "1px solid #ccc",
-      "borderRadius": 3,
-      "padding": 10,
-    }
-  }
+  className="EventNoteCard"
 >
   <div
+    className="Card FeedCardFrame"
     style={
       Object {
-        "alignItems": "center",
-        "display": "flex",
-        "flexDirection": "row",
-        "justifyContent": "space-between",
+        "border": "1px solid #ccc",
+        "borderRadius": 3,
+        "padding": 10,
       }
     }
   >
@@ -26,139 +19,158 @@ exports[`matches snapshot 1`] = `
         Object {
           "alignItems": "center",
           "display": "flex",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
         }
       }
     >
-      <div>
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+          }
+        }
+      >
         <div>
-          <a
-            href="/students/55"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Mari
-             
-            Skywalker
-          </a>
-        </div>
-        <div>
-          9th grade
-        </div>
-        <div>
-          <span
-            className="Homeroom"
-            style={Object {}}
-          >
+          <div>
             <a
-              href="/homerooms/13"
+              href="/students/55"
+              style={
+                Object {
+                  "fontWeight": "bold",
+                }
+              }
             >
-              SHS-052
+              Mari
+               
+              Skywalker
             </a>
-            <span>
-              <span>
-                 
-              </span>
-               with 
+          </div>
+          <div>
+            9th grade
+          </div>
+          <div>
+            <span
+              className="Homeroom"
+              style={Object {}}
+            >
               <a
-                className="Educator"
-                href="mailto:lt@demo.studentinsights.org"
-                style={Object {}}
+                href="/homerooms/13"
               >
-                Lois Teacher
+                SHS-052
               </a>
+              <span>
+                <span>
+                   
+                </span>
+                 with 
+                <a
+                  className="Educator"
+                  href="mailto:lt@demo.studentinsights.org"
+                  style={Object {}}
+                >
+                  Lois Teacher
+                </a>
+              </span>
             </span>
-          </span>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "display": "flex",
+            "flexDirection": "column",
+          }
+        }
+      >
+        <div>
+          <div>
+            <span>
+              by 
+            </span>
+            <a
+              className="Educator"
+              href="mailto:kt@demo.studentinsights.org"
+              style={
+                Object {
+                  "fontWeight": "bold",
+                }
+              }
+            >
+              Kevin Teacher
+            </a>
+          </div>
+        </div>
+        <div>
+          <div>
+            in 
+            9th Grade Experience
+          </div>
+        </div>
+        <div>
+          <div>
+            14 years ago
+             on 
+            3/5
+          </div>
         </div>
       </div>
     </div>
     <div
       style={
         Object {
-          "alignItems": "flex-end",
-          "display": "flex",
-          "flexDirection": "column",
+          "marginBottom": 20,
+          "marginTop": 20,
         }
       }
     >
       <div>
-        <span>
-          by 
-        </span>
-        <a
-          className="Educator"
-          href="mailto:kt@demo.studentinsights.org"
+        hello!
+      </div>
+    </div>
+    <div
+      style={
+        Object {
+          "display": "flex",
+          "justifyContent": "flex-end",
+          "marginBottom": 5,
+        }
+      }
+    >
+      <div>
+        <span
+          className="HouseBadge"
           style={
             Object {
-              "fontWeight": "bold",
+              "backgroundColor": "#333",
+              "color": "white",
+              "marginLeft": 5,
+              "opacity": 0.5,
+              "padding": 5,
             }
           }
         >
-          Kevin Teacher
-        </a>
-      </div>
-      <div>
-        in 
-        9th Grade Experience
-      </div>
-      <div>
-        14 years ago
-         on 
-        3/5
+          Beacon house
+        </span>
+        <span
+          className="Badge"
+          style={
+            Object {
+              "backgroundColor": "#139DEA",
+              "color": "white",
+              "marginLeft": 5,
+              "opacity": 0.5,
+              "padding": 5,
+            }
+          }
+        >
+          9th Grade Experience
+        </span>
       </div>
     </div>
-  </div>
-  <div
-    style={
-      Object {
-        "marginBottom": 20,
-        "marginTop": 20,
-      }
-    }
-  >
-    <div>
-      hello!
-    </div>
-  </div>
-  <div
-    style={
-      Object {
-        "display": "flex",
-        "justifyContent": "flex-end",
-        "marginBottom": 5,
-      }
-    }
-  >
-    <span
-      className="HouseBadge"
-      style={
-        Object {
-          "backgroundColor": "#333",
-          "color": "white",
-          "marginLeft": 5,
-          "opacity": 0.5,
-          "padding": 5,
-        }
-      }
-    >
-      Beacon house
-    </span>
-    <span
-      className="NoteBadge"
-      style={
-        Object {
-          "backgroundColor": "#139DEA",
-          "color": "white",
-          "marginLeft": 5,
-          "opacity": 0.5,
-          "padding": 5,
-        }
-      }
-    >
-      9th Grade Experience
-    </span>
   </div>
 </div>
 `;

--- a/app/assets/javascripts/home/__snapshots__/HomeFeed.test.js.snap
+++ b/app/assets/javascripts/home/__snapshots__/HomeFeed.test.js.snap
@@ -39,23 +39,16 @@ exports[`HomeFeedPure pure component matches snapshot 1`] = `
     </span>
   </div>
   <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
+    className="EventNoteCard"
   >
     <div
+      className="Card FeedCardFrame"
       style={
         Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
         }
       }
     >
@@ -64,443 +57,159 @@ exports[`HomeFeedPure pure component matches snapshot 1`] = `
           Object {
             "alignItems": "center",
             "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
           }
         }
       >
-        <div>
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
           <div>
-            <a
-              href="/students/18"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Winnie
-               
-              Disney
-            </a>
-          </div>
-          <div>
-            Kindergarten
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
+            <div>
               <a
-                href="/homerooms/1"
+                href="/students/18"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
               >
-                HEA 003
+                Winnie
+                 
+                Disney
               </a>
-              <span>
-                <span>
-                   
-                </span>
-                 with 
+            </div>
+            <div>
+              Kindergarten
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
                 <a
-                  className="Educator"
-                  href="mailto:vivian@demo.studentinsights.org"
-                  style={Object {}}
+                  href="/homerooms/1"
                 >
-                  Vivian Teacher
+                  HEA 003
                 </a>
+                <span>
+                  <span>
+                     
+                  </span>
+                   with 
+                  <a
+                    className="Educator"
+                    href="mailto:vivian@demo.studentinsights.org"
+                    style={Object {}}
+                  >
+                    Vivian Teacher
+                  </a>
+                </span>
               </span>
-            </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              MTSS Meeting
+            </div>
+          </div>
+          <div>
+            <div>
+              12 days ago
+               on 
+              3/1
+            </div>
           </div>
         </div>
       </div>
       <div
         style={
           Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
+            "marginBottom": 20,
+            "marginTop": 20,
           }
         }
       >
         <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          MTSS Meeting
-        </div>
-        <div>
-          12 days ago
-           on 
-          3/1
-        </div>
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        hello there!
+          hello there!
 
 Philis is meeting with parent next week and will present an attendance contract.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#EB4B26",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        MTSS Meeting
-      </span>
-    </div>
-  </div>
-  <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-          }
-        }
-      >
-        <div>
-          <div>
-            <a
-              href="/students/103"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Donald
-               
-              Duck
-            </a>
-          </div>
-          <div>
-            10th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
-              <a
-                href="/homerooms/4"
-              >
-                SHS ALL
-              </a>
-            </span>
-          </div>
         </div>
       </div>
       <div
         style={
           Object {
-            "alignItems": "flex-end",
             "display": "flex",
-            "flexDirection": "column",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
           }
         }
       >
         <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
+          <span
+            className="Badge"
             style={
               Object {
-                "fontWeight": "bold",
+                "backgroundColor": "#EB4B26",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
               }
             }
           >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          9th Grade Experience
-        </div>
-        <div>
-          6 years ago
-           on 
-          12/2
-        </div>
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Not engaged in academic work and misbehaving in class.  There have been meetings between the teacher and support staff, and Sam has talked with Donald twice this week.  Philis following up with outside providers as well.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="HouseBadge"
-        style={
-          Object {
-            "backgroundColor": "#333",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Broadway house
-      </span>
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#139DEA",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        9th Grade Experience
-      </span>
-    </div>
-  </div>
-  <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-          }
-        }
-      >
-        <div>
-          <div>
-            <a
-              href="/students/72"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Rapunzel
-               
-              White
-            </a>
-          </div>
-          <div>
-            10th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
-              <a
-                href="/homerooms/4"
-              >
-                SHS ALL
-              </a>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        style={
-          Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
-          }
-        }
-      >
-        <div>
-          <span>
-            by 
+            MTSS Meeting
           </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          Parent conversation
-        </div>
-        <div>
-          6 years ago
-           on 
-          11/5
         </div>
       </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Not engaged in academic work and misbehaving in class.  There have been meetings between the teacher and support staff, and Sam has talked with Rapunzel twice this week.  Philis following up with outside providers as well.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="HouseBadge"
-        style={
-          Object {
-            "backgroundColor": "#333",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Highland house
-      </span>
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#CDD71A",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Parent conversation
-      </span>
     </div>
   </div>
   <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
+    className="EventNoteCard"
   >
     <div
+      className="Card FeedCardFrame"
       style={
         Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
         }
       }
     >
@@ -509,602 +218,318 @@ Philis is meeting with parent next week and will present an attendance contract.
           Object {
             "alignItems": "center",
             "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
           }
         }
       >
-        <div>
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
           <div>
-            <a
-              href="/students/18"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Winnie
-               
-              Disney
-            </a>
-          </div>
-          <div>
-            Kindergarten
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
+            <div>
               <a
-                href="/homerooms/1"
+                href="/students/103"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
               >
-                HEA 003
+                Donald
+                 
+                Duck
               </a>
-              <span>
-                <span>
-                   
-                </span>
-                 with 
+            </div>
+            <div>
+              10th grade
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
                 <a
-                  className="Educator"
-                  href="mailto:vivian@demo.studentinsights.org"
-                  style={Object {}}
+                  href="/homerooms/4"
                 >
-                  Vivian Teacher
+                  SHS ALL
                 </a>
               </span>
-            </span>
+            </div>
           </div>
         </div>
-      </div>
-      <div
-        style={
-          Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
-          }
-        }
-      >
-        <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
             }
-          >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          Something else
-        </div>
-        <div>
-          6 years ago
-           on 
-          10/28
-        </div>
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Lila will look into a referral to a big sister program.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#666",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
           }
-        }
-      >
-        Something else
-      </span>
-    </div>
-  </div>
-  <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-          }
-        }
-      >
-        <div>
+        >
           <div>
-            <a
-              href="/students/38"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Winnie
-               
-              Disney
-            </a>
-          </div>
-          <div>
-            10th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
-              <a
-                href="/homerooms/4"
-              >
-                SHS ALL
-              </a>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        style={
-          Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
-          }
-        }
-      >
-        <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          10th Grade Experience
-        </div>
-        <div>
-          6 years ago
-           on 
-          10/25
-        </div>
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Meredith is setting up a family meeting to discuss absences and tardies, and to follow up on concerns about supporting morning routines at home.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="HouseBadge"
-        style={
-          Object {
-            "backgroundColor": "#333",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Highland house
-      </span>
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#333333",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        10th Grade Experience
-      </span>
-    </div>
-  </div>
-  <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-          }
-        }
-      >
-        <div>
-          <div>
-            <a
-              href="/students/69"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Rapunzel
-               
-              Skywalker
-            </a>
-          </div>
-          <div>
-            10th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
-              <a
-                href="/homerooms/4"
-              >
-                SHS ALL
-              </a>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        style={
-          Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
-          }
-        }
-      >
-        <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          SST Meeting
-        </div>
-        <div>
-          6 years ago
-           on 
-          10/24
-        </div>
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Philis is meeting with parent next week and will present an attendance contract.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="HouseBadge"
-        style={
-          Object {
-            "backgroundColor": "#333",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Highland house
-      </span>
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#31AB39",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        SST Meeting
-      </span>
-    </div>
-  </div>
-  <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-          }
-        }
-      >
-        <div>
-          <div>
-            <a
-              href="/students/51"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Daisy
-               
-              Poppins
-            </a>
-          </div>
-          <div>
-            9th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
-              <a
-                href="/homerooms/5"
-              >
-                SHS 942
-              </a>
+            <div>
               <span>
-                <span>
-                   
-                </span>
-                 with 
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              9th Grade Experience
+            </div>
+          </div>
+          <div>
+            <div>
+              6 years ago
+               on 
+              12/2
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "marginBottom": 20,
+            "marginTop": 20,
+          }
+        }
+      >
+        <div>
+          Not engaged in academic work and misbehaving in class.  There have been meetings between the teacher and support staff, and Sam has talked with Donald twice this week.  Philis following up with outside providers as well.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="HouseBadge"
+            style={
+              Object {
+                "backgroundColor": "#333",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            Broadway house
+          </span>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#139DEA",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            9th Grade Experience
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="EventNoteCard"
+  >
+    <div
+      className="Card FeedCardFrame"
+      style={
+        Object {
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
+          <div>
+            <div>
+              <a
+                href="/students/72"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Rapunzel
+                 
+                White
+              </a>
+            </div>
+            <div>
+              10th grade
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
                 <a
-                  className="Educator"
-                  href="mailto:jodi@demo.studentinsights.org"
-                  style={Object {}}
+                  href="/homerooms/4"
                 >
-                  Jodi Teacher
+                  SHS ALL
                 </a>
               </span>
-            </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              Parent conversation
+            </div>
+          </div>
+          <div>
+            <div>
+              6 years ago
+               on 
+              11/5
+            </div>
           </div>
         </div>
       </div>
       <div
         style={
           Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
+            "marginBottom": 20,
+            "marginTop": 20,
           }
         }
       >
         <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
+          Not engaged in academic work and misbehaving in class.  There have been meetings between the teacher and support staff, and Sam has talked with Rapunzel twice this week.  Philis following up with outside providers as well.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="HouseBadge"
             style={
               Object {
-                "fontWeight": "bold",
+                "backgroundColor": "#333",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
               }
             }
           >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          SST Meeting
-        </div>
-        <div>
-          6 years ago
-           on 
-          10/16
+            Highland house
+          </span>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#CDD71A",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            Parent conversation
+          </span>
         </div>
       </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Not engaged in academic work and misbehaving in class.  There have been meetings between the teacher and support staff, and Sam has talked with Daisy twice this week.  Philis following up with outside providers as well.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="HouseBadge"
-        style={
-          Object {
-            "backgroundColor": "#333",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Highland house
-      </span>
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#31AB39",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        SST Meeting
-      </span>
     </div>
   </div>
   <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
+    className="EventNoteCard"
   >
     <div
+      className="Card FeedCardFrame"
       style={
         Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
         }
       }
     >
@@ -1113,145 +538,317 @@ Philis is meeting with parent next week and will present an attendance contract.
           Object {
             "alignItems": "center",
             "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
+          <div>
+            <div>
+              <a
+                href="/students/18"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Winnie
+                 
+                Disney
+              </a>
+            </div>
+            <div>
+              Kindergarten
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
+                <a
+                  href="/homerooms/1"
+                >
+                  HEA 003
+                </a>
+                <span>
+                  <span>
+                     
+                  </span>
+                   with 
+                  <a
+                    className="Educator"
+                    href="mailto:vivian@demo.studentinsights.org"
+                    style={Object {}}
+                  >
+                    Vivian Teacher
+                  </a>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              Something else
+            </div>
+          </div>
+          <div>
+            <div>
+              6 years ago
+               on 
+              10/28
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "marginBottom": 20,
+            "marginTop": 20,
           }
         }
       >
         <div>
-          <div>
-            <a
-              href="/students/13"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
+          Lila will look into a referral to a big sister program.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#666",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
               }
-            >
-              Rapunzel
-               
-              Poppins
-            </a>
-          </div>
+            }
+          >
+            Something else
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="EventNoteCard"
+  >
+    <div
+      className="Card FeedCardFrame"
+      style={
+        Object {
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
           <div>
-            Kindergarten
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
+            <div>
               <a
-                href="/homerooms/1"
+                href="/students/38"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
               >
-                HEA 003
+                Winnie
+                 
+                Disney
               </a>
-              <span>
-                <span>
-                   
-                </span>
-                 with 
+            </div>
+            <div>
+              10th grade
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
                 <a
-                  className="Educator"
-                  href="mailto:vivian@demo.studentinsights.org"
-                  style={Object {}}
+                  href="/homerooms/4"
                 >
-                  Vivian Teacher
+                  SHS ALL
                 </a>
               </span>
-            </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              10th Grade Experience
+            </div>
+          </div>
+          <div>
+            <div>
+              6 years ago
+               on 
+              10/25
+            </div>
           </div>
         </div>
       </div>
       <div
         style={
           Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
+            "marginBottom": 20,
+            "marginTop": 20,
           }
         }
       >
         <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
+          Meredith is setting up a family meeting to discuss absences and tardies, and to follow up on concerns about supporting morning routines at home.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="HouseBadge"
             style={
               Object {
-                "fontWeight": "bold",
+                "backgroundColor": "#333",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
               }
             }
           >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          Something else
-        </div>
-        <div>
-          6 years ago
-           on 
-          10/16
+            Highland house
+          </span>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#333333",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            10th Grade Experience
+          </span>
         </div>
       </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Not engaged in academic work and misbehaving in class.  There have been meetings between the teacher and support staff, and Sam has talked with Rapunzel twice this week.  Philis following up with outside providers as well.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#666",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Something else
-      </span>
     </div>
   </div>
   <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
+    className="EventNoteCard"
   >
     <div
+      className="Card FeedCardFrame"
       style={
         Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
         }
       }
     >
@@ -1260,454 +857,809 @@ Philis is meeting with parent next week and will present an attendance contract.
           Object {
             "alignItems": "center",
             "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
           }
         }
       >
-        <div>
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
           <div>
-            <a
-              href="/students/6"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Snow
-               
-              Kenobi
-            </a>
-          </div>
-          <div>
-            5th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
+            <div>
               <a
-                href="/homerooms/2"
+                href="/students/69"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
               >
-                HEA 500
+                Rapunzel
+                 
+                Skywalker
               </a>
-              <span>
-                <span>
-                   
-                </span>
-                 with 
+            </div>
+            <div>
+              10th grade
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
                 <a
-                  className="Educator"
-                  href="mailto:sarah@demo.studentinsights.org"
-                  style={Object {}}
+                  href="/homerooms/4"
                 >
-                  Sarah Teacher
+                  SHS ALL
                 </a>
               </span>
-            </span>
+            </div>
           </div>
         </div>
-      </div>
-      <div
-        style={
-          Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
-          }
-        }
-      >
-        <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
             }
-          >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          9th Grade Experience
-        </div>
-        <div>
-          6 years ago
-           on 
-          10/4
-        </div>
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Meetings with staff about lack of academic progress.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#139DEA",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
           }
-        }
-      >
-        9th Grade Experience
-      </span>
-    </div>
-  </div>
-  <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-          }
-        }
-      >
-        <div>
+        >
           <div>
-            <a
-              href="/students/103"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Donald
-               
-              Duck
-            </a>
-          </div>
-          <div>
-            10th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
-              <a
-                href="/homerooms/4"
-              >
-                SHS ALL
-              </a>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        style={
-          Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
-          }
-        }
-      >
-        <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          9th Grade Experience
-        </div>
-        <div>
-          6 years ago
-           on 
-          10/4
-        </div>
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Meredith is setting up a family meeting to discuss absences and tardies, and to follow up on concerns about supporting morning routines at home.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="HouseBadge"
-        style={
-          Object {
-            "backgroundColor": "#333",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Broadway house
-      </span>
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#139DEA",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        9th Grade Experience
-      </span>
-    </div>
-  </div>
-  <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-          }
-        }
-      >
-        <div>
-          <div>
-            <a
-              href="/students/56"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Rapunzel
-               
-              Skywalker
-            </a>
-          </div>
-          <div>
-            9th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
-              <a
-                href="/homerooms/5"
-              >
-                SHS 942
-              </a>
+            <div>
               <span>
-                <span>
-                   
-                </span>
-                 with 
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              SST Meeting
+            </div>
+          </div>
+          <div>
+            <div>
+              6 years ago
+               on 
+              10/24
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "marginBottom": 20,
+            "marginTop": 20,
+          }
+        }
+      >
+        <div>
+          Philis is meeting with parent next week and will present an attendance contract.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="HouseBadge"
+            style={
+              Object {
+                "backgroundColor": "#333",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            Highland house
+          </span>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#31AB39",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            SST Meeting
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="EventNoteCard"
+  >
+    <div
+      className="Card FeedCardFrame"
+      style={
+        Object {
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
+          <div>
+            <div>
+              <a
+                href="/students/51"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Daisy
+                 
+                Poppins
+              </a>
+            </div>
+            <div>
+              9th grade
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
                 <a
-                  className="Educator"
-                  href="mailto:jodi@demo.studentinsights.org"
-                  style={Object {}}
+                  href="/homerooms/5"
                 >
-                  Jodi Teacher
+                  SHS 942
+                </a>
+                <span>
+                  <span>
+                     
+                  </span>
+                   with 
+                  <a
+                    className="Educator"
+                    href="mailto:jodi@demo.studentinsights.org"
+                    style={Object {}}
+                  >
+                    Jodi Teacher
+                  </a>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              SST Meeting
+            </div>
+          </div>
+          <div>
+            <div>
+              6 years ago
+               on 
+              10/16
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "marginBottom": 20,
+            "marginTop": 20,
+          }
+        }
+      >
+        <div>
+          Not engaged in academic work and misbehaving in class.  There have been meetings between the teacher and support staff, and Sam has talked with Daisy twice this week.  Philis following up with outside providers as well.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="HouseBadge"
+            style={
+              Object {
+                "backgroundColor": "#333",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            Highland house
+          </span>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#31AB39",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            SST Meeting
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="EventNoteCard"
+  >
+    <div
+      className="Card FeedCardFrame"
+      style={
+        Object {
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
+          <div>
+            <div>
+              <a
+                href="/students/13"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Rapunzel
+                 
+                Poppins
+              </a>
+            </div>
+            <div>
+              Kindergarten
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
+                <a
+                  href="/homerooms/1"
+                >
+                  HEA 003
+                </a>
+                <span>
+                  <span>
+                     
+                  </span>
+                   with 
+                  <a
+                    className="Educator"
+                    href="mailto:vivian@demo.studentinsights.org"
+                    style={Object {}}
+                  >
+                    Vivian Teacher
+                  </a>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              Something else
+            </div>
+          </div>
+          <div>
+            <div>
+              6 years ago
+               on 
+              10/16
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "marginBottom": 20,
+            "marginTop": 20,
+          }
+        }
+      >
+        <div>
+          Not engaged in academic work and misbehaving in class.  There have been meetings between the teacher and support staff, and Sam has talked with Rapunzel twice this week.  Philis following up with outside providers as well.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#666",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            Something else
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="EventNoteCard"
+  >
+    <div
+      className="Card FeedCardFrame"
+      style={
+        Object {
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
+          <div>
+            <div>
+              <a
+                href="/students/6"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Snow
+                 
+                Kenobi
+              </a>
+            </div>
+            <div>
+              5th grade
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
+                <a
+                  href="/homerooms/2"
+                >
+                  HEA 500
+                </a>
+                <span>
+                  <span>
+                     
+                  </span>
+                   with 
+                  <a
+                    className="Educator"
+                    href="mailto:sarah@demo.studentinsights.org"
+                    style={Object {}}
+                  >
+                    Sarah Teacher
+                  </a>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              9th Grade Experience
+            </div>
+          </div>
+          <div>
+            <div>
+              6 years ago
+               on 
+              10/4
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "marginBottom": 20,
+            "marginTop": 20,
+          }
+        }
+      >
+        <div>
+          Meetings with staff about lack of academic progress.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#139DEA",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            9th Grade Experience
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="EventNoteCard"
+  >
+    <div
+      className="Card FeedCardFrame"
+      style={
+        Object {
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
+          <div>
+            <div>
+              <a
+                href="/students/103"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Donald
+                 
+                Duck
+              </a>
+            </div>
+            <div>
+              10th grade
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
+                <a
+                  href="/homerooms/4"
+                >
+                  SHS ALL
                 </a>
               </span>
-            </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              9th Grade Experience
+            </div>
+          </div>
+          <div>
+            <div>
+              6 years ago
+               on 
+              10/4
+            </div>
           </div>
         </div>
       </div>
       <div
         style={
           Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
+            "marginBottom": 20,
+            "marginTop": 20,
           }
         }
       >
         <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
+          Meredith is setting up a family meeting to discuss absences and tardies, and to follow up on concerns about supporting morning routines at home.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="HouseBadge"
             style={
               Object {
-                "fontWeight": "bold",
+                "backgroundColor": "#333",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
               }
             }
           >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          Parent conversation
-        </div>
-        <div>
-          6 years ago
-           on 
-          10/3
+            Broadway house
+          </span>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#139DEA",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            9th Grade Experience
+          </span>
         </div>
       </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Lila will look into a referral to a big sister program.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="HouseBadge"
-        style={
-          Object {
-            "backgroundColor": "#333",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Beacon house
-      </span>
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#CDD71A",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Parent conversation
-      </span>
     </div>
   </div>
   <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
+    className="EventNoteCard"
   >
     <div
+      className="Card FeedCardFrame"
       style={
         Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
         }
       }
     >
@@ -1716,159 +1668,663 @@ Philis is meeting with parent next week and will present an attendance contract.
           Object {
             "alignItems": "center",
             "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
+          <div>
+            <div>
+              <a
+                href="/students/56"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Rapunzel
+                 
+                Skywalker
+              </a>
+            </div>
+            <div>
+              9th grade
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
+                <a
+                  href="/homerooms/5"
+                >
+                  SHS 942
+                </a>
+                <span>
+                  <span>
+                     
+                  </span>
+                   with 
+                  <a
+                    className="Educator"
+                    href="mailto:jodi@demo.studentinsights.org"
+                    style={Object {}}
+                  >
+                    Jodi Teacher
+                  </a>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              Parent conversation
+            </div>
+          </div>
+          <div>
+            <div>
+              6 years ago
+               on 
+              10/3
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "marginBottom": 20,
+            "marginTop": 20,
           }
         }
       >
         <div>
-          <div>
-            <a
-              href="/students/53"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
+          Lila will look into a referral to a big sister program.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="HouseBadge"
+            style={
+              Object {
+                "backgroundColor": "#333",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
               }
-            >
-              Olaf
-               
-              Mouse
-            </a>
-          </div>
+            }
+          >
+            Beacon house
+          </span>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#CDD71A",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            Parent conversation
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="EventNoteCard"
+  >
+    <div
+      className="Card FeedCardFrame"
+      style={
+        Object {
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
           <div>
-            9th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
+            <div>
               <a
-                href="/homerooms/5"
+                href="/students/53"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
               >
-                SHS 942
+                Olaf
+                 
+                Mouse
               </a>
-              <span>
-                <span>
-                   
-                </span>
-                 with 
+            </div>
+            <div>
+              9th grade
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
                 <a
-                  className="Educator"
-                  href="mailto:jodi@demo.studentinsights.org"
-                  style={Object {}}
+                  href="/homerooms/5"
                 >
-                  Jodi Teacher
+                  SHS 942
+                </a>
+                <span>
+                  <span>
+                     
+                  </span>
+                   with 
+                  <a
+                    className="Educator"
+                    href="mailto:jodi@demo.studentinsights.org"
+                    style={Object {}}
+                  >
+                    Jodi Teacher
+                  </a>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              Parent conversation
+            </div>
+          </div>
+          <div>
+            <div>
+              6 years ago
+               on 
+              9/30
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "marginBottom": 20,
+            "marginTop": 20,
+          }
+        }
+      >
+        <div>
+          Meredith is setting up a family meeting to discuss absences and tardies, and to follow up on concerns about supporting morning routines at home.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="HouseBadge"
+            style={
+              Object {
+                "backgroundColor": "#333",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            Elm house
+          </span>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#CDD71A",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            Parent conversation
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="EventNoteCard"
+  >
+    <div
+      className="Card FeedCardFrame"
+      style={
+        Object {
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
+          <div>
+            <div>
+              <a
+                href="/students/21"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Elsa
+                 
+                Kenobi
+              </a>
+            </div>
+            <div>
+              5th grade
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
+                <a
+                  href="/homerooms/3"
+                >
+                  WSNS 501
+                </a>
+                <span>
+                  <span>
+                     
+                  </span>
+                   with 
+                  <a
+                    className="Educator"
+                    href="mailto:marcus@demo.studentinsights.org"
+                    style={Object {}}
+                  >
+                    Marcus Teacher
+                  </a>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              10th Grade Experience
+            </div>
+          </div>
+          <div>
+            <div>
+              6 years ago
+               on 
+              9/23
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "marginBottom": 20,
+            "marginTop": 20,
+          }
+        }
+      >
+        <div>
+          Not engaged in academic work and misbehaving in class.  There have been meetings between the teacher and support staff, and Sam has talked with Elsa twice this week.  Philis following up with outside providers as well.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#333333",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            10th Grade Experience
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="EventNoteCard"
+  >
+    <div
+      className="Card FeedCardFrame"
+      style={
+        Object {
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
+          <div>
+            <div>
+              <a
+                href="/students/72"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Rapunzel
+                 
+                White
+              </a>
+            </div>
+            <div>
+              10th grade
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
+                <a
+                  href="/homerooms/4"
+                >
+                  SHS ALL
                 </a>
               </span>
-            </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              Something else
+            </div>
+          </div>
+          <div>
+            <div>
+              6 years ago
+               on 
+              9/22
+            </div>
           </div>
         </div>
       </div>
       <div
         style={
           Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
+            "marginBottom": 20,
+            "marginTop": 20,
           }
         }
       >
         <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
+          Engagement issues in ELA, sometimes shutting down altogether and refusing to engage in academic work.  Other times this is more disruptive, lashing out and yelling at other students and interfering with their learning.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="HouseBadge"
             style={
               Object {
-                "fontWeight": "bold",
+                "backgroundColor": "#333",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
               }
             }
           >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          Parent conversation
-        </div>
-        <div>
-          6 years ago
-           on 
-          9/30
+            Highland house
+          </span>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#666",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            Something else
+          </span>
         </div>
       </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Meredith is setting up a family meeting to discuss absences and tardies, and to follow up on concerns about supporting morning routines at home.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="HouseBadge"
-        style={
-          Object {
-            "backgroundColor": "#333",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Elm house
-      </span>
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#CDD71A",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Parent conversation
-      </span>
     </div>
   </div>
   <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
+    className="EventNoteCard"
   >
     <div
+      className="Card FeedCardFrame"
       style={
         Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
         }
       }
     >
@@ -1877,884 +2333,318 @@ Philis is meeting with parent next week and will present an attendance contract.
           Object {
             "alignItems": "center",
             "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
           }
         }
       >
-        <div>
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
           <div>
-            <a
-              href="/students/21"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Elsa
-               
-              Kenobi
-            </a>
-          </div>
-          <div>
-            5th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
+            <div>
               <a
-                href="/homerooms/3"
+                href="/students/114"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
               >
-                WSNS 501
+                Rapunzel
+                 
+                Pan
               </a>
-              <span>
-                <span>
-                   
-                </span>
-                 with 
+            </div>
+            <div>
+              10th grade
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
                 <a
-                  className="Educator"
-                  href="mailto:marcus@demo.studentinsights.org"
-                  style={Object {}}
+                  href="/homerooms/4"
                 >
-                  Marcus Teacher
+                  SHS ALL
                 </a>
               </span>
-            </span>
+            </div>
           </div>
         </div>
-      </div>
-      <div
-        style={
-          Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
-          }
-        }
-      >
-        <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
             }
-          >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          10th Grade Experience
-        </div>
-        <div>
-          6 years ago
-           on 
-          9/23
-        </div>
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Not engaged in academic work and misbehaving in class.  There have been meetings between the teacher and support staff, and Sam has talked with Elsa twice this week.  Philis following up with outside providers as well.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#333333",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
           }
-        }
-      >
-        10th Grade Experience
-      </span>
-    </div>
-  </div>
-  <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-          }
-        }
-      >
-        <div>
+        >
           <div>
-            <a
-              href="/students/72"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Rapunzel
-               
-              White
-            </a>
-          </div>
-          <div>
-            10th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
-              <a
-                href="/homerooms/4"
-              >
-                SHS ALL
-              </a>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        style={
-          Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
-          }
-        }
-      >
-        <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          Something else
-        </div>
-        <div>
-          6 years ago
-           on 
-          9/22
-        </div>
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Engagement issues in ELA, sometimes shutting down altogether and refusing to engage in academic work.  Other times this is more disruptive, lashing out and yelling at other students and interfering with their learning.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="HouseBadge"
-        style={
-          Object {
-            "backgroundColor": "#333",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Highland house
-      </span>
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#666",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Something else
-      </span>
-    </div>
-  </div>
-  <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-          }
-        }
-      >
-        <div>
-          <div>
-            <a
-              href="/students/114"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Rapunzel
-               
-              Pan
-            </a>
-          </div>
-          <div>
-            10th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
-              <a
-                href="/homerooms/4"
-              >
-                SHS ALL
-              </a>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        style={
-          Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
-          }
-        }
-      >
-        <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          MTSS Meeting
-        </div>
-        <div>
-          6 years ago
-           on 
-          9/22
-        </div>
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Meetings with staff about lack of academic progress.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="HouseBadge"
-        style={
-          Object {
-            "backgroundColor": "#333",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Highland house
-      </span>
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#EB4B26",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        MTSS Meeting
-      </span>
-    </div>
-  </div>
-  <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-          }
-        }
-      >
-        <div>
-          <div>
-            <a
-              href="/students/109"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Donald
-               
-              Pan
-            </a>
-          </div>
-          <div>
-            10th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
-              <a
-                href="/homerooms/4"
-              >
-                SHS ALL
-              </a>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        style={
-          Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
-          }
-        }
-      >
-        <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          Parent conversation
-        </div>
-        <div>
-          6 years ago
-           on 
-          9/17
-        </div>
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Meredith is setting up a family meeting to discuss absences and tardies, and to follow up on concerns about supporting morning routines at home.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="HouseBadge"
-        style={
-          Object {
-            "backgroundColor": "#333",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Beacon house
-      </span>
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#CDD71A",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Parent conversation
-      </span>
-    </div>
-  </div>
-  <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-          }
-        }
-      >
-        <div>
-          <div>
-            <a
-              href="/students/99"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Aladdin
-               
-              White
-            </a>
-          </div>
-          <div>
-            10th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
-              <a
-                href="/homerooms/4"
-              >
-                SHS ALL
-              </a>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        style={
-          Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
-          }
-        }
-      >
-        <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          MTSS Meeting
-        </div>
-        <div>
-          7 years ago
-           on 
-          9/11
-        </div>
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Meetings with staff about lack of academic progress.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="HouseBadge"
-        style={
-          Object {
-            "backgroundColor": "#333",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Highland house
-      </span>
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#EB4B26",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        MTSS Meeting
-      </span>
-    </div>
-  </div>
-  <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-          }
-        }
-      >
-        <div>
-          <div>
-            <a
-              href="/students/18"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Winnie
-               
-              Disney
-            </a>
-          </div>
-          <div>
-            Kindergarten
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
-              <a
-                href="/homerooms/1"
-              >
-                HEA 003
-              </a>
+            <div>
               <span>
-                <span>
-                   
-                </span>
-                 with 
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              MTSS Meeting
+            </div>
+          </div>
+          <div>
+            <div>
+              6 years ago
+               on 
+              9/22
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "marginBottom": 20,
+            "marginTop": 20,
+          }
+        }
+      >
+        <div>
+          Meetings with staff about lack of academic progress.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="HouseBadge"
+            style={
+              Object {
+                "backgroundColor": "#333",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            Highland house
+          </span>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#EB4B26",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            MTSS Meeting
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="EventNoteCard"
+  >
+    <div
+      className="Card FeedCardFrame"
+      style={
+        Object {
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
+          <div>
+            <div>
+              <a
+                href="/students/109"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Donald
+                 
+                Pan
+              </a>
+            </div>
+            <div>
+              10th grade
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
                 <a
-                  className="Educator"
-                  href="mailto:vivian@demo.studentinsights.org"
-                  style={Object {}}
+                  href="/homerooms/4"
                 >
-                  Vivian Teacher
+                  SHS ALL
                 </a>
               </span>
-            </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              Parent conversation
+            </div>
+          </div>
+          <div>
+            <div>
+              6 years ago
+               on 
+              9/17
+            </div>
           </div>
         </div>
       </div>
       <div
         style={
           Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
+            "marginBottom": 20,
+            "marginTop": 20,
           }
         }
       >
         <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
+          Meredith is setting up a family meeting to discuss absences and tardies, and to follow up on concerns about supporting morning routines at home.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="HouseBadge"
             style={
               Object {
-                "fontWeight": "bold",
+                "backgroundColor": "#333",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
               }
             }
           >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          Parent conversation
-        </div>
-        <div>
-          7 years ago
-           on 
-          9/9
+            Beacon house
+          </span>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#CDD71A",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            Parent conversation
+          </span>
         </div>
       </div>
-    </div>
-    <div
-      style={
-        Object {
-          "marginBottom": 20,
-          "marginTop": 20,
-        }
-      }
-    >
-      <div>
-        Philis is meeting with parent next week and will present an attendance contract.
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
-        }
-      }
-    >
-      <span
-        className="NoteBadge"
-        style={
-          Object {
-            "backgroundColor": "#CDD71A",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
-          }
-        }
-      >
-        Parent conversation
-      </span>
     </div>
   </div>
   <div
-    className="Card EventNoteCard"
-    style={
-      Object {
-        "border": "1px solid #ccc",
-        "borderRadius": 3,
-        "marginTop": 20,
-        "padding": 10,
-      }
-    }
+    className="EventNoteCard"
   >
     <div
+      className="Card FeedCardFrame"
       style={
         Object {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
         }
       }
     >
@@ -2763,126 +2653,464 @@ Philis is meeting with parent next week and will present an attendance contract.
           Object {
             "alignItems": "center",
             "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
           }
         }
       >
-        <div>
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
           <div>
-            <a
-              href="/students/70"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              Mowgli
-               
-              Pan
-            </a>
-          </div>
-          <div>
-            10th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
+            <div>
               <a
-                href="/homerooms/4"
+                href="/students/99"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
               >
-                SHS ALL
+                Aladdin
+                 
+                White
               </a>
-            </span>
+            </div>
+            <div>
+              10th grade
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
+                <a
+                  href="/homerooms/4"
+                >
+                  SHS ALL
+                </a>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              MTSS Meeting
+            </div>
+          </div>
+          <div>
+            <div>
+              7 years ago
+               on 
+              9/11
+            </div>
           </div>
         </div>
       </div>
       <div
         style={
           Object {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexDirection": "column",
+            "marginBottom": 20,
+            "marginTop": 20,
           }
         }
       >
         <div>
-          <span>
-            by 
-          </span>
-          <a
-            className="Educator"
-            href="mailto:uri@demo.studentinsights.org"
+          Meetings with staff about lack of academic progress.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="HouseBadge"
             style={
               Object {
-                "fontWeight": "bold",
+                "backgroundColor": "#333",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
               }
             }
           >
-            Uri Disney
-          </a>
-        </div>
-        <div>
-          in 
-          9th Grade Experience
-        </div>
-        <div>
-          7 years ago
-           on 
-          9/8
+            Highland house
+          </span>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#EB4B26",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            MTSS Meeting
+          </span>
         </div>
       </div>
     </div>
+  </div>
+  <div
+    className="EventNoteCard"
+  >
     <div
+      className="Card FeedCardFrame"
       style={
         Object {
-          "marginBottom": 20,
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
           "marginTop": 20,
+          "padding": 10,
         }
       }
     >
-      <div>
-        Meetings with staff about lack of academic progress.
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
+          <div>
+            <div>
+              <a
+                href="/students/18"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Winnie
+                 
+                Disney
+              </a>
+            </div>
+            <div>
+              Kindergarten
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
+                <a
+                  href="/homerooms/1"
+                >
+                  HEA 003
+                </a>
+                <span>
+                  <span>
+                     
+                  </span>
+                   with 
+                  <a
+                    className="Educator"
+                    href="mailto:vivian@demo.studentinsights.org"
+                    style={Object {}}
+                  >
+                    Vivian Teacher
+                  </a>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              Parent conversation
+            </div>
+          </div>
+          <div>
+            <div>
+              7 years ago
+               on 
+              9/9
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "marginBottom": 20,
+            "marginTop": 20,
+          }
+        }
+      >
+        <div>
+          Philis is meeting with parent next week and will present an attendance contract.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#CDD71A",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            Parent conversation
+          </span>
+        </div>
       </div>
     </div>
+  </div>
+  <div
+    className="EventNoteCard"
+  >
     <div
+      className="Card FeedCardFrame"
       style={
         Object {
-          "display": "flex",
-          "justifyContent": "flex-end",
-          "marginBottom": 5,
+          "border": "1px solid #ccc",
+          "borderRadius": 3,
+          "marginTop": 20,
+          "padding": 10,
         }
       }
     >
-      <span
-        className="HouseBadge"
+      <div
         style={
           Object {
-            "backgroundColor": "#333",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
           }
         }
       >
-        Beacon house
-      </span>
-      <span
-        className="NoteBadge"
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
+          <div>
+            <div>
+              <a
+                href="/students/70"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Mowgli
+                 
+                Pan
+              </a>
+            </div>
+            <div>
+              10th grade
+            </div>
+            <div>
+              <span
+                className="Homeroom"
+                style={Object {}}
+              >
+                <a
+                  href="/homerooms/4"
+                >
+                  SHS ALL
+                </a>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div>
+            <div>
+              <span>
+                by 
+              </span>
+              <a
+                className="Educator"
+                href="mailto:uri@demo.studentinsights.org"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Uri Disney
+              </a>
+            </div>
+          </div>
+          <div>
+            <div>
+              in 
+              9th Grade Experience
+            </div>
+          </div>
+          <div>
+            <div>
+              7 years ago
+               on 
+              9/8
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
         style={
           Object {
-            "backgroundColor": "#139DEA",
-            "color": "white",
-            "marginLeft": 5,
-            "opacity": 0.5,
-            "padding": 5,
+            "marginBottom": 20,
+            "marginTop": 20,
           }
         }
       >
-        9th Grade Experience
-      </span>
+        <div>
+          Meetings with staff about lack of academic progress.
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "flex-end",
+            "marginBottom": 5,
+          }
+        }
+      >
+        <div>
+          <span
+            className="HouseBadge"
+            style={
+              Object {
+                "backgroundColor": "#333",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            Beacon house
+          </span>
+          <span
+            className="Badge"
+            style={
+              Object {
+                "backgroundColor": "#139DEA",
+                "color": "white",
+                "marginLeft": 5,
+                "opacity": 0.5,
+                "padding": 5,
+              }
+            }
+          >
+            9th Grade Experience
+          </span>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/assets/javascripts/home/__snapshots__/IncidentCard.test.js.snap
+++ b/app/assets/javascripts/home/__snapshots__/IncidentCard.test.js.snap
@@ -1,0 +1,149 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`matches snapshot 1`] = `
+<div
+  className="IncidentCard"
+>
+  <div
+    className="Card FeedCardFrame"
+    style={
+      Object {
+        "border": "1px solid #ccc",
+        "borderRadius": 3,
+        "padding": 10,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+          }
+        }
+      >
+        <div>
+          <div>
+            <a
+              href="/students/100"
+              style={
+                Object {
+                  "fontWeight": "bold",
+                }
+              }
+            >
+              Mowgli
+               
+              Pan
+            </a>
+          </div>
+          <div>
+            10th grade
+          </div>
+          <div>
+            <span
+              className="Homeroom"
+              style={Object {}}
+            >
+              <a
+                href="/homerooms/4"
+              >
+                SHS ALL
+              </a>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "display": "flex",
+            "flexDirection": "column",
+          }
+        }
+      >
+        <div />
+        <div>
+          <div>
+            in 
+            Locker room/gym
+          </div>
+        </div>
+        <div>
+          <div>
+            13 days ago
+             on 
+            2/28
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      style={
+        Object {
+          "marginBottom": 20,
+          "marginTop": 20,
+        }
+      }
+    >
+      <div>
+        Earlier today something happened with the student that was concerning and we did this to de-escalate and support them in the moment, and then took these steps to understand the underlying challenges they're facing, and adapt how we're working with them moving forward.
+         (code: 
+        OT
+        )
+      </div>
+    </div>
+    <div
+      style={
+        Object {
+          "display": "flex",
+          "justifyContent": "flex-end",
+          "marginBottom": 5,
+        }
+      }
+    >
+      <div>
+        <span
+          className="HouseBadge"
+          style={
+            Object {
+              "backgroundColor": "#333",
+              "color": "white",
+              "marginLeft": 5,
+              "opacity": 0.5,
+              "padding": 5,
+            }
+          }
+        >
+          Beacon house
+        </span>
+        <span
+          className="Badge"
+          style={
+            Object {
+              "backgroundColor": "rgb(255, 140, 0)",
+              "color": "white",
+              "marginLeft": 5,
+              "opacity": 0.5,
+              "padding": 5,
+            }
+          }
+        >
+          Incident
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -17,6 +17,10 @@ class PerDistrict
     ENV['DISTRICT_NAME']
   end
 
+  def include_incident_cards?
+    EnvironmentVariable.is_true('FEED_INCLUDE_INCIDENT_CARDS') || false
+  end
+
   # The schools shown on the admin page are in different orders,
   # with pilot schools in New Bedford shown first.
   def ordered_schools_for_admin_page

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -19,9 +19,15 @@ class HomeController < ApplicationController
       days_back: 3,
       days_ahead: 0
     })
+    incident_cards = if params[:include_incident_cards] || PerDistrict.new.include_incident_cards?
+      feed.incident_cards(time_now, limit)
+    else
+      []
+    end
     feed_cards = feed.merge_sort_and_limit_cards([
       event_note_cards,
-      birthday_cards
+      birthday_cards,
+      incident_cards
     ], limit)
 
     render json: {

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -14,19 +14,25 @@ describe HomeController, :type => :controller do
       }))
     end
 
-    it 'works end-to-end for birthday and event_note' do
+    it 'works end-to-end for event_note, incident and birthday' do
       event_note = create_event_note(time_now, {
         student: pals.shs_freshman_mari,
         event_note_type: EventNoteType.find(305)
       })
+      incident = DisciplineIncident.create!({
+        incident_code: 'Bullying',
+        occurred_at: time_now - 4.days,
+        student: pals.shs_freshman_mari
+      })
       sign_in(pals.shs_jodi)
       get :feed_json, params: {
         time_now: time_now.to_i.to_s,
-        limit: 4
+        limit: 4,
+        include_incident_cards: true
       }
       json = JSON.parse(response.body)
       expect(response.status).to eq 200
-      expect(json['feed_cards'].length).to eq 2
+      expect(json['feed_cards'].length).to eq 3
       expect(json).to eq({
         "feed_cards"=>[{
           "type"=>"birthday_card",
@@ -36,6 +42,33 @@ describe HomeController, :type => :controller do
             "first_name"=>"Mari",
             "last_name"=>"Kenobi",
             "date_of_birth"=>"2004-03-12T00:00:00.000Z"
+          }
+        }, {
+          "type"=>"incident_card",
+          "timestamp"=>"2018-03-09T11:03:00.000Z",
+          "json"=>{
+            "id"=>incident.id,
+            "incident_code"=>"Bullying",
+            "incident_location"=>nil,
+            "incident_description"=>nil,
+            "occurred_at"=>"2018-03-09T11:03:00.000Z",
+            "has_exact_time"=>nil,
+            "student"=>{
+              "id"=>pals.shs_freshman_mari.id,
+              "grade"=>"9",
+              "first_name"=>"Mari",
+              "last_name"=>"Kenobi",
+              "house"=>"Beacon",
+              "homeroom"=>{
+                "id"=>pals.shs_jodi_homeroom.id,
+                "name"=>"SHS 942",
+                "educator"=>{
+                  "id"=>pals.shs_jodi.id,
+                  "email"=>"jodi@demo.studentinsights.org",
+                  "full_name"=>"Teacher, Jodi"
+                }
+              }
+            }
           }
         }, {
           "type"=>"event_note_card",

--- a/spec/lib/feed_spec.rb
+++ b/spec/lib/feed_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Feed do
 
   describe '#incident_cards' do
     it 'works correctly' do
-      DisciplineIncident.create!({
+      incident = DisciplineIncident.create!({
         incident_code: 'Bullying',
         occurred_at: time_now - 4.days,
         student: pals.shs_freshman_mari
@@ -84,7 +84,7 @@ RSpec.describe Feed do
       expect(cards.first.type).to eq :incident_card
       expect(cards.first.timestamp.to_date).to eq(Date.parse('2018-03-09'))
       expect(cards.first.json.as_json).to eq({
-        "id" => 1,
+        "id" => incident.id,
         "incident_code" => "Bullying",
         "incident_description" => nil,
         "incident_location" => nil,

--- a/spec/lib/feed_spec.rb
+++ b/spec/lib/feed_spec.rb
@@ -70,4 +70,43 @@ RSpec.describe Feed do
       expect(cards.first.json['id']).to eq(pals.shs_freshman_mari.id)
     end
   end
+
+  describe '#incident_cards' do
+    it 'works correctly' do
+      DisciplineIncident.create!({
+        incident_code: 'Bullying',
+        occurred_at: time_now - 4.days,
+        student: pals.shs_freshman_mari
+      })
+      feed = Feed.new(pals.shs_jodi)
+      cards = feed.incident_cards(time_now, 3)
+      expect(cards.length).to eq 1
+      expect(cards.first.type).to eq :incident_card
+      expect(cards.first.timestamp.to_date).to eq(Date.parse('2018-03-09'))
+      expect(cards.first.json.as_json).to eq({
+        "id" => 1,
+        "incident_code" => "Bullying",
+        "incident_description" => nil,
+        "incident_location" => nil,
+        "occurred_at" => '2018-03-09T11:03:00.000Z',
+        "has_exact_time" => nil,
+        "student" => {
+          "id"=>pals.shs_freshman_mari.id,
+          "grade"=>"9",
+          "first_name"=>"Mari",
+          "last_name"=>"Kenobi",
+          "house"=>"Beacon",
+          "homeroom"=>{
+            "id"=>pals.shs_jodi_homeroom.id,
+            "name"=>"SHS 942",
+            "educator"=>{
+              "id"=>pals.shs_jodi.id,
+              "email"=>"jodi@demo.studentinsights.org",
+              "full_name"=>"Teacher, Jodi"
+            }
+          }
+        }
+      })
+    end
+  end
 end


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
Show more of what we know about what's going on with students, improve zero-day for home page in new districts.

# What does this PR do?
Adds discipline incidents into the home page feed.
<img width="629" alt="screen shot 2018-03-15 at 11 21 51 pm" src="https://user-images.githubusercontent.com/1056957/37502565-c5be43f4-28a9-11e8-8a74-371e7c11bfcd.png">

Also factors out the formatting from `EventNoteCard` into `FeedCardFrame` for re-use in the incident card.  No regressions:

<img width="637" alt="screen shot 2018-03-15 at 11 22 09 pm" src="https://user-images.githubusercontent.com/1056957/37502579-d73ab2ac-28a9-11e8-8298-05e84ec4380a.png">

# Checklists
+ [x] Author checked latest in IE - Home page
+ [x] Author included specs for new code
