### PR TITLE
Add factory_girl_rails and faker to production Gemfile for generating demo data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,13 +34,13 @@ gem 'thor'
 gem 'uglifier', '>= 1.3.0'
 gem 'wicked_pdf'
 gem 'wkhtmltopdf-binary'
+gem 'factory_girl_rails' # used to seed demo data in production
 
 group :development, :test do
   gem 'bourbon', '~> 4.3.2'
   gem 'capybara'
   gem 'database_cleaner'
   gem 'descriptive-statistics'
-  gem 'factory_girl_rails'
   gem 'faker'
   gem 'launchy'
   gem 'pry' # Set a breakpoint in your ruby code by adding `binding.pry`

--- a/Gemfile
+++ b/Gemfile
@@ -34,14 +34,16 @@ gem 'thor'
 gem 'uglifier', '>= 1.3.0'
 gem 'wicked_pdf'
 gem 'wkhtmltopdf-binary'
-gem 'factory_girl_rails' # used to seed demo data in production
+
+# used to seed demo data in production
+gem 'factory_girl_rails'
+gem 'faker'
 
 group :development, :test do
   gem 'bourbon', '~> 4.3.2'
   gem 'capybara'
   gem 'database_cleaner'
   gem 'descriptive-statistics'
-  gem 'faker'
   gem 'launchy'
   gem 'pry' # Set a breakpoint in your ruby code by adding `binding.pry`
   gem 'rack-test'


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Running `bundle exec rake db:seed` for the production demo site fails, because the seed task uses FactoryGirl and Faker and those gems aren't installed.  I think this was introduced in https://github.com/studentinsights/studentinsights/pull/1508, which removed `FakeIncident` to consolidate into the `DisciplineIncident` factory and use it in seeding.

Alternately, we could remove `FactoryGirl` from the seed path, but that may lead to forking the demo data and test data uses.

# What does this PR do?
Adds both gems to the production Gemfile.  I deployed this to the demo site and ran it manually to verify it works.

There's probably some minimal memory overhead for these gems, and this is pure waste in production since we're not using these in the production sites aside from the demo site, but I'm not sure we need to worry about that right now.