### PR TITLE
Fix bundler version to what Heroku buildpack uses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,4 +380,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.15.4
+   1.15.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,4 +380,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.16.1
+   1.15.4


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
mismatch between development and production bundler

# What does this PR do?
Reverts bundler to 1.15.2, matching the Heroku buildpack ([docs](https://devcenter.heroku.com/articles/ruby-support#libraries).  The buildpack has an [open issue](https://github.com/heroku/heroku-buildpack-ruby/issues/655) to bump to 1.16.1 but no PR.  The Heroku docs explain why they don't allow changing the production version of bundler and https://github.com/heroku/heroku-buildpack-ruby/pull/638#issuecomment-350109892 references problems with bundler 1.16.0.

Locally, bundler gives bad advice, which leads to this problem:
```
$ bundle
The latest bundler is 1.16.1, but you are currently running 1.15.4.
To update, run `gem install bundler`
Warning: the running version of Bundler (1.15.4) is older than the version that created the lockfile (1.16.1). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
```

This came up from doing not-great things to test changes for https://github.com/studentinsights/studentinsights/pull/1462 in production.  This is really atypical - I'm trying to install a new version of a gem in a one-off production dyno without impacting the production web dyno.  Doing this in production is necessary because testing this requires running through the proxy setup.

Here's what came up in production:
```
The latest bundler is 1.16.1, but you are currently running 1.15.2.
To update, run `gem install bundler`
~ $ bundle update devise_ldap_authenticatable
Warning: the running version of Bundler (1.15.2) is older than the version that created the lockfile (1.16.1). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
Fetching gem metadata from https://rubygems.org/............
Fetching version metadata from https://rubygems.org/..
Fetching dependency metadata from https://rubygems.org/.
Your lockfile was created by an old Bundler that left some things out.
Because of the missing DEPENDENCIES, we can only install gems one at a time, instead of installing 3 at a time.
You can fix this by adding the missing gems to your Gemfile, running bundle install, and then removing the gems from your Gemfile.
The missing gems are:
* actionpack depended upon by actioncable
...

fatal: No live threads left. Deadlock?
```

It seems like this operation in Bundler 1.16.1 tries to parallelize requests to install gems, but can't if there aren't multiple threads available, or is doing something else that I don't understand.  We don't want to deal with any of this, and it's better to have dev/production match anyway, and use the version Heroku curates.