### PR TITLE
Add socks.conf to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ studentinsights.sublime-workspace
 
 public/build
 public/dev
+
+# For qgsocksify
+socks.conf


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
This file is generated if you run qgsocksify locally, and writes out IP and port info that we wouldn't ever want to check in.

# What does this PR do?
gitignore it
