### PR TITLE
Add in file for New Bedford educators import

### DIFF
--- a/config/district_new_bedford.yml
+++ b/config/district_new_bedford.yml
@@ -1,4 +1,5 @@
 remote_filenames:
+  FILENAME_FOR_EDUCATORS_IMPORT:      ../newbedford/istaff.csv
   FILENAME_FOR_STUDENTS_IMPORT:       ../newbedford/istudent.csv
   FILENAME_FOR_BEHAVIOR_IMPORT:       ../newbedford/iconduct.csv
   FILENAME_FOR_ASSESSMENT_IMPORT:     ../newbedford/iassessments.csv

--- a/config/district_somerville.yml
+++ b/config/district_somerville.yml
@@ -1,6 +1,6 @@
 remote_filenames:
-  FILENAME_FOR_STUDENTS_IMPORT:                     students_export.txt
   FILENAME_FOR_EDUCATORS_IMPORT:                    educators_export.txt
+  FILENAME_FOR_STUDENTS_IMPORT:                     students_export.txt
   FILENAME_FOR_BEHAVIOR_IMPORT:                     behavior_export.txt
   FILENAME_FOR_ASSESSMENT_IMPORT:                   assessment_export.txt
   FILENAME_FOR_ATTENDANCE_IMPORT:                   attendance_export.txt


### PR DESCRIPTION
# Who is this PR for?
New Bedford educators

# What problem does this PR fix?
We haven't imported the set of educators yet, since LDAP integration wasn't working before, but now it is!

# What does this PR do?
Point the importer to the educators file to import it.