### PR TITLE
Allow demo district_key

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -6,7 +6,13 @@
 class PerDistrict
   NEW_BEDFORD = 'new_bedford'
   SOMERVILLE = 'somerville'
-  VALID_DISTRICT_KEYS = [NEW_BEDFORD, SOMERVILLE]
+  DEMO = 'demo'
+
+  VALID_DISTRICT_KEYS = [
+    NEW_BEDFORD,
+    SOMERVILLE,
+    DEMO
+  ]
 
   def initialize(options = {})
     @district_key = options[:district_key] || ENV['DISTRICT_KEY'] || nil
@@ -42,6 +48,8 @@ class PerDistrict
       login_name + '@k12.somerville.ma.us'
     elsif @district_key == NEW_BEDFORD
       login_name + '@newbedford.org'
+    elsif @district_key == DEMO
+      raise "PerDistrict#from_import_login_name_to_email not supported for district_key: {DEMO}"
     else
       raise_not_handled!
     end

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -28,7 +28,6 @@ class SchoolsController < ApplicationController
   end
 
   def school_administrator_dashboard
-    puts '#school_administrator_dashboard'
     dashboard_students = students_for_dashboard(@school)
       .includes([homeroom: :educator], :dashboard_absences, :event_notes, :dashboard_tardies)
     dashboard_students_json = dashboard_students.map do |student|


### PR DESCRIPTION
# Who is this PR for?
people using the demo site

# What problem does this PR fix?
the demo site is down

# What does this PR do?
Allows 'demo' as a district_key value; this was made stricter in https://github.com/studentinsights/studentinsights/pull/1547/files#diff-9ba06106d1f1d97c7f2d9ece90d5b81dR11 this fixes it up for the demo site.

It also removes a stray log statement from https://github.com/studentinsights/studentinsights/pull/1549.
