### PR TITLE
Performance optimizations for Feed and Authorizer, with test case 

### DIFF
--- a/app/lib/feed.rb
+++ b/app/lib/feed.rb
@@ -6,25 +6,13 @@ class Feed
 
   # Return a list of `FeedCard`s for the feed based on event notes.
   def event_note_cards(from_time, limit)
-    # This is a performance optimization - we check the authorization
-    # of one at a time, so that we can exit early
-    recent_event_notes = unsafe_authorization! do
-      unsafe_event_notes = EventNote
-        .includes(:student)
-        .where(is_restricted: false)
-        .where('recorded_at < ?', from_time)
-        .order(recorded_at: :desc)
-
-      authorized_event_notes = []
-      unsafe_event_notes.each do |unsafe_event_note|
-        if @authorizer.is_authorized_for_note?(unsafe_event_note)
-          authorized_event_notes << unsafe_event_note
-        end
-        break if authorized_event_notes.size >= limit
-      end
-      authorized_event_notes
-    end
-
+    recent_event_notes = EventNote
+      .where(student_id: authorized_students.map(&:id))
+      .where(is_restricted: false)
+      .where('recorded_at < ?', from_time)
+      .order(recorded_at: :desc)
+      .limit(limit)
+      .includes(student: :homeroom)
     recent_event_notes.map {|event_note| event_note_card(event_note) }
   end
 
@@ -35,24 +23,23 @@ class Feed
     limit = options[:limit] || 3
     days_back = options[:days_back] || 7
     days_ahead = options[:days_ahead] || 7
-    students = @authorizer.authorized do
-      Student.select(:id, :primary_email, :first_name, :last_name, :date_of_birth)
-        .where('extract(doy from date_of_birth) > ?', time_now.yday - days_back)
-        .where('extract(doy from date_of_birth) <= ?', time_now.yday + days_ahead)
-        .order('extract(doy from date_of_birth) DESC')
-        .limit(limit)
-    end
+    students = Student
+      .where(id: authorized_students.map(&:id))
+      .where('extract(doy from date_of_birth) > ?', time_now.yday - days_back)
+      .where('extract(doy from date_of_birth) <= ?', time_now.yday + days_ahead)
+      .order('extract(doy from date_of_birth) DESC')
+      .limit(limit)
     students.map { |student| birthday_card(student, time_now) }
   end
 
   # Returns recent discipline incidents.
   def incident_cards(time_now, limit)
-    students = @authorizer.authorized { Student.all }
     incidents = DisciplineIncident
-      .where(student_id: students.map(&:id))
+      .where(student_id: authorized_students.map(&:id))
       .where('occurred_at < ?', time_now)
       .order(occurred_at: :desc)
       .limit(limit)
+      .includes(student: :homeroom)
     incidents.map {|incident| incident_card(incident) }
   end
 
@@ -63,9 +50,9 @@ class Feed
   end
 
   private
-  # This is just to tag a block as unsafe in terms of authorization
-  def unsafe_authorization!
-    yield
+  # Performance optimization to cache across methods
+  def authorized_students
+    @authorized_students ||= @authorizer.authorized { Student.all }
   end
 
   # Create json for exactly what UI needs and return as `FeedCard`

--- a/app/lib/perf_test.rb
+++ b/app/lib/perf_test.rb
@@ -1,0 +1,116 @@
+class PerfTest
+  # Holds timing data
+  class Timer
+    def initialize()
+      @measurements = []
+    end
+
+    # not attr_reader so it doesn't puts by default (values are large!)
+    def measurements
+      @measurements
+    end
+
+    def measure(tag)
+      value = nil
+      timing = Benchmark.measure { value = yield }
+      puts tag + timing.to_s
+      @measurements << {tag: tag, timing: timing, value: value}
+      value
+    end
+
+    def report
+      tuples = @measurements.map do |measurement|
+        ms = (measurement[:timing].real * 1000).round
+        [measurement[:tag], ms]
+      end
+      tuples.sort_by {|t| [t[0], t[1]] }
+    end
+  end
+
+  # For testing the feed
+  def self.feed(percentage, options = {})
+    timer = PerfTest.new.run(0.1) do |t, educator|
+      time_now = options[:time_now] || Time.at(1521552855)
+      limit = options[:limit] || 10
+      feed = Feed.new(educator)
+      event_note_cards = t.measure('event_note_cards') do
+        feed.event_note_cards(time_now, limit)
+      end
+      incident_cards = t.measure('incident_cards') do
+        feed.incident_cards(time_now, limit)
+      end
+      birthday_cards = t.measure('birthday_cards') do
+        feed.birthday_cards(time_now, limit, {
+          limit: 3,
+          days_back: 3,
+          days_ahead: 0
+        })
+      end
+      t.measure('feed_cards') do
+        feed.merge_sort_and_limit_cards([
+          event_note_cards,
+          birthday_cards,
+          incident_cards
+        ], limit)
+      end
+    end
+    pp timer.report
+    timer
+  end
+
+  # Generic usage:
+  # timer = perf_test.run(0.10) do |t, educator|
+  #   t.measure('whatever') { do_something_for(educator) }
+  #   t.measure('foo') { do_something_else_for(educator) }
+  # end;nil
+  # pp timer.report
+  def run(percentage, &block)
+    timer = Timer.new
+
+    puts
+    puts
+    puts 'Getting test set...'
+    educator_ids = test_educator_ids(percentage)
+    puts "Test set includes #{educator_ids.size} educators: [#{educator_ids.sort.join(',')}]"
+    puts 'Done.'
+    puts
+    puts
+    puts 'Starting test run...'
+    run_for_all_educators(timer, educator_ids, &block)
+    puts 'Done.'
+    puts
+    puts
+    timer
+  end
+
+  def test_educator_ids(percent, options = {})
+    seed = options[:seed] || 42
+    fixed_educator_ids = options[:fixed_educator_ids] || []
+    all_educator_ids = Educator.all.select(:id).map(&:id)
+    sample_size = percent * all_educator_ids.size
+    sample_educator_ids = all_educator_ids.sample(sample_size, random: Random.new(seed))
+    (sample_educator_ids + fixed_educator_ids).uniq
+  end
+
+  private
+  def debug!
+    Rails.configuration.log_level = :debug
+    ActiveRecord::Base.logger = Logger.new(STDOUT)
+  end
+
+  def reset!
+    ActiveRecord::Base.connection.query_cache.clear
+  end
+
+  def run_for_all_educators(t, educator_ids, &block)
+    educator_ids.each do |educator_id|
+      reset!
+      puts
+      puts "Starting for educator: #{educator_id}..."
+      educator = Educator.find(educator_id)
+      t.measure('all_for_educator') do
+        block.yield(t, educator)
+      end
+    end
+  end
+end

--- a/app/lib/perf_test.rb
+++ b/app/lib/perf_test.rb
@@ -1,5 +1,41 @@
 class PerfTest
-  # Holds timing data
+  # Helper class to print summary stats like p50, p95
+  #
+  # Usage:
+  #
+  #   Reporter.new.report({
+  #     unoptimized: unoptimized_timer.report,
+  #     optimized: optimized_timer.report
+  #   })
+  #
+  # or json = JSON.parse(IO.read('runs.json'));nil
+  # Reporter.new.report(json)
+  class Reporter
+    def report(timer_reports_map)
+      timer_reports_map.each do |report_key, tuples|
+        puts
+        puts "#{report_key.upcase}, sample size: #{tuples.size}"
+        tuples.group_by {|t| t[0]}.each do |key, ts|
+          values = ts.map {|t| t[1] }
+          p50 = percentile(values, 0.50).round
+          p95 = percentile(values, 0.95).round
+          puts "  #{key.ljust(25)}\tmedian: #{p50}ms\t\tp95: #{p95}ms"
+        end
+      end
+      nil
+    end
+
+    private
+    # copied from https://stackoverflow.com/questions/11784843/calculate-95th-percentile-in-ruby
+    def percentile(values, percentile)
+      values_sorted = values.sort
+      k = (percentile*(values_sorted.length-1)+1).floor - 1
+      f = (percentile*(values_sorted.length-1)+1).modulo(1)
+      return values_sorted[k] + (f * (values_sorted[k+1] - values_sorted[k]))
+    end
+  end
+
+  # Helper class to hold timing data
   class Timer
     def initialize()
       @measurements = []
@@ -27,7 +63,7 @@ class PerfTest
     end
   end
 
-  # For testing the feed
+  # Usage for testing the feed
   def self.feed(percentage, options = {})
     timer = PerfTest.new.run(0.1) do |t, educator|
       time_now = options[:time_now] || Time.at(1521552855)
@@ -58,7 +94,7 @@ class PerfTest
     timer
   end
 
-  # Generic usage:
+  # Generic perftest usage:
   # timer = perf_test.run(0.10) do |t, educator|
   #   t.measure('whatever') { do_something_for(educator) }
   #   t.measure('foo') { do_something_else_for(educator) }


### PR DESCRIPTION
# Who is this PR for?
all educators, but HS classroom teachers were the initial focus

# What problem does this PR fix?
The home feed has latency up to 30 seconds for some HS teachers, particularly those who don't have schoolwide, gradelevel, or districtwide access.  This makes this mostly unusable beyond a prototype, and prevents shipping this as the home page for all educators.

# What does this PR do?
Makes a few performance optimizations to `Feed` and to `Authorizer`.  There's no functional changes, just optimizing the query latency for the feed endpoint.  This also adds the test case and some maybe useful code for other perf test cases.  No tests break because there are no functional changes.

The test case works by grabbing some educators, then essentially running `home_controller#feed_json` with some more instrumentation around it.  I ran this with a known set of educators I was trying to optimize for, then generalized to a consistent sample of 10% of educators.  The test runs below don't all use the same set of educators, and even when they do there's some variability across tests runs.  I did test runs in new one-off dynos to try to get repeatable results, but there's still just a bunch of variability.  But overall this cuts the p95 to ~41 seconds to ~3 seconds for total request latency (with raw data below).

This PR includes two main optimizations.  The first is to `Authorizer`, which was repeatedly querying for educator section and homeroom data.  I'm not sure why this change works (it's counter-intuitive to me), but by turning on ActiveRecord debug logging the effect is clear.  The second  is to `Feed`, which came from noticing that `event_note_cards` and `incident_cards` both were slow enough that it might be worth paralleling out in the client.  I looked at what they were doing, and rolled back https://github.com/studentinsights/studentinsights/pull/1548 to optimize across all methods with the new improvement to `Authorizer`.  This worked great because if we just cache `authorized_students` within the feed, it simplifies all the other methods and is also faster.

test case data:
```
MASTER_SMALL, sample size: 45
  all_for_educator         	median: 14381ms		p95: 41457ms
  birthday_cards           	median: 16ms		p95: 30ms
  event_note_cards         	median: 5270ms		p95: 24921ms
  feed_cards               	median: 0ms		p95: 0ms
  incident_cards           	median: 8662ms		p95: 16662ms

FIRST_CDB25D5_SMALL, sample size: 45
  all_for_educator         	median: 4270ms		p95: 4917ms
  birthday_cards           	median: 12ms		p95: 48ms
  event_note_cards         	median: 2493ms		p95: 2640ms
  feed_cards               	median: 0ms		p95: 0ms
  incident_cards           	median: 1800ms		p95: 2335ms

FIRST_CDB25D5_TEN, sample size: 645
  all_for_educator         	median: 3588ms		p95: 5283ms
  birthday_cards           	median: 11ms		p95: 16ms
  event_note_cards         	median: 2008ms		p95: 2778ms
  feed_cards               	median: 0ms		p95: 0ms
  incident_cards           	median: 1530ms		p95: 2646ms

SECOND_121D502_KNOWN, sample size: 185
  all_for_educator         	median: 1652ms		p95: 2689ms
  birthday_cards           	median: 21ms		p95: 214ms
  event_note_cards         	median: 1503ms		p95: 2527ms
  feed_cards               	median: 0ms		p95: 0ms
  incident_cards           	median: 87ms		p95: 335ms

SECOND_121D502_TEN, sample size: 645
  all_for_educator         	median: 470ms		p95: 1274ms
  birthday_cards           	median: 4ms		p95: 42ms
  event_note_cards         	median: 391ms		p95: 1234ms
  feed_cards               	median: 0ms		p95: 0ms
  incident_cards           	median: 20ms		p95: 83ms

FINAL_131D502_TEN, sample size: 485
  all_for_educator         	median: 833ms		p95: 2965ms
  birthday_cards           	median: 7ms		p95: 70ms
  event_note_cards         	median: 774ms		p95: 2629ms
  feed_cards               	median: 0ms		p95: 0ms
  incident_cards           	median: 9ms		p95: 211ms

FINALFINAL_131D502_TEN, sample size: 485
  all_for_educator         	median: 464ms		p95: 1736ms
  birthday_cards           	median: 4ms		p95: 42ms
  event_note_cards         	median: 439ms		p95: 1673ms
  feed_cards               	median: 0ms		p95: 0ms
  incident_cards           	median: 13ms		p95: 102ms
```