### PR TITLE
Filter out event note text from logs

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:password, :text]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,7 @@
-# Be sure to restart your server when you modify this file.
-
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password, :text]
+Rails.application.config.filter_parameters += [
+  :password,
+  :text, # Filtering this one out because the `text` field in the event_notes and
+         # event_note_revisions tables can contain sensitive information about
+         # students that we want to keep out of logs.
+]


### PR DESCRIPTION
# Who is this PR for?

Developers who use the logs and get email alerts from our logging service. 

# What problem does this PR fix?

Event note text is currently printed in the logs as plaintext. This isn't the best security practice because it makes the surface larger for accessing sensitive event note data. We want to shrink that surface and make it as small as possible. If the logging service sends an email alert that includes a log trace of an event note being created/updated, without filtering in place we'll have copies of sensitive event note text in developers' inboxes.

# What does this PR do?

Filters out any field named "text" from the logs.

## Event note creation log (demo data, master branch)
![screen shot 2018-03-21 at 10 29 43 am](https://user-images.githubusercontent.com/3209501/37720184-b815b54e-2cf4-11e8-8a0c-cc7e1e67b2f9.png)

## Event note creation log (demo data, this branch)
![screen shot 2018-03-21 at 10 31 00 am](https://user-images.githubusercontent.com/3209501/37720183-b7a8ca88-2cf4-11e8-900b-62ff9969bf64.png)
