### PR TITLE
Update New Bedford domain suffix to be correct

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -47,7 +47,7 @@ class PerDistrict
     if @district_key == SOMERVILLE
       login_name + '@k12.somerville.ma.us'
     elsif @district_key == NEW_BEDFORD
-      login_name + '@newbedford.org'
+      login_name + '@newbedfordschools.org'
     elsif @district_key == DEMO
       raise "PerDistrict#from_import_login_name_to_email not supported for district_key: {DEMO}"
     else

--- a/spec/config_objects/per_district_spec.rb
+++ b/spec/config_objects/per_district_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe PerDistrict do
   describe '#from_import_login_name_to_email' do
     it 'works' do
       expect(for_somerville.from_import_login_name_to_email('foo')).to eq('foo@k12.somerville.ma.us')
-      expect(for_new_bedford.from_import_login_name_to_email('foo')).to eq('foo@newbedford.org')
+      expect(for_new_bedford.from_import_login_name_to_email('foo')).to eq('foo@newbedfordschools.org')
       expect { PerDistrict.new(district_key: 'wat').from_import_login_name_to_email('foo') }.to raise_error Exceptions::DistrictKeyNotHandledError
     end
   end

--- a/spec/importers/file_importers/educators_importer_spec.rb
+++ b/spec/importers/file_importers/educators_importer_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe EducatorsImporter do
                 ENV['DISTRICT_KEY'] = PerDistrict::NEW_BEDFORD
                 educators_importer.import_row(row)
                 educator = Educator.last
-                expect(educator.email).to eq('jyoung@newbedford.org')
+                expect(educator.email).to eq('jyoung@newbedfordschools.org')
               end
 
               context 'multiple educators' do


### PR DESCRIPTION
# Who is this PR for?
NB educators, JV in particular.

# What problem does this PR fix?
Folks can't sign in.

# What does this PR do?
Updates the domain suffix for New Bedford to actually be correct :)  This will require a manual migration too.