### PR TITLE
Add in timing measurements for absences dashboard

### DIFF
--- a/app/assets/javascripts/components/MountTimer.js
+++ b/app/assets/javascripts/components/MountTimer.js
@@ -1,0 +1,40 @@
+import React from 'react';
+
+
+// A higher-order component for measuring the mount timing of this
+// component tree.
+class MountTimer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.willMount = null;
+    this.didMount = null;
+  }
+
+  componentWillMount() {
+    this.willMount = performance.now();
+  }
+
+  componentDidMount() {
+    const {onTiming} = this.props;
+    this.didMount = performance.now();
+    const diff = Math.round(this.didMount - this.willMount);
+
+    console.log('didMount:', performance.now());
+    if (onTiming) {
+      onTiming(diff);
+    } else {
+      console.log('MountTimer: ', diff);  // eslint-disable-line no-console
+    }
+  }
+
+  render() {
+    const {children} = this.props;
+    return children;
+  }
+}
+MountTimer.propTypes = {
+  children: React.PropTypes.node.isRequired,
+  onTiming: React.PropTypes.func
+};
+
+export default MountTimer;

--- a/app/assets/javascripts/components/MountTimer.js
+++ b/app/assets/javascripts/components/MountTimer.js
@@ -2,7 +2,9 @@ import React from 'react';
 
 
 // A higher-order component for measuring the mount timing of this
-// component tree.
+// component tree.  This measures the aggregate timing for 
+// the tree.  Look at https://reactjs.org/docs/perf.html if you want
+// more profiling data.
 class MountTimer extends React.Component {
   constructor(props) {
     super(props);
@@ -19,7 +21,6 @@ class MountTimer extends React.Component {
     this.didMount = performance.now();
     const diff = Math.round(this.didMount - this.willMount);
 
-    console.log('didMount:', performance.now());
     if (onTiming) {
       onTiming(diff);
     } else {

--- a/app/assets/javascripts/components/MountTimer.test.js
+++ b/app/assets/javascripts/components/MountTimer.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import MountTimer from './MountTimer';
+
+it('renders without crashing', () => {
+  const props = {
+    onTiming: jest.fn()
+  };
+  const el = document.createElement('div');
+  ReactDOM.render(<MountTimer {...props}><div>hello!</div></MountTimer>, el);
+  expect(props.onTiming).toHaveBeenCalled();
+});

--- a/app/assets/javascripts/helpers/measurePageLoad.js
+++ b/app/assets/javascripts/helpers/measurePageLoad.js
@@ -1,3 +1,9 @@
+// Call this to get page load data using the Performance Timing API.
+// It expects to be called in the page load cycle, and then calls back
+// with data on page load.
+//
+// usage:
+// measurePageLoad(info => console.log(JSON.stringify(info, null, 2)));
 export default function measurePageLoad(callback) {
   window.onload = () => {
     setTimeout(() => {
@@ -8,7 +14,6 @@ export default function measurePageLoad(callback) {
 
       const info = {pageLoadTime, networkTime, renderTime};
       callback(info);
-      window.info = info;
     }, 0);
   };
 }

--- a/app/assets/javascripts/helpers/measurePageLoad.js
+++ b/app/assets/javascripts/helpers/measurePageLoad.js
@@ -1,0 +1,14 @@
+export default function measurePageLoad(callback) {
+  window.onload = () => {
+    setTimeout(() => {
+      const perfData = window.performance.timing; 
+      const pageLoadTime = perfData.loadEventEnd - perfData.navigationStart;
+      const networkTime = perfData.responseEnd - perfData.requestStart;
+      const renderTime = perfData.domComplete - perfData.domLoading;
+
+      const info = {pageLoadTime, networkTime, renderTime};
+      callback(info);
+      window.info = info;
+    }, 0);
+  };
+}

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/SchoolAdministratorDashboards.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/SchoolAdministratorDashboards.js
@@ -1,21 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Switch, Route} from 'react-router-dom';
-
+import MountTimer from '../../components/MountTimer';
 import DashboardOverview from './DashboardOverview';
 import SchoolwideAbsences from './absences_dashboard/SchoolwideAbsences';
 import SchoolwideTardies from './tardies_dashboard/SchoolwideTardies';
 
-export default function SchoolAdministratorDashboards ( {serializedData} ) {
-  const {students} = serializedData;
-  return(
-  <Switch>
-    <Route exact path="/" render={ () => <DashboardOverview />} />
-    <Route path="/absences_dashboard" render={ () => <SchoolwideAbsences dashboardStudents={students}/>} />
-    <Route path="/tardies_dashboard" render={ () => <SchoolwideTardies dashboardStudents={students}/>} />
-  </Switch>);
+class SchoolAdministratorDashboards extends React.Component {
+  render() {
+    const {students} = this.props.serializedData;
+    return (
+      <MountTimer>
+        <Switch>
+          <Route exact path="/" render={ () => <DashboardOverview />} />
+          <Route path="/absences_dashboard" render={ () => <SchoolwideAbsences dashboardStudents={students}/>} />
+          <Route path="/tardies_dashboard" render={ () => <SchoolwideTardies dashboardStudents={students}/>} />
+        </Switch>
+      </MountTimer>
+    );
+  }
 }
 
 SchoolAdministratorDashboards.propTypes = {
   serializedData: PropTypes.object.isRequired
 };
+
+export default SchoolAdministratorDashboards;

--- a/app/assets/javascripts/school_administrator_dashboard/main.js
+++ b/app/assets/javascripts/school_administrator_dashboard/main.js
@@ -1,5 +1,5 @@
 import { HashRouter } from 'react-router-dom';
-
+import measurePageLoad from '../helpers/measurePageLoad';
 import SchoolAdministratorDashboards from  './dashboard_components/SchoolAdministratorDashboards';
 import MixpanelUtils from '../helpers/mixpanel_utils.jsx';
 
@@ -7,6 +7,7 @@ export default function renderSchoolAdminDashboardMain(el) {
   const serializedData = $('#serialized-data').data();
   MixpanelUtils.registerUser(serializedData.currentEducator);
   MixpanelUtils.track('PAGE_VISIT', { page_key: 'SCHOOL_DASHBOARD' });
+
   window.ReactDOM.render(
     <HashRouter>
       <SchoolAdministratorDashboards
@@ -14,4 +15,6 @@ export default function renderSchoolAdminDashboardMain(el) {
     </HashRouter>,
     el
   );
+
+  measurePageLoad(info => console.log(JSON.stringify(info, null, 2))); // eslint-disable-line no-console
 }

--- a/ui/config/performance-timing-api.js
+++ b/ui/config/performance-timing-api.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * performance-timing.js: Polyfill for performance.timing object
  * For greatest accuracy, this needs to be run as soon as possible in the page, preferably inline.
@@ -6,94 +7,94 @@
  * @license WTFPL (http://www.wtfpl.net/txt/copying)
  */
 (function (window) {
-    'use strict';
+  'use strict';
 
-    var
-        document = window.document,
-        loadParams,
-        setTimeout = window.setTimeout,
-        D = Date,
-        dateNow = D.now ? function () { return D.now(); } : function () { return (new D()).getTime(); },
-        M = Math,
-        min = M.min,
-        start = dateNow(); // this is the earliest time we can get without built-in timing
+  let
+    document = window.document,
+    loadParams,
+    setTimeout = window.setTimeout,
+    D = Date,
+    dateNow = D.now ? function () { return D.now(); } : function () { return (new D()).getTime(); },
+    M = Math,
+    min = M.min,
+    start = dateNow(); // this is the earliest time we can get without built-in timing
 
-    function domLoad() {
-        var
-            time = dateNow(),
-            timing = window.performance.timing;
+  function domLoad() {
+    let
+      time = dateNow(),
+      timing = window.performance.timing;
 
         /* DOMContentLoadedEventEnd value is set via domReady function.
          * However, this function may run before domReady does (making the value 0), so we check for the falsey value
          */
-        timing.domContentLoadedEventEnd = timing.domContentLoadedEventStart = min(timing.domContentLoadedEventEnd, time) || time;
+    timing.domContentLoadedEventEnd = timing.domContentLoadedEventStart = min(timing.domContentLoadedEventEnd, time) || time;
         /* If this function runs before domReady then DOMComplete will equal DOMContentLoadedEventStart
          * Otherwise there will be a few ms difference
          */
-        timing.domComplete = timing.loadingEventEnd = timing.loadingEventStart = M.max(timing.domContentLoadedEventEnd, time);
+    timing.domComplete = timing.loadingEventEnd = timing.loadingEventStart = M.max(timing.domContentLoadedEventEnd, time);
+    try {
+      window.removeEventListener.apply(window, loadParams);
+    } catch (e) {
+      try {
+        window.detachEvent('onload', domLoad);
+      } catch (ignore) {}
+    }
+  }
+
+  function domReady() {
+    let
+      readyState = document.readyState,
+      time = dateNow(),
+      timing = window.performance.timing;
+
+    if (readyState === 'uninitialized' || readyState === 'loading' || readyState === 'interactive') {
+      if (readyState === 'loading') {
+        timing.domLoading = timing.domLoading || time;
+      } else if (readyState === 'interactive') {
+        timing.domInteractive = timing.domInteractive || time;
+      }
+
+      setTimeout(domReady, 9);
+
+      return;
+    }
+
+    timing.domInteractive = timing.domInteractive || timing.domComplete || time;
+    timing.domLoading = timing.domLoading || min(timing.navigationStart, time);
+    timing.domContentLoadedEventEnd = timing.domContentLoadedEventStart = min(timing.domInteractive, time);
+    if (window.history.length) {
+      timing.unloadEventEnd = timing.unloadEventStart = timing.navigationStart;
+    }
+  }
+
+  window.performance = window.performance || window.webkitPerformance || window.msPerformance || window.mozPerformance;
+  if (window.performance === undefined) {
+    window.performance = {};
+    window.performance.timing = {
+      domComplete:                0,
+      domContentLoadedEventEnd:   0,
+      domContentLoadedEventStart: 0,
+      domInteractive:             0,
+      domLoading:                 0,
+      legacyNavigationStart:      start,
+      loadEventEnd:               0,
+      loadEventStart:             0,
+      navigationStart:            start,
+      unloadEventEnd:             0,
+      unloadEventStart:           0
+    };
+    loadParams = ['load', domLoad, false];
+
+    if (document.readyState !== 'complete') {
+      try {
+        window.addEventListener.apply(window, loadParams);
+      } catch (e) {
         try {
-            window.removeEventListener.apply(window, loadParams);
-        } catch (e) {
-            try {
-                window.detachEvent('onload', domLoad);
-            } catch (ignore) {}
-        }
+          window.attachEvent('onload', domLoad);
+        } catch (ignore) {}
+      }
     }
 
-    function domReady() {
-        var
-            readyState = document.readyState,
-            time = dateNow(),
-            timing = window.performance.timing;
-
-        if (readyState === 'uninitialized' || readyState === 'loading' || readyState === 'interactive') {
-            if (readyState === 'loading') {
-                timing.domLoading = timing.domLoading || time;
-            } else if (readyState === 'interactive') {
-                timing.domInteractive = timing.domInteractive || time;
-            }
-
-            setTimeout(domReady, 9);
-
-            return;
-        }
-
-        timing.domInteractive = timing.domInteractive || timing.domComplete || time;
-        timing.domLoading = timing.domLoading || min(timing.navigationStart, time);
-        timing.domContentLoadedEventEnd = timing.domContentLoadedEventStart = min(timing.domInteractive, time);
-        if (window.history.length) {
-            timing.unloadEventEnd = timing.unloadEventStart = timing.navigationStart;
-        }
-    }
-
-    window.performance = window.performance || window.webkitPerformance || window.msPerformance || window.mozPerformance;
-    if (window.performance === undefined) {
-        window.performance = {};
-        window.performance.timing = {
-            domComplete:                0,
-            domContentLoadedEventEnd:   0,
-            domContentLoadedEventStart: 0,
-            domInteractive:             0,
-            domLoading:                 0,
-            legacyNavigationStart:      start,
-            loadEventEnd:               0,
-            loadEventStart:             0,
-            navigationStart:            start,
-            unloadEventEnd:             0,
-            unloadEventStart:           0
-        };
-        loadParams = ['load', domLoad, false];
-
-        if (document.readyState !== 'complete') {
-            try {
-                window.addEventListener.apply(window, loadParams);
-            } catch (e) {
-                try {
-                    window.attachEvent('onload', domLoad);
-                } catch (ignore) {}
-            }
-        }
-
-        setTimeout(domReady, 0);
-    }
+    setTimeout(domReady, 0);
+  }
 }(global));

--- a/ui/config/performance-timing-api.js
+++ b/ui/config/performance-timing-api.js
@@ -1,0 +1,99 @@
+/**
+ * performance-timing.js: Polyfill for performance.timing object
+ * For greatest accuracy, this needs to be run as soon as possible in the page, preferably inline.
+ * The values returned are necessarily not absolutely accurate, but are close enough for general purposes.
+ * @author ShirtlessKirk. Copyright (c) 2014.
+ * @license WTFPL (http://www.wtfpl.net/txt/copying)
+ */
+(function (window) {
+    'use strict';
+
+    var
+        document = window.document,
+        loadParams,
+        setTimeout = window.setTimeout,
+        D = Date,
+        dateNow = D.now ? function () { return D.now(); } : function () { return (new D()).getTime(); },
+        M = Math,
+        min = M.min,
+        start = dateNow(); // this is the earliest time we can get without built-in timing
+
+    function domLoad() {
+        var
+            time = dateNow(),
+            timing = window.performance.timing;
+
+        /* DOMContentLoadedEventEnd value is set via domReady function.
+         * However, this function may run before domReady does (making the value 0), so we check for the falsey value
+         */
+        timing.domContentLoadedEventEnd = timing.domContentLoadedEventStart = min(timing.domContentLoadedEventEnd, time) || time;
+        /* If this function runs before domReady then DOMComplete will equal DOMContentLoadedEventStart
+         * Otherwise there will be a few ms difference
+         */
+        timing.domComplete = timing.loadingEventEnd = timing.loadingEventStart = M.max(timing.domContentLoadedEventEnd, time);
+        try {
+            window.removeEventListener.apply(window, loadParams);
+        } catch (e) {
+            try {
+                window.detachEvent('onload', domLoad);
+            } catch (ignore) {}
+        }
+    }
+
+    function domReady() {
+        var
+            readyState = document.readyState,
+            time = dateNow(),
+            timing = window.performance.timing;
+
+        if (readyState === 'uninitialized' || readyState === 'loading' || readyState === 'interactive') {
+            if (readyState === 'loading') {
+                timing.domLoading = timing.domLoading || time;
+            } else if (readyState === 'interactive') {
+                timing.domInteractive = timing.domInteractive || time;
+            }
+
+            setTimeout(domReady, 9);
+
+            return;
+        }
+
+        timing.domInteractive = timing.domInteractive || timing.domComplete || time;
+        timing.domLoading = timing.domLoading || min(timing.navigationStart, time);
+        timing.domContentLoadedEventEnd = timing.domContentLoadedEventStart = min(timing.domInteractive, time);
+        if (window.history.length) {
+            timing.unloadEventEnd = timing.unloadEventStart = timing.navigationStart;
+        }
+    }
+
+    window.performance = window.performance || window.webkitPerformance || window.msPerformance || window.mozPerformance;
+    if (window.performance === undefined) {
+        window.performance = {};
+        window.performance.timing = {
+            domComplete:                0,
+            domContentLoadedEventEnd:   0,
+            domContentLoadedEventStart: 0,
+            domInteractive:             0,
+            domLoading:                 0,
+            legacyNavigationStart:      start,
+            loadEventEnd:               0,
+            loadEventStart:             0,
+            navigationStart:            start,
+            unloadEventEnd:             0,
+            unloadEventStart:           0
+        };
+        loadParams = ['load', domLoad, false];
+
+        if (document.readyState !== 'complete') {
+            try {
+                window.addEventListener.apply(window, loadParams);
+            } catch (e) {
+                try {
+                    window.attachEvent('onload', domLoad);
+                } catch (ignore) {}
+            }
+        }
+
+        setTimeout(domReady, 0);
+    }
+}(global));

--- a/ui/config/setupTests.js
+++ b/ui/config/setupTests.js
@@ -7,6 +7,12 @@ import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-15.4';
 Enzyme.configure({ adapter: new Adapter() });
 
+// These are for MountTimer and measurePageLoad.
+// See https://gist.github.com/ShirtlessKirk/eb41720a797411defae6
+import './performance-timing-api.js';
+import {performance} from 'perf_hooks';
+global.performance = performance;
+
 // https://github.com/jefflau/jest-fetch-mock
 global.fetch = require('jest-fetch-mock'); // eslint-disable-line no-undef
 


### PR DESCRIPTION
# Who is this PR for?
developers, @edavidsonsawyer in particular

# What problem does this PR fix?
We don't have a way to get measurements on client-side performance in IE right now

# What does this PR do?
Adds a `measurePageLoad` function for grabbing page load timing data, and adds `MountTimer` which measures the time to mount a React component tree.

# Checklists
+ [x] Author checked latest in IE - Absences dashboard as smoke test
+ [x] Author included specs for new code
