### PR TITLE
scripts/deploy/all

### DIFF
--- a/scripts/deploy/all.sh
+++ b/scripts/deploy/all.sh
@@ -4,7 +4,6 @@ git fetch origin
 
 echo "🚢  Deploying...";
 yarn run concurrently \
-  --kill-others \
   --names "demo,somerville,new-bedford" \
   -c "yellow.bold,blue.bold,magenta.bold" \
   'scripts/deploy/deploy.sh demo' \

--- a/scripts/deploy/all.sh
+++ b/scripts/deploy/all.sh
@@ -3,7 +3,10 @@ echo "🚢  Fetching from GitHub...";
 git fetch origin
 
 echo "🚢  Deploying...";
-yarn run concurrently --kill-others \
+yarn run concurrently \
+  --kill-others \
+  --names "demo,somerville,new-bedford" \
+  -c "yellow.bold,blue.bold,magenta.bold" \
   'scripts/deploy/deploy.sh demo' \
   'scripts/deploy/deploy.sh somerville' \
   'scripts/deploy/deploy.sh new-bedford' \

--- a/scripts/deploy/all.sh
+++ b/scripts/deploy/all.sh
@@ -1,0 +1,11 @@
+# Deploy to all sites in parallel
+echo "🚢  Fetching from GitHub...";
+git fetch origin
+
+echo "🚢  Deploying...";
+yarn run concurrently --kill-others \
+  'scripts/deploy/deploy.sh demo' \
+  'scripts/deploy/deploy.sh somerville' \
+  'scripts/deploy/deploy.sh new-bedford' \
+
+echo "🚢  Done.";

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -5,7 +5,6 @@
 for remote in "$@"
 do
     echo "🚢  🚢  🚢  Deploying code to $remote.";
-    git fetch origin
     git push $remote origin/master:master
     echo;
     echo "⚙  ⚙  ⚙  Migrating the database for $remote.";


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Adds a new `script/deploy/all.sh` that uses `concurrently` to run all deploys concurrently and color-code their output.  This is a small convenience for deploying across all sites without running each in parallel windows.

<img width="1251" alt="screen shot 2018-03-26 at 11 06 29 am" src="https://user-images.githubusercontent.com/1056957/37914676-c3f44f70-30e5-11e8-8163-59908aaad4c6.png">
