### PR TITLE
Fix UI bug causing note taking interruption

### DIFF
--- a/app/assets/javascripts/helpers/prop_types.jsx
+++ b/app/assets/javascripts/helpers/prop_types.jsx
@@ -8,6 +8,7 @@ const PropTypes = {
     onClickSaveService: React.PropTypes.func.isRequired,
     onClickDiscontinueService: React.PropTypes.func.isRequired,
     onChangeNoteInProgressText: React.PropTypes.func.isRequired,
+    onClickNoteType: React.PropTypes.func.isRequired
   }),
   requests: React.PropTypes.shape({
     saveNote: React.PropTypes.string,

--- a/app/assets/javascripts/helpers/prop_types.jsx
+++ b/app/assets/javascripts/helpers/prop_types.jsx
@@ -3,12 +3,12 @@ import React from 'react';
 const PropTypes = {
   // UI actions, stepping stone to Flux
   actions: React.PropTypes.shape({
-    onColumnClicked: React.PropTypes.func.isRequired,
-    onClickSaveNotes: React.PropTypes.func.isRequired,
-    onClickSaveService: React.PropTypes.func.isRequired,
-    onClickDiscontinueService: React.PropTypes.func.isRequired,
-    onChangeNoteInProgressText: React.PropTypes.func.isRequired,
-    onClickNoteType: React.PropTypes.func.isRequired
+    onColumnClicked: React.PropTypes.func,
+    onClickSaveNotes: React.PropTypes.func,
+    onClickSaveService: React.PropTypes.func,
+    onClickDiscontinueService: React.PropTypes.func,
+    onChangeNoteInProgressText: React.PropTypes.func,
+    onClickNoteType: React.PropTypes.func
   }),
   requests: React.PropTypes.shape({
     saveNote: React.PropTypes.string,

--- a/app/assets/javascripts/helpers/prop_types.jsx
+++ b/app/assets/javascripts/helpers/prop_types.jsx
@@ -6,7 +6,8 @@ const PropTypes = {
     onColumnClicked: React.PropTypes.func.isRequired,
     onClickSaveNotes: React.PropTypes.func.isRequired,
     onClickSaveService: React.PropTypes.func.isRequired,
-    onClickDiscontinueService: React.PropTypes.func.isRequired
+    onClickDiscontinueService: React.PropTypes.func.isRequired,
+    onChangeNoteInProgressText: React.PropTypes.func.isRequired,
   }),
   requests: React.PropTypes.shape({
     saveNote: React.PropTypes.string,

--- a/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
+++ b/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
@@ -48,6 +48,8 @@ class RestrictedNotesPageContainer extends React.Component {
     this.onClickSaveNotes = this.onClickSaveNotes.bind(this);
     this.onSaveNotesDone = this.onSaveNotesDone.bind(this);
     this.onSaveNotesFail = this.onSaveNotesFail.bind(this);
+    this.onClickNoteType = this.onClickNoteType.bind(this);
+    this.onChangeNoteInProgressText = this.onChangeNoteInProgressText.bind(this);
   }
 
   componentWillMount(props, state) {
@@ -70,7 +72,9 @@ class RestrictedNotesPageContainer extends React.Component {
     const updatedFeed = merge(this.state.feed, { event_notes: updatedEventNotes });
     this.setState({
       feed: updatedFeed,
-      requests: merge(this.state.requests, { saveNote: null })
+      requests: merge(this.state.requests, { saveNote: null }),
+      noteInProgressText: '',
+      noteInProgressType: null,
     });
   }
 
@@ -78,6 +82,16 @@ class RestrictedNotesPageContainer extends React.Component {
     this.setState({
       requests: merge(this.state.requests, { saveNote: 'error' })
     });
+  }
+
+  onClickNoteType(event) {
+    const noteInProgressType = parseInt(event.target.name);
+
+    this.setState({ noteInProgressType });
+  }
+
+  onChangeNoteInProgressText(event) {
+    this.setState({ noteInProgressText: event.target.value });
   }
 
   render() {
@@ -98,6 +112,8 @@ class RestrictedNotesPageContainer extends React.Component {
               nowMomentFn: this.props.nowMomentFn,
               actions: this.props.actions || {
                 onClickSaveNotes: this.onClickSaveNotes,
+                onClickNoteType: this.onClickNoteType,
+                onChangeNoteInProgressText: this.onChangeNoteInProgressText,
               },
               showingRestrictedNotes: true,
               helpContent: this.renderNotesHelpContent(),

--- a/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
+++ b/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
@@ -107,7 +107,7 @@ class RestrictedNotesPageContainer extends React.Component {
               'student',
               'requests',
               'noteInProgressText',
-              'noteInProgressType',
+              'noteInProgressType'
             ), {
               nowMomentFn: this.props.nowMomentFn,
               actions: this.props.actions || {

--- a/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
+++ b/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
@@ -18,13 +18,19 @@ class RestrictedNotesPageContainer extends React.Component {
     this.state = {
       // context
       currentEducator: serializedData.currentEducator,
+
       // constants
       educatorsIndex: serializedData.educatorsIndex,
       eventNoteTypesIndex: serializedData.eventNoteTypesIndex,
+
       // data
       feed: serializedData.feed,
       student: serializedData.student,
+
       // ui
+      noteInProgressText: '',
+      noteInProgressType: null,
+
       // This map holds the state of network requests for various actions.  This allows UI components to branch on this
       // and show waiting messages or error messages.
       // The state of a network request is described with null (no requests in-flight),
@@ -85,7 +91,9 @@ class RestrictedNotesPageContainer extends React.Component {
               'eventNoteTypesIndex',
               'feed',
               'student',
-              'requests'
+              'requests',
+              'noteInProgressText',
+              'noteInProgressType',
             ), {
               nowMomentFn: this.props.nowMomentFn,
               actions: this.props.actions || {

--- a/app/assets/javascripts/student_profile/Api.js
+++ b/app/assets/javascripts/student_profile/Api.js
@@ -50,6 +50,7 @@ class Api {
         student_id: studentId
       }
     };
+
     return this._post(url, body);
   }
 

--- a/app/assets/javascripts/student_profile/NotesDetails.js
+++ b/app/assets/javascripts/student_profile/NotesDetails.js
@@ -4,7 +4,6 @@ import React from 'react';
 import HelpBubble from './HelpBubble.js';
 import SectionHeading from '../components/SectionHeading';
 
-
 const styles = {
   notesContainer: {
     flex: 1,
@@ -90,6 +89,8 @@ class NotesDetails extends React.Component {
           onCancel={this.onCancelNotes}
           requestState={this.props.requests.saveNote}
           noteInProgressText={this.props.noteInProgressText}
+          noteInProgressType={this.props.noteInProgressType}
+          onClickNoteType={this.props.actions.onClickNoteType}
           onChangeNoteInProgressText={this.props.actions.onChangeNoteInProgressText} />
       );
     }
@@ -135,6 +136,7 @@ NotesDetails.propTypes = {
   feed: PropTypes.feed.isRequired,
   requests: React.PropTypes.object.isRequired,
   noteInProgressText: React.PropTypes.string.isRequired,
+  noteInProgressType: React.PropTypes.number,
 
   showingRestrictedNotes: React.PropTypes.bool.isRequired,
   title: React.PropTypes.string.isRequired,

--- a/app/assets/javascripts/student_profile/NotesDetails.js
+++ b/app/assets/javascripts/student_profile/NotesDetails.js
@@ -131,7 +131,9 @@ NotesDetails.propTypes = {
   actions: React.PropTypes.shape({
     onClickSaveNotes: React.PropTypes.func.isRequired,
     onEventNoteAttachmentDeleted: React.PropTypes.func,
-    onDeleteEventNoteAttachment: React.PropTypes.func
+    onDeleteEventNoteAttachment: React.PropTypes.func,
+    onChangeNoteInProgressText: React.PropTypes.func.isRequired,
+    onClickNoteType: React.PropTypes.func.isRequired
   }),
   feed: PropTypes.feed.isRequired,
   requests: React.PropTypes.object.isRequired,

--- a/app/assets/javascripts/student_profile/NotesDetails.js
+++ b/app/assets/javascripts/student_profile/NotesDetails.js
@@ -75,7 +75,11 @@ class NotesDetails extends React.Component {
   }
 
   renderTakeNotesSection() {
-    if (this.state.isTakingNotes || this.props.requests.saveNote !== null) {
+    const showTakeNotes = this.state.isTakingNotes ||
+                          this.props.requests.saveNote !== null ||
+                          this.props.noteInProgressText.length > 0;
+
+    if (showTakeNotes) {
       return (
         <TakeNotes
           // TODO(kr) thread through
@@ -84,7 +88,9 @@ class NotesDetails extends React.Component {
           currentEducator={this.props.currentEducator}
           onSave={this.onClickSaveNotes}
           onCancel={this.onCancelNotes}
-          requestState={this.props.requests.saveNote} />
+          requestState={this.props.requests.saveNote}
+          noteInProgressText={this.props.noteInProgressText}
+          onChangeNoteInProgressText={this.props.actions.onChangeNoteInProgressText} />
       );
     }
 
@@ -128,6 +134,7 @@ NotesDetails.propTypes = {
   }),
   feed: PropTypes.feed.isRequired,
   requests: React.PropTypes.object.isRequired,
+  noteInProgressText: React.PropTypes.string.isRequired,
 
   showingRestrictedNotes: React.PropTypes.bool.isRequired,
   title: React.PropTypes.string.isRequired,

--- a/app/assets/javascripts/student_profile/page_container.jsx
+++ b/app/assets/javascripts/student_profile/page_container.jsx
@@ -152,9 +152,12 @@ function fromPair(key, value) {
       }
 
       const updatedFeed = merge(this.state.feed, { event_notes: updatedEventNotes });
+
       this.setState({
         feed: updatedFeed,
-        requests: merge(this.state.requests, { saveNote: null })
+        requests: merge(this.state.requests, { saveNote: null }),
+        noteInProgressText: '',
+        noteInProgressType: null,
       });
     },
 

--- a/app/assets/javascripts/student_profile/page_container.jsx
+++ b/app/assets/javascripts/student_profile/page_container.jsx
@@ -55,10 +55,10 @@ function fromPair(key, value) {
         iepDocument: serializedData.iepDocument,
         sections: serializedData.sections,
         currentEducatorAllowedSections: serializedData.currentEducatorAllowedSections,
-        noteInProgressText: '',
-        noteInProgressType: null,
 
         // ui
+        noteInProgressText: '',
+        noteInProgressType: null,
         selectedColumnKey: queryParams.column || 'interventions',
 
         // This map holds the state of network requests for various actions.  This allows UI components to branch on this

--- a/app/assets/javascripts/student_profile/page_container.jsx
+++ b/app/assets/javascripts/student_profile/page_container.jsx
@@ -55,6 +55,7 @@ function fromPair(key, value) {
         iepDocument: serializedData.iepDocument,
         sections: serializedData.sections,
         currentEducatorAllowedSections: serializedData.currentEducatorAllowedSections,
+        noteInProgressText: '',
 
         // ui
         selectedColumnKey: queryParams.column || 'interventions',
@@ -112,6 +113,10 @@ function fromPair(key, value) {
         column_key: columnKey
       });
       this.setState({ selectedColumnKey: columnKey });
+    },
+
+    onChangeNoteInProgressText: function(event) {
+      this.setState({ noteInProgressText: event.target.value });
     },
 
     onClickSaveNotes: function(eventNoteParams) {
@@ -246,7 +251,8 @@ function fromPair(key, value) {
               'iepDocument',
               'sections',
               'currentEducatorAllowedSections',
-              'requests'
+              'requests',
+              'noteInProgressText'
             ), {
               nowMomentFn: this.props.nowMomentFn,
               actions: this.props.actions || {
@@ -254,7 +260,8 @@ function fromPair(key, value) {
                 onClickSaveNotes: this.onClickSaveNotes,
                 onDeleteEventNoteAttachment: this.onDeleteEventNoteAttachment,
                 onClickSaveService: this.onClickSaveService,
-                onClickDiscontinueService: this.onClickDiscontinueService
+                onClickDiscontinueService: this.onClickDiscontinueService,
+                onChangeNoteInProgressText: this.onChangeNoteInProgressText
               }
             })} />
         </div>

--- a/app/assets/javascripts/student_profile/page_container.jsx
+++ b/app/assets/javascripts/student_profile/page_container.jsx
@@ -56,6 +56,7 @@ function fromPair(key, value) {
         sections: serializedData.sections,
         currentEducatorAllowedSections: serializedData.currentEducatorAllowedSections,
         noteInProgressText: '',
+        noteInProgressType: null,
 
         // ui
         selectedColumnKey: queryParams.column || 'interventions',
@@ -113,6 +114,12 @@ function fromPair(key, value) {
         column_key: columnKey
       });
       this.setState({ selectedColumnKey: columnKey });
+    },
+
+    onClickNoteType: function(event) {
+      const noteInProgressType = parseInt(event.target.name);
+
+      this.setState({ noteInProgressType });
     },
 
     onChangeNoteInProgressText: function(event) {
@@ -252,7 +259,8 @@ function fromPair(key, value) {
               'sections',
               'currentEducatorAllowedSections',
               'requests',
-              'noteInProgressText'
+              'noteInProgressText',
+              'noteInProgressType'
             ), {
               nowMomentFn: this.props.nowMomentFn,
               actions: this.props.actions || {
@@ -261,7 +269,8 @@ function fromPair(key, value) {
                 onDeleteEventNoteAttachment: this.onDeleteEventNoteAttachment,
                 onClickSaveService: this.onClickSaveService,
                 onClickDiscontinueService: this.onClickDiscontinueService,
-                onChangeNoteInProgressText: this.onChangeNoteInProgressText
+                onChangeNoteInProgressText: this.onChangeNoteInProgressText,
+                onClickNoteType: this.onClickNoteType
               }
             })} />
         </div>

--- a/app/assets/javascripts/student_profile/page_container.jsx
+++ b/app/assets/javascripts/student_profile/page_container.jsx
@@ -266,14 +266,15 @@ function fromPair(key, value) {
               'noteInProgressType'
             ), {
               nowMomentFn: this.props.nowMomentFn,
-              actions: this.props.actions || {
+              actions: {
                 onColumnClicked: this.onColumnClicked,
                 onClickSaveNotes: this.onClickSaveNotes,
                 onDeleteEventNoteAttachment: this.onDeleteEventNoteAttachment,
                 onClickSaveService: this.onClickSaveService,
                 onClickDiscontinueService: this.onClickDiscontinueService,
                 onChangeNoteInProgressText: this.onChangeNoteInProgressText,
-                onClickNoteType: this.onClickNoteType
+                onClickNoteType: this.onClickNoteType,
+                ...this.props.actions,
               }
             })} />
         </div>

--- a/app/assets/javascripts/student_profile/student_profile_page.jsx
+++ b/app/assets/javascripts/student_profile/student_profile_page.jsx
@@ -136,6 +136,7 @@ import {cumulativeByMonthFromEvents} from './QuadConverter';
         tardies: React.PropTypes.array,
         absences: React.PropTypes.array
       }),
+      noteInProgressText: React.PropTypes.string.isRequired,
 
       access: React.PropTypes.object,
       iepDocument: React.PropTypes.object,
@@ -281,7 +282,8 @@ import {cumulativeByMonthFromEvents} from './QuadConverter';
                 showingRestrictedNotes={false}
                 helpContent={this.renderNotesHelpContent()}
                 helpTitle="What is a Note?"
-                title="Notes" />
+                title="Notes"
+                noteInProgressText={this.props.noteInProgressText} />
               <ServicesDetails
                 student={this.props.student}
                 serviceTypesIndex={this.props.serviceTypesIndex}

--- a/app/assets/javascripts/student_profile/student_profile_page.jsx
+++ b/app/assets/javascripts/student_profile/student_profile_page.jsx
@@ -137,6 +137,7 @@ import {cumulativeByMonthFromEvents} from './QuadConverter';
         absences: React.PropTypes.array
       }),
       noteInProgressText: React.PropTypes.string.isRequired,
+      noteInProgressType: React.PropTypes.number,
 
       access: React.PropTypes.object,
       iepDocument: React.PropTypes.object,
@@ -283,7 +284,8 @@ import {cumulativeByMonthFromEvents} from './QuadConverter';
                 helpContent={this.renderNotesHelpContent()}
                 helpTitle="What is a Note?"
                 title="Notes"
-                noteInProgressText={this.props.noteInProgressText} />
+                noteInProgressText={this.props.noteInProgressText}
+                noteInProgressType={this.props.noteInProgressType} />
               <ServicesDetails
                 student={this.props.student}
                 serviceTypesIndex={this.props.serviceTypesIndex}

--- a/app/assets/javascripts/student_profile/take_notes.jsx
+++ b/app/assets/javascripts/student_profile/take_notes.jsx
@@ -64,14 +64,13 @@ export default React.createClass({
     currentEducator: React.PropTypes.object.isRequired,
     requestState: React.PropTypes.string, // or null
     noteInProgressText: React.PropTypes.string.isRequired,
+    noteInProgressType: React.PropTypes.number,
+    onClickNoteType: React.PropTypes.func.isRequired,
     onChangeNoteInProgressText: React.PropTypes.func.isRequired,
   },
 
   getInitialState: function() {
-    return {
-      eventNoteTypeId: null,
-      attachmentUrls: []
-    };
+    return { attachmentUrls: [] };
   },
 
   // Focus on note-taking text area when it first appears.
@@ -93,9 +92,9 @@ export default React.createClass({
   },
 
   disabledSaveButton: function () {
-    return (
-      this.state.eventNoteTypeId === null || !this.isValidAttachmentUrls()
-    );
+    const {noteInProgressType} = this.props;
+
+    return (noteInProgressType === null || !this.isValidAttachmentUrls());
   },
 
   isValidAttachmentUrls: function () {
@@ -115,10 +114,6 @@ export default React.createClass({
       });
     const filteredAttachmentUrls = updatedAttachmentUrls.filter(this.stringNotEmpty);
     this.setState({ attachmentUrls: filteredAttachmentUrls });
-  },
-
-  onClickNoteType: function(noteTypeId, event) {
-    this.setState({ eventNoteTypeId: noteTypeId });
   },
 
   onClickCancel: function(event) {
@@ -210,16 +205,24 @@ export default React.createClass({
 
   // TODO(kr) extract button UI
   renderNoteButton: function(eventNoteTypeId) {
-    const eventNoteType = this.props.eventNoteTypesIndex[eventNoteTypeId];
+    const {
+      onClickNoteType,
+      eventNoteTypesIndex,
+      noteInProgressType
+    } = this.props;
+
+    const eventNoteType = eventNoteTypesIndex[eventNoteTypeId];
+
     return (
       <button
         className="btn note-type"
-        onClick={this.onClickNoteType.bind(this, eventNoteTypeId)}
+        onClick={onClickNoteType}
         tabIndex={-1}
+        name={eventNoteTypeId}
         style={merge(styles.serviceButton, {
           background: '#eee',
           outline: 0,
-          border: (this.state.eventNoteTypeId === eventNoteTypeId)
+          border: (noteInProgressType === eventNoteTypeId)
             ? '4px solid rgba(49, 119, 201, 0.75)'
             : '4px solid white'
         })}>

--- a/app/assets/javascripts/student_profile/take_notes.jsx
+++ b/app/assets/javascripts/student_profile/take_notes.jsx
@@ -62,13 +62,14 @@ export default React.createClass({
     onSave: React.PropTypes.func.isRequired,
     onCancel: React.PropTypes.func.isRequired,
     currentEducator: React.PropTypes.object.isRequired,
-    requestState: React.PropTypes.string // or null
+    requestState: React.PropTypes.string, // or null
+    noteInProgressText: React.PropTypes.string.isRequired,
+    onChangeNoteInProgressText: React.PropTypes.func.isRequired,
   },
 
   getInitialState: function() {
     return {
       eventNoteTypeId: null,
-      text: '',
       attachmentUrls: []
     };
   },
@@ -105,10 +106,6 @@ export default React.createClass({
     });
   },
 
-  onChangeText: function(event) {
-    this.setState({ text: event.target.value });
-  },
-
   onChangeAttachmentUrl: function(changedIndex, event) {
     const newValue = event.target.value;
     const updatedAttachmentUrls = (this.state.attachmentUrls.length === changedIndex)
@@ -138,6 +135,8 @@ export default React.createClass({
   },
 
   render: function() {
+    const {noteInProgressText} = this.props;
+
     return (
       <div className="TakeNotes" style={styles.dialog}>
         {this.renderNoteHeader({
@@ -148,8 +147,8 @@ export default React.createClass({
           rows={10}
           style={styles.textarea}
           ref={function(ref) { this.textareaRef = ref; }.bind(this)}
-          value={this.state.text}
-          onChange={this.onChangeText} />
+          value={noteInProgressText}
+          onChange={this.props.onChangeNoteInProgressText} />
         <div style={{ marginBottom: 5, marginTop: 20 }}>
           What are these notes from?
         </div>

--- a/app/assets/javascripts/student_profile/take_notes.jsx
+++ b/app/assets/javascripts/student_profile/take_notes.jsx
@@ -121,10 +121,12 @@ export default React.createClass({
   },
 
   onClickSave: function(event) {
-    const params = merge(
-      _.pick(this.state, 'eventNoteTypeId', 'text'),
-      this.eventNoteUrlsForSave()
-    );
+    const {noteInProgressText, noteInProgressType} = this.props;
+
+    const params = merge({
+      eventNoteTypeId: noteInProgressType,
+      text: noteInProgressText,
+    }, this.eventNoteUrlsForSave());
 
     this.props.onSave(params);
   },

--- a/spec/javascripts/student_profile/NotesDetails.test.js
+++ b/spec/javascripts/student_profile/NotesDetails.test.js
@@ -11,9 +11,13 @@ describe('NotesDetails', function() {
       const mergedProps = merge(props || {}, {
         eventNoteTypesIndex: studentProfile.eventNoteTypesIndex,
         educatorsIndex: {},
+        noteInProgressText: '',
+        noteInProgressType: null,
         actions: {
           onClickSaveNotes: function () {},
-          onEventNoteAttachmentDeleted: function () {}
+          onEventNoteAttachmentDeleted: function () {},
+          onChangeNoteInProgressText: function () {},
+          onClickNoteType: function () {}
         },
         feed: {
           event_notes: [],

--- a/spec/javascripts/student_profile/page_container_spec.jsx
+++ b/spec/javascripts/student_profile/page_container_spec.jsx
@@ -119,6 +119,8 @@ describe('PageContainer', function() {
         text: 'hello!'
       });
 
+      expect(component.props.actions.onChangeNoteInProgressText).toHaveBeenCalled();
+
       expect(component.props.actions.onClickSaveNotes).toHaveBeenCalledWith({
         eventNoteTypeId: 300,
         text: 'hello!',

--- a/spec/javascripts/student_profile/page_container_spec.jsx
+++ b/spec/javascripts/student_profile/page_container_spec.jsx
@@ -18,13 +18,12 @@ describe('PageContainer', function() {
 
     createSpyActions: function() {
       return {
+        // Just mock the functions that make server calls
         onColumnClicked: jest.fn(),
         onClickSaveNotes: jest.fn(),
         onClickSaveService: jest.fn(),
         onClickDiscontinueService: jest.fn(),
-        onDeleteEventNoteAttachment: jest.fn(),
-        onChangeNoteInProgressText: jest.fn(),
-        onClickNoteType: jest.fn()
+        onDeleteEventNoteAttachment: jest.fn()
       };
     },
 
@@ -118,8 +117,6 @@ describe('PageContainer', function() {
         eventNoteTypeText: 'SST Meeting',
         text: 'hello!'
       });
-
-      expect(component.props.actions.onChangeNoteInProgressText).toHaveBeenCalled();
 
       expect(component.props.actions.onClickSaveNotes).toHaveBeenCalledWith({
         eventNoteTypeId: 300,

--- a/spec/javascripts/student_profile/page_container_spec.jsx
+++ b/spec/javascripts/student_profile/page_container_spec.jsx
@@ -22,7 +22,9 @@ describe('PageContainer', function() {
         onClickSaveNotes: jest.fn(),
         onClickSaveService: jest.fn(),
         onClickDiscontinueService: jest.fn(),
-        onDeleteEventNoteAttachment: jest.fn()
+        onDeleteEventNoteAttachment: jest.fn(),
+        onChangeNoteInProgressText: jest.fn(),
+        onClickNoteType: jest.fn()
       };
     },
 
@@ -42,7 +44,9 @@ describe('PageContainer', function() {
         queryParams: {},
         history: SpecSugar.history(),
         actions: helpers.createSpyActions(),
-        api: helpers.createSpyApi()
+        api: helpers.createSpyApi(),
+        noteInProgressText: '',
+        noteInProgressType: null,
       });
       return ReactDOM.render(<PageContainer {...mergedProps} />, el); //eslint-disable-line react/no-render-return-value
     },

--- a/spec/javascripts/student_profile/take_notes_spec.jsx
+++ b/spec/javascripts/student_profile/take_notes_spec.jsx
@@ -17,7 +17,11 @@ describe('TakeNotes', function() {
         currentEducator: currentEducator,
         onSave: jest.fn(),
         onCancel: jest.fn(),
-        requestState: null
+        onClickNoteType: jest.fn(),
+        onChangeNoteInProgressText: jest.fn(),
+        requestState: null,
+        noteInProgressText: '',
+        noteInProgressType: null
       });
       window.ReactDOM.render(<TakeNotes {...mergedProps} />, el);
     }


### PR DESCRIPTION
# Who is this PR for?

Educators who take notes in Insights. 

# What problem does this PR fix?

If start taking a note on a student and then click on to a different column, the note you were taking is lost when you go back to the Intervention/Note Taking tab. 

## GIF of the problem:

![ui-bug](https://user-images.githubusercontent.com/3209501/37918936-1a677c5e-30e8-11e8-9bb2-4caf2f0d31c1.gif)

# What does this PR do?

Persists note-in-progress text across the different panels/columns in the Student Profile Page. 

# GIF (this branch, bugfix):

![ui-bug-fixed](https://user-images.githubusercontent.com/3209501/37931404-1d233b9a-310b-11e8-925f-62fc48f42cc2.gif)

# What's next? 

Persisting event note attachments too. 