### PR TITLE
Add two more guards to section page

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -9,12 +9,12 @@ class SectionsController < ApplicationController
   end
 
   def show
-
-    section_students = serialize_students(@current_section.students)
+    students = authorized { @current_section.students } # extra layer while transitioning K8 to use sections
+    students_json = serialize_students(students.map(&:id))
     section = serialize_section(@current_section)
 
     @serialized_data = {
-      students: section_students,
+      students: students_json,
       educators: @current_section.educators,
       section: section,
       sections: current_educator.allowed_sections,
@@ -25,8 +25,12 @@ class SectionsController < ApplicationController
 
   private
   def authorize_and_assign_section
-    requested_section = Section.find(params[:id])
+    # Extra layer while transitioning K8 to use sections
+    if !current_educator.districtwide_access && !current_educator.school.is_high_school?
+      return redirect_to homepage_path_for_role(current_educator)
+    end
 
+    requested_section = Section.find(params[:id])
     if current_educator.is_authorized_for_section(requested_section)
       @current_section = requested_section
     else
@@ -42,9 +46,12 @@ class SectionsController < ApplicationController
     end
   end
 
-  def serialize_students(students)
-    students.select('students.*, student_section_assignments.grade_numeric')
-            .as_json(methods: [:event_notes, :most_recent_school_year_discipline_incidents_count, :most_recent_school_year_absences_count, :most_recent_school_year_tardies_count])
+  def serialize_students(student_ids)
+    Student.all
+      .joins(:student_section_assignments)
+      .where(id: student_ids)
+      .select('students.*, student_section_assignments.grade_numeric')
+      .as_json(methods: [:event_notes, :most_recent_school_year_discipline_incidents_count, :most_recent_school_year_absences_count, :most_recent_school_year_tardies_count])
   end
 
   def serialize_section(section)


### PR DESCRIPTION
# Who is this PR for?
students

# What problem does this PR fix?
Adds in two additional authorization guards for extra safekeeping while we transition K8 schools to use sections instead of homerooms

# What does this PR do?
Guards to make sure educator is districtwide or assigned to the HS, and explicitly does an additional  student-level authorization check.

The existing specs are changed because they were setting up students that wouldn't satisfy full authorization checks (eg they're in another school and different grade level).

# Checklists
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code