### PR TITLE
Persist event note attachment URLs in progress across student profile

### DIFF
--- a/app/assets/javascripts/helpers/prop_types.jsx
+++ b/app/assets/javascripts/helpers/prop_types.jsx
@@ -8,7 +8,8 @@ const PropTypes = {
     onClickSaveService: React.PropTypes.func,
     onClickDiscontinueService: React.PropTypes.func,
     onChangeNoteInProgressText: React.PropTypes.func,
-    onClickNoteType: React.PropTypes.func
+    onClickNoteType: React.PropTypes.func,
+    onChangeAttachmentUrl: React.PropTypes.func,
   }),
   requests: React.PropTypes.shape({
     saveNote: React.PropTypes.string,

--- a/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
+++ b/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
@@ -51,6 +51,7 @@ class RestrictedNotesPageContainer extends React.Component {
     this.onSaveNotesFail = this.onSaveNotesFail.bind(this);
     this.onClickNoteType = this.onClickNoteType.bind(this);
     this.onChangeNoteInProgressText = this.onChangeNoteInProgressText.bind(this);
+    this.onChangeAttachmentUrl = this.onChangeAttachmentUrl.bind(this);
   }
 
   componentWillMount(props, state) {
@@ -95,6 +96,24 @@ class RestrictedNotesPageContainer extends React.Component {
     this.setState({ noteInProgressText: event.target.value });
   }
 
+  onChangeAttachmentUrl(event) {
+    const newValue = event.target.value;
+    const changedIndex = parseInt(event.target.name);
+    const {noteInProgressAttachmentUrls} = this.state;
+
+    const updatedAttachmentUrls = (noteInProgressAttachmentUrls.length === changedIndex)
+      ? noteInProgressAttachmentUrls.concat(newValue)
+      : noteInProgressAttachmentUrls.map((attachmentUrl, index) => {
+        return (changedIndex === index) ? newValue : attachmentUrl;
+      });
+
+    const filteredAttachments = updatedAttachmentUrls.filter((urlString) => {
+      return urlString.length !== 0;
+    });
+
+    this.setState({ noteInProgressAttachmentUrls: filteredAttachments });
+  }
+
   render() {
     return (
       <div className="RestrictedNotesPageContainer">
@@ -112,10 +131,12 @@ class RestrictedNotesPageContainer extends React.Component {
               'noteInProgressAttachmentUrls'
             ), {
               nowMomentFn: this.props.nowMomentFn,
-              actions: this.props.actions || {
+              actions: {
                 onClickSaveNotes: this.onClickSaveNotes,
                 onClickNoteType: this.onClickNoteType,
                 onChangeNoteInProgressText: this.onChangeNoteInProgressText,
+                onChangeAttachmentUrl: this.onChangeAttachmentUrl,
+                ...this.props.actions
               },
               showingRestrictedNotes: true,
               helpContent: this.renderNotesHelpContent(),

--- a/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
+++ b/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
@@ -30,6 +30,7 @@ class RestrictedNotesPageContainer extends React.Component {
       // ui
       noteInProgressText: '',
       noteInProgressType: null,
+      noteInProgressAttachmentUrls: [],
 
       // This map holds the state of network requests for various actions.  This allows UI components to branch on this
       // and show waiting messages or error messages.

--- a/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
+++ b/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
@@ -77,6 +77,7 @@ class RestrictedNotesPageContainer extends React.Component {
       requests: merge(this.state.requests, { saveNote: null }),
       noteInProgressText: '',
       noteInProgressType: null,
+      noteInProgressAttachmentUrls: []
     });
   }
 

--- a/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
+++ b/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
@@ -108,7 +108,8 @@ class RestrictedNotesPageContainer extends React.Component {
               'student',
               'requests',
               'noteInProgressText',
-              'noteInProgressType'
+              'noteInProgressType',
+              'noteInProgressAttachmentUrls'
             ), {
               nowMomentFn: this.props.nowMomentFn,
               actions: this.props.actions || {

--- a/app/assets/javascripts/student_profile/NotesDetails.js
+++ b/app/assets/javascripts/student_profile/NotesDetails.js
@@ -136,7 +136,8 @@ NotesDetails.propTypes = {
     onEventNoteAttachmentDeleted: React.PropTypes.func,
     onDeleteEventNoteAttachment: React.PropTypes.func,
     onChangeNoteInProgressText: React.PropTypes.func.isRequired,
-    onClickNoteType: React.PropTypes.func.isRequired
+    onClickNoteType: React.PropTypes.func.isRequired,
+    onChangeAttachmentUrl: React.PropTypes.func.isRequired,
   }),
   feed: PropTypes.feed.isRequired,
   requests: React.PropTypes.object.isRequired,

--- a/app/assets/javascripts/student_profile/NotesDetails.js
+++ b/app/assets/javascripts/student_profile/NotesDetails.js
@@ -76,7 +76,8 @@ class NotesDetails extends React.Component {
   renderTakeNotesSection() {
     const showTakeNotes = this.state.isTakingNotes ||
                           this.props.requests.saveNote !== null ||
-                          this.props.noteInProgressText.length > 0;
+                          this.props.noteInProgressText.length > 0 ||
+                          this.props.noteInProgressAttachmentUrls.length > 0;
 
     if (showTakeNotes) {
       return (
@@ -90,8 +91,10 @@ class NotesDetails extends React.Component {
           requestState={this.props.requests.saveNote}
           noteInProgressText={this.props.noteInProgressText}
           noteInProgressType={this.props.noteInProgressType}
+          noteInProgressAttachmentUrls={this.props.noteInProgressAttachmentUrls}
           onClickNoteType={this.props.actions.onClickNoteType}
-          onChangeNoteInProgressText={this.props.actions.onChangeNoteInProgressText} />
+          onChangeNoteInProgressText={this.props.actions.onChangeNoteInProgressText}
+          onChangeAttachmentUrl={this.props.actions.onChangeAttachmentUrl} />
       );
     }
 
@@ -137,8 +140,12 @@ NotesDetails.propTypes = {
   }),
   feed: PropTypes.feed.isRequired,
   requests: React.PropTypes.object.isRequired,
+
   noteInProgressText: React.PropTypes.string.isRequired,
   noteInProgressType: React.PropTypes.number,
+  noteInProgressAttachmentUrls: React.PropTypes.arrayOf(
+    React.PropTypes.string
+  ).isRequired,
 
   showingRestrictedNotes: React.PropTypes.bool.isRequired,
   title: React.PropTypes.string.isRequired,

--- a/app/assets/javascripts/student_profile/page_container.jsx
+++ b/app/assets/javascripts/student_profile/page_container.jsx
@@ -177,6 +177,7 @@ function fromPair(key, value) {
         requests: merge(this.state.requests, { saveNote: null }),
         noteInProgressText: '',
         noteInProgressType: null,
+        noteInProgressAttachmentUrls: []
       });
     },
 

--- a/app/assets/javascripts/student_profile/page_container.jsx
+++ b/app/assets/javascripts/student_profile/page_container.jsx
@@ -59,6 +59,7 @@ function fromPair(key, value) {
         // ui
         noteInProgressText: '',
         noteInProgressType: null,
+        noteInProgressAttachmentUrls: [],
         selectedColumnKey: queryParams.column || 'interventions',
 
         // This map holds the state of network requests for various actions.  This allows UI components to branch on this
@@ -124,6 +125,24 @@ function fromPair(key, value) {
 
     onChangeNoteInProgressText: function(event) {
       this.setState({ noteInProgressText: event.target.value });
+    },
+
+    onChangeAttachmentUrl: function(event) {
+      const newValue = event.target.value;
+      const changedIndex = parseInt(event.target.name);
+      const {noteInProgressAttachmentUrls} = this.state;
+
+      const updatedAttachmentUrls = (noteInProgressAttachmentUrls.length === changedIndex)
+        ? noteInProgressAttachmentUrls.concat(newValue)
+        : noteInProgressAttachmentUrls.map((attachmentUrl, index) => {
+          return (changedIndex === index) ? newValue : attachmentUrl;
+        });
+
+      const filteredAttachments = updatedAttachmentUrls.filter((urlString) => {
+        return urlString.length !== 0;
+      });
+
+      this.setState({ noteInProgressAttachmentUrls: filteredAttachments });
     },
 
     onClickSaveNotes: function(eventNoteParams) {
@@ -263,7 +282,8 @@ function fromPair(key, value) {
               'currentEducatorAllowedSections',
               'requests',
               'noteInProgressText',
-              'noteInProgressType'
+              'noteInProgressType',
+              'noteInProgressAttachmentUrls'
             ), {
               nowMomentFn: this.props.nowMomentFn,
               actions: {
@@ -274,6 +294,7 @@ function fromPair(key, value) {
                 onClickDiscontinueService: this.onClickDiscontinueService,
                 onChangeNoteInProgressText: this.onChangeNoteInProgressText,
                 onClickNoteType: this.onClickNoteType,
+                onChangeAttachmentUrl: this.onChangeAttachmentUrl,
                 ...this.props.actions,
               }
             })} />

--- a/app/assets/javascripts/student_profile/student_profile_page.jsx
+++ b/app/assets/javascripts/student_profile/student_profile_page.jsx
@@ -138,7 +138,9 @@ import {cumulativeByMonthFromEvents} from './QuadConverter';
       }),
       noteInProgressText: React.PropTypes.string.isRequired,
       noteInProgressType: React.PropTypes.number,
-
+      noteInProgressAttachmentUrls: React.PropTypes.arrayOf(
+        React.PropTypes.string
+      ).isRequired,
       access: React.PropTypes.object,
       iepDocument: React.PropTypes.object,
       sections: React.PropTypes.array,
@@ -285,7 +287,8 @@ import {cumulativeByMonthFromEvents} from './QuadConverter';
                 helpTitle="What is a Note?"
                 title="Notes"
                 noteInProgressText={this.props.noteInProgressText}
-                noteInProgressType={this.props.noteInProgressType} />
+                noteInProgressType={this.props.noteInProgressType}
+                noteInProgressAttachmentUrls={this.props.noteInProgressAttachmentUrls }/>
               <ServicesDetails
                 student={this.props.student}
                 serviceTypesIndex={this.props.serviceTypesIndex}

--- a/app/assets/javascripts/student_profile/take_notes.jsx
+++ b/app/assets/javascripts/student_profile/take_notes.jsx
@@ -63,14 +63,16 @@ export default React.createClass({
     onCancel: React.PropTypes.func.isRequired,
     currentEducator: React.PropTypes.object.isRequired,
     requestState: React.PropTypes.string, // or null
+
     noteInProgressText: React.PropTypes.string.isRequired,
     noteInProgressType: React.PropTypes.number,
+    noteInProgressAttachmentUrls: React.PropTypes.arrayOf(
+      React.PropTypes.string
+    ).isRequired,
+
     onClickNoteType: React.PropTypes.func.isRequired,
     onChangeNoteInProgressText: React.PropTypes.func.isRequired,
-  },
-
-  getInitialState: function() {
-    return { attachmentUrls: [] };
+    onChangeAttachmentUrl: React.PropTypes.func.isRequired,
   },
 
   // Focus on note-taking text area when it first appears.
@@ -82,12 +84,11 @@ export default React.createClass({
     return { url: urlString };
   },
 
-  stringNotEmpty: function (urlString) {
-    return urlString.length !== 0;
-  },
-
   eventNoteUrlsForSave: function () {
-    const urlsToSave = this.state.attachmentUrls.map(this.wrapUrlInObject);
+    const {noteInProgressAttachmentUrls} = this.props;
+
+    const urlsToSave = noteInProgressAttachmentUrls.map(this.wrapUrlInObject);
+
     return { eventNoteAttachments: urlsToSave };
   },
 
@@ -98,22 +99,13 @@ export default React.createClass({
   },
 
   isValidAttachmentUrls: function () {
-    return _.all(this.state.attachmentUrls, function (url) {
+    const {noteInProgressAttachmentUrls} = this.props;
+
+    return _.all(noteInProgressAttachmentUrls, function (url) {
       return (url.slice(0, 7) === 'http://'  ||
               url.slice(0, 8) === 'https://' ||
               url.length      === 0);
     });
-  },
-
-  onChangeAttachmentUrl: function(changedIndex, event) {
-    const newValue = event.target.value;
-    const updatedAttachmentUrls = (this.state.attachmentUrls.length === changedIndex)
-      ? this.state.attachmentUrls.concat(newValue)
-      : this.state.attachmentUrls.map(function(attachmentUrl, index) {
-        return (changedIndex === index) ? newValue : attachmentUrl;
-      });
-    const filteredAttachmentUrls = updatedAttachmentUrls.filter(this.stringNotEmpty);
-    this.setState({ attachmentUrls: filteredAttachmentUrls });
   },
 
   onClickCancel: function(event) {
@@ -234,14 +226,16 @@ export default React.createClass({
   },
 
   renderAttachmentLinkArea: function () {
+    const {noteInProgressAttachmentUrls} = this.props;
     const isValidUrls = this.isValidAttachmentUrls();
+
     const urls = (isValidUrls)
-      ? this.state.attachmentUrls.concat('')
-      : this.state.attachmentUrls;
+      ? noteInProgressAttachmentUrls.concat('')
+      : noteInProgressAttachmentUrls;
 
     return (
       <div>
-        {urls.map(function (url, index) {
+        {urls.map((url, index) => {
           return this.renderAttachmentLinkInput(url, index);
         }, this)}
         <div
@@ -256,11 +250,14 @@ export default React.createClass({
   },
 
   renderAttachmentLinkInput: function (value, index) {
+    const {onChangeAttachmentUrl} = this.props;
+
     return (
       <div key={index}>
         <input
           value={value}
-          onChange={this.onChangeAttachmentUrl.bind(this, index)}
+          name={index}
+          onChange={onChangeAttachmentUrl}
           placeholder="Please use the format https://www.example.com."
           style={{
             marginBottom: '20px',

--- a/spec/javascripts/student_profile/NotesDetails.test.js
+++ b/spec/javascripts/student_profile/NotesDetails.test.js
@@ -13,11 +13,13 @@ describe('NotesDetails', function() {
         educatorsIndex: {},
         noteInProgressText: '',
         noteInProgressType: null,
+        noteInProgressAttachmentUrls: [],
         actions: {
           onClickSaveNotes: function () {},
           onEventNoteAttachmentDeleted: function () {},
           onChangeNoteInProgressText: function () {},
-          onClickNoteType: function () {}
+          onClickNoteType: function () {},
+          onChangeAttachmentUrl: function () {}
         },
         feed: {
           event_notes: [],

--- a/spec/javascripts/student_profile/take_notes_spec.jsx
+++ b/spec/javascripts/student_profile/take_notes_spec.jsx
@@ -19,9 +19,11 @@ describe('TakeNotes', function() {
         onCancel: jest.fn(),
         onClickNoteType: jest.fn(),
         onChangeNoteInProgressText: jest.fn(),
+        onChangeAttachmentUrl: jest.fn(),
         requestState: null,
         noteInProgressText: '',
-        noteInProgressType: null
+        noteInProgressType: null,
+        noteInProgressAttachmentUrls: []
       });
       window.ReactDOM.render(<TakeNotes {...mergedProps} />, el);
     }


### PR DESCRIPTION
# Who is this PR for?

Educators who add event note URL attachments in the student profile page. 

# What problem does this PR fix?

If the educator clicks over to a different section of the profile, any event note URLs they've added go away. 

# What does this PR do?

Fixes the UI bug, finishes up thread of work started with #1568.

## GIF (Internet Explorer, regular note)

![event-note-attachment-persist](https://user-images.githubusercontent.com/3209501/38110945-e186b558-3362-11e8-9cd4-a558eb5f2af0.gif)

## GIF (Internet Explorer, restricted note)

![event-note-attachment-persist-restricted](https://user-images.githubusercontent.com/3209501/38110938-dde9af68-3362-11e8-9474-2409802653e3.gif)
