### PR TITLE
Make login case insensitive 

### DIFF
--- a/app/lib/ldap_authenticatable_tiny/strategy.rb
+++ b/app/lib/ldap_authenticatable_tiny/strategy.rb
@@ -15,7 +15,7 @@ module Devise
       def authenticate!
         email = authentication_hash[:email]
         begin
-          educator = Educator.find_by_email(email)
+          educator = Educator.find_by_email(email.downcase)
           fail!(:not_found_in_database) and return unless educator.present?
           fail!(:invalid) and return unless is_authorized_by_ldap?(email, password)
           success!(educator) and return

--- a/spec/lib/ldap_authenticatable_tiny_spec.rb
+++ b/spec/lib/ldap_authenticatable_tiny_spec.rb
@@ -57,6 +57,18 @@ RSpec.describe 'LdapAuthenticatableTiny' do
       expect(strategy.user).to eq nil
     end
 
+    it 'calls success! even when cases are different' do
+      strategy = test_strategy
+      allow(strategy).to receive(:authentication_hash) { { email: 'URI@demo.studentinsights.org' } }
+      allow(strategy).to receive(:password) { 'supersecure' }
+      allow(strategy).to receive(:is_authorized_by_ldap?).with('URI@demo.studentinsights.org', 'supersecure').and_return true
+      strategy.authenticate!
+
+      expect(strategy.result).to eq :success
+      expect(strategy.message).to eq nil
+      expect(strategy.user).to eq pals.uri
+    end
+
     it 'calls success! when valid Educator and is_authorized_by_ldap?' do
       strategy = test_strategy
       allow(strategy).to receive(:authentication_hash) { { email: 'uri@demo.studentinsights.org' } }


### PR DESCRIPTION
# Who is this PR for?

Educators who log into Insights and don't want to have to worry about if their email is typed uppercase or lowercase.

# What does this PR do?

Make the login code check for emails case-insensitively when comparing user-entered emails with emails in our database. 

We still pass the original, non-downcased email over to the LDAP server for authentication. 