### PR TITLE
Add in signin counts to admin educator overview, make it easier to scan user list

### DIFF
--- a/app/views/admin/educators/authorization.html.erb
+++ b/app/views/admin/educators/authorization.html.erb
@@ -46,21 +46,48 @@
   %>
   </pre>
 
-  <table style="margin-top: 40px; text-align: left;">
+  <table style="margin-top: 40px; text-align: left; border-collapse: collapse;">
       <thead>
-        <tr>
-          <th>Email</th>
-          <th>Name</th>
-          <th>Homepage</th>
+        <tr style="vertical-align: top;">
+          <th style="padding: 5px; background: #ccc;">Logins<br/>(all time)</th>
+          <th style="padding: 5px; background: #ccc;">Last login<br/>(days ago)</th>
+          <th style="padding: 5px; background: #ccc;">Email</th>
+          <th style="padding: 5px; background: #ccc;">Name</th>
+          <th style="padding: 5px; background: #ccc;">School</th>
+          <th style="padding: 5px; background: #ccc;">Homepage</th>
         </tr>
       </thead>
       <tbody>
-        <% @all_educators.map do |educator| %>
-          <% path = PathsForEducator.new(educator).homepage_path %>
+        <%
+          def sort_key(educator)
+            type_sort_key = {
+              nothing: 0,
+              districtwide: 10,
+              school: 20,
+              section: 30,
+              homeroom: 40
+            }[Authorizer.new(educator).homepage_type]
+            [educator.school.try(:name), type_sort_key]
+          end
+          sorted_educators = @all_educators.sort_by {|e| sort_key(e) }
+        %>
+        <% sorted_educators.map do |educator| %>
+          <%
+            days_since_last_sign_in = if educator.last_sign_in_at.nil?
+              0
+            else
+              ((Time.now - educator.last_sign_in_at) / 1.day).round
+            end
+            path = PathsForEducator.new(educator).homepage_path 
+          %>
           <tr>
-            <td><%= educator.email %></td>
-            <td><%= link_to educator.full_name, "/educators/view/#{educator.id}" %></td>
-            <td><%= link_to path, path %></td>
+            <td style="padding: 5px;"><%= educator.sign_in_count %></td>
+            <td style="padding: 5px;"><%= days_since_last_sign_in %></td>
+            
+            <td style="padding: 5px;"><%= educator.email %></td>
+            <td style="padding: 5px;"><%= link_to educator.full_name, "/educators/view/#{educator.id}" %></td>
+            <td style="padding: 5px;"><%= educator.school.try(:name) %></td>
+            <td style="padding: 5px;"><%= link_to path, path %></td>
         <% end %>
       </tbody>
     </table>


### PR DESCRIPTION
# Who is this PR for?
project team, school leads

# What problem does this PR fix?
Easier to see schools that educators belong to, and rough usage stats in the admin page.  Sorts users by school and role for easier scanning.

# What does this PR do?
<img width="900" alt="screen shot 2018-03-28 at 7 29 32 am" src="https://user-images.githubusercontent.com/1056957/38026404-f78bf408-3259-11e8-82fc-4bed2ffe97bc.png">
