### PR TITLE
Fix bug with sorting by nil school name

### DIFF
--- a/app/views/admin/educators/authorization.html.erb
+++ b/app/views/admin/educators/authorization.html.erb
@@ -67,7 +67,7 @@
               section: 30,
               homeroom: 40
             }[Authorizer.new(educator).homepage_type]
-            [educator.school.try(:name), type_sort_key]
+            [educator.school.try(:name) || 'None', type_sort_key]
           end
           sorted_educators = @all_educators.sort_by {|e| sort_key(e) }
         %>


### PR DESCRIPTION
# Who is this PR for?
NB project leads

# What problem does this PR fix?
bug in https://github.com/studentinsights/studentinsights/pull/1577, can't sort arrays that contain different types (eg, string vs. nil)
