### PR TITLE
Update navbar links by role, in preparation for cutting over to /home for homepage

### DIFF
--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -130,20 +130,6 @@ class Authorizer
     true
   end
 
-  # There are five types of entry experiences, depending on levels
-  # of access.
-  def homepage_type
-    begin
-      return :districtwide if @educator.districtwide_access?
-      return :school if @educator.schoolwide_access? || @educator.has_access_to_grade_levels?
-      return :section if @educator.school.school_type == 'HS' && @educator.default_section
-      return :homeroom if @educator.school.school_type != 'HS' && @educator.default_homeroom
-      return :nothing
-    rescue Exceptions::NoAssignedHomeroom, Exceptions::NoAssignedSections => err
-      :nothing
-    end
-  end
-
   # TODO(kr) remove implementation
   def students_for_school_overview
     return [] unless @educator.school.present?

--- a/app/views/admin/educators/authorization.html.erb
+++ b/app/views/admin/educators/authorization.html.erb
@@ -40,7 +40,7 @@
 <div style="padding: 20px">
   <pre><%=
     hash = Hash.new(0);
-    homepage_types = @all_educators.map {|e| Authorizer.new(e).homepage_type }
+    homepage_types = @all_educators.map {|e| PathsForEducator.new(e).homepage_type }
     homepage_types.each {|value| hash[value] += 1};
     JSON.pretty_generate(hash)
   %>
@@ -54,6 +54,7 @@
           <th style="padding: 5px; background: #ccc;">Email</th>
           <th style="padding: 5px; background: #ccc;">Name</th>
           <th style="padding: 5px; background: #ccc;">School</th>
+          <th style="padding: 5px; background: #ccc;">Links</th>
           <th style="padding: 5px; background: #ccc;">Homepage</th>
         </tr>
       </thead>
@@ -66,7 +67,7 @@
               school: 20,
               section: 30,
               homeroom: 40
-            }[Authorizer.new(educator).homepage_type]
+            }[PathsForEducator.new(educator).homepage_type]
             [educator.school.try(:name) || 'None', type_sort_key]
           end
           sorted_educators = @all_educators.sort_by {|e| sort_key(e) }
@@ -103,6 +104,7 @@
             <td style="padding: 5px;"><%= educator.email %></td>
             <td style="padding: 5px;"><%= link_to educator.full_name, "/educators/view/#{educator.id}" %></td>
             <td style="padding: 5px;"><%= educator.school.try(:name) %></td>
+            <td><%= PathsForEducator.new(educator).navbar_links.to_a.join('<br />') %></td>
             <td style="padding: 5px;"><%= link_to path, path %></td>
         <% end %>
       </tbody>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,31 +31,7 @@
           </div>
         </a>
         <% if educator_signed_in? %>
-          <div class="nav-options">
-            <% if current_educator.districtwide_access? %>
-              <%= link_to 'Admin', educators_districtwide_url %>
-              &nbsp; &nbsp; &nbsp;
-            <% elsif current_educator.schoolwide_access? || current_educator.has_access_to_grade_levels? %>
-              <%= link_to 'Roster', school_path(current_educator.school) %>
-              &nbsp;
-            <% end %>
-            <% if current_educator.school.present? && current_educator.schoolwide_access? && !current_educator.districtwide_access? %>
-              <%= link_to "Absences", school_administrator_dashboard_school_path(current_educator.school) + '#/absences_dashboard' %>
-              &nbsp;
-              <%= link_to "Tardies", school_administrator_dashboard_school_path(current_educator.school) + '#/tardies_dashboard' %>
-              &nbsp;
-              &nbsp; &nbsp; &nbsp;
-            <% end %>
-            <%= link_to "My notes", educators_notes_feed_path %>
-            &nbsp;
-            <%= link_to "Home", home_path %>
-            &nbsp;
-            &nbsp; &nbsp;
-            <p class="search-label">Search for student:</p>
-            <input class="student-searchbar" />
-            &nbsp; &nbsp; &nbsp;
-            <%= link_to "Sign Out", destroy_educator_session_path, method: :delete %>
-          </div>
+          <%= render partial: 'shared/navbar_signed_in', locals: { educator: current_educator } %>
         <% else %>
           <div class="sign-in-container">
             <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>

--- a/app/views/shared/_navbar_signed_in.html.erb
+++ b/app/views/shared/_navbar_signed_in.html.erb
@@ -1,0 +1,38 @@
+<div class="nav-options">
+  <% # Show different links based on role and access %>
+  <% links = PathsForEducator.new(educator).navbar_links %>
+
+  <% if links.include?(:district) %>
+    <%= link_to 'District', educators_districtwide_url %>
+    &nbsp; &nbsp; &nbsp;
+  <% elsif links.include?(:school) %>
+    <%= link_to 'Roster', school_path(educator.school) %>
+    &nbsp;
+    <%= link_to "Absences", school_administrator_dashboard_school_path(educator.school) + '#/absences_dashboard' %>
+    &nbsp;
+    <%= link_to "Tardies", school_administrator_dashboard_school_path(educator.school) + '#/tardies_dashboard' %>
+    &nbsp;
+    &nbsp; &nbsp; &nbsp;
+  <% end %>
+
+  <% if links.include?(:sections) %>
+    <%= link_to 'Sections', section_path(educator.default_section) %>
+    &nbsp;
+  <% end %>
+
+  <% if links.include?(:homeroom) %>
+  <%= link_to 'Homeroom', homeroom_path(educator.default_homeroom) %>
+    &nbsp;
+  <% end %>
+
+  <% # Everyone has these %>
+  <%= link_to "My notes", educators_notes_feed_path %>
+  &nbsp;
+  <%= link_to "Home", home_path %>
+  &nbsp;
+  &nbsp; &nbsp;
+  <p class="search-label">Search for student:</p>
+  <input class="student-searchbar" />
+  &nbsp; &nbsp; &nbsp;
+  <%= link_to "Sign Out", destroy_educator_session_path, method: :delete %>
+</div>

--- a/spec/lib/paths_for_educator_spec.rb
+++ b/spec/lib/paths_for_educator_spec.rb
@@ -23,4 +23,29 @@ RSpec.describe PathsForEducator do
     expect(PathsForEducator.new(pals.shs_hugo_art_teacher).homepage_path).to eq "/sections/#{pals.shs_second_period_ceramics.id}"
     expect(PathsForEducator.new(pals.shs_fatima_science_teacher).homepage_path).to eq "/sections/#{pals.shs_third_period_physics.id}"
   end
+
+  it '#navbar_links' do
+    def navbar_links(educator)
+      PathsForEducator.new(educator).navbar_links
+    end
+
+    expect(navbar_links(pals.uri)).to eq [:district].to_set
+
+    # healey
+    expect(navbar_links(pals.healey_laura_principal)).to eq [:school].to_set
+    expect(navbar_links(pals.healey_ell_teacher)).to eq [].to_set
+    expect(navbar_links(pals.healey_sped_teacher)).to eq [].to_set
+    expect(navbar_links(pals.healey_vivian_teacher)).to eq [:homeroom].to_set
+    expect(navbar_links(pals.healey_sarah_teacher)).to eq [:homeroom].to_set
+
+    # west
+    expect(navbar_links(pals.west_marcus_teacher)).to eq [:homeroom].to_set
+
+    # high school (TestPals doesn't match actual production HS roles and permisssions)
+    expect(navbar_links(pals.shs_jodi)).to eq [].to_set
+    expect(navbar_links(pals.shs_ninth_grade_counselor)).to eq [:school].to_set
+    expect(navbar_links(pals.shs_bill_nye)).to eq [:sections].to_set
+    expect(navbar_links(pals.shs_hugo_art_teacher)).to eq [:sections].to_set
+    expect(navbar_links(pals.shs_fatima_science_teacher)).to eq [:sections].to_set
+  end
 end

--- a/spec/views/shared/_navbar_signed_in_spec.rb
+++ b/spec/views/shared/_navbar_signed_in_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+
+describe '_navbar_signed_in partial' do
+  let!(:pals) { TestPals.create! }
+
+  def expect_common_links(rendered)
+    expect(rendered).to include('My notes')
+    expect(rendered).to include('Home')
+    expect(rendered).to include('Search for student:')
+    expect(rendered).to include('Sign Out')
+  end
+
+  it 'works for Uri' do
+    render partial: 'shared/navbar_signed_in', :locals => { educator: pals.uri }
+    expect(rendered).to include('District')
+    expect(rendered).not_to include('Roster')
+    expect(rendered).not_to include('Absences')
+    expect(rendered).not_to include('Tardies')
+    expect(rendered).not_to include('Sections')
+    expect(rendered).not_to include('Homeroom')
+    expect_common_links(rendered)
+  end
+
+  it 'works for Vivian' do
+    render partial: 'shared/navbar_signed_in', :locals => { educator: pals.healey_vivian_teacher }
+    expect(rendered).not_to include('District')
+    expect(rendered).not_to include('Roster')
+    expect(rendered).not_to include('Absences')
+    expect(rendered).not_to include('Tardies')
+    expect(rendered).not_to include('Sections')
+    expect(rendered).to include('Homeroom')
+    expect_common_links(rendered)
+  end
+
+  it 'works for Laura' do
+    render partial: 'shared/navbar_signed_in', :locals => { educator: pals.healey_laura_principal }
+    expect(rendered).not_to include('District')
+    expect(rendered).to include('Roster')
+    expect(rendered).to include('Absences')
+    expect(rendered).to include('Tardies')
+    expect(rendered).not_to include('Sections')
+    expect(rendered).not_to include('Homeroom')
+    expect_common_links(rendered)
+  end
+
+  it 'works for Bill' do
+    render partial: 'shared/navbar_signed_in', :locals => { educator: pals.shs_bill_nye }
+    expect(rendered).not_to include('District')
+    expect(rendered).not_to include('Roster')
+    expect(rendered).not_to include('Absences')
+    expect(rendered).not_to include('Tardies')
+    expect(rendered).to include('Sections')
+    expect(rendered).not_to include('Homeroom')
+    expect_common_links(rendered)
+  end
+end


### PR DESCRIPTION
# Who is this PR for?
This is related to https://github.com/studentinsights/studentinsights/pull/1585, and is a shorter-term alternative to https://github.com/studentinsights/studentinsights/compare/refactor/navbar (which aimed to replace the server-side navbar HTML and CSS with UI code, but is a more involved change).

# What problem does this PR fix?
It updates the navbar links for different users based on their roles, in preparation for changing the "home page" which is currently different by role.  This essentially takes the current home page values and translates them to links in the navbar, so that users still have links to access the pages they've previously seen when they first sign in.

There's a bunch of complexity in the authorization rules, and the users in `TestPals` don't exactly match production.  There's no change here to actual authorization code, but the default home page is changed so that if the teacher has a homeroom at the HS they won't be shown the homeroom page.  In production data, no HS teachers have a homeroom set so this has no functional difference, but expresses in code that right now the Homeroom view is only for K8 teachers (and avoiding expanding the surface area of the product).

# Screenshot (if adding a client-side feature)
### Classroom teacher
<img width="1107" alt="screen shot 2018-04-03 at 4 56 11 pm" src="https://user-images.githubusercontent.com/1056957/38275482-063f7a64-3760-11e8-9255-86295cd9bd31.png">

### HS teacher
<img width="1107" alt="screen shot 2018-04-03 at 4 55 49 pm" src="https://user-images.githubusercontent.com/1056957/38275484-0659e17e-3760-11e8-9ddb-59c7872584b1.png">

### Schoolwide
<img width="1107" alt="screen shot 2018-04-03 at 4 55 59 pm" src="https://user-images.githubusercontent.com/1056957/38275483-064ca644-3760-11e8-8606-5642ba23d553.png">

### Districtwide
<img width="1107" alt="screen shot 2018-04-03 at 4 55 35 pm" src="https://user-images.githubusercontent.com/1056957/38275485-066e1cd4-3760-11e8-8840-bcbdb7b6028f.png">

### Adds in links to the admin educator page for simpler debugging
<img width="968" alt="screen shot 2018-04-03 at 4 53 33 pm" src="https://user-images.githubusercontent.com/1056957/38275346-9756b388-375f-11e8-9b11-eff741026b00.png">

# Checklists
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code

I tested these manually locally across roles as well.

This script verified in production that the change to `homepage_type` has no impact:
```
# (pasting in homepage_type)
output = []
educators = Educator.all
educators.each do |educator|
  old_homepage_type = Authorizer.new(educator).homepage_type
  @educator = educator
  new_homepage_type = homepage_type
  output << {
    old_homepage_type: old_homepage_type,
    new_homepage_type: new_homepage_type,
    match: old_homepage_type == new_homepage_type
  }
end
pp output.select {|o| !o[:match] };nil
```