### PR TITLE
Remove flash notice to keep navbar layout fixed

### DIFF
--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -84,8 +84,8 @@
 
   .flash {
     position: absolute;
-    right: 390px;
-    top: 61px;
+    right: 40px;
+    top: 62px;
   }
 
   /* SIGN IN FLOW & MESSAGES */

--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -39,6 +39,7 @@
 
   .navwrap {
     margin: 0 20px;
+    padding-bottom: 20px;
     position: relative;
     bottom: 1px;
     display: flex;
@@ -82,15 +83,12 @@
   }
 
   .flash {
-    padding: 10px;
+    position: absolute;
+    right: 390px;
+    top: 61px;
   }
 
   /* SIGN IN FLOW & MESSAGES */
-
-  .notice {
-    color: $warning-green;
-    font-weight: 700;
-  }
 
   .alert {
     color: $warning-red;

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -134,11 +134,6 @@ class SchoolsController < ApplicationController
     unless authorizer.is_authorized_for_school?(@school)
       return redirect_to homepage_path_for_role(current_educator)
     end
-
-    if current_educator.has_access_to_grade_levels?
-      grade_message = " Showing students in grades #{current_educator.grade_level_access.to_sentence}."
-      flash[:notice] << grade_message if flash[:notice]
-    end
   end
 
   def set_school

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,6 @@
         <% end %>
       </div>
       <div class="flash">
-        <p class="notice"><%= notice %></p>
         <p class="alert"><%= alert %></p>
       </div>
     </div>

--- a/spec/features/sign_in_feature_spec.rb
+++ b/spec/features/sign_in_feature_spec.rb
@@ -7,7 +7,7 @@ describe 'educator sign in', type: :feature do
   context 'teacher signs in' do
     def expect_successful_sign_in_for(educator)
       educator_sign_in(educator)
-      expect(page).to have_content 'Signed in successfully.'
+      expect(page).to have_content 'Search for student:'
     end
 
     it { expect_successful_sign_in_for(pals.healey_sarah_teacher) }


### PR DESCRIPTION
# Who is this PR for?
educators, developers

# What problem does this PR fix?
The flash messages about signing in and out aren't super informative, and right now they change the layout of the page based on whether they're present or not.  This removes notices, and moves error messages so they stay within the containing navbar.

# Screenshot (if adding a client-side feature)
### before
<img width="1019" alt="screen shot 2018-04-03 at 8 13 03 pm" src="https://user-images.githubusercontent.com/1056957/38282053-f941b05e-377b-11e8-921c-c0f4662b64ef.png">
<img width="1022" alt="screen shot 2018-04-03 at 8 12 56 pm" src="https://user-images.githubusercontent.com/1056957/38282054-f9508728-377b-11e8-8884-f09b6119fad7.png">
<img width="1025" alt="screen shot 2018-04-03 at 8 12 48 pm" src="https://user-images.githubusercontent.com/1056957/38282055-f95c8ea6-377b-11e8-8700-e319e78173c2.png">

### after
<img width="1022" alt="screen shot 2018-04-03 at 8 19 49 pm" src="https://user-images.githubusercontent.com/1056957/38282116-665a676c-377c-11e8-9df1-4714be4714e2.png">
<img width="1024" alt="screen shot 2018-04-03 at 8 19 30 pm" src="https://user-images.githubusercontent.com/1056957/38282118-667772ee-377c-11e8-9209-b1e367077f96.png">
<img width="1023" alt="screen shot 2018-04-03 at 8 19 39 pm" src="https://user-images.githubusercontent.com/1056957/38282117-666763c2-377c-11e8-9d24-4776193cf978.png">
