### PR TITLE
Fix date formatting in absences box to use nth

### DIFF
--- a/app/assets/javascripts/home/CheckStudentsWithHighAbsences.js
+++ b/app/assets/javascripts/home/CheckStudentsWithHighAbsences.js
@@ -94,7 +94,7 @@ export class CheckStudentsWithHighAbsencesView extends React.Component {
   // Branching on singular and plural and zero.
   renderCopy(totalStudents) {
     const now = this.context.nowFn();
-    const dateText = now.clone().subtract(45, 'days').format('MMMM Qo');
+    const dateText = now.clone().subtract(45, 'days').format('MMMM Do');
     const sinceEl = <span>Since {dateText}:</span>;
     if (totalStudents === 0) {
       return <div>There are <b>no students</b> missing school recently who {"haven't"} been mentioned in SST yet.</div>;

--- a/app/assets/javascripts/home/__snapshots__/CheckStudentsWithHighAbsences.test.js.snap
+++ b/app/assets/javascripts/home/__snapshots__/CheckStudentsWithHighAbsences.test.js.snap
@@ -70,7 +70,7 @@ exports[`CheckStudentsWithHighAbsencesView handles when limit reached 1`] = `
        been mentioned in SST yet.  
       <span>
         Since 
-        January 1st
+        January 27th
         :
       </span>
     </div>
@@ -192,7 +192,7 @@ exports[`CheckStudentsWithHighAbsencesView pure component matches snapshot 1`] =
        been mentioned in SST yet.  
       <span>
         Since 
-        January 1st
+        January 27th
         :
       </span>
     </div>


### PR DESCRIPTION
From https://github.com/studentinsights/studentinsights/pull/1593, fix the date formatting.  The bug here using `Qo` for "quarter" looked correctly but wasn't actually the right date.