### PR TITLE
Add loading message when getting more feed cards

### DIFF
--- a/app/assets/javascripts/home/HomeFeed.js
+++ b/app/assets/javascripts/home/HomeFeed.js
@@ -21,6 +21,7 @@ class HomeFeed extends React.Component {
     super(props);
     this.state = {
       hasLoadedAnyData: false,
+      isFetching: false,
       error: null,
       cards: []
     };
@@ -37,6 +38,8 @@ class HomeFeed extends React.Component {
   }
 
   fetchFeed(nowTimestamp) {
+    this.setState({isFetching: true});
+
     const {limit, educatorId} = this.props;
     const params = {
       limit,
@@ -55,13 +58,17 @@ class HomeFeed extends React.Component {
     const cards = mergeCards(previousCards, newCards);
     this.setState({
       cards,
+      isFetching: false,
       hasLoadedAnyData: true, 
       error: null
     });
   }
 
   onRejected(error) {
-    this.setState({error});
+    this.setState({
+      isFetching: false,
+      error
+    });
   }
 
   onMore(event) {
@@ -94,7 +101,10 @@ class HomeFeed extends React.Component {
 
   renderSeeMore(feedCards) {
     const {limit} = this.props;
+    const {isFetching} = this.state;
+
     if (feedCards.length < limit) return null;
+    if (isFetching) return <span style={{display: 'block', ...styles.card}}>Loading more...</span>;
     return <a
       className="HomeFeed-load-more"
       style={{display: 'block', ...styles.card}}

--- a/app/assets/javascripts/home/HomeFeed.test.js
+++ b/app/assets/javascripts/home/HomeFeed.test.js
@@ -101,6 +101,7 @@ describe('HomeFeed', () => {
           seeMoreLinks: 1
         });
         ReactTestUtils.Simulate.click($(el).find('.HomeFeed-load-more').get(0));
+        expect($(el).html()).toContain('Loading more...');
         setTimeout(() => {
           expectRenderedFeed(el, {
             eventNoteCards: 20,


### PR DESCRIPTION
# Who is this PR for?
all educators

# What problem does this PR fix?
When you click "see more" on the home page feed, there's no UX feedback during loading.

# What does this PR do?
### before
<img width="629" alt="screen shot 2018-04-04 at 6 09 30 am" src="https://user-images.githubusercontent.com/1056957/38301964-1f1690b2-37cf-11e8-8c83-1fb427ab45e5.png">

### after
<img width="654" alt="screen shot 2018-04-04 at 6 11 27 am" src="https://user-images.githubusercontent.com/1056957/38301968-223f3924-37cf-11e8-8e2b-24de1227c348.png">


# Checklists
+ [x] Author checked latest in IE - Home page
+ [x] Author included specs for new code
