### PR TITLE
Add newlines to make import task logging more readable

### DIFF
--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -151,6 +151,6 @@ class ImportTask
   end
 
   def log(msg)
-    @log.write "💾 ImportTask 💾: #{msg}"
+    @log.write("\n\n💾  ImportTask: #{msg}")
   end
 end


### PR DESCRIPTION
# Who is this PR for?

Developers who work with the data import process. 

# What problem does this PR fix?

We lost newlines when we moved from using `puts` to `write`, so the log output for the import task got difficult to read: 

![screen shot 2018-04-04 at 9 15 10 am](https://user-images.githubusercontent.com/3209501/38313458-b17296a8-37e9-11e8-8af9-0f96a2bb8195.png)

Adding in newlines automatically makes the logs more legible:  

![screen shot 2018-04-04 at 9 19 23 am](https://user-images.githubusercontent.com/3209501/38313470-b840b14a-37e9-11e8-834f-eaff0aac6da1.png)
