### PR TITLE
Add more detailed info to import records page

### DIFF
--- a/app/models/import_record.rb
+++ b/app/models/import_record.rb
@@ -8,4 +8,22 @@ class ImportRecord < ActiveRecord::Base
     time_ended - time_started
   end
 
+  def time_started_display
+    time_to_display(time_to_est(time_started))
+  end
+
+  def time_ended_display
+    time_to_display(time_to_est(time_ended))
+  end
+
+  private
+
+    def time_to_est(time)
+      time.in_time_zone('Eastern Time (US & Canada)')
+    end
+
+    def time_to_display(time)
+      time.strftime("%m/%d/%Y %l:%M %p")
+    end
+
 end

--- a/app/views/import_records/index.html.erb
+++ b/app/views/import_records/index.html.erb
@@ -1,15 +1,22 @@
 <% @import_records.each do |record| %>
   <div style="border: 1px solid #eee; padding: 15px; margin: 15px;">
     <div style="margin-bottom: 15px; border-bottom: 1px solid #eee; font-size: 18px;">
-      <%= record.created_at.strftime("%m/%d/%Y") %>
+      Import Record #<%= record.id %>
     </div>
     <% if record.completed? %>
+      <div>Job completed in <%= distance_of_time_in_words(record.time_to_complete) %>.</div>
+      <div style="margin: 10px 0;">
+        <div>Started: <%= record.time_started_display %>.</div>
+        <div>Ended: <%= record.time_ended_display %>.</div>
+      </div>
+      <div style="margin: 10px 0;">Down-to-the-file details:</div>
       <div>
-        Completed in <%= distance_of_time_in_words(record.time_to_complete) %>.
+        <pre style="font-size: 15px; color: #3D3D3D"><%= JSON.pretty_generate(JSON.parse(record.importer_timing_json)) %></pre>
       </div>
     <% else %>
       <div>
-        Process did not complete.
+        <div>Job did not complete.</div>
+        <div style="margin: 10px 0;">Started: <%= record.time_started_display %>.</div>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
# Who is this PR for?

Anyone who has to debug the data import process. 😄 

# What problem does this PR fix?

We're storing a bunch of detailed information about the data import process in the database, but we're not surfacing much of it in the "Import records" view in the app. Surfacing more of that data will paint a more complete picture of what's going on with data import and simplify debugging.

# Screenshot (local data)

![screen shot 2018-04-04 at 10 03 11 am](https://user-images.githubusercontent.com/3209501/38316042-68653f78-37ef-11e8-9383-30a9fdc33c81.png)
