### PR TITLE
Store import options in database and display on "Import Records" page

### DIFF
--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -1,14 +1,16 @@
 class ImportTask
 
   def initialize(options:)
+    @options = options
+
     # options["school"] is an optional filter; imports all schools if nil
-    @school = options.fetch("school", nil)
+    @school = @options.fetch("school", nil)
 
     # options["source"] describes which external data sources to import from
-    @source = options.fetch("source", ["x2", "star"])
+    @source = @options.fetch("source", ["x2", "star"])
 
     # options["only_recent_attendance"]
-    @only_recent_attendance = options.fetch("only_recent_attendance", false)
+    @only_recent_attendance = @options.fetch("only_recent_attendance", false)
 
     @log = Rails.env.test? ? LogHelper::Redirect.instance.file : STDOUT
   end
@@ -66,7 +68,10 @@ class ImportTask
   ## SET UP COMMAND LINE REPORT AND DATABASE RECORD ##
 
   def create_import_record
-    ImportRecord.create(time_started: DateTime.current)
+    ImportRecord.create(
+      task_options_json: @options.to_json,
+      time_started: DateTime.current,
+    )
   end
 
   def create_report

--- a/app/views/import_records/index.html.erb
+++ b/app/views/import_records/index.html.erb
@@ -9,6 +9,12 @@
         <div>Started: <%= record.time_started_display %>.</div>
         <div>Ended: <%= record.time_ended_display %>.</div>
       </div>
+      <% if record.task_options_json.present? %>
+        <div style="margin: 10px 0;">Options:</div>
+        <div>
+          <pre style="font-size: 15px; color: #3D3D3D"><%= JSON.pretty_generate(JSON.parse(record.task_options_json)) %></pre>
+        </div>
+      <% end %>
       <div style="margin: 10px 0;">Down-to-the-file details:</div>
       <div>
         <pre style="font-size: 15px; color: #3D3D3D"><%= JSON.pretty_generate(JSON.parse(record.importer_timing_json)) %></pre>
@@ -17,6 +23,12 @@
       <div>
         <div>Job did not complete.</div>
         <div style="margin: 10px 0;">Started: <%= record.time_started_display %>.</div>
+        <% if record.task_options_json.present? %>
+          <div style="margin: 10px 0;">Options:</div>
+          <div>
+            <pre style="font-size: 15px; color: #3D3D3D"><%= JSON.pretty_generate(JSON.parse(record.task_options_json)) %></pre>
+          </div>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/db/migrate/20180404152512_add_task_options_to_importer_records.rb
+++ b/db/migrate/20180404152512_add_task_options_to_importer_records.rb
@@ -1,0 +1,5 @@
+class AddTaskOptionsToImporterRecords < ActiveRecord::Migration[5.1]
+  def change
+    add_column :import_records, :task_options_json, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180402153329) do
+ActiveRecord::Schema.define(version: 20180404152512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -186,6 +186,7 @@ ActiveRecord::Schema.define(version: 20180402153329) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "importer_timing_json"
+    t.text "task_options_json"
   end
 
   create_table "intervention_types", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
# Who is this PR for?

Developers who need to debug the data import process. 😄 

# What problem does this PR fix?

Right now there's no visibility into what options were passed down to the import task. Historical import records don't tell us too much if we don't know what options were passed in.

# What does this PR do?

Store import task options in the database as JSON and display on "Import Records" page. 

# Screenshot (local data)

![screen shot 2018-04-04 at 10 39 23 am](https://user-images.githubusercontent.com/3209501/38318236-7c6cd5e4-37f4-11e8-9e81-6f093ef34e81.png)
