### PR TITLE
Classroom balancing principal prototype 

### DIFF
--- a/app/assets/javascripts/components/Bar.js
+++ b/app/assets/javascripts/components/Bar.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+// Render a horizontal Bar that is filled with `color` and is a
+// `percentage` of the width of the container.
+export default class Bar extends React.Component {
+
+  render() {
+    const {styles, innerStyles, percent, threshold} = this.props;
+    const title = this.props.title || percent + '%';
+
+    return (
+      <div title={title} style={{
+        color: 'black',
+        cursor: 'default',
+        display: 'inline-block',
+        width: percent + '%',
+        height: '100%',
+        ...styles
+      }}>
+        <div style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100%',
+          ...innerStyles
+        }}>
+          {percent > threshold ? `${Math.round(percent)}%` : '\u00A0' }
+        </div>
+      </div>
+    );
+  }
+
+}
+
+Bar.propTypes = {
+  percent: React.PropTypes.number.isRequired,
+  threshold: React.PropTypes.number.isRequired,
+  styles: React.PropTypes.object,
+  innerStyles: React.PropTypes.object,
+  title: React.PropTypes.string
+};

--- a/app/assets/javascripts/components/Bar.test.js
+++ b/app/assets/javascripts/components/Bar.test.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Bar from './Bar';
+
+it('renders without crashing', () => {
+  const el = document.createElement('div');
+  ReactDOM.render(<Bar percent={11} threshold={10} />, el);
+});

--- a/app/assets/javascripts/equity/Breakdown.js
+++ b/app/assets/javascripts/equity/Breakdown.js
@@ -49,19 +49,21 @@ const percentageOf = function(students, key, value) {
     0
     : 100 * (countMap[value] || 0) / total;
 };
+
 const LETTERS = _.range(65, 65 + 26).map(c => String.fromCharCode(c));
+
 const codes = _.flatten(LETTERS.map((outer) => {
   return LETTERS.map((inner) => {
     return [outer, inner].join('');
   });
 }));
+
 const bucket = function(value, buckets) {
   return buckets[hashCode(value) % buckets.length];
 }
 const hashCode = function(s){
   return s.split("").reduce(function(a,b){a=((a<<5)-a)+b.charCodeAt(0);return a&a},0);
 }
-
 
 const styles = {
   bar: {
@@ -71,34 +73,23 @@ const styles = {
   }
 };
 
-export default React.createClass({
-  displayName: 'CohortBreakdown',
+export default class Breakdown extends React.Component {
 
-  propTypes: {
-    students: React.PropTypes.arrayOf(React.PropTypes.shape({
-      race: React.PropTypes.string,
-      disability: React.PropTypes.string,
-      limited_english_proficiency: React.PropTypes.string,
-      gender: React.PropTypes.string,
-      grade: React.PropTypes.string,
-      free_reduced_lunch: React.PropTypes.string,
-      hispanic_latino: React.PropTypes.bool,
-      homeroom_id: React.PropTypes.number,
-      homeroom_name: React.PropTypes.string
-    })).isRequired
-  },
+  constructor(props) {
+    super(props);
 
-  getInitialState: function() {
-    return {
+    this.state = {
       gradeFilter: _.first(orderedGrades)
     };
-  },
 
-  onGradeClicked: function(grade) {
+    this.onGradeClicked = this.onGradeClicked.bind(this);
+  }
+
+  onGradeClicked(grade) {
     this.setState({ gradeFilter: grade });
-  },
+  }
 
-  render: function() {
+  render() {
     // Clean and filter
     const {gradeFilter} = this.state;
     const rawStudents = this.props.students;
@@ -274,9 +265,24 @@ export default React.createClass({
         </div>
       </div>
     );
-  },
+  }
 
-  renderTitle: function(title) {
+  renderTitle(title) {
     return <div style={{marginTop: 50}}><b>{title}</b></div>;
   }
-});
+
+}
+
+Breakdown.propTypes = {
+  students: React.PropTypes.arrayOf(React.PropTypes.shape({
+    race: React.PropTypes.string,
+    disability: React.PropTypes.string,
+    limited_english_proficiency: React.PropTypes.string,
+    gender: React.PropTypes.string,
+    grade: React.PropTypes.string,
+    free_reduced_lunch: React.PropTypes.string,
+    hispanic_latino: React.PropTypes.bool,
+    homeroom_id: React.PropTypes.number,
+    homeroom_name: React.PropTypes.string
+  })).isRequired
+};

--- a/app/assets/javascripts/equity/Breakdown.js
+++ b/app/assets/javascripts/equity/Breakdown.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 import Bar from '../components/Bar';
 import {colors} from '../helpers/Theme';
 

--- a/app/assets/javascripts/equity/Breakdown.js
+++ b/app/assets/javascripts/equity/Breakdown.js
@@ -1,0 +1,282 @@
+import React from 'react';
+import Bar from '../components/Bar';
+import {colors} from '../helpers/Theme';
+
+// Translate null values
+function cleanNulls(students) {
+  return students.map((student) => {
+    return {
+      ...student,
+      race: (student.race) ? student.race : 'Unknown'
+    };
+  });
+};
+
+const orderedGrades = [ 'PK', 'KF', '1', '2', '3', '4', '5', '6', '7', '8' ];
+
+// Helpers
+// Returns [{key, count}]
+const countBy = function(students, key) {
+  return _.map(_.groupBy(students, key), (students, value) => {
+    return {[key]: value, count: students.length};
+  });
+};
+
+// Returns {foo: count, bar: count}
+const makeCountMap = function(students, key) {
+  return countBy(students, key).reduce((map, item) => {
+    map[item[key]] = item.count;
+    return map;
+  }, {});
+}
+
+// Returns [{key, count}], filling in zero values for `allValues`
+// if they're not present.
+const completeCountBy = function(students, key, allValues) {
+  return allValues.map((value) => {
+    const matches = _.where(students, { [key]: value });
+    return { [key]: value, count: matches.length };
+  });
+}
+
+// Returns percent as integer 0-100
+const percentageOf = function(students, key, value) {
+  const countMap = makeCountMap(students, key);
+  const total = Object.keys(countMap).reduce((sum, key) => {
+    return sum + countMap[key];
+  }, 0);
+  return (total === 0) ?
+    0
+    : 100 * (countMap[value] || 0) / total;
+};
+const LETTERS = _.range(65, 65 + 26).map(c => String.fromCharCode(c));
+const codes = _.flatten(LETTERS.map((outer) => {
+  return LETTERS.map((inner) => {
+    return [outer, inner].join('');
+  });
+}));
+const bucket = function(value, buckets) {
+  return buckets[hashCode(value) % buckets.length];
+}
+const hashCode = function(s){
+  return s.split("").reduce(function(a,b){a=((a<<5)-a)+b.charCodeAt(0);return a&a},0);
+}
+
+
+const styles = {
+  bar: {
+    color: 'black',
+    backgroundColor: '#ccc',
+    borderLeft: '1px solid #aaa'
+  }
+};
+
+export default React.createClass({
+  displayName: 'CohortBreakdown',
+
+  propTypes: {
+    students: React.PropTypes.arrayOf(React.PropTypes.shape({
+      race: React.PropTypes.string,
+      disability: React.PropTypes.string,
+      limited_english_proficiency: React.PropTypes.string,
+      gender: React.PropTypes.string,
+      grade: React.PropTypes.string,
+      free_reduced_lunch: React.PropTypes.string,
+      hispanic_latino: React.PropTypes.bool,
+      homeroom_id: React.PropTypes.number,
+      homeroom_name: React.PropTypes.string
+    })).isRequired
+  },
+
+  getInitialState: function() {
+    return {
+      gradeFilter: _.first(orderedGrades)
+    };
+  },
+
+  onGradeClicked: function(grade) {
+    this.setState({ gradeFilter: grade });
+  },
+
+  render: function() {
+    // Clean and filter
+    const {gradeFilter} = this.state;
+    const rawStudents = this.props.students;
+    const cleanedStudents = cleanNulls(rawStudents);
+    const students = (gradeFilter === null)
+      ? cleanedStudents
+      : cleanedStudents.filter(student => student.grade === gradeFilter);
+    const allRaces = _.sortBy(_.uniq(_.map(cleanedStudents, 'race')));
+
+
+    // Compute
+    const studentsByHomeroom = _.map(_.groupBy(students, 'homeroom_name'), (students, homeroomName) => {
+      return {
+        homeroomName,
+        students,
+        homeroomId: students[0].homeroom_id
+      };
+    });
+    const statsForHomerooms = studentsByHomeroom.map(({homeroomName, homeroomId, students}) => {
+      const grades = _.uniq(_.map(students, 'grade'));
+      const raceGroups = completeCountBy(students, 'race', allRaces);
+      const lunchMap = makeCountMap(students, 'free_reduced_lunch');
+      const lunchPercent = 100 - percentageOf(students, 'free_reduced_lunch', 'Not Eligible');
+      const hispanicPercent = percentageOf(students, 'hispanic_latino', true);
+      const disabilityPercent = 100 - percentageOf(students, 'disability', null);
+      const lepPercent = 100 - percentageOf(students, 'limited_english_proficiency', 'Fluent');
+      const colorPercent = 100 * students.filter(s => s.hispanic_latino || s.race !== 'White').length / students.length;
+
+      return {
+        homeroomName,
+        homeroomId,
+        grades,
+        raceGroups,
+        lunchMap,
+        lunchPercent,
+        disabilityPercent,
+        lepPercent,
+        hispanicPercent,
+        colorPercent,
+        studentCount: students.length
+      };
+    });
+
+    // Render
+    // Keep colors consistent
+    const color = d3.scale.ordinal()
+      .domain(_.sortBy(allRaces, race => race.length))
+      // .range(['#ffffe0','#ffcb91','#fe906a','#e75758','#c0223b','#8b0000']);
+      // .range(['#66c2a5','#fc8d62','#8da0cb','#e78ac3','#a6d854','#ffd92f','#e5c494','#b3b3b3']);
+      .range(['#1b9e77','#d95f02','#7570b3','#e7298a','#66a61e','#e6ab02','#a6761d','#666666']);
+    const sortedStatsForHomerooms = _.sortBy(statsForHomerooms, ({grades, studentCount}) => {
+      if (grades.length === 1) return (100 * orderedGrades.indexOf(grades[0])) - studentCount;
+      if (grades.length > 1) return -1000 - studentCount;
+      return -2000 - studentCount;
+    });
+
+    return (
+      <div style={{margin: 40}}>
+        <div>
+          {this.renderTitle('Select a grade')}
+          <div style={{margin: 5}}>
+            {orderedGrades.map((grade) => {
+              return <button
+                style={{
+                  padding: 15,
+                  paddingTop: 10,
+                  paddingBottom: 10,
+                  cursor: 'pointer',
+                  margin: 3,
+                  width: '5em',
+                  border: '1px solid #ccc',
+                  backgroundColor: (grade === gradeFilter) ? colors.selection : '#eee'
+                }}
+                key={grade}
+                onClick={this.onGradeClicked.bind(this, grade)}>{grade}</button>;
+            })}
+          </div>
+          <div style={{margin: 5}}>This excludes mixed grade homerooms.</div>
+        </div>
+        <div>
+          {this.renderTitle('Compare across homeroom')}
+          <table style={{width: '100%', margin: 5, marginTop: 10, borderCollapse: 'collapse'}}>
+            <thead style={{borderBottom: '1px solid #999'}}>
+              <tr>
+                <th style={{padding: 5, textAlign: 'left', fontWeight: 'bold'}}>Homeroom</th>
+                <th style={{padding: 5, textAlign: 'left', fontWeight: 'bold'}}>Size</th>
+                <th style={{padding: 5, textAlign: 'left', fontWeight: 'bold'}}>Disability</th>
+                <th style={{padding: 5, textAlign: 'left', fontWeight: 'bold'}}>Limited English</th>
+                <th style={{padding: 5, textAlign: 'left', fontWeight: 'bold'}}>Low income</th>
+                <th style={{padding: 5, textAlign: 'left', fontWeight: 'bold'}}>Racial composition</th>
+                <th title="Not white or Hispanic" style={{cursor: 'help', padding: 5, textAlign: 'left', fontWeight: 'bold'}}>Students of color</th>
+                <th style={{padding: 5, textAlign: 'left', fontWeight: 'bold'}}>Hispanic</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedStatsForHomerooms.map((statsForHomeroom) => {
+                const {
+                  homeroomName,
+                  homeroomId,
+                  studentCount,
+                  raceGroups,
+                  grades,
+                  lunchPercent,
+                  hispanicPercent,
+                  disabilityPercent,
+                  lepPercent,
+                  colorPercent
+                } = statsForHomeroom;
+                const total = _.map(raceGroups, 'count').reduce((sum, a) => {
+                  return sum + a;
+                }, 0);
+
+                return (
+                  <tr key={homeroomName} style={{marginBottom: 20}}>
+                    <td style={{width: '5em', padding: 5}}>
+                      <a href={`/homerooms/${homeroomId}`}>{homeroomName}</a>
+                    </td>
+                    <td style={{width: '3em', padding: 5}}>{studentCount}</td>
+                    <td style={{height: '100%', width: 140, padding: 5}}>
+                      <Bar percent={disabilityPercent} styles={styles.bar} threshold={10} />
+                    </td>
+                    <td style={{height: '100%', width: 140, padding: 5}}>
+                      <Bar percent={lepPercent} styles={styles.bar} threshold={10} />
+                    </td>
+                    <td style={{height: '100%', width: 140, padding: 5}}>
+                      <Bar percent={lunchPercent} styles={styles.bar} threshold={10} />
+                    </td>
+                    <td style={{padding: 5}}>
+                      <div style={{flex: 1, width: 400, backgroundColor: 'white', height: '3em'}}>
+                        {_.sortBy(raceGroups, 'race').map((group) => {
+                          const {race, count} = group;
+                          const percent = 100 * count / total;
+                          const title = Math.round(percent) + '% ' + race;
+                          if (percent === 0) return null;
+
+                          return (
+                            <Bar
+                              key={race}
+                              percent={percent}
+                              threshold={10}
+                              title={title}
+                              styles={{backgroundColor: color(race)}}
+                              innerStyles={{color: 'white'}} />
+                          );
+                        })}
+                      </div>
+                    </td>
+                    <td style={{height: '100%', width: 140, padding: 5}}>
+                      <Bar percent={colorPercent} styles={styles.bar} threshold={10} />
+                    </td>
+                    <td style={{height: '100%', width: 140, padding: 5}}>
+                      <Bar percent={hispanicPercent} styles={styles.bar} threshold={10} />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        <div>
+          {this.renderTitle('Color key')}
+          <div style={{margin: 5}}>
+            {allRaces.map((race) => {
+              return <div key={race} style={{
+                display: 'inline-block',
+                margin: 10,
+                color: 'white',
+                padding: 5,
+                backgroundColor: color(race)
+              }}>{race}</div>;
+            })}
+          </div>
+        </div>
+      </div>
+    );
+  },
+
+  renderTitle: function(title) {
+    return <div style={{marginTop: 50}}><b>{title}</b></div>;
+  }
+});

--- a/app/assets/javascripts/equity/Breakdown.js
+++ b/app/assets/javascripts/equity/Breakdown.js
@@ -11,7 +11,7 @@ function cleanNulls(students) {
       race: (student.race) ? student.race : 'Unknown'
     };
   });
-};
+}
 
 const orderedGrades = [ 'PK', 'KF', '1', '2', '3', '4', '5', '6', '7', '8' ];
 
@@ -29,7 +29,7 @@ const makeCountMap = function(students, key) {
     map[item[key]] = item.count;
     return map;
   }, {});
-}
+};
 
 // Returns [{key, count}], filling in zero values for `allValues`
 // if they're not present.
@@ -38,7 +38,7 @@ const completeCountBy = function(students, key, allValues) {
     const matches = _.where(students, { [key]: value });
     return { [key]: value, count: matches.length };
   });
-}
+};
 
 // Returns percent as integer 0-100
 const percentageOf = function(students, key, value) {
@@ -50,21 +50,6 @@ const percentageOf = function(students, key, value) {
     0
     : 100 * (countMap[value] || 0) / total;
 };
-
-const LETTERS = _.range(65, 65 + 26).map(c => String.fromCharCode(c));
-
-const codes = _.flatten(LETTERS.map((outer) => {
-  return LETTERS.map((inner) => {
-    return [outer, inner].join('');
-  });
-}));
-
-const bucket = function(value, buckets) {
-  return buckets[hashCode(value) % buckets.length];
-}
-const hashCode = function(s){
-  return s.split("").reduce(function(a,b){a=((a<<5)-a)+b.charCodeAt(0);return a&a},0);
-}
 
 const styles = {
   bar: {
@@ -192,7 +177,6 @@ export default class Breakdown extends React.Component {
                   homeroomId,
                   studentCount,
                   raceGroups,
-                  grades,
                   lunchPercent,
                   hispanicPercent,
                   disabilityPercent,

--- a/app/assets/javascripts/equity/Breakdown.test.js
+++ b/app/assets/javascripts/equity/Breakdown.test.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Breakdown from './Breakdown';
+
+it('renders without crashing', () => {
+  const el = document.createElement('div');
+  ReactDOM.render(<Breakdown students={[]} />, el);
+});

--- a/app/assets/javascripts/equity/SchoolEquityPrincipalPage.js
+++ b/app/assets/javascripts/equity/SchoolEquityPrincipalPage.js
@@ -36,3 +36,6 @@ export default class SchoolEquityPrincipalPage extends React.Component {
 
 }
 
+SchoolEquityPrincipalPage.propTypes = {
+  schoolId: React.PropTypes.string.isRequired
+};

--- a/app/assets/javascripts/equity/SchoolEquityPrincipalPage.js
+++ b/app/assets/javascripts/equity/SchoolEquityPrincipalPage.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import GenericLoader from '../components/GenericLoader';
+import ExperimentalBanner from '../components/ExperimentalBanner';
+import {apiFetchJson} from '../helpers/apiFetchJson';
+import Breakdown from '../equity/Breakdown';
+
+export default class SchoolEquityPrincipalPage extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.fetchSchoolOverviewData = this.fetchSchoolOverviewData.bind(this);
+    this.renderBreakdown = this.renderBreakdown.bind(this);
+  }
+
+  fetchSchoolOverviewData() {
+    const {schoolId} = this.props;
+    const url = `/schools/${schoolId}/overview_json`;
+    return apiFetchJson(url);
+  }
+
+  render() {
+    return (
+      <div className="SchoolEquityPrincipalPage">
+        <ExperimentalBanner />
+        <GenericLoader
+          promiseFn={this.fetchSchoolOverviewData}
+          render={this.renderBreakdown} />
+      </div>
+    );
+  }
+
+  renderBreakdown(json) {
+    return <Breakdown students={json.students} school={json.school} />;
+  }
+
+}
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
       get 'absences' => 'ui#ui'
       get 'tardies' => 'ui#ui'
       get 'courses' => 'ui#ui'
+      get 'equity/principal' => 'ui#ui'
     end
   end
 end

--- a/ui/App.js
+++ b/ui/App.js
@@ -10,7 +10,7 @@ import DashboardLoader from '../app/assets/javascripts/school_administrator_dash
 import SchoolCoursesPage from '../app/assets/javascripts/school_courses/SchoolCoursesPage';
 import MountTimer from '../app/assets/javascripts/components/MountTimer';
 import measurePageLoad from '../app/assets/javascripts/helpers/measurePageLoad';
-
+import SchoolEquityPrincipalPage from '../app/assets/javascripts/equity/SchoolEquityPrincipalPage';
 
 // This is the top-level component, only handling routing.
 // The core model is still "new page, new load," this just
@@ -52,6 +52,7 @@ class App extends React.Component {
           <Route exact path="/schools/:id/absences" render={this.renderAbsencesDashboard.bind(this)}/>
           <Route exact path="/schools/:id/tardies" render={this.renderTardiesDashboard.bind(this)}/>
           <Route render={() => this.renderNotFound()} />
+          <Route exact path="/schools/:id/equity/principal" render={this.renderSchoolEquityPrincipalPage.bind(this)}/>
         </Switch>
       </MountTimer>
     );
@@ -64,6 +65,12 @@ class App extends React.Component {
     return <HomePage
       educatorId={id}
       educatorLabels={labels} />;
+  }
+
+  renderSchoolEquityPrincipalPage(routeProps) {
+    const schoolId = routeProps.match.params.id;
+    this.trackVisit(routeProps, 'SCHOOL_EQUITY_PRINCIPAL_PAGE');
+    return <SchoolEquityPrincipalPage schoolId={schoolId} />;
   }
 
   renderSchoolCoursesPage(routeProps) {
@@ -101,7 +108,7 @@ App.propTypes = {
   currentEducator: React.PropTypes.shape({
     id: React.PropTypes.number.isRequired,
     admin: React.PropTypes.bool.isRequired,
-    school_id: React.PropTypes.number.isRequired,
+    school_id: React.PropTypes.number,
     labels: React.PropTypes.arrayOf(React.PropTypes.string).isRequired
   }).isRequired
 };

--- a/ui/App.js
+++ b/ui/App.js
@@ -51,8 +51,8 @@ class App extends React.Component {
           <Route exact path="/home" render={this.renderHomePage.bind(this)}/>
           <Route exact path="/schools/:id/absences" render={this.renderAbsencesDashboard.bind(this)}/>
           <Route exact path="/schools/:id/tardies" render={this.renderTardiesDashboard.bind(this)}/>
-          <Route render={() => this.renderNotFound()} />
           <Route exact path="/schools/:id/equity/principal" render={this.renderSchoolEquityPrincipalPage.bind(this)}/>
+          <Route render={() => this.renderNotFound()} />
         </Switch>
       </MountTimer>
     );

--- a/ui/index.js
+++ b/ui/index.js
@@ -42,6 +42,7 @@ if (mainEl) {
   if (!didRoute) {
     const serializedData = $('#serialized-data').data() || {};
     const {currentEducator} = serializedData;
-    ReactDOM.render(<BrowserRouter><App currentEducator={currentEducator} /></BrowserRouter>, mainEl);
+    ReactDOM.render(
+      <BrowserRouter><App currentEducator={currentEducator} /></BrowserRouter>, mainEl);
   }
 }


### PR DESCRIPTION
# Who is this PR for?

Exploratory views of equity in classroom assignments by race, disability, and other factors; manually cherry-picked from @kevinrobinson's `feature/classroom-composition` branch:

https://github.com/studentinsights/studentinsights/tree/feature/classroom-composition

# What problem does this PR fix?

There's no dedicated view that surfaces equity data about classrooms for principals/administrators. 

This ships a V1 of what an exploratory page for principals to see classroom-level equity data could look like. The feature is shipped "dark," with no links to it in the UI, so we can show it to a few administrators for early feedback and conversation. 

The page is found at `/schools/:id/equity/principal`, where `:id` is a school local ID like "HEA" for the Healey School. 

# Screenshot — demo data

![screen shot 2018-04-05 at 2 13 31 pm](https://user-images.githubusercontent.com/3209501/38386817-90f16358-38db-11e8-88a5-d137fbb6af79.png)


# GIF — authorized districtwide educator, demo data, IE

![uri-equity](https://user-images.githubusercontent.com/3209501/38386591-af3911c2-38da-11e8-845e-fc2db2236727.gif)

# GIF — K teacher, unauthorized 

![vivian-equity](https://user-images.githubusercontent.com/3209501/38386557-9f624eee-38da-11e8-8662-1801c4280687.gif)

# Note on authorization 

+ The first layer of authorization for this endpoint is the auth-by-default provided by `ApplicationController`, which checks that the educator is logged in with `authenticate_educator!`.

+ The second layer is provided by `SchoolsController`, which provides the JSON for the page, and calls `authorize_for_school` to make sure the logged-in educator has appropriate school permissions (either schoolwide or districtwide). 