### PR TITLE
Fix bug with student section assignment import

### DIFF
--- a/app/importers/file_importers/student_section_assignments_importer.rb
+++ b/app/importers/file_importers/student_section_assignments_importer.rb
@@ -38,6 +38,10 @@ class StudentSectionAssignmentsImporter
     SchoolFilter.new(@school_scope)
   end
 
+  def school_ids_dictionary
+    @dictionary ||= School.all.map { |school| [school.local_id, school.id] }.to_h
+  end
+
   def delete_rows
     #Delete all stale rows no longer included in the import
     #For the schools imported during this run of the importer
@@ -48,10 +52,11 @@ class StudentSectionAssignmentsImporter
   end
 
   def import_row(row)
-    student_section_assignment = StudentSectionAssignmentRow.new(row).build
-    if student_section_assignment
-      student_section_assignment.save!
-      @imported_assignments.push(student_section_assignment.id)
+    assignment = StudentSectionAssignmentRow.new(row, school_ids_dictionary).build
+
+    if assignment
+      assignment.save!
+      @imported_assignments.push(assignment.id)
     else
       @log.write("Student Section Assignment Import invalid row: #{row}")
     end

--- a/app/importers/rows/student_section_assignment_row.rb
+++ b/app/importers/rows/student_section_assignment_row.rb
@@ -14,19 +14,34 @@ class StudentSectionAssignmentRow < Struct.new(:row, :school_ids_dictionary)
   end
 
   def build
-    if student and section
-      student_section_assignment = StudentSectionAssignment.find_or_initialize_by(student: student,
-                                                                                section: section)
-      return student_section_assignment
-    end
+    return if course.nil? || student.nil? || section.nil?
+
+    StudentSectionAssignment.find_or_initialize_by(student: student, section: section)
   end
 
   def student
-    return Student.find_by_local_id(row[:local_id]) if row[:local_id]
+    return unless row[:local_id]
+
+    Student.find_by_local_id(row[:local_id])
+  end
+
+  def course
+    return unless row[:course_number]
+
+    school_local_id = row[:school_local_id]
+    school_id = school_ids_dictionary[school_local_id]
+
+    Course.find_by(course_number: row[:course_number], school_id: school_id)
   end
 
   def section
-    return Section.find_by_section_number(row[:section_number]) if row[:section_number]
+    return unless row[:section_number]
+
+    Section.find_by(
+      section_number: row[:section_number],
+      course: course,
+      term_local_id: row[:term_local_id]
+    )
   end
 
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,5 +1,8 @@
 class Course < ActiveRecord::Base
-  validates :course_number, presence: true, uniqueness: { scope: [:course_number, :school_id] }
+  validates :course_number, presence: true, uniqueness: {
+    # Different courses at different schools can have the same course number
+    scope: [:course_number, :school_id]
+  }
   validates :school, presence: true
   has_many :sections
   belongs_to :school

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,5 +1,7 @@
 class Section < ActiveRecord::Base
-  validates :section_number, presence: true, uniqueness: { scope: [:section_number, :course_id, :term_local_id] }
+  validates :section_number, presence: true, uniqueness: {
+    scope: [:section_number, :course_id, :term_local_id]
+  }
   validates :course, presence: true
   belongs_to :course
   has_many :student_section_assignments

--- a/spec/importers/file_importers/student_section_assignments_importer_spec.rb
+++ b/spec/importers/file_importers/student_section_assignments_importer_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe StudentSectionAssignmentsImporter do
+  before { School.seed_somerville_schools }
+  let(:high_school) { School.find_by_local_id('SHS') }
 
   let(:student_section_assignments_importer) {
     described_class.new(options: {
@@ -9,17 +11,20 @@ RSpec.describe StudentSectionAssignmentsImporter do
   }
 
   describe '#import_row' do
-    let!(:school) { FactoryGirl.create(:shs) }
-    let!(:section) { FactoryGirl.create(:section) }
+    let!(:course) { FactoryGirl.create(:course, school: high_school) }
+    let!(:section) { FactoryGirl.create(:section, course: course) }
     let!(:student) { FactoryGirl.create(:student) }
 
     context 'happy path' do
-      let(:row) { { local_id:student.local_id,
-                    course_number:section.course.course_number,
-                    school_local_id: 'SHS',
-                    section_number:section.section_number,
-                    term_local_id:'FY'
-                } }
+      let(:row) {
+        {
+          local_id: student.local_id,
+          course_number: section.course.course_number,
+          school_local_id: 'SHS',
+          section_number: section.section_number,
+          term_local_id: 'FY'
+        }
+      }
 
         before do
           student_section_assignments_importer.import_row(row)
@@ -36,11 +41,14 @@ RSpec.describe StudentSectionAssignmentsImporter do
     end
 
     context 'student lasid is missing' do
-      let(:row) { { course_number:section.course.course_number,
-                  school_local_id: 'SHS',
-                  section_number:section.section_number,
-                  term_local_id:'FY'
-              } }
+      let(:row) {
+        {
+          course_number: section.course.course_number,
+          school_local_id: 'SHS',
+          section_number: section.section_number,
+          term_local_id: 'FY'
+        }
+      }
 
       before do
         student_section_assignments_importer.import_row(row)
@@ -52,11 +60,14 @@ RSpec.describe StudentSectionAssignmentsImporter do
     end
 
     context 'section is missing' do
-      let(:row) { { local_id:student.local_id,
-                  course_number:section.course.course_number,
-                  school_local_id: 'SHS',
-                  term_local_id:'FY'
-              } }
+      let(:row) {
+        {
+          local_id: student.local_id,
+          course_number: section.course.course_number,
+          school_local_id: 'SHS',
+          term_local_id: 'FY'
+        }
+      }
 
       before do
         student_section_assignments_importer.import_row(row)
@@ -68,12 +79,15 @@ RSpec.describe StudentSectionAssignmentsImporter do
     end
 
     context 'student does not exist' do
-      let(:row) { { local_id:'NO EXIST',
-                  course_number:section.course.course_number,
-                  school_local_id: 'SHS',
-                  section_number:section.section_number,
-                  term_local_id:'FY'
-              } }
+      let(:row) {
+        {
+          local_id: 'NO EXIST',
+          course_number: section.course.course_number,
+          school_local_id: 'SHS',
+          section_number: section.section_number,
+          term_local_id: 'FY'
+        }
+      }
 
       before do
         student_section_assignments_importer.import_row(row)
@@ -85,12 +99,15 @@ RSpec.describe StudentSectionAssignmentsImporter do
     end
 
     context 'section does not exist' do
-    let(:row) { { local_id:student.local_id,
-                  course_number:section.course.course_number,
-                  school_local_id: 'SHS',
-                  section_number:'NO EXIST',
-                  term_local_id:'FY'
-              } }
+      let(:row) {
+        {
+          local_id: student.local_id,
+          course_number: section.course.course_number,
+          school_local_id: 'SHS',
+          section_number: 'NO EXIST',
+          term_local_id: 'FY'
+        }
+      }
 
       before do
         student_section_assignments_importer.import_row(row)
@@ -104,15 +121,17 @@ RSpec.describe StudentSectionAssignmentsImporter do
 
   describe '#delete_rows' do
     let(:log) { LogHelper::Redirect.instance.file }
-    let!(:school) { FactoryGirl.create(:shs) }
     let!(:section) { FactoryGirl.create(:section) }
     let!(:student) { FactoryGirl.create(:student) }
-    let(:row) { { local_id:student.local_id,
-      course_number:section.course.course_number,
-      school_local_id: section.course.school.local_id,
-      section_number:section.section_number,
-      term_local_id: section.term_local_id
-    } }
+    let(:row) {
+      {
+        local_id: student.local_id,
+        course_number: section.course.course_number,
+        school_local_id: section.course.school.local_id,
+        section_number: section.section_number,
+        term_local_id: section.term_local_id
+      }
+    }
 
     context 'happy path' do
       let(:student_section_assignments_importer) {

--- a/spec/importers/rows/student_section_assignment_row_spec.rb
+++ b/spec/importers/rows/student_section_assignment_row_spec.rb
@@ -1,22 +1,94 @@
 require 'rails_helper'
 
 RSpec.describe StudentSectionAssignmentRow do
-
   describe '#build' do
+    before { School.seed_somerville_schools }
+    let(:dictionary) {
+      School.all.map { |school| [school.local_id, school.id] }.to_h
+    }
 
-    let(:student_section_assignment_row) { described_class.new(row) }
+    let(:student_section_assignment_row) { described_class.new(row, dictionary) }
     let(:student_section_assignment) { student_section_assignment_row.build }
+    let(:healey_school) { School.find_by_local_id('HEA') }
+    let(:brown_school) { School.find_by_local_id('BRN') }
 
     context 'happy path' do
+      let!(:student) { FactoryGirl.create(:high_school_student) }
+      let!(:course) {
+        FactoryGirl.create(
+          :course, course_number: 'F100', school: healey_school
+        )
+      }
+      let!(:section) {
+        FactoryGirl.create(
+          :section, course: course, section_number: 'MUSIC-005', term_local_id: 'FY'
+        )
+      }
+
+      let(:row) {
+        {
+          local_id: student.local_id,
+          section_number: 'MUSIC-005',
+          course_number: 'F100',
+          school_local_id: 'HEA',
+          term_local_id: 'FY'
+        }
+      }
+
+      it 'assigns the correct values' do
+        expect(student_section_assignment.student).to eq(student)
+        expect(student_section_assignment.section).to eq(section)
+      end
+    end
+
+    context 'section with same section_number at different school' do
+      let!(:another_course) {
+        FactoryGirl.create(:course, course_number: 'F100', school: brown_school)
+      }
+      let!(:another_section) {
+        FactoryGirl.create(
+          :section, course: another_course, section_number: 'MUSIC-005', term_local_id: 'FY'
+        )
+      }
+
+      let!(:student) { FactoryGirl.create(:high_school_student) }
+      let!(:course) {
+        FactoryGirl.create(:course, course_number: 'F100', school: healey_school)
+      }
+      let!(:section) {
+        FactoryGirl.create(
+          :section, course: course, section_number: 'MUSIC-005', term_local_id: 'FY'
+        )
+      }
+
+      let(:row) {
+        {
+          local_id: student.local_id,
+          section_number: 'MUSIC-005',
+          course_number: 'F100',
+          school_local_id: 'HEA',
+          term_local_id: 'FY'
+        }
+      }
+
+      it 'assigns the correct values' do
+        expect(student_section_assignment.student).to eq(student)
+        expect(student_section_assignment.section).to eq(section)
+      end
+    end
+
+    context 'no course info or school_local_id' do
       let!(:section) { FactoryGirl.create(:section) }
       let!(:student) { FactoryGirl.create(:high_school_student) }
-      let(:row) { { local_id: student.local_id,
-                    section_number: section.section_number,
-                } }
+      let(:row) {
+        {
+          local_id: student.local_id,
+          section_number: section.section_number,
+        }
+      }
 
-      it 'assigns info correctly' do
-        expect(student_section_assignment.student).to eq student
-        expect(student_section_assignment.section).to eq section
+      it 'returns nil' do
+        expect(student_section_assignment).to be_nil
       end
     end
   end


### PR DESCRIPTION
# What does this do? 

Reverts studentinsights/studentinsights#1588.

# Notes

The original bugfix — https://github.com/studentinsights/studentinsights/pull/1580 — looked good based on manual QA and automated testing. When it shipped and I tried to run a one-off import job, I didn't see any log output and thought that the one-off job might have failed. So I reverted with studentinsights/studentinsights#1588.

Further investigation over the next couple days revealed that the one-off import job had really succeeded. I wasn't seeing log output because we had changed the import job default to run in the background. The logs weren't showing up in my console, but the Heroku worker dyno was indeed writing logs in the background. 

This PR should be good to go, so I'm reverting the revert. After this deploys I'll kick off another one-off job and verify that student section assignment looks fixed.