### PR TITLE
Add percentile range graphic to exploratory equity view

### DIFF
--- a/app/assets/javascripts/equity/Breakdown.js
+++ b/app/assets/javascripts/equity/Breakdown.js
@@ -3,6 +3,16 @@ import _ from 'lodash';
 import Bar from '../components/Bar';
 import {colors} from '../helpers/Theme';
 
+
+// Compute range, excluding null and undefined values.
+function range(students, accessor) {
+  const filtered = students.filter(s => accessor(s) !== null && accessor(s) !== undefined);
+  return [
+    accessor(_.min(filtered, accessor)),
+    accessor(_.max(filtered, accessor))
+  ];
+}
+
 // Translate null values
 function cleanNulls(students) {
   return students.map((student) => {
@@ -136,12 +146,14 @@ export default class Breakdown extends React.Component {
         students, 'most_recent_star_math_percentile', 25);
       const highestQuartileStarMath = percentageOverLimit(
         students, 'most_recent_star_math_percentile', 75);
+      const starMathPercentileRange = range(students, s => s.most_recent_star_math_percentile);
 
       // Star Reading
       const lowestQuartileStarReading = percentageUnderLimit(
         students, 'most_recent_star_reading_percentile', 25);
       const highestQuartileStarReading = percentageOverLimit(
         students, 'most_recent_star_reading_percentile', 75);
+      const starReadingPercentileRange = range(students, s => s.most_recent_star_reading_percentile);
 
       return {
         homeroomName,
@@ -161,6 +173,8 @@ export default class Breakdown extends React.Component {
         highestQuartileStarMath,
         lowestQuartileStarReading,
         highestQuartileStarReading,
+        starMathPercentileRange,
+        starReadingPercentileRange,
         studentCount: students.length
       };
     });
@@ -242,10 +256,16 @@ export default class Breakdown extends React.Component {
                   STAR Math<br/>Bottom Quartile
                 </th>
                 <th style={{padding: 5, textAlign: 'left', fontWeight: 'bold'}}>
+                  STAR Math<br/>Percentile range
+                </th>
+                <th style={{padding: 5, textAlign: 'left', fontWeight: 'bold'}}>
                   STAR Math<br/>Top Quartile
                 </th>
                 <th style={{padding: 5, textAlign: 'left', fontWeight: 'bold'}}>
                   STAR Reading<br/>Bottom Quartile
+                </th>
+                <th style={{padding: 5, textAlign: 'left', fontWeight: 'bold'}}>
+                  STAR Reading<br/>Percentile range
                 </th>
                 <th style={{padding: 5, textAlign: 'left', fontWeight: 'bold'}}>
                   STAR Reading<br/>Top Quartile
@@ -271,6 +291,8 @@ export default class Breakdown extends React.Component {
                   highestQuartileStarMath,
                   lowestQuartileStarReading,
                   highestQuartileStarReading,
+                  starMathPercentileRange,
+                  starReadingPercentileRange
                 } = statsForHomeroom;
                 const total = _.map(raceGroups, 'count').reduce((sum, a) => {
                   return sum + a;
@@ -338,10 +360,16 @@ export default class Breakdown extends React.Component {
                       <Bar percent={lowestQuartileStarMath} styles={styles.bar} threshold={10} />
                     </td>
                     <td style={{height: '100%', width: 140, padding: 5}}>
+                      {this.renderPercentileRangeBar(starMathPercentileRange)}
+                    </td>
+                    <td style={{height: '100%', width: 140, padding: 5}}>
                       <Bar percent={highestQuartileStarMath} styles={styles.bar} threshold={10} />
                     </td>
                     <td style={{height: '100%', width: 140, padding: 5}}>
                       <Bar percent={lowestQuartileStarReading} styles={styles.bar} threshold={10} />
+                    </td>
+                    <td style={{height: '100%', width: 140, padding: 5}}>
+                      {this.renderPercentileRangeBar(starReadingPercentileRange)}
                     </td>
                     <td style={{height: '100%', width: 140, padding: 5}}>
                       <Bar percent={highestQuartileStarReading} styles={styles.bar} threshold={10} />
@@ -366,6 +394,16 @@ export default class Breakdown extends React.Component {
             })}
           </div>
         </div>
+      </div>
+    );
+  }
+
+  renderPercentileRangeBar(range) {
+    return (
+      <div style={{position: 'relative', width: 100, backgroundColor: '#eee', height: 1}}>
+        <div style={{position: 'absolute', background: '#eee', left: range[0], width: range[1] - range[0], height: 6, top: -1}}>{'\u00A0'}</div>
+        <div style={{position: 'absolute', borderLeft: '1px solid #aaa', fontSize: 10, paddingLeft: 3, left: range[0], top: -5}}>{range[0]}</div>
+        <div style={{position: 'absolute', borderLeft: '1px solid #aaa', fontSize: 10, paddingLeft: 3, left: range[1], top: -5}}>{range[1]}</div>
       </div>
     );
   }


### PR DESCRIPTION
# Who is this PR for?
Insights team, principals

# What problem does this PR fix?
exploratory analysis

# What does this PR do?
Adds on to the awesome work in https://github.com/studentinsights/studentinsights/pull/1609, to see the range of scores as well, and see what that suggests.

# Screenshot (if adding a client-side feature)
In isolation:
<img width="124" alt="screen shot 2018-04-10 at 7 51 03 am" src="https://user-images.githubusercontent.com/1056957/38555405-f15739e6-3c93-11e8-8b21-2b7f77c25e11.png">

With other STAR context:
<img width="705" alt="screen shot 2018-04-10 at 7 47 09 am" src="https://user-images.githubusercontent.com/1056957/38555397-e7f57e08-3c93-11e8-8b68-fa3b63fe5a1b.png">
