### PR TITLE
Update Delayed::Job failures modes

### DIFF
--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -1,3 +1,4 @@
+# These methods are all hooks for https://github.com/collectiveidea/delayed_job
 class ImportJob
 
   def initialize(options:)
@@ -16,4 +17,14 @@ class ImportJob
     6.hours
   end
 
+  def error(job, exception)
+    extra_info =  { "hook" => "error", "job" => job.as_json }
+    ErrorMailer.error_report(exception, extra_info).deliver_now if Rails.env.production?
+  end
+
+  def failure(job)
+    extra_info =  { "hook" => "failure", "job" => job.as_json }
+    exception = StandardError.new('ImportJob#failure')
+    ErrorMailer.error_report(exception, extra_info).deliver_now if Rails.env.production?
+  end
 end

--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -18,12 +18,12 @@ class ImportJob
   end
 
   def error(job, exception)
-    extra_info =  { "hook" => "error", "job" => job.as_json }
+    extra_info =  { "hook" => "error", "job" => job.as_json(except: :log) }
     ErrorMailer.error_report(exception, extra_info).deliver_now if Rails.env.production?
   end
 
   def failure(job)
-    extra_info =  { "hook" => "failure", "job" => job.as_json }
+    extra_info =  { "hook" => "failure", "job" => job.as_json(except: :log) }
     exception = StandardError.new('ImportJob#failure')
     ErrorMailer.error_report(exception, extra_info).deliver_now if Rails.env.production?
   end

--- a/app/mailers/error_mailer.rb
+++ b/app/mailers/error_mailer.rb
@@ -4,7 +4,7 @@ class ErrorMailer < ActionMailer::Base
     @target_emails = ENV['ERROR_MAILER_LIST'].split(',')
     @subject = "ERROR: Student Insights ErrorMailer"
     @error_message = error.message
-    @error_backtrace = error.backtrace
+    @error_backtrace = error.backtrace || []
     @extra_info = extra_info
 
     mail(

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,1 +1,28 @@
+# This is overridden in specific jobs, but in general we don't want anything to run this long ever.
 Delayed::Worker.max_run_time = 24.hours
+
+# For the import job, we want it to run as one big job since the steps are sequential and dependent
+# on running in a particular order.  The job overall is idempotent, but dependending on where it fails,
+# the database may be in a somewhat inconsistent state (eg, only some records in a table are updated but
+# others are still stale).  We tolerate that, and on failure re-run the entire job.
+#
+# The failure cases we've seen are running out of memory or a dyno restart from a config change, when
+# Heroku sends a SIGERM and then SIGKILL.  In that case, we want want the job to be retried one more
+# time and then be marked as "failed" and not retried anymore if it fails the second time.  This
+# Delayed::Job record will stay in the database, and we'll see it in the import_records page.  Other
+# monitoring will catch and notify us that the failure occurred.
+#
+# If we didn't set `raise_signal_exception`, when the task was killed the job would stay locked and
+# when the worker dyno comes back up, it wouldn't be retried.  Hours laters (depending on the max_run_time),
+# Delayed::Job would release the job and it would be retried then.  If the job kept failing (eg, if it 
+# kept running out of memory), this would go on indefinitely for up to `max_attempts`, which with the 
+# default settings means it would keep retrying for ~20 days.
+#
+# More reading:
+# see https://github.com/collectiveidea/delayed_job#gory-details
+# https://stackoverflow.com/questions/10438100/long-running-delayed-job-jobs-stay-locked-after-a-restart-on-heroku
+Delayed::Worker.raise_signal_exceptions = true
+Delayed::Worker.max_attempts = 2
+Delayed::Worker.destroy_failed_jobs = false
+
+


### PR DESCRIPTION
# Who is this PR for?
NB educators

# What problem does this PR fix?
NB import jobs have been failing, and repeatedly retrying and failing.  We haven't been notified of these, and they haven't healed themselves because the root problem is still active.

# What does this PR do?
Changes the tuning for Delayed::Job to get different behavior in failure modes (see comments in code) and adds in email notifications on import job failures (although these aren't currently working, which we need to look at separately).

I'll verify this manually - deploy, run the import, clear the job queue, and then try killings some import tasks to see this behaves as expected.

After that we should be stable and can look at the actual issue with the import and why it's running out of memory.