### PR TITLE
Fix sorting for times and days in discipline dashboard

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
@@ -61,6 +61,34 @@ class SchoolDisciplineDashboard extends React.Component {
       title: "Incidents by " + selectedChart};
   }
 
+  sortChartData(chart) {
+    switch(chart.type) {
+    case 'time': return this.sortByTime(chart.disciplineIncidents);
+    case 'day': return this.sortByDay(chart.disciplineIncidents);
+    default: return chart.disciplineIncidents;
+    }
+  }
+
+  sortByDay(incidentsGroupedByDay) {
+    const dayOrder = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    let sortedHash = {};
+    dayOrder.forEach((day) => {
+      if (incidentsGroupedByDay[day]) sortedHash[day] = incidentsGroupedByDay[day];
+    });
+    return sortedHash;
+  }
+
+  sortByTime(incidentsGroupedByTime) {
+    const sortedTimes = Object.keys(incidentsGroupedByTime).sort((a, b) => {
+      return new Date('1970/01/01 ' + a) - new Date('1970/01/01 ' + b);
+    });
+    let sortedHash = {};
+    sortedTimes.forEach((hour) => {
+      sortedHash[hour] = incidentsGroupedByTime[hour];
+    });
+    return sortedHash;
+  }
+
   render() {
     const selectedChart = this.getChartData(this.state.selectedChart);
     return(
@@ -86,7 +114,7 @@ class SchoolDisciplineDashboard extends React.Component {
   }
 
   renderDisciplineChart(selectedChart) {
-    const categories = Object.keys(selectedChart.disciplineIncidents);
+    const categories = Object.keys(this.sortChartData(selectedChart));
     const seriesData = categories.map((type) => {
       const incidents = this.filterIncidentDates(selectedChart.disciplineIncidents[type]);
       return [type, incidents.length];

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolwideDisciplineIncidents.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolwideDisciplineIncidents.js
@@ -17,7 +17,7 @@ class SchoolWideDisciplineIncidents extends React.Component {
         if (moment.utc(incident.occurred_at).isSameOrAfter(moment.utc(startDate))) {
           schoolDisciplineEvents.push({
             student_id: incident.student_id,
-            location: incident.incident_location,
+            location: incident.incident_location || "Not Recorded",
             time: incident.has_exact_time ? moment.utc(incident.occurred_at).format("h A") : "Not Logged",
             classroom: student.homeroom_label || "No Homeroom",
             grade: student.grade,


### PR DESCRIPTION
# Who is this PR for?
Dashboard Users

# What problem does this PR fix?
Times and days of the week are not sorted in the discipline dashboard charts

# What does this PR do?
Imposes order on the time and day charts


# Checklists


+ [x] Author checked latest in IE - Discipline Dashboard
+ [x] Reviewer checked latest in IE - Discipline Dashboard
