### PR TITLE
Fix distribution of demo discipline incidents has_exact_time

### DIFF
--- a/spec/factories/discipline_incidents.rb
+++ b/spec/factories/discipline_incidents.rb
@@ -143,7 +143,7 @@ FactoryBot.define do
     sequence(:incident_code) { example_incident_codes.sample }
     sequence(:incident_location) { example_incident_locations.sample }
     sequence(:incident_description) { example_incident_descriptions.sample }
-    has_exact_time { if Random::rand(1.0) > 0.91 then true else false end }
+    has_exact_time { if Random::rand(1.0) > 0.084 then true else false end }
     occurred_at do
       time = DemoDataUtil.random_time
       if has_exact_time then time else time.beginning_of_day end


### PR DESCRIPTION
# Who is this PR for?

Devs working with the demo data.

# What problem does this PR fix?

Demo data doesn't match production! 

```
# production:

DisciplineIncident.count
=> 16884

DisciplineIncident.where(has_exact_time: true).count
=> 15450

DisciplineIncident.where(has_exact_time: false).count
=> 1434
```

Looks like the demo data generator has it backwards, instead of ~90% of discipline incidents **not** having an exact time, ~90% **do** have an exact time in the database. 

# What does this PR do?

Make the demo data generator match what we see in production, 91.6% of discipline incidents have an exact time.