### PR TITLE
Reduce logging frequency in attendance and behavior importers

### DIFF
--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -18,11 +18,10 @@ class AttendanceImporter
 
     @data.each_with_index do |row, index|
       import_row(row) if filter.include?(row)
-      @log.write(
-        "\r#{@success_count} valid rows imported, #{@error_list.size} invalid rows skipped"
-      )
+      @log.write("processed ${index} rows.") if index % 1000
     end
 
+    @log.write("\r#{@success_count} valid rows imported, #{@error_list.size} invalid rows skipped\n")
     @error_summary = @error_list.each_with_object(Hash.new(0)) do |error, memo|
       memo[error] += 1
     end

--- a/app/importers/file_importers/behavior_importer.rb
+++ b/app/importers/file_importers/behavior_importer.rb
@@ -15,13 +15,12 @@ class BehaviorImporter
     @success_count = 0
     @error_list = []
 
-    @data.each.each_with_index do |row, index|
+    @data.each_with_index do |row, index|
       import_row(row) if filter.include?(row)
-      @log.write(
-        "\r#{@success_count} valid rows imported, #{@error_list.size} invalid rows skipped"
-      )
+      @log.write("processed ${index} rows.") if index % 1000
     end
 
+    @log.write("\r#{@success_count} valid rows imported, #{@error_list.size} invalid rows skipped\n")
     @error_summary = @error_list.each_with_object(Hash.new(0)) do |error, memo|
       memo[error] += 1
     end


### PR DESCRIPTION
# Who is this PR for?
NB educators, developers

# What problem does this PR fix?
There's a lot going on with the imports; I'll write that up separately.  For now, this reduces logging intensity of the attendance and behavior importers.  We were logging a line of text for every CSV row, and with the change in https://github.com/studentinsights/studentinsights/pull/1606 to keep that in memory and write it to the database after, this is the point at which the import job runs out of memory.  This fixes that immediate problem by reducing the frequency of the logging, then we'll see what comes up next :)

There's other things visible in the logs related to https://github.com/studentinsights/studentinsights/pull/1613, but going to ship this and run again and the report out the rest after.