### PR TITLE
Adding SST Dates to Discipline Dashboard

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
@@ -6,6 +6,7 @@ import DashboardHelpers from '../DashboardHelpers';
 import StudentsTable from '../StudentsTable';
 import DashboardBarChart from '../DashboardBarChart';
 import DateSlider from '../DateSlider';
+import {latestNoteDateText} from '../../../helpers/latestNoteDateText';
 
 class SchoolDisciplineDashboard extends React.Component {
 
@@ -153,7 +154,7 @@ class SchoolDisciplineDashboard extends React.Component {
         id: student.id,
         first_name: student.first_name,
         last_name: student.last_name,
-        last_sst_date_text: student.last_sst_date_text,
+        last_sst_date_text: latestNoteDateText(300, student.event_notes),
         events: studentDisciplineIncidentCounts[student.id] || 0
       });
     });

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolwideDisciplineIncidents.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolwideDisciplineIncidents.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import SchoolDisciplineDashboard from './SchoolDisciplineDashboard';
 import DashboardHelpers from '../DashboardHelpers';
-import {latestNoteDateText} from '../../../helpers/latestNoteDateText';
 
 class SchoolWideDisciplineIncidents extends React.Component {
 
@@ -24,8 +23,7 @@ class SchoolWideDisciplineIncidents extends React.Component {
             day: moment.utc(incident.occurred_at).format("ddd"),
             offense: incident.incident_code,
             student_race: student.race,
-            occurred_at: incident.occurred_at,
-            last_sst_date_text: latestNoteDateText(300, student.event_notes)
+            occurred_at: incident.occurred_at
           });
         }
       });


### PR DESCRIPTION
# Who is this PR for?
Dashboard Users

# What problem does this PR fix?
SST dates were not displaying in the discipline dashboard

# What does this PR do?
Adds the dates!

# Screenshot (if adding a client-side feature)
![screen shot 2018-04-13 at 1 46 07 pm](https://user-images.githubusercontent.com/638809/38749900-2dba9808-3f21-11e8-86f0-6f27520d486f.png)

# Checklists

+ [x] Author checked latest in IE - Discipline Dashboard
+ [ ] Reviewer checked latest in IE - Discipline Dashboard
