### PR TITLE
Send district key context to Rollbar errors: server-side

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -18,7 +18,12 @@ Rollbar.configure do |config|
 
   # If you want to attach custom data to all exception and message reports,
   # provide a lambda like the following. It should return a hash.
-  config.custom_data_method = lambda { { deployment_key: ENV["DEPLOYMENT_KEY"] } }
+  config.custom_data_method = lambda {
+    {
+      deployment_key: ENV["DEPLOYMENT_KEY"],
+      district_key: ENV["DISTRICT_KEY"],
+    }
+  }
 
   # Add exception class names to the exception_level_filters hash to
   # change the level that exception is reported at. Note that if an exception


### PR DESCRIPTION
# Who is this PR for?

Developers who get error emails from Rollbar.

# What problem does this PR fix?

We don't know which school district / Heroku instance the error is coming from! 

# What does this PR do?

Sends the district key as an extra bit of information along with the error report. 