### PR TITLE
log.puts instead of .write, hash invalid rows

### DIFF
--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -18,15 +18,15 @@ class AttendanceImporter
 
     @data.each_with_index do |row, index|
       import_row(row) if filter.include?(row)
-      @log.write("processed #{index} rows.") if index % 10000 == 0
+      @log.puts("processed #{index} rows.") if index % 10000 == 0
     end
 
-    @log.write("\r#{@success_count} valid rows imported, #{@error_list.size} invalid rows skipped\n")
+    @log.puts("\r#{@success_count} valid rows imported, #{@error_list.size} invalid rows skipped")
     @error_summary = @error_list.each_with_object(Hash.new(0)) do |error, memo|
       memo[error] += 1
     end
-    @log.write("\n\nAttendanceImporter: Invalid rows summary: ")
-    @log.write(@error_summary)
+    @log.puts("\n\nAttendanceImporter: Invalid rows summary: ")
+    @log.puts(@error_summary)
   end
 
   def remote_file_name

--- a/app/importers/file_importers/behavior_importer.rb
+++ b/app/importers/file_importers/behavior_importer.rb
@@ -17,15 +17,15 @@ class BehaviorImporter
 
     @data.each_with_index do |row, index|
       import_row(row) if filter.include?(row)
-      @log.write("processed #{index} rows.") if index % 10000 == 0
+      @log.puts("processed #{index} rows.") if index % 10000 == 0
     end
 
-    @log.write("\r#{@success_count} valid rows imported, #{@error_list.size} invalid rows skipped\n")
+    @log.puts("\r#{@success_count} valid rows imported, #{@error_list.size} invalid rows skipped")
     @error_summary = @error_list.each_with_object(Hash.new(0)) do |error, memo|
       memo[error] += 1
     end
-    @log.write("\n\nBehaviorImporter: Invalid rows summary: ")
-    @log.write(@error_summary)
+    @log.puts("\n\nBehaviorImporter: Invalid rows summary: ")
+    @log.puts(@error_summary)
   end
 
   def client

--- a/app/importers/file_importers/courses_sections_importer.rb
+++ b/app/importers/file_importers/courses_sections_importer.rb
@@ -44,10 +44,10 @@ class CoursesSectionsImporter
         section = SectionRow.new(row, school_ids_dictionary, course.id).build
         section.save
       else
-        @log.puts("Course import invalid row: #{row}")
+        @log.puts("Course import invalid row")
       end
     else
-      @log.puts("Course import invalid row missing school_local_id: #{row}")
+      @log.puts("Course import invalid row missing school_local_id")
     end
   end
 

--- a/app/importers/file_importers/courses_sections_importer.rb
+++ b/app/importers/file_importers/courses_sections_importer.rb
@@ -44,10 +44,10 @@ class CoursesSectionsImporter
         section = SectionRow.new(row, school_ids_dictionary, course.id).build
         section.save
       else
-        @log.write("Course import invalid row: #{row}")
+        @log.puts("Course import invalid row: #{row}")
       end
     else
-      @log.write("Course import invalid row missing school_local_id: #{row}")
+      @log.puts("Course import invalid row missing school_local_id: #{row}")
     end
   end
 

--- a/app/importers/file_importers/csv_downloader.rb
+++ b/app/importers/file_importers/csv_downloader.rb
@@ -30,6 +30,6 @@ class CsvDownloader
 
   private
   def log(msg)
-    @log.write "CsvDownloader: #{msg}"
+    @log.puts "CsvDownloader: #{msg}"
   end
 end

--- a/app/importers/file_importers/educator_section_assignments_importer.rb
+++ b/app/importers/file_importers/educator_section_assignments_importer.rb
@@ -1,5 +1,3 @@
-require 'digest/sha1'
-
 class EducatorSectionAssignmentsImporter
 
   def initialize(options:)
@@ -55,7 +53,7 @@ class EducatorSectionAssignmentsImporter
       educator_section_assignment.save!
       @imported_assignments.push(educator_section_assignment.id)
     else
-      @log.puts("Educator Section Assignment Import invalid row: #{Digest::SHA1.hexdigest(row)}")
+      @log.puts("Educator Section Assignment Import invalid row")
     end
   end
 

--- a/app/importers/file_importers/educator_section_assignments_importer.rb
+++ b/app/importers/file_importers/educator_section_assignments_importer.rb
@@ -1,3 +1,5 @@
+require 'digest/sha1'
+
 class EducatorSectionAssignmentsImporter
 
   def initialize(options:)
@@ -53,7 +55,7 @@ class EducatorSectionAssignmentsImporter
       educator_section_assignment.save!
       @imported_assignments.push(educator_section_assignment.id)
     else
-      @log.write("Educator Section Assignment Import invalid row: #{row}")
+      @log.puts("Educator Section Assignment Import invalid row: #{Digest::SHA1.hexdigest(row)}")
     end
   end
 

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -1,5 +1,3 @@
-require 'digest/sha1'
-
 class EducatorsImporter
 
   def initialize(options:)
@@ -48,7 +46,7 @@ class EducatorsImporter
       homeroom = Homeroom.find_by_name(row[:homeroom]) if row[:homeroom]
       homeroom.update(educator: educator) if homeroom.present?
     else
-      @log.puts("EducatorsImporter: nil EducatorRow, skipping row with hash: #{Digest::SHA1.hexdigest(row)}")
+      @log.puts("EducatorsImporter: nil EducatorRow, skipping row")
     end
   end
 

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -1,3 +1,5 @@
+require 'digest/sha1'
+
 class EducatorsImporter
 
   def initialize(options:)
@@ -46,7 +48,7 @@ class EducatorsImporter
       homeroom = Homeroom.find_by_name(row[:homeroom]) if row[:homeroom]
       homeroom.update(educator: educator) if homeroom.present?
     else
-      @log.write("EducatorsImporter: nil EducatorRow, skipping row: #{row}")
+      @log.puts("EducatorsImporter: nil EducatorRow, skipping row with hash: #{Digest::SHA1.hexdigest(row)}")
     end
   end
 

--- a/app/importers/file_importers/star_math_importer.rb
+++ b/app/importers/file_importers/star_math_importer.rb
@@ -70,6 +70,6 @@ class StarMathImporter
   end
 
   def log(msg)
-    @log.write "StarMathImporter: #{msg}"
+    @log.puts "StarMathImporter: #{msg}"
   end
 end

--- a/app/importers/file_importers/star_reading_importer.rb
+++ b/app/importers/file_importers/star_reading_importer.rb
@@ -8,12 +8,12 @@ class StarReadingImporter
   def import
     return unless zip_file_name.present? && remote_file_name.present?
 
-    @log.write("\nDownloading ZIP file #{zip_file_name}...")
+    @log.puts("\nDownloading ZIP file #{zip_file_name}...")
 
     downloaded_zip = client.download_file(zip_file_name)
 
     Zip::File.open(downloaded_zip) do |zipfile|
-      @log.write("\nImporting #{remote_file_name}...")
+      @log.puts("\nImporting #{remote_file_name}...")
 
       data_string = zipfile.read(remote_file_name).encode('UTF-8', 'binary', {
         invalid: :replace, undef: :replace, replace: ''

--- a/app/importers/file_importers/student_section_assignments_importer.rb
+++ b/app/importers/file_importers/student_section_assignments_importer.rb
@@ -1,5 +1,3 @@
-require 'digest/sha1'
-
 class StudentSectionAssignmentsImporter
 
   def initialize(options:)
@@ -60,7 +58,7 @@ class StudentSectionAssignmentsImporter
       assignment.save!
       @imported_assignments.push(assignment.id)
     else
-      @log.puts("Student Section Assignment Import invalid row: #{Digest::SHA1.hexdigest(row)}")
+      @log.puts("Student Section Assignment Import invalid row")
     end
   end
 end

--- a/app/importers/file_importers/student_section_assignments_importer.rb
+++ b/app/importers/file_importers/student_section_assignments_importer.rb
@@ -1,3 +1,5 @@
+require 'digest/sha1'
+
 class StudentSectionAssignmentsImporter
 
   def initialize(options:)
@@ -58,7 +60,7 @@ class StudentSectionAssignmentsImporter
       assignment.save!
       @imported_assignments.push(assignment.id)
     else
-      @log.write("Student Section Assignment Import invalid row: #{row}")
+      @log.puts("Student Section Assignment Import invalid row: #{Digest::SHA1.hexdigest(row)}")
     end
   end
 end

--- a/app/importers/file_importers/student_section_grades_importer.rb
+++ b/app/importers/file_importers/student_section_grades_importer.rb
@@ -1,3 +1,5 @@
+require 'digest/sha1'
+
 class StudentSectionGradesImporter
 
   # Most of our file importer classes match to a SQL file in the /x2_export folder.
@@ -65,7 +67,7 @@ class StudentSectionGradesImporter
     if student_section_assignment
       student_section_assignment.save!
     else
-      @log.write("Student Section Grade Import invalid row: #{row}")
+      @log.puts("Student Section Grade Import invalid row: #{Digest::SHA1.hexdigest(row)}")
     end
   end
 end

--- a/app/importers/file_importers/student_section_grades_importer.rb
+++ b/app/importers/file_importers/student_section_grades_importer.rb
@@ -1,5 +1,3 @@
-require 'digest/sha1'
-
 class StudentSectionGradesImporter
 
   # Most of our file importer classes match to a SQL file in the /x2_export folder.
@@ -67,7 +65,7 @@ class StudentSectionGradesImporter
     if student_section_assignment
       student_section_assignment.save!
     else
-      @log.puts("Student Section Grade Import invalid row: #{Digest::SHA1.hexdigest(row)}")
+      @log.puts("Student Section Grade Import invalid row")
     end
   end
 end

--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -157,7 +157,7 @@ class ImportTask
 
   def log(msg)
     full_msg = "\n\n💾  ImportTask: #{msg}"
-    @log.write full_msg
+    @log.puts full_msg
     @record.log += full_msg
   end
 end

--- a/app/reports/assessments_report.rb
+++ b/app/reports/assessments_report.rb
@@ -1,7 +1,7 @@
 class AssessmentsReport < Struct.new :log
 
   def print_report
-    log.write(report)
+    log.puts(report)
   end
 
   private

--- a/app/reports/cleanup_report.rb
+++ b/app/reports/cleanup_report.rb
@@ -1,7 +1,7 @@
 class CleanupReport < Struct.new :log, :file_name, :pre_cleanup_size, :post_cleanup_size
 
   def print
-    log.write("CleanupReport:\n" + [extra_spacing, before_text, after_text, extra_spacing].join("\n"))
+    log.puts("CleanupReport:\n" + [extra_spacing, before_text, after_text, extra_spacing].join("\n"))
   end
 
   def extra_spacing

--- a/app/reports/import_task_report.rb
+++ b/app/reports/import_task_report.rb
@@ -96,6 +96,6 @@ class ImportTaskReport
   end
 
   def log(msg)
-    @log.write "ImportTaskReport: #{msg}"
+    @log.puts "ImportTaskReport: #{msg}"
   end
 end


### PR DESCRIPTION
more from https://github.com/studentinsights/studentinsights/pull/1613#issuecomment-381155196.

This changes `log.write` back to `logs.puts` (changed in https://github.com/studentinsights/studentinsights/pull/1547 for no particular reason; I think I thought they were equivalent).  Since `write` doesn't put a newline at the end, in the import task when there's a lot of logging, there's a lot of data written without ever flushing.  This was particularly influential before https://github.com/studentinsights/studentinsights/pull/1621, when we logged a full line of text status for every row in the attendance and behavior files.  This switches everything back to puts.  I believe this also explains why jobs would appear not to run - I just ran into this now where a job looked like it wasn't running, and soon as I cycle the dyno there's many many log lines that must have been running for a while but never flushing.

Separately, this hashes the output of invalid rows in logging; these contain data we don't want in logs.