### PR TITLE
Send district context to Rollbar errors: client-side

### DIFF
--- a/app/views/shared/_rollbar.html.erb
+++ b/app/views/shared/_rollbar.html.erb
@@ -25,6 +25,7 @@
     if (env) {
       payload.environment = env.railsEnvironment;
       payload.deploymentKey = env.deploymentKey;
+      payload.districtKey = env.districtKey;
     }
   }
 


### PR DESCRIPTION
# Who is this PR for?

Developers who get error emails from Rollbar.

# What problem does this PR fix?

We don't know which school district / Heroku instance the error is coming from! 

# What does this PR do?

Sends the district key as an extra bit of information along with the error report. 