### PR TITLE
Ensure absences and tardies are being eager loaded

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -44,7 +44,9 @@ class SchoolsController < ApplicationController
   #Individual dashboard data endpoints will replace school_administrator_dashboard once they're stable
   def absence_dashboard_data
     student_absence_data = students_for_dashboard(@school)
-      .includes([homeroom: :educator], :dashboard_absences, :event_notes)
+      .includes([homeroom: :educator], :absences, :event_notes)
+      .where("absences.occurred_at >= ?", 1.year.ago).references(:absences)
+
     student_absence_data_json = student_absence_data.map do |student|
       individual_student_absence_data(student)
     end
@@ -54,7 +56,9 @@ class SchoolsController < ApplicationController
 
   def tardies_dashboard_data
     student_tardies_data = students_for_dashboard(@school)
-      .includes([homeroom: :educator], :dashboard_tardies, :event_notes)
+      .includes([homeroom: :educator], :tardies, :event_notes)
+      .where("tardies.occurred_at >= ?", 1.year.ago).references(:tardies)
+
     student_tardies_data_json = student_tardies_data.map do |student|
       individual_student_tardies_data(student)
     end


### PR DESCRIPTION
# Who is this PR for?

Users of the absences/tardies dashboards.

# What problem does this PR fix?

Slow to load: 12-15 seconds to see data in production. 

# Notes

I loaded the schools/hea/absences/ page in my local environment. In the logs I saw an N+1 pattern, meaning that each absence record was being loaded one by one instead of all at once:

![screen shot 2018-04-16 at 1 41 30 pm](https://user-images.githubusercontent.com/3209501/38830404-d0049642-4181-11e8-8a2f-1c4c1d4fcf6d.png)

I saw that the query code for this endpoint JSON was using `includes`, but it was passing a named scoped association `:dashboard_absences` to the includes clause instead of just `:absences`. I tried passing down `:absences` and saw that the N+1 pattern went away:

![screen shot 2018-04-16 at 1 50 33 pm](https://user-images.githubusercontent.com/3209501/38830555-57cb04d0-4182-11e8-8f67-a0fcd3e26a82.png)

I wanted to add back in the "only load absences for the past year" feature provided by `:dashboard_absences`, so I used a `where` clause as described in the docs: http://guides.rubyonrails.org/active_record_querying.html#specifying-conditions-on-eager-loaded-associations.

Here's what the logs looked like now:

![screen shot 2018-04-16 at 2 09 25 pm](https://user-images.githubusercontent.com/3209501/38830649-a5a4e50e-4182-11e8-9d68-4c92bffcea41.png)

Along the way I saw significant performance improvements. Here is the timing I saw from the from the GET request to the JSON endpoint at the beginning, before any refactors:

```
[0] Completed 200 OK in 5985ms (Views: 4358.3ms | ActiveRecord: 399.0ms)
```

Here's what I see now:

```
[0] Completed 200 OK in 1639ms (Views: 1136.4ms | ActiveRecord: 118.2ms)
```

So it looks like making sure absences and tardies are being eager loaded makes the endpoint 3 times faster. @edavidsonsawyer, do you see a similar improvement on your end? (I'm using the "more demo data" setting by the way.) I changed only the dark endpoints here so we could ship this PR and it wouldn't affect any of the user-facing dashboard pages. 