### PR TITLE
Dashboard Students Table UX Improvements

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashResetButton.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashResetButton.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+
+//Custom button to reset category selection in Dashboard
+class DashResetButton extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onKeyDown = this.onKeyDown.bind(this);
+  }
+
+  componentDidMount() {
+    document.addEventListener('keydown', this.onKeyDown);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.onKeyDown);
+  }
+
+  // Key code 27 is the ESC key
+  onKeyDown(e) {
+    if (e.keyCode == 27) this.props.clearSelection();
+  }
+
+  render() {
+    return (
+      <div className="DashResetButton">
+        <a
+          style={{
+            backgroundColor: '#FFA500'
+          }}
+          onClick={this.props.clearSelection}>
+          {this.props.selectedCategory && 'Reset Students (ESC)'}
+        </a>
+      </div>
+    );
+  }
+}
+DashResetButton.propTypes = {
+  selectedCategory: PropTypes.string,
+  clearSelection: PropTypes.func.isRequired
+};
+
+export default DashResetButton;

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
@@ -79,8 +79,12 @@ class StudentsTable extends React.Component {
   render() {
     return(
       <div className= 'StudentsList'>
+        {this.props.selectedCategory && <button onClick={this.props.resetFn}>All Students</button>}
         <table className='students-list'>
-          <caption>{this.renderCaption()}</caption>
+          {this.props.selectedCategory?
+            <caption style={{backgroundColor:'#FFA500'}}>{this.renderCaption()}</caption> :
+            <caption>{this.renderCaption()}</caption>
+          }
           <thead>
             <tr>
               <th
@@ -88,7 +92,7 @@ class StudentsTable extends React.Component {
                   className={this.headerClassName('last_name')}>Name</th>
               <th
                   onClick={this.onClickHeader.bind(null, 'events', 'number')}
-                  className={this.headerClassName('events')}>Incidents</th>
+                  className={this.headerClassName('events')}>{this.props.incidentType}</th>
               <th
                   onClick={this.onClickHeader.bind(null, 'last_sst_date_text', 'date')}
                   className={this.headerClassName('last_sst_date_text')}>Last SST</th>
@@ -136,6 +140,8 @@ StudentsTable.propTypes = {
     last_sst_date_text: SharedPropTypes.nullableWithKey(PropTypes.string)
   })).isRequired,
   selectedCategory: PropTypes.string,
+  incidentType: PropTypes.string.isRequired, //Specific incident type being displayed
+  resetFn: PropTypes.func.isRequired, //Function to reset student list to display all students
   schoolYearFlag: PropTypes.bool
 };
 

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
@@ -7,6 +7,7 @@ import {
 } from '../../helpers/SortHelpers';
 import * as Routes from '../../helpers/Routes';
 import SharedPropTypes from '../../helpers/prop_types.jsx';
+import DashResetButton from './DashResetButton';
 
 
 class StudentsTable extends React.Component {
@@ -79,12 +80,11 @@ class StudentsTable extends React.Component {
   render() {
     return(
       <div className= 'StudentsList'>
-        {this.props.selectedCategory && <button onClick={this.props.resetFn}>All Students</button>}
+        <div style={{display: 'flex', justifyContent: 'space-between'}}>
+          {this.renderCaption()}
+          <DashResetButton clearSelection={this.props.resetFn} selectedCategory={this.props.selectedCategory}/>
+        </div>
         <table className='students-list'>
-          {this.props.selectedCategory?
-            <caption style={{backgroundColor:'#FFA500'}}>{this.renderCaption()}</caption> :
-            <caption>{this.renderCaption()}</caption>
-          }
           <thead>
             <tr>
               <th

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
@@ -146,7 +146,9 @@ class SchoolAbsenceDashboard extends React.Component {
     return (
       <StudentsTable
         rows = {rows}
-        selectedCategory = {this.state.selectedHomeroom}/>
+        selectedCategory = {this.state.selectedHomeroom}
+        incidentType={"Absences"}
+        resetFn={this.resetStudentList}/>
     );
   }
 

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
@@ -164,7 +164,9 @@ class SchoolDisciplineDashboard extends React.Component {
     return (
       <StudentsTable
         rows = {rows}
-        selectedCategory = {this.state.selectedCategory}/>
+        selectedCategory = {this.state.selectedCategory}
+        incidentType={"Discipline Incidents"}
+        resetFn={this.resetStudentList}/>
     );
   }
 }

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolTardiesDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolTardiesDashboard.js
@@ -144,8 +144,10 @@ class SchoolTardiesDashboard extends React.Component {
     return (
       <StudentsTable
         rows = {rows}
-        selectedHomeroom = {this.state.selectedHomeroom}
-        schoolYearFlag ={true}/>
+        selectedCategory = {this.state.selectedHomeroom}
+        schoolYearFlag ={true}
+        incidentType={"Tardies"}
+        resetFn={this.resetStudentList}/>
     );
   }
 }

--- a/spec/javascripts/school_administrator_dashboard/StudentsTable.test.js
+++ b/spec/javascripts/school_administrator_dashboard/StudentsTable.test.js
@@ -6,7 +6,7 @@ import {createStudents} from './DashboardTestData.js';
 
 describe('Dashboard Students Table', () => {
   const nowMoment = moment.utc();
-  const table = shallow(<StudentsTable rows={createStudents(nowMoment)}/>);
+  const table = shallow(<StudentsTable rows={createStudents(nowMoment)} incidentType={"Test Incidents"} resetFn={(value) => null}/>);
 
   it('renders the students list', () => {
     expect(table.find("div").hasClass("StudentsList")).toEqual(true);
@@ -14,7 +14,7 @@ describe('Dashboard Students Table', () => {
 
   it('renders headers for name, incident count and last SST', () => {
     const headerTexts = table.find('thead th').map(node => node.text());
-    expect(headerTexts).toEqual(['Name', 'Incidents', 'Last SST']);
+    expect(headerTexts).toEqual(['Name', 'Test Incidents', 'Last SST']);
   });
 
   it('renders the first row', () => {

--- a/spec/javascripts/school_administrator_dashboard/StudentsTable.test.js
+++ b/spec/javascripts/school_administrator_dashboard/StudentsTable.test.js
@@ -9,7 +9,7 @@ describe('Dashboard Students Table', () => {
   const table = shallow(<StudentsTable rows={createStudents(nowMoment)} incidentType={"Test Incidents"} resetFn={(value) => null}/>);
 
   it('renders the students list', () => {
-    expect(table.find("div").hasClass("StudentsList")).toEqual(true);
+    expect(table.find("div").first().hasClass("StudentsList")).toEqual(true);
   });
 
   it('renders headers for name, incident count and last SST', () => {


### PR DESCRIPTION
# Who is this PR for?
Dashboard Users

# What problem does this PR fix?
User testing indicated it was easy to be confused about when a user had selected a particular homeroom and didn't know how to reset the student list. 

# What does this PR do?
Adds a "reset student list" button to the student list and highlights the list title when a subgroup is selected.

# Screenshot (if adding a client-side feature)
![student_list_ux](https://user-images.githubusercontent.com/638809/38847087-d7bdedf6-41cd-11e8-8985-d949a391030d.gif)


# Checklists

## Javascript QA

+ [x] Author checked latest in IE - Absence Dashboard
+ [x] Author checked latest in IE - Tardies Dashboard
+ [x] Author checked latest in IE - Discipline Dashboard
+ [x] Reviewer checked latest in IE - Absence Dashboard
+ [x] Reviewer checked latest in IE - Tardies Dashboard
+ [x] Reviewer checked latest in IE - Discipline Dashboard
