### PR TITLE
Ship individual absences/tardies endpoints

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -27,21 +27,6 @@ class SchoolsController < ApplicationController
     })
   end
 
-  def school_administrator_dashboard
-    dashboard_students = students_for_dashboard(@school)
-      .includes([homeroom: :educator], :dashboard_absences, :event_notes, :dashboard_tardies)
-    dashboard_students_json = dashboard_students.map do |student|
-      individual_student_dashboard_data(student)
-    end
-
-    @serialized_data = {
-      students: dashboard_students_json,
-      current_educator: current_educator
-    }
-    render 'shared/serialized_data'
-  end
-
-  #Individual dashboard data endpoints will replace school_administrator_dashboard once they're stable
   def absence_dashboard_data
     student_absence_data = students_for_dashboard(@school)
       .includes([homeroom: :educator], :dashboard_absences, :event_notes)

--- a/app/lib/paths_for_educator.rb
+++ b/app/lib/paths_for_educator.rb
@@ -17,8 +17,8 @@ class PathsForEducator
     end
 
     if @educator.school.present? && @educator.schoolwide_access? && !@educator.districtwide_access?
-      links[:absences] = url_helpers.school_administrator_dashboard_school_path(@educator.school) + '#/absences_dashboard'
-      links[:tardies] = url_helpers.school_administrator_dashboard_school_path(@educator.school) + '#/tardies_dashboard'
+      links[:absences] = url_helpers.absences_school_path(@educator.school)
+      links[:tardies] = url_helpers.tardies_school_path(@educator.school)
     end
 
     if @educator.school.present? && @educator.school.is_high_school? && @educator.sections.size > 0

--- a/app/views/educators/districtwide_admin_homepage.html.erb
+++ b/app/views/educators/districtwide_admin_homepage.html.erb
@@ -21,8 +21,8 @@
               <li class="school-name">
                 <%= school.name %><br/>
                 <%= link_to 'Roster', school_url(school) %>
-                | <%= link_to 'Absences', school_administrator_dashboard_school_url(school) + '#/absences_dashboard' %>
-                | <%= link_to 'Tardies', school_administrator_dashboard_school_url(school) + '#/tardies_dashboard' %>
+                | <%= link_to 'Absences', absences_school_url(school) %>
+                | <%= link_to 'Tardies', tardies_school_url(school) %>
               </li>
           <% end %>
         </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,6 @@ Rails.application.routes.draw do
   resources :schools, only: [:show] do
     member do
       get :overview
-      get :school_administrator_dashboard
       get :overview_json
       get :csv
       get 'absences' => 'ui#ui'

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -170,10 +170,10 @@ describe SchoolsController, :type => :controller do
 
   end
 
-  describe '#dashboard' do
+  describe '#absence_dashboard_data' do
     def make_request(school_id)
       request.env['HTTPS'] = 'on'
-      get :school_administrator_dashboard, params: { id: school_id }
+      get :absence_dashboard_data, params: { id: school_id }
     end
 
     context 'districtwide access' do

--- a/spec/lib/paths_for_educator_spec.rb
+++ b/spec/lib/paths_for_educator_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe PathsForEducator do
     # healey
     expect(navbar_links(pals.healey_laura_principal)).to eq({
       school: '/schools/hea',
-      absences: '/schools/hea/school_administrator_dashboard#/absences_dashboard',
-      tardies: '/schools/hea/school_administrator_dashboard#/tardies_dashboard'
+      absences: '/schools/hea/absences',
+      tardies: '/schools/hea/tardies',
     })
     expect(navbar_links(pals.healey_ell_teacher)).to eq({})
     expect(navbar_links(pals.healey_sped_teacher)).to eq({})


### PR DESCRIPTION
# Who is this PR for?

School and district administrators who use the absences and tardies dashboards to gain insights into attendance issues. 

# What problem does this PR fix?

Dashboards slow to load.

# What does this PR do?

Speeds up dashboard loading by ~45% (based on what we've seen locally) by subbing in individual endpoints that load less data. More detail on measurements here: https://github.com/studentinsights/studentinsights/pull/1630#issuecomment-382035893.

# GIF (principal user role, Internet Explorer)

![schoolwide](https://user-images.githubusercontent.com/3209501/38885014-118e5728-4237-11e8-8e88-0df82ced6df0.gif)

# GIF (districtwide admin user role, Internet Explorer)

![districtwide](https://user-images.githubusercontent.com/3209501/38884927-ccef3ea2-4236-11e8-9137-680acdf80f07.gif)
