### PR TITLE
Only send SST note data to dashboard pages

### DIFF
--- a/app/assets/javascripts/helpers/latestNoteDateText.js
+++ b/app/assets/javascripts/helpers/latestNoteDateText.js
@@ -2,6 +2,12 @@ import _ from 'lodash';
 
 // Find the latest event note of a particular type, and return a string
 // of that date.
+
+// TODO (ARS): Sometimes we want to use this function on a list of notes that
+// all have the same event_note_type. In that case we just want to use the sorting
+// and text formatting functions here. We could switch the order of the arguments
+// passed in and make eventNoteTypeId an optional second argument.
+
 export function latestNoteDateText(eventNoteTypeId, eventNotes) {
   const sortedEventNotes = _.sortBy(eventNotes, note => new Date(note.recorded_at));
   const latestNoteOfType = _.findLast(sortedEventNotes, { event_note_type_id: eventNoteTypeId });

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashboardHelpers.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashboardHelpers.js
@@ -5,12 +5,7 @@ import _ from 'lodash';
 export default {
 
   groupByHomeroom: function(studentRecords) {
-    const studentsByHomeroom = _.groupBy(studentRecords, 'homeroom_label');
-    if (studentsByHomeroom[null]) {
-      studentsByHomeroom["No Homeroom"] = studentsByHomeroom[null];
-      delete studentsByHomeroom[null];
-    }
-    return studentsByHomeroom;
+    return _.groupBy(studentRecords, 'homeroom_label');
   },
 
   averageDailyAttendance: function(absenceEventsByDay, size) {

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
@@ -138,7 +138,7 @@ class SchoolAbsenceDashboard extends React.Component {
         id: student.id,
         first_name: student.first_name,
         last_name: student.last_name,
-        last_sst_date_text: latestNoteDateText(300, student.event_notes),
+        last_sst_date_text: latestNoteDateText(300, student.sst_notes),
         events: studentAbsenceCounts[student.id] || 0
       });
     });

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
@@ -157,7 +157,7 @@ class SchoolDisciplineDashboard extends React.Component {
         id: student.id,
         first_name: student.first_name,
         last_name: student.last_name,
-        last_sst_date_text: latestNoteDateText(300, student.event_notes),
+        last_sst_date_text: latestNoteDateText(300, student.sst_notes),
         events: studentDisciplineIncidentCounts[student.id] || 0
       });
     });

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolwideDisciplineIncidents.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolwideDisciplineIncidents.js
@@ -18,7 +18,7 @@ class SchoolWideDisciplineIncidents extends React.Component {
             student_id: incident.student_id,
             location: incident.incident_location || "Not Recorded",
             time: incident.has_exact_time ? moment.utc(incident.occurred_at).startOf('hour').format('h:mm a') : "Not Logged",
-            classroom: student.homeroom_label || "No Homeroom",
+            classroom: student.homeroom_label,
             grade: student.grade,
             day: moment.utc(incident.occurred_at).format("ddd"),
             offense: incident.incident_code,

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolTardiesDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolTardiesDashboard.js
@@ -136,7 +136,7 @@ class SchoolTardiesDashboard extends React.Component {
         id: student.id,
         first_name: student.first_name,
         last_name: student.last_name,
-        last_sst_date_text: latestNoteDateText(300, student.event_notes),
+        last_sst_date_text: latestNoteDateText(300, student.sst_notes),
         events: studentTardyCounts[student.id] || 0
       });
     });

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -165,66 +165,48 @@ class SchoolsController < ApplicationController
     end
   end
 
-  # Methods for Dashboard
-
-  def individual_student_dashboard_data(student)
-    # This is a temporary workaround for New Bedford
-    homeroom_label = student.try(:homeroom).try(:educator).try(:full_name) || student.try(:homeroom).try(:name)
-    HashWithIndifferentAccess.new({
-      first_name: student.first_name,
-      last_name: student.last_name,
-      id: student.id,
-      grade: student.grade,
-      race: student.race,
-      homeroom_label: homeroom_label,
-      absences: student.dashboard_absences,
-      tardies: student.dashboard_tardies,
-      event_notes: student.event_notes
-    })
-  end
+  # Methods for Dashboards #
 
   def individual_student_absence_data(student)
-    # Gathers only the information needed for a specific dashboard view.
-    homeroom_label = student.try(:homeroom).try(:educator).try(:full_name) || student.try(:homeroom).try(:name)
-    HashWithIndifferentAccess.new({
+    {
       first_name: student.first_name,
       last_name: student.last_name,
       id: student.id,
-      homeroom_label: homeroom_label,
+      homeroom_label: homeroom_label(student.homeroom),
       absences: student.dashboard_absences,
       event_notes: student.event_notes
-    })
+    }
   end
 
   def individual_student_tardies_data(student)
-    # Gathers only the information needed for a specific dashboard view.
-    homeroom_label = student.try(:homeroom).try(:educator).try(:full_name) || student.try(:homeroom).try(:name)
-    HashWithIndifferentAccess.new({
+    {
       first_name: student.first_name,
       last_name: student.last_name,
       id: student.id,
-      homeroom_label: homeroom_label,
+      homeroom_label: homeroom_label(student.homeroom),
       tardies: student.dashboard_tardies,
       event_notes: student.event_notes
     })
   end
 
   def individual_student_discipline_data(student)
-    # Gathers only the information needed for a specific dashboard view.
-    homeroom_label = student.try(:homeroom).try(:educator).try(:full_name) || student.try(:homeroom).try(:name)
-    HashWithIndifferentAccess.new({
+    {
       first_name: student.first_name,
       last_name: student.last_name,
       id: student.id,
-      homeroom_label: homeroom_label,
+      homeroom_label: homeroom_label(student.homeroom),
       grade: student.grade,
       race: student.race,
       discipline_incidents: student.discipline_incidents,
-      event_notes: student.event_notes
+      event_notes: student.event_notes.where(event_note_type_id: 300)
     })
   end
 
   def students_for_dashboard(school)
     school.students.active
+  end
+
+  def homeroom_label(homeroom)
+    homeroom.try(:educator).try(:full_name) || homeroom.try(:name) || "No Homeroom"
   end
 end

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -29,7 +29,7 @@ class SchoolsController < ApplicationController
 
   def absence_dashboard_data
     student_absence_data = students_for_dashboard(@school)
-      .includes([homeroom: :educator], :dashboard_absences, :event_notes)
+      .includes([homeroom: :educator], :dashboard_absences, :sst_notes)
     student_absence_data_json = student_absence_data.map do |student|
       individual_student_absence_data(student)
     end
@@ -39,7 +39,7 @@ class SchoolsController < ApplicationController
 
   def tardies_dashboard_data
     student_tardies_data = students_for_dashboard(@school)
-      .includes([homeroom: :educator], :dashboard_tardies, :event_notes)
+      .includes([homeroom: :educator], :dashboard_tardies, :sst_notes)
     student_tardies_data_json = student_tardies_data.map do |student|
       individual_student_tardies_data(student)
     end
@@ -174,7 +174,7 @@ class SchoolsController < ApplicationController
       id: student.id,
       homeroom_label: homeroom_label(student.homeroom),
       absences: student.dashboard_absences,
-      event_notes: student.event_notes
+      sst_notes: student.sst_notes,
     }
   end
 
@@ -185,8 +185,8 @@ class SchoolsController < ApplicationController
       id: student.id,
       homeroom_label: homeroom_label(student.homeroom),
       tardies: student.dashboard_tardies,
-      event_notes: student.event_notes
-    })
+      sst_notes: student.sst_notes,
+    }
   end
 
   def individual_student_discipline_data(student)
@@ -198,8 +198,8 @@ class SchoolsController < ApplicationController
       grade: student.grade,
       race: student.race,
       discipline_incidents: student.discipline_incidents,
-      event_notes: student.event_notes.where(event_note_type_id: 300)
-    })
+      sst_notes: student.sst_notes,
+    }
   end
 
   def students_for_dashboard(school)

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -28,7 +28,7 @@ class SchoolsController < ApplicationController
   end
 
   def absence_dashboard_data
-    student_absence_data = students_for_dashboard(@school)
+    student_absence_data = active_students(@school)
       .includes([homeroom: :educator], :dashboard_absences, :sst_notes)
     student_absence_data_json = student_absence_data.map do |student|
       individual_student_absence_data(student)
@@ -38,7 +38,7 @@ class SchoolsController < ApplicationController
   end
 
   def tardies_dashboard_data
-    student_tardies_data = students_for_dashboard(@school)
+    student_tardies_data = active_students(@school)
       .includes([homeroom: :educator], :dashboard_tardies, :sst_notes)
     student_tardies_data_json = student_tardies_data.map do |student|
       individual_student_tardies_data(student)
@@ -48,7 +48,7 @@ class SchoolsController < ApplicationController
   end
 
   def discipline_dashboard_data
-    student_discipline_data = students_for_dashboard(@school)
+    student_discipline_data = active_students(@school)
       .includes([homeroom: :educator], :discipline_incidents, :event_notes)
     student_discipline_data_json = student_discipline_data.map do |student|
       individual_student_discipline_data(student)
@@ -202,7 +202,7 @@ class SchoolsController < ApplicationController
     }
   end
 
-  def students_for_dashboard(school)
+  def active_students(school)
     school.students.active
   end
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -14,15 +14,18 @@ class Student < ActiveRecord::Base
   has_many :event_notes, dependent: :destroy
   has_many :services, dependent: :destroy
   has_many :tardies, dependent: :destroy
-  has_many :dashboard_tardies, -> { where('occurred_at >= ?', 1.year.ago) },
-    class_name: "Tardy"
   has_many :absences, dependent: :destroy
-  has_many :dashboard_absences, -> { where('occurred_at >= ?', 1.year.ago) },
-    class_name: "Absence"
   has_many :discipline_incidents, dependent: :destroy
   has_one :iep_document, dependent: :destroy
   has_many :student_section_assignments
   has_many :sections, through: :student_section_assignments
+
+  has_many :dashboard_tardies, -> { where('occurred_at >= ?', 1.year.ago) },
+    class_name: "Tardy"
+  has_many :dashboard_absences, -> { where('occurred_at >= ?', 1.year.ago) },
+    class_name: "Absence"
+  has_many :sst_notes, -> { where(event_note_type_id: 300) },
+    class_name: "EventNote"
 
   has_one :student_risk_level, dependent: :destroy
 

--- a/spec/javascripts/school_administrator_dashboard/DashboardTestData.js
+++ b/spec/javascripts/school_administrator_dashboard/DashboardTestData.js
@@ -1,5 +1,4 @@
-
-//stubbed events for dashboard specs
+// Stubbed events for dashboard specs
 export function createTestEvents(nowMoment) {
   return {
     oneMonthAgo: {
@@ -29,8 +28,7 @@ export function createTestEvents(nowMoment) {
   };
 }
 
-
-//stubbed students for dashboard specs
+// Stubbed students for dashboard specs
 export function createStudents(nowMoment) {
   const testEvents = createTestEvents(nowMoment);
   return [{
@@ -87,7 +85,7 @@ export function createStudents(nowMoment) {
   {
     first_name: 'Pulcinella',
     last_name: 'Vecchi',
-    homeroom_label: null,
+    homeroom_label: 'No Homeroom',
     id: 6,
     absences: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo],
     tardies: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo],
@@ -96,10 +94,9 @@ export function createStudents(nowMoment) {
   }];
 }
 
-
 export function createSchoolTardyEvents(nowMoment) {
   const testEvents = createTestEvents(nowMoment);
-  
+
   const oneMonthAgo = nowMoment.clone().subtract(1, 'months').format('YYYY-MM-DD');
   const threeMonthsAgo = nowMoment.clone().subtract(3, 'months').format('YYYY-MM-DD');
   const fourMonthsAgo = nowMoment.clone().subtract(4, 'months').format('YYYY-MM-DD');
@@ -113,4 +110,3 @@ export function createSchoolTardyEvents(nowMoment) {
 
   return schoolTardyEvents;
 }
-


### PR DESCRIPTION
# Who is this PR for?

Users of the absences/tardies dashboards.

# What problem does this PR fix?

Slow load times: ~4 seconds to see data in production. (Note that this was a major improvement from a couple days ago when load times were at 12+ seconds! See #1629, #1630.)

# What does this PR do?

Since we're only displaying Last SST Note on the dashboard views, only send down SST Notes data to the front-end by using a scoped query. If we need to use more event note data in the dashboards, we can always add to the query.

I tested the effect of these changes on load times (local environment, "more students mode" demo data, absences dashboard). I loaded each page 5 times to account for caching effects.

**loading the dashboard on `master`:**

```
1. [0] Completed 200 OK in 2486ms (Views: 1696.9ms | ActiveRecord: 78.8ms)
2. [0] Completed 200 OK in 2253ms (Views: 1638.0ms | ActiveRecord: 58.5ms)
3. [0] Completed 200 OK in 2228ms (Views: 1601.4ms | ActiveRecord: 82.4ms)
4. [0] Completed 200 OK in 2169ms (Views: 1630.0ms | ActiveRecord: 69.7ms)
5. [0] Completed 200 OK in 2195ms (Views: 1625.7ms | ActiveRecord: 58.5ms)
```

**loading the dashboard on this brach:**

```
1. [0] Completed 200 OK in 1401ms (Views: 635.2ms | ActiveRecord: 59.5ms)
2. [0] Completed 200 OK in 1011ms (Views: 570.9ms | ActiveRecord: 36.7ms)
3. [0] Completed 200 OK in 1259ms (Views: 732.3ms | ActiveRecord: 30.4ms)
4. [0] Completed 200 OK in 1143ms (Views: 657.9ms | ActiveRecord: 37.5ms)
5. [0] Completed 200 OK in 1093ms (Views: 585.7ms | ActiveRecord: 48.3ms)
```

Overall it looks like this change cuts load times by 50%. 

This PR also makes some other changes to the dashboard Ruby code which I'll add individual GitHub comments on.