### PR TITLE
Fix nondeterministic spec

### DIFF
--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -90,17 +90,17 @@ RSpec.describe Authorizer do
   describe '#authorized' do
     describe 'Student' do
       it 'limits access with Student.all' do
-        expect(authorized(pals.uri) { Student.all }).to eq [
+        expect(authorized(pals.uri) { Student.all }).to match_array [
           pals.healey_kindergarten_student,
           pals.shs_freshman_mari
         ]
-        expect(authorized(pals.healey_vivian_teacher) { Student.all }).to eq [
+        expect(authorized(pals.healey_vivian_teacher) { Student.all }).to match_array [
           pals.healey_kindergarten_student
         ]
-        expect(authorized(pals.shs_jodi) { Student.all }).to eq [
+        expect(authorized(pals.shs_jodi) { Student.all }).to match_array [
           pals.shs_freshman_mari
         ]
-        expect(authorized(pals.shs_bill_nye) { Student.all }).to eq [
+        expect(authorized(pals.shs_bill_nye) { Student.all }).to match_array [
           pals.shs_freshman_mari
         ]
       end


### PR DESCRIPTION
# Who is this PR for?

Developers.

# What problem does this PR fix?

Authorizer spec can fail non-deterministically because it's sensitive to array order, see https://travis-ci.org/studentinsights/studentinsights/builds/368166588.

# What does this PR do?

Uses RSpec's `match_array` which cares about array contents but is insensitive to order. 