### PR TITLE
Limit dashboard students table height and make scrollable

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
@@ -78,8 +78,8 @@ class StudentsTable extends React.Component {
   }
 
   render() {
-    return(
-      <div className= 'StudentsList'>
+    return (
+      <div className='StudentsList' style={style.root}>
         <div style={{display: 'flex', justifyContent: 'space-between'}}>
           {this.renderCaption()}
           <DashResetButton clearSelection={this.props.resetFn} selectedCategory={this.props.selectedCategory}/>
@@ -145,6 +145,9 @@ StudentsTable.propTypes = {
 };
 
 const style = {
+  root: {
+    marginTop: 20
+  },
   table: {
     width: 450,
     border: '1px solid #ccc',
@@ -161,13 +164,17 @@ const style = {
     display: 'block',
     width: 450,
     height: 480,
-    overflowY: 'scroll'
+    overflowY: 'scroll',
+    borderTop: '1px solid #ccc',
+    borderBottom: '1px solid #ccc',
   },
   td: {
     width: 150,
+    textAlign: 'left',
   },
   th: {
     width: 150,
+    textAlign: 'left',
   }
 };
 

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
@@ -84,42 +84,41 @@ class StudentsTable extends React.Component {
           {this.renderCaption()}
           <DashResetButton clearSelection={this.props.resetFn} selectedCategory={this.props.selectedCategory}/>
         </div>
-        <table className='students-list'>
-          <thead>
+        <table className='students-list' style={style.table}>
+          <thead style={style.thead}>
             <tr>
-              <th
+              <th style={style.th}
                   onClick={this.onClickHeader.bind(null, 'last_name', 'string')}
                   className={this.headerClassName('last_name')}>Name</th>
-              <th
+              <th style={style.th}
                   onClick={this.onClickHeader.bind(null, 'events', 'number')}
                   className={this.headerClassName('events')}>{this.props.incidentType}</th>
-              <th
+              <th style={style.th}
                   onClick={this.onClickHeader.bind(null, 'last_sst_date_text', 'date')}
                   className={this.headerClassName('last_sst_date_text')}>Last SST</th>
             </tr>
           </thead>
-          <tfoot>
-            <tr>
-              <td>{'Total: '}</td>
-              <td>{this.totalEvents()}</td>
-              <td></td>
-            </tr>
-          </tfoot>
-          <tbody>
+          <tbody style={style.tbody}>
             {this.orderedRows().map(student => {
               return (
                 <tr key={student.id}>
-                  <td>
+                  <td style={style.td}>
                     <a href={Routes.studentProfile(student.id)}>
                       {student.first_name} {student.last_name}
                     </a>
                   </td>
-                  <td>{student.events}</td>
-                  <td>{student.last_sst_date_text}</td>
+                  <td style={style.td}>{student.events}</td>
+                  <td style={style.td}>{student.last_sst_date_text}</td>
                 </tr>
               );
             })}
           </tbody>
+          <tfoot style={style.tfoot}>
+            <tr>
+              <td style={style.td}>{'Total: '}</td>
+              <td style={style.td}>{this.totalEvents()}</td>
+            </tr>
+          </tfoot>
         </table>
       </div>
     );
@@ -143,6 +142,33 @@ StudentsTable.propTypes = {
   incidentType: PropTypes.string.isRequired, //Specific incident type being displayed
   resetFn: PropTypes.func.isRequired, //Function to reset student list to display all students
   schoolYearFlag: PropTypes.bool
+};
+
+const style = {
+  table: {
+    width: 450,
+    border: '1px solid #ccc',
+  },
+  thead: {
+    display: 'block',
+    width: 450,
+  },
+  tfoot: {
+    display: 'block',
+    width: 450,
+  },
+  tbody: {
+    display: 'block',
+    width: 450,
+    height: 480,
+    overflowY: 'scroll'
+  },
+  td: {
+    width: 150,
+  },
+  th: {
+    width: 150,
+  }
 };
 
 export default StudentsTable;

--- a/app/assets/stylesheets/components/school_dashboard.scss
+++ b/app/assets/stylesheets/components/school_dashboard.scss
@@ -1,4 +1,3 @@
-
 .DashboardContainer {
   display: flex;
   height: 85vh;
@@ -50,22 +49,8 @@
 }
 
 table.students-list {
-  margin: auto;
-  border: 1px solid #ccc;
-  width: 100%;
-
   thead th, tfoot td {
-    height: 30px;
-    line-height: 30px;
     text-align: left;
-  }
-
-  tfoot {
-    width: 100%;
-    border-bottom: 1px solid #ccc;
-  }
-
-  tbody td, thead th, tfoot td {
   }
 
   tbody {
@@ -73,5 +58,4 @@ table.students-list {
     border-bottom: 1px solid #ccc;
   }
 }
-
 

--- a/app/assets/stylesheets/components/school_dashboard.scss
+++ b/app/assets/stylesheets/components/school_dashboard.scss
@@ -43,19 +43,3 @@
 .ui-datepicker-next {
   float: right;
 }
-
-.StudentsList {
-  margin-top: 20px;
-}
-
-table.students-list {
-  thead th, tfoot td {
-    text-align: left;
-  }
-
-  tbody {
-    border-top: 1px solid #ccc;
-    border-bottom: 1px solid #ccc;
-  }
-}
-


### PR DESCRIPTION
# Who is this PR for?

Dashboard users. 

# What problem does this PR fix?

Height of the table is huge, awkward to navigate. Here's what it look like with an amount of demo data equal to the number of students at Healey School:

![big-list](https://user-images.githubusercontent.com/3209501/38945011-eb62adfa-42fa-11e8-9f12-bcd324eef3ff.gif)

# What does this PR do?

Caps the dashboard students table height at 480px and sets overflow-Y to scroll to make a scrollbar appear by default in Internet Explorer. 

# GIF (absences)
![absences-fixed-table](https://user-images.githubusercontent.com/3209501/38954325-f13cff20-4316-11e8-9057-c6bf5e64c549.gif)

# GIF (tardies)
![tardies-fixed-table](https://user-images.githubusercontent.com/3209501/38954320-f11ece4c-4316-11e8-9d20-d14f1a401027.gif)

# GIF (discipline)
![discipline-fixed-table](https://user-images.githubusercontent.com/3209501/38954323-f12e1aaa-4316-11e8-9cc9-c7315466f068.gif)

# Checklists

## Javascript QA

+ [x] Author checked latest in IE - Absences Dashboard
+ [x] Author checked latest in IE - Tardies Dashboard
+ [x] Author checked latest in IE - Discipline Dashboard
+ [ ] Reviewer checked latest in IE - Absences Dashboard
+ [ ] Reviewer checked latest in IE - Tardies Dashboard
+ [ ] Reviewer checked latest in IE - Discipline Dashboard