### PR TITLE
 Fix another nondeterministic spec in authorizer_spec.rb

### DIFF
--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Authorizer do
 
       it 'if `select` was used on an ActiveRecord::Relation for students, fields needed for authorization are added in' do
         thin_relation = Student.select(:id, :local_id).all
-        expect((authorized(pals.uri) { thin_relation }).map(&:id)).to eq([
+        expect((authorized(pals.uri) { thin_relation }).map(&:id)).to match_array([
           pals.healey_kindergarten_student.id,
           pals.shs_freshman_mari.id
         ])


### PR DESCRIPTION
# Who is this PR for?

Developers. 

# What problem does this PR fix?

Non-deterministic spec failure. 

# What does this PR do?

Uses `match_array`, which is an order-insensitive matcher. 