### PR TITLE
Handle SignalException in import task; don't rely on Delayed::Job for restarts

### DIFF
--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -15,24 +15,30 @@ class ImportTask
   end
 
   def connect_transform_import
-    @record = create_import_record
-    @report = create_report
+    begin
+      @record = create_import_record
+      @report = create_report
 
-    log('Starting validation...')
-    validate_district_option
-    seed_schools_if_needed
-    validate_school_options
-    log('Done validation.')
+      log('Starting validation...')
+      validate_district_option
+      seed_schools_if_needed
+      validate_school_options
+      log('Done validation.')
 
-    log('Starting importing work...')
-    @report.print_initial_counts_report
-    import_all_the_data
-    log('Done importing work.')
+      log('Starting importing work...')
+      @report.print_initial_counts_report
+      import_all_the_data
+      log('Done importing work.')
 
-    log('Starting update tasks and final report...')
-    run_update_tasks
-    @report.print_final_counts_report
-    log('Done.')
+      log('Starting update tasks and final report...')
+      run_update_tasks
+      @report.print_final_counts_report
+      log('Done.')
+    rescue SignalException => e
+      log("Encountered a SignalException!: #{e}")
+      log('Putting a new job into the queue...')
+      Delayed::Job.enqueue ImportJob.new(options: @options)
+    end
   end
 
   private

--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -37,7 +37,9 @@ class ImportTask
     rescue SignalException => e
       log("Encountered a SignalException!: #{e}")
       log('Putting a new job into the queue...')
-      Delayed::Job.enqueue ImportJob.new(options: @options)
+      Delayed::Job.enqueue ImportJob.new(
+        options: @options.merge({ attempt: @options.attempt + 1 })
+      )
     end
   end
 

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -8,19 +8,23 @@ Delayed::Worker.max_run_time = 24.hours
 #
 # The failure cases we've seen are running out of memory or a dyno restart from a config change, when
 # Heroku sends a SIGERM and then SIGKILL.  In that case, we want want the job to be retried one more
-# time and then be marked as "failed" and not retried anymore if it fails the second time.  This
-# Delayed::Job record will stay in the database, and we'll see it in the import_records page.  Other
-# monitoring will catch and notify us that the failure occurred.
+# time and then not retried anymore if it fails the second time.
 #
+# We found that creating this flow was difficult to do through Delayed::Job config. Instead, we're
+# handling SIGTERM in the ImportTask class with `rescue SignalException`.
+#
+# * * We may be able to remove these two lines of config since they don't appear to be having
+# * * an effect, see https://github.com/studentinsights/studentinsights/issues/1626#issue-314269511:
+Delayed::Worker.max_attempts = 2
+Delayed::Worker.destroy_failed_jobs = false
+
 # If we didn't set `raise_signal_exception`, when the task was killed the job would stay locked and
 # when the worker dyno comes back up, it wouldn't be retried.  Hours laters (depending on the max_run_time),
 # Delayed::Job would release the job and it would be retried then.  If the job kept failing (eg, if it
 # kept running out of memory), this would go on indefinitely for up to `max_attempts`, which with the
 # default settings means it would keep retrying for ~20 days.
-#
+Delayed::Worker.raise_signal_exceptions = true
+
 # More reading:
 # see https://github.com/collectiveidea/delayed_job#gory-details
 # https://stackoverflow.com/questions/10438100/long-running-delayed-job-jobs-stay-locked-after-a-restart-on-heroku
-Delayed::Worker.raise_signal_exceptions = true
-Delayed::Worker.max_attempts = 2
-Delayed::Worker.destroy_failed_jobs = false

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -14,8 +14,8 @@ Delayed::Worker.max_run_time = 24.hours
 #
 # If we didn't set `raise_signal_exception`, when the task was killed the job would stay locked and
 # when the worker dyno comes back up, it wouldn't be retried.  Hours laters (depending on the max_run_time),
-# Delayed::Job would release the job and it would be retried then.  If the job kept failing (eg, if it 
-# kept running out of memory), this would go on indefinitely for up to `max_attempts`, which with the 
+# Delayed::Job would release the job and it would be retried then.  If the job kept failing (eg, if it
+# kept running out of memory), this would go on indefinitely for up to `max_attempts`, which with the
 # default settings means it would keep retrying for ~20 days.
 #
 # More reading:
@@ -24,5 +24,3 @@ Delayed::Worker.max_run_time = 24.hours
 Delayed::Worker.raise_signal_exceptions = true
 Delayed::Worker.max_attempts = 2
 Delayed::Worker.destroy_failed_jobs = false
-
-

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -22,10 +22,12 @@ class Import
       desc: "Import data in a background job"
 
     def import
+      job_options = options.merge({ attempt: 0 })
+
       if options.fetch(:background)
-        Delayed::Job.enqueue ImportJob.new(options: options)
+        Delayed::Job.enqueue ImportJob.new(options: job_options)
       else
-        ImportTask.new(options: options).connect_transform_import
+        ImportTask.new(options: job_options).connect_transform_import
       end
     end
   end


### PR DESCRIPTION
# Who is this PR for?
Nightly import job.

# What problem does this PR fix?

Two problems.

First problem: the nightly import job often gets interrupted by Heroku deploys or restarts. This causes it to end. We'd like to gracefully restart. As @kevinrobinson writes in `delayed_job_config.rb`:

  > The failure cases we've seen are running out of memory or a dyno restart from a config change, when Heroku sends a SIGERM and then SIGKILL.  In that case, we want want the job to be retried one more time and then be marked as "failed" and not retried anymore if it fails the second time. 

Second problem: Delayed::Job isn't restarting jobs that fail, even after @kevinrobinson changed the config in #1613.

Quoting @kevinrobinson again: 

> It doesn't look like "destroyed_failed_jobs = false" worked. Logs show this line: Job ImportJob (id=73) REMOVED permanently because of 1 consecutive failures. That's the opposite of what I thought that config line would do :\ So I think we are still in a state where if there's a deploy, the job just gets interrupted and dropped.
> ...
> And in trying to debug this now, I can't seem to get the workers to pick up jobs in the queue. It may be there's some "backoff on failure" config that I can't understand. The README in their repo doesn't describe this though so I got stuck and couldn't debug further because I couldn't get any jobs to run. Before stopping, I cleared the queue again so it was empty when I stopped.

# What does this PR do?
Add code to handle restarting the job ourselves. This logic is very simple to add, whereas the Delayed::Job config doesn't seem to work properly and is very difficult to read and debug. I'd rather skip dealing with Delayed::Job and just roll this ourselves.

# GIF

![retry](https://user-images.githubusercontent.com/3209501/39010698-007c95e0-43d5-11e8-9651-7e5f3e00b051.gif)

This shows how interrupting the worker task causes the job to log the signal interruption, re-try exactly once, and then give up if interrupted again leaving now Delayed::Job behind. 

# Next steps

+ Trigger a manual import job and a manual `heroku restart` in production to verify that this works as expected
+ Verify that removing the Delayed::Job config for `destroy_failed_jobs` and `max_attempts` has no effect