### PR TITLE
Save more import process logs

### DIFF
--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -173,5 +173,6 @@ class ImportTask
     full_msg = "\n\n💾  ImportTask: #{msg}"
     @log.puts full_msg
     @record.log += full_msg
+    @record.save
   end
 end


### PR DESCRIPTION
# Who is this PR for?

Developers working on debugging the import process.

# What problem does this PR fix?

Logs aren't being saved and sent to the Import Records page except after a successful import; we want to capture logs even when there's a SIGTERM sent to the job (see #1638).

# What does this PR do?

Saves the logs of an Import Process job every time they're added to (about ~20 times per import task).