### PR TITLE
Adding range captions to dashboard charts

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashRangeButtons.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashRangeButtons.js
@@ -18,18 +18,19 @@ class DashRangeButtons extends React.Component {
   render() {
     return (
       <div className="DashRangeButtons">
+        Filter by:
         <DashButton
           onClick={() => this.onClick(this.props.schoolYearFilter, 'schoolYear')}
           isSelected={this.state.selectedButton === 'schoolYear'}
           buttonText={'School Year'}/>
-      <DashButton
-          onClick={() => this.onClick(this.props.ninetyDayFilter, 'ninetyDays')}
-          isSelected={this.state.selectedButton === 'ninetyDays'}
-          buttonText={'90 Days'}/>
-      <DashButton
-          onClick={() => this.onClick(this.props.fortyFiveDayFilter, 'fortyFiveDays')}
-          isSelected={this.state.selectedButton === 'fortyFiveDays'}
-          buttonText={'45 Days'}/>
+        <DashButton
+            onClick={() => this.onClick(this.props.ninetyDayFilter, 'ninetyDays')}
+            isSelected={this.state.selectedButton === 'ninetyDays'}
+            buttonText={'90 Days'}/>
+        <DashButton
+            onClick={() => this.onClick(this.props.fortyFiveDayFilter, 'fortyFiveDays')}
+            isSelected={this.state.selectedButton === 'fortyFiveDays'}
+            buttonText={'45 Days'}/>
       </div>
     );
   }

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
@@ -15,7 +15,8 @@ class SchoolAbsenceDashboard extends React.Component {
     super(props);
     this.state = {
       displayDates: this.props.dateRange,
-      selectedHomeroom: null
+      selectedHomeroom: null,
+      selectedRange: 'School Year'
     };
     this.setStudentList = (highchartsEvent) => {
       this.setState({selectedHomeroom: highchartsEvent.point.category});
@@ -87,7 +88,7 @@ class SchoolAbsenceDashboard extends React.Component {
           seriesData = {filteredAttendanceSeries}
           yAxisMin = {80}
           yAxisMax = {100}
-          titleText = {'Average Attendance By Month'}
+          titleText = {'Average Attendance By Month (' + this.state.selectedRange + ')'}
           measureText = {'Attendance (Percent)'}
           tooltip = {{
             pointFormat: 'Average Daily Attendance: <b>{point.y}</b>',
@@ -111,7 +112,7 @@ class SchoolAbsenceDashboard extends React.Component {
           seriesData = {homeroomSeries}
           yAxisMin = {80}
           yAxisMax = {100}
-          titleText = {'Average Attendance By Homeroom'}
+          titleText = {'Average Attendance By Homeroom (' + this.state.selectedRange + ')'}
           measureText = {'Attendance (Percent)'}
           tooltip = {{
             pointFormat: 'Average Daily Attendance: <b>{point.y}</b>',
@@ -154,9 +155,15 @@ class SchoolAbsenceDashboard extends React.Component {
     return (
       <div className="DashboardRangeButtons">
         <DashRangeButtons
-          schoolYearFilter={() => this.setState({displayDates: DashboardHelpers.filterDates(dateRange, schoolYearStart, today)})}
-          ninetyDayFilter={() => this.setState({displayDates: DashboardHelpers.filterDates(dateRange, ninetyDaysAgo, today)})}
-          fortyFiveDayFilter={() => this.setState({displayDates: DashboardHelpers.filterDates(dateRange, fortyFiveDaysAgo, today)})}/>
+          schoolYearFilter={() => this.setState({
+            displayDates: DashboardHelpers.filterDates(dateRange, schoolYearStart, today),
+            selectedRange: 'School Year'})}
+          ninetyDayFilter={() => this.setState({
+            displayDates: DashboardHelpers.filterDates(dateRange, ninetyDaysAgo, today),
+            selectedRange: '90 Days'})}
+          fortyFiveDayFilter={() => this.setState({
+            displayDates: DashboardHelpers.filterDates(dateRange, fortyFiveDaysAgo, today),
+            selectedRange: '45 Days'})}/>
       </div>
     );
   }

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
@@ -61,13 +61,13 @@ class SchoolAbsenceDashboard extends React.Component {
   render() {
     return (
         <div className="DashboardContainer">
-          <div className="DashboardChartsColumn">
-            {this.renderMonthlyAbsenceChart()}
-            {this.renderHomeroomAbsenceChart()}
-          </div>
           <div className="DashboardRosterColumn">
             {this.renderRangeSelector()}
             {this.renderStudentAbsenceTable()}
+          </div>
+          <div className="DashboardChartsColumn">
+            {this.renderMonthlyAbsenceChart()}
+            {this.renderHomeroomAbsenceChart()}
           </div>
         </div>
     );

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
@@ -88,7 +88,7 @@ class SchoolAbsenceDashboard extends React.Component {
           seriesData = {filteredAttendanceSeries}
           yAxisMin = {80}
           yAxisMax = {100}
-          titleText = {'Average Attendance By Month (' + this.state.selectedRange + ')'}
+          titleText = {`Average Attendance By Month (${this.state.selectedRange})`}
           measureText = {'Attendance (Percent)'}
           tooltip = {{
             pointFormat: 'Average Daily Attendance: <b>{point.y}</b>',
@@ -112,7 +112,7 @@ class SchoolAbsenceDashboard extends React.Component {
           seriesData = {homeroomSeries}
           yAxisMin = {80}
           yAxisMax = {100}
-          titleText = {'Average Attendance By Homeroom (' + this.state.selectedRange + ')'}
+          titleText = {`Average Attendance By Homeroom (${this.state.selectedRange})`}
           measureText = {'Attendance (Percent)'}
           tooltip = {{
             pointFormat: 'Average Daily Attendance: <b>{point.y}</b>',

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolTardiesDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolTardiesDashboard.js
@@ -66,12 +66,12 @@ class SchoolTardiesDashboard extends React.Component {
   render() {
     return (
         <div className="DashboardContainer">
+          <div className="DashboardRosterColumn">
+            {this.renderStudentTardiesTable()}
+          </div>
           <div className="DashboardChartsColumn">
             {this.renderMonthlyTardiesChart()}
             {this.renderHomeroomTardiesChart()}
-          </div>
-          <div className="DashboardRosterColumn">
-            {this.renderStudentTardiesTable()}
           </div>
         </div>
     );

--- a/app/assets/stylesheets/components/school_dashboard.scss
+++ b/app/assets/stylesheets/components/school_dashboard.scss
@@ -39,10 +39,11 @@
 .DashRangeButtons {
   display: flex;
   justify-content: space-between;
+  align-items: flex-end;
   padding: 20px 40px 0px 40px;
   margin-top: 10px;
   .DashButton {
-    width: 33%;
+    width: 25%;
   }
 }
 

--- a/app/assets/stylesheets/components/school_dashboard.scss
+++ b/app/assets/stylesheets/components/school_dashboard.scss
@@ -13,7 +13,7 @@
 .DashboardRosterColumn {
   flex: 1;
   vertical-align: top;
-  padding-right: 20px;
+  padding-left: 20px;
 }
 
 .DashboardChart {


### PR DESCRIPTION
# Who is this PR for?
Dashboard Users

# What problem does this PR fix?
The charts show data within the selected range, but don't communicate that to users

# What does this PR do?
Adds a caption to the chart so it explains the range. See discussion in #1631 

# Screenshot (if adding a client-side feature)
![chartcaptions](https://user-images.githubusercontent.com/638809/39060722-26d6360e-4490-11e8-84a5-2deec53a2ded.gif)
