### PR TITLE
Remove exit statement

### DIFF
--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -46,8 +46,6 @@ class ImportTask
       end
 
       log('Bye!')
-
-      exit
     end
   end
 


### PR DESCRIPTION
# Who is this PR for?

Developers.

# What problem does this PR fix?

The `exit` statement at the end of the ImportTask SIGTERM cleanup was meant to simply exit the job, but instead it triggers a Rollbar error email.

# What does this PR do?

Removes the exit statement; Heroku sends its own SIGKILL several seconds after sending SIGTERM. 