### PR TITLE
Work on absences dashboard info heirarchy

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashButton.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashButton.js
@@ -1,16 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-
 //Custom all purpose dashboard button
 class DashButton extends React.Component {
 
   render() {
+    const {isSelected} = this.props;
     return (
       <div className="DashButton">
         <a
           style={{
-            backgroundColor: this.props.isSelected? 'rgba(49, 119, 201, 0.75)' : '',
+            backgroundColor: isSelected ? 'rgba(49, 119, 201, 0.75)' : '',
+            color: isSelected ? 'white' : 'black',
             width: '100%',
             display: 'flex',
             justifyContent: 'center'
@@ -22,6 +23,7 @@ class DashButton extends React.Component {
     );
   }
 }
+
 DashButton.propTypes = {
   buttonText: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashRangeButtons.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashRangeButtons.js
@@ -17,20 +17,22 @@ class DashRangeButtons extends React.Component {
 
   render() {
     return (
-      <div className="DashRangeButtons">
-        Filter by:
-        <DashButton
-          onClick={() => this.onClick(this.props.schoolYearFilter, 'schoolYear')}
-          isSelected={this.state.selectedButton === 'schoolYear'}
-          buttonText={'School Year'}/>
-        <DashButton
-            onClick={() => this.onClick(this.props.ninetyDayFilter, 'ninetyDays')}
-            isSelected={this.state.selectedButton === 'ninetyDays'}
-            buttonText={'90 Days'}/>
-        <DashButton
-            onClick={() => this.onClick(this.props.fortyFiveDayFilter, 'fortyFiveDays')}
-            isSelected={this.state.selectedButton === 'fortyFiveDays'}
-            buttonText={'45 Days'}/>
+      <div className="DashRangeButtonWrapper">
+        <div className="DashRangeButtons">
+          Filter:
+          <DashButton
+            onClick={() => this.onClick(this.props.schoolYearFilter, 'schoolYear')}
+            isSelected={this.state.selectedButton === 'schoolYear'}
+            buttonText='This School Year' />
+          <DashButton
+              onClick={() => this.onClick(this.props.ninetyDayFilter, 'ninetyDays')}
+              isSelected={this.state.selectedButton === 'ninetyDays'}
+              buttonText='Past 90 Days' />
+          <DashButton
+              onClick={() => this.onClick(this.props.fortyFiveDayFilter, 'fortyFiveDays')}
+              isSelected={this.state.selectedButton === 'fortyFiveDays'}
+              buttonText='Past 45 Days' />
+        </div>
       </div>
     );
   }

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
@@ -95,8 +95,8 @@ class StudentsTable extends React.Component {
               <th style={style.th}
                   onClick={this.onClickHeader.bind(null, 'events', 'number')}
                   className={this.headerClassName('events')}>
-                {this.props.incidentType}<br/>
-                <span style={{fontWeight: 'normal'}}>({this.props.incidentSubtitle})</span>
+                {this.props.incidentType}
+                {this.renderIncidentTypeSubtitle()}
               </th>
               <th style={style.th}
                   onClick={this.onClickHeader.bind(null, 'last_sst_date_text', 'date')}
@@ -137,6 +137,15 @@ class StudentsTable extends React.Component {
     return this.props.selectedCategory
       ? this.props.selectedCategory + schoolYearCaption
       : "All Students" + schoolYearCaption;
+  }
+
+  renderIncidentTypeSubtitle() {
+    const {incidentSubtitle} = this.props;
+    if (!incidentSubtitle) return;
+
+    return (
+      <span style={{fontWeight: 'normal'}}><br/>({this.props.incidentSubtitle})</span>
+    );
   }
 }
 

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
@@ -80,7 +80,7 @@ class StudentsTable extends React.Component {
   render() {
     return (
       <div className='StudentsList' style={style.root}>
-        <div style={{display: 'flex', justifyContent: 'space-between'}}>
+        <div style={style.caption}>
           {this.renderCaption()}
           <DashResetButton clearSelection={this.props.resetFn} selectedCategory={this.props.selectedCategory}/>
         </div>
@@ -89,13 +89,20 @@ class StudentsTable extends React.Component {
             <tr>
               <th style={style.th}
                   onClick={this.onClickHeader.bind(null, 'last_name', 'string')}
-                  className={this.headerClassName('last_name')}>Name</th>
+                  className={this.headerClassName('last_name')}>
+                Name
+              </th>
               <th style={style.th}
                   onClick={this.onClickHeader.bind(null, 'events', 'number')}
-                  className={this.headerClassName('events')}>{this.props.incidentType}</th>
+                  className={this.headerClassName('events')}>
+                {this.props.incidentType}<br/>
+                <span style={{fontWeight: 'normal'}}>({this.props.incidentSubtitle})</span>
+              </th>
               <th style={style.th}
                   onClick={this.onClickHeader.bind(null, 'last_sst_date_text', 'date')}
-                  className={this.headerClassName('last_sst_date_text')}>Last SST</th>
+                  className={this.headerClassName('last_sst_date_text')}>
+                Last SST
+              </th>
             </tr>
           </thead>
           <tbody style={style.tbody}>
@@ -125,8 +132,11 @@ class StudentsTable extends React.Component {
   }
 
   renderCaption() {
-    const schoolYearCaption = this.props.schoolYearFlag? " (School Year)" : "";
-    return this.props.selectedCategory ? this.props.selectedCategory + schoolYearCaption : "All Students" + schoolYearCaption;
+    const schoolYearCaption = this.props.schoolYearFlag ? " (School Year)" : "";
+
+    return this.props.selectedCategory
+      ? this.props.selectedCategory + schoolYearCaption
+      : "All Students" + schoolYearCaption;
   }
 }
 
@@ -140,17 +150,25 @@ StudentsTable.propTypes = {
   })).isRequired,
   selectedCategory: PropTypes.string,
   incidentType: PropTypes.string.isRequired, //Specific incident type being displayed
+  incidentSubtitle: PropTypes.string,
   resetFn: PropTypes.func.isRequired, //Function to reset student list to display all students
   schoolYearFlag: PropTypes.bool
 };
 
 const style = {
   root: {
-    marginTop: 20
+    marginTop: 20,
+    border: '1px solid #ccc',
+    // borderRight: '1px solid #ccc',
+    // borderLeft: '1px solid #ccc',
+  },
+  caption: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: 5,
   },
   table: {
     width: 450,
-    border: '1px solid #ccc',
   },
   thead: {
     display: 'block',
@@ -175,6 +193,7 @@ const style = {
   th: {
     width: 150,
     textAlign: 'left',
+    verticalAlign: 'bottom'
   }
 };
 

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
@@ -80,11 +80,11 @@ class StudentsTable extends React.Component {
   render() {
     return (
       <div className='StudentsList' style={style.root}>
-        <div style={style.caption}>
-          {this.renderCaption()}
-          <DashResetButton clearSelection={this.props.resetFn} selectedCategory={this.props.selectedCategory}/>
-        </div>
         <table className='students-list' style={style.table}>
+          <div style={style.caption}>
+            {this.renderCaption()}
+            <DashResetButton clearSelection={this.props.resetFn} selectedCategory={this.props.selectedCategory}/>
+          </div>
           <thead style={style.thead}>
             <tr>
               <th style={style.th}
@@ -167,9 +167,6 @@ StudentsTable.propTypes = {
 const style = {
   root: {
     marginTop: 20,
-    border: '1px solid #ccc',
-    // borderRight: '1px solid #ccc',
-    // borderLeft: '1px solid #ccc',
   },
   caption: {
     display: 'flex',
@@ -178,6 +175,7 @@ const style = {
   },
   table: {
     width: 450,
+    border: '1px solid #ccc',
   },
   thead: {
     display: 'block',

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
@@ -16,7 +16,7 @@ class SchoolAbsenceDashboard extends React.Component {
     this.state = {
       displayDates: this.props.dateRange,
       selectedHomeroom: null,
-      selectedRange: 'School Year'
+      selectedRange: 'This School Year'
     };
     this.setStudentList = (highchartsEvent) => {
       this.setState({selectedHomeroom: highchartsEvent.point.category});
@@ -60,9 +60,10 @@ class SchoolAbsenceDashboard extends React.Component {
 
   render() {
     return (
+      <div>
+        {this.renderRangeSelector()}
         <div className="DashboardContainer">
           <div className="DashboardRosterColumn">
-            {this.renderRangeSelector()}
             {this.renderStudentAbsenceTable()}
           </div>
           <div className="DashboardChartsColumn">
@@ -70,6 +71,7 @@ class SchoolAbsenceDashboard extends React.Component {
             {this.renderHomeroomAbsenceChart()}
           </div>
         </div>
+      </div>
     );
   }
 
@@ -137,11 +139,14 @@ class SchoolAbsenceDashboard extends React.Component {
       });
     });
 
+    const {selectedRange} = this.state;
+
     return (
       <StudentsTable
-        rows = {rows}
-        selectedCategory = {this.state.selectedHomeroom}
-        incidentType={"Absences"}
+        rows={rows}
+        selectedCategory={this.state.selectedHomeroom}
+        incidentType='Absences'
+        incidentSubtitle={selectedRange}
         resetFn={this.resetStudentList}/>
     );
   }
@@ -157,13 +162,13 @@ class SchoolAbsenceDashboard extends React.Component {
         <DashRangeButtons
           schoolYearFilter={() => this.setState({
             displayDates: DashboardHelpers.filterDates(dateRange, schoolYearStart, today),
-            selectedRange: 'School Year'})}
+            selectedRange: 'This School Year'})}
           ninetyDayFilter={() => this.setState({
             displayDates: DashboardHelpers.filterDates(dateRange, ninetyDaysAgo, today),
-            selectedRange: '90 Days'})}
+            selectedRange: 'Past 90 Days'})}
           fortyFiveDayFilter={() => this.setState({
             displayDates: DashboardHelpers.filterDates(dateRange, fortyFiveDaysAgo, today),
-            selectedRange: '45 Days'})}/>
+            selectedRange: 'Past 45 Days'})}/>
       </div>
     );
   }

--- a/app/assets/stylesheets/components/school_dashboard.scss
+++ b/app/assets/stylesheets/components/school_dashboard.scss
@@ -40,7 +40,7 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  padding: 20px 40px 0px 40px;
+  padding: 20px 40px 0 0;
   margin-top: 10px;
   .DashButton {
     width: 25%;

--- a/app/assets/stylesheets/components/school_dashboard.scss
+++ b/app/assets/stylesheets/components/school_dashboard.scss
@@ -7,7 +7,7 @@
   flex: 2 1;
   display: flex;
   flex-direction: column;
-  padding: 10px 20px 0px 20px
+  padding: 0 20px;
 }
 
 .DashboardRosterColumn {
@@ -21,7 +21,6 @@
   width: 100%;
   margin-top: 20px;
   padding: 10px 10px 10px 10px;
-  border: 1px solid #ccc;
 
   div {
     height: 100%;
@@ -36,12 +35,19 @@
   margin-bottom: 7px;
 }
 
+.DashRangeButtonWrapper {
+  border-top: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+  padding: 10px 20px;
+  margin: 20px;
+}
+
 .DashRangeButtons {
-  display: flex;
   justify-content: space-between;
+  display: flex;
   align-items: flex-end;
-  padding: 20px 40px 0 0;
-  margin-top: 10px;
+  width: 500px;
+
   .DashButton {
     width: 25%;
   }


### PR DESCRIPTION
# Who is this PR for?

Absences dashboard users.

# What does this PR do?

## GIF 

![info-heirarchy](https://user-images.githubusercontent.com/3209501/39074450-0e496ae4-44b7-11e8-938e-9de4f49e1fe9.gif)

## Main changes

+ Moves the filter buttons above both the charts and the students table to make it visually clearer that clicking the filter buttons will change both the charts and the table
+ Adds a subtitle to the students table showing what time range the # of absences column represents 
+ Purely stylistically, removes some of the border lines to make the page feel less blocky