### PR TITLE
Remove schoolYearFlag API from dashboard students table

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
@@ -9,18 +9,18 @@ import * as Routes from '../../helpers/Routes';
 import SharedPropTypes from '../../helpers/prop_types.jsx';
 import DashResetButton from './DashResetButton';
 
-
 class StudentsTable extends React.Component {
 
   constructor(props) {
     super(props);
+
     this.state = {
       sortBy: 'events',
       sortType: 'number',
       sortDesc: true,
       selectedCategory: null,
-      schoolYearFlag: false
     };
+
     this.onClickHeader = this.onClickHeader.bind(this);
   }
 
@@ -132,11 +132,9 @@ class StudentsTable extends React.Component {
   }
 
   renderCaption() {
-    const schoolYearCaption = this.props.schoolYearFlag ? " (School Year)" : "";
+    const {selectedCategory} = this.props;
 
-    return this.props.selectedCategory
-      ? this.props.selectedCategory + schoolYearCaption
-      : "All Students" + schoolYearCaption;
+    return selectedCategory ? selectedCategory : 'All Students';
   }
 
   renderIncidentTypeSubtitle() {
@@ -158,10 +156,9 @@ StudentsTable.propTypes = {
     last_sst_date_text: SharedPropTypes.nullableWithKey(PropTypes.string)
   })).isRequired,
   selectedCategory: PropTypes.string,
-  incidentType: PropTypes.string.isRequired, //Specific incident type being displayed
+  incidentType: PropTypes.string.isRequired, // Specific incident type being displayed
   incidentSubtitle: PropTypes.string,
-  resetFn: PropTypes.func.isRequired, //Function to reset student list to display all students
-  schoolYearFlag: PropTypes.bool
+  resetFn: PropTypes.func.isRequired, // Function to reset student list to display all students
 };
 
 const style = {

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolTardiesDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolTardiesDashboard.js
@@ -170,9 +170,8 @@ class SchoolTardiesDashboard extends React.Component {
 
     return (
       <StudentsTable
-        rows = {rows}
-        selectedCategory = {this.state.selectedHomeroom}
-        schoolYearFlag ={true}
+        rows={rows}
+        selectedCategory={this.state.selectedHomeroom}
         incidentType='Tardies'
         incidentSubtitle={selectedRange}
         resetFn={this.resetStudentList}/>


### PR DESCRIPTION
# Who is this PR for?

Tardies dashboard users.

# What problem does this PR fix?

In #1646 I added a commit that said "Remove schoolYearFlag API in favor of incident subtitle", but I made a mistake and didn't commit all the code that I meant to commit. The result is that this is broken in production and says "School Year" at the top of the table no matter what:

![remove-school-year-flag](https://user-images.githubusercontent.com/3209501/39132621-e168a706-46d7-11e8-8f6e-25f5043847e3.gif)

# What does this PR do?

Removes the old `schoolYearFlag` API.

## GIF (this branch, Internet Explorer)

![remove-school-year-flag-fix](https://user-images.githubusercontent.com/3209501/39133125-0d65de54-46d9-11e8-96a3-fe33943f6a49.gif)

## GIF (this branch, Internet Explorer, selected category)

![remove-school-year-flag-selected-category](https://user-images.githubusercontent.com/3209501/39133204-49331820-46d9-11e8-8e37-731842273f96.gif)
