### PR TITLE
Sorting homerooms by attendance and tardies

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
@@ -39,12 +39,25 @@ class SchoolAbsenceDashboard extends React.Component {
     return monthlySchoolAttendance;
   }
 
-  filteredHomeRoomAttendance(dailyHomeroomAttendance) {
-    return _.map(dailyHomeroomAttendance, (homeroom) => {
-      return this.state.displayDates.map((date) => {
-        return homeroom[date];
+  monthlyHomeroomAttendance(dailyHomeroomAttendance) {
+    let monthlyHomeroomAttendance = {};
+    Object.keys(dailyHomeroomAttendance).forEach((homeroom) => {
+      const rawAvg = _.sum(dailyHomeroomAttendance[homeroom])/dailyHomeroomAttendance[homeroom].length;
+      const monthlyAverage = Math.round(rawAvg*10)/10;
+      monthlyHomeroomAttendance[homeroom] = monthlyAverage;
+    });
+
+    return monthlyHomeroomAttendance;
+  }
+
+  filteredHomeroomAttendance(dailyHomeroomAttendance) {
+    let filteredHomeroomAttendance = {};
+    Object.keys(dailyHomeroomAttendance).forEach((homeroom) => {
+      filteredHomeroomAttendance[homeroom] = this.state.displayDates.map((date) => {
+        return dailyHomeroomAttendance[homeroom][date];
       });
     });
+    return filteredHomeroomAttendance;
   }
 
   studentAbsenceCounts() {
@@ -102,15 +115,19 @@ class SchoolAbsenceDashboard extends React.Component {
 
   renderHomeroomAbsenceChart() {
     const homeroomAverageDailyAttendance = this.props.homeroomAverageDailyAttendance;
-    const filteredHomeRoomAttendance = this.filteredHomeRoomAttendance(homeroomAverageDailyAttendance);
-    const homeroomSeries = filteredHomeRoomAttendance.map((homeroom) => {
-      const rawAvg = _.sum(homeroom)/homeroom.length;
-      return Math.round(rawAvg*10)/10;
+    const filteredHomeroomAttendance = this.filteredHomeroomAttendance(homeroomAverageDailyAttendance); //remove dates outside of selected range
+    const monthlyHomeroomAttendance = this.monthlyHomeroomAttendance(filteredHomeroomAttendance); //Average homeroom attendance by month
+    const homerooms = Object.keys(monthlyHomeroomAttendance).sort((a,b) => { //sort homerooms by attendance, low to high
+      return monthlyHomeroomAttendance[a] - monthlyHomeroomAttendance[b];
     });
+    const homeroomSeries = homerooms.map((homeroom) => {
+      return monthlyHomeroomAttendance[homeroom];
+    });
+
     return (
         <DashboardBarChart
           id = {'string'}
-          categories = {{categories: Object.keys(homeroomAverageDailyAttendance)}}
+          categories = {{categories: homerooms}}
           seriesData = {homeroomSeries}
           yAxisMin = {80}
           yAxisMax = {100}

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolTardiesDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolTardiesDashboard.js
@@ -132,7 +132,9 @@ class SchoolTardiesDashboard extends React.Component {
 
   renderHomeroomTardiesChart() {
     const homeroomTardyEvents = this.homeroomTardyEventsSince(this.state.startDate);
-    const homerooms = Object.keys(homeroomTardyEvents);
+    const homerooms = Object.keys(homeroomTardyEvents).sort((a,b) => {
+      return homeroomTardyEvents[b] - homeroomTardyEvents[a];
+    });
     const homeroomSeries = homerooms.map((homeroom) => {
       return homeroomTardyEvents[homeroom];
     });


### PR DESCRIPTION
# Who is this PR for?
Dashboard users

# What problem does this PR fix?
Homerooms aren't ordered in any particular way, but users are interested in seeing which ones have higher/lower attendance and tardies.

# What does this PR do?
Sorts homerooms by attendance and number of tardies.
# Screenshot (if adding a client-side feature)
Absences unsorted:
![unsortedabsences](https://user-images.githubusercontent.com/638809/39197425-6f91aa98-47b2-11e8-9a44-541315cc1130.gif)

Absences sorted:
![sortedabsences](https://user-images.githubusercontent.com/638809/39197433-73f75ef2-47b2-11e8-94fc-fb3b05281cf2.gif)

Tardies unsorted:
![unsortedtardies](https://user-images.githubusercontent.com/638809/39197444-77edae4e-47b2-11e8-9b3f-a1070302e008.gif)

Tardies sorted:
![sortedtardies](https://user-images.githubusercontent.com/638809/39197452-7b410ca8-47b2-11e8-9ee3-62255808bd9d.gif)

# Checklists

## Javascript QA

+ [x] Author checked latest in IE - Absence Dashboard
+ [x] Author checked latest in IE - Tardies Dashboard
+ [ ] Reviewer checked latest in IE - Absence Dashboard
+ [ ] Reviewer checked latest in IE - Tardies Dashboard
