### PR TITLE
Export more attendance columns

### DIFF
--- a/x2_export/attendance_export.sql
+++ b/x2_export/attendance_export.sql
@@ -4,6 +4,10 @@ SELECT
   'local_id', -- LASID
   'absence',
   'tardy',
+  'dismissed',
+  'reason',
+  'excused',
+  'comment',
   'event_date',
   'school_local_id'
 UNION ALL
@@ -12,6 +16,10 @@ SELECT
   STD_ID_LOCAL,
   ATT_ABSENT_IND,
   ATT_TARDY_IND,
+  ATT_DISMISSED_IND,
+  ATT_REASON_CODE,
+  ATT_EXCUSED_IND,
+  ATT_COMMENT,
   IF(sa.ATT_DATE > Date(Now()), NULL, sa.ATT_DATE) AS 'event_date',
   SKL_SCHOOL_ID
 FROM student


### PR DESCRIPTION
# Who is this PR for?

Educators looking at attendance events in Insights.

# What problem does this PR fix?

We're missing key data about whether absences/tardies are excused or not, related to medical reasons or not. 

# What does this PR do?

Adds additional columns to our SQL export so that we can start exploring how to add these additional fields into Insights. Changing the SQL export to add fields will send more fields to the SFTP site, but won't automatically send more fields to the Insights database — that will require modifying the importer code. 