### PR TITLE
New design banner

### DIFF
--- a/app/assets/javascripts/components/DesignChangesBanner.js
+++ b/app/assets/javascripts/components/DesignChangesBanner.js
@@ -2,7 +2,7 @@
 export default function DesignChangesBanner() {
   return (
     <div style={styles.banner}>
-      <span>We've made some design changes here this week!</span>
+      <span>We made some design changes here this week!</span>
       <span style={{ marginLeft: 10 }}>Please let us know what you think.</span>
     </div>
   );

--- a/app/assets/javascripts/components/DesignChangesBanner.js
+++ b/app/assets/javascripts/components/DesignChangesBanner.js
@@ -1,0 +1,18 @@
+// Let users know that we changed a page design recently
+export default function DesignChangesBanner() {
+  return (
+    <div style={styles.banner}>
+      <span>We've made some design changes here this week!</span>
+      <span style={{ marginLeft: 10 }}>Please let us know what you think.</span>
+    </div>
+  );
+}
+
+const styles = {
+  banner: {
+    background: '#4a9de2',
+    color: 'white',
+    fontWeight: 'bold',
+    padding: 20
+  }
+};

--- a/app/assets/javascripts/components/DesignChangesBanner.test.js
+++ b/app/assets/javascripts/components/DesignChangesBanner.test.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import DesignChangesBanner from './DesignChangesBanner';
+
+it('renders without crashing', () => {
+  const el = document.createElement('div');
+  ReactDOM.render(<DesignChangesBanner />, el);
+});

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
@@ -7,7 +7,7 @@ import StudentsTable from '../StudentsTable';
 import DashboardBarChart from '../DashboardBarChart';
 import {latestNoteDateText} from '../../../helpers/latestNoteDateText';
 import DashRangeButtons from '../DashRangeButtons';
-
+import DesignChangesBanner from '../../../components/DesignChangesBanner';
 
 class SchoolAbsenceDashboard extends React.Component {
 
@@ -61,6 +61,7 @@ class SchoolAbsenceDashboard extends React.Component {
   render() {
     return (
       <div>
+        <DesignChangesBanner />
         {this.renderRangeSelector()}
         <div className="DashboardContainer">
           <div className="DashboardRosterColumn">

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolTardiesDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/tardies_dashboard/SchoolTardiesDashboard.js
@@ -7,7 +7,7 @@ import StudentsTable from '../StudentsTable';
 import DashboardBarChart from '../DashboardBarChart';
 import {latestNoteDateText} from '../../../helpers/latestNoteDateText';
 import DashRangeButtons from '../DashRangeButtons';
-
+import DesignChangesBanner from '../../../components/DesignChangesBanner';
 
 class SchoolTardiesDashboard extends React.Component {
 
@@ -86,6 +86,7 @@ class SchoolTardiesDashboard extends React.Component {
   render() {
     return (
       <div>
+        <DesignChangesBanner />
         {this.renderRangeSelector()}
         <div className="DashboardContainer">
           <div className="DashboardRosterColumn">


### PR DESCRIPTION
# Who is this PR for?

Educators who use Insights

# What problem does this PR fix?

We ship new changes / features / designs often. This could be jarring or unexpected for educators who use Insights as part of their daily rhythm if the changes are large enough. Was talking about this with @kevinrobinson earlier today vis a vis the design revisions we made to the Absences and Tardies dashboards last week.

# What does this PR do?

Adds a banner along the lines of the Experimental Banner for when we introduce new design changes. This adds more communication with the end user, letting them know that a familiar page has changed. We'd remove the banner at the end of the week.

## Screenshot (absences)
![screen shot 2018-04-24 at 2 35 16 pm](https://user-images.githubusercontent.com/3209501/39209889-c2895de4-47cc-11e8-968b-84724adffd9a.png)

## Screenshot (tardies)
![screen shot 2018-04-24 at 2 35 21 pm](https://user-images.githubusercontent.com/3209501/39209888-c278427a-47cc-11e8-8113-000214e5fddb.png)

