### PR TITLE
WIP – Show grade level on students table in Absences/Tardies dashboards

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
@@ -86,11 +86,16 @@ class StudentsTable extends React.Component {
             <DashResetButton clearSelection={this.props.resetFn} selectedCategory={this.props.selectedCategory}/>
           </div>
           <thead style={style.thead}>
-            <tr>
-              <th style={style.th}
+            <tr style={style.tr}>
+              <th style={{...style.th, ...style.name}}
                   onClick={this.onClickHeader.bind(null, 'last_name', 'string')}
                   className={this.headerClassName('last_name')}>
                 Name
+              </th>
+              <th style={style.th}
+                  onClick={this.onClickHeader.bind(null, 'grade', 'date')}
+                  className={this.headerClassName('grade')}>
+                Grade
               </th>
               <th style={style.th}
                   onClick={this.onClickHeader.bind(null, 'events', 'number')}
@@ -108,12 +113,13 @@ class StudentsTable extends React.Component {
           <tbody style={style.tbody}>
             {this.orderedRows().map(student => {
               return (
-                <tr key={student.id}>
-                  <td style={style.td}>
+                <tr key={student.id} style={style.tr}>
+                  <td style={{...style.td, ...style.name}}>
                     <a href={Routes.studentProfile(student.id)}>
                       {student.first_name} {student.last_name}
                     </a>
                   </td>
+                  <td style={style.td}>{student.grade}</td>
                   <td style={style.td}>{student.events}</td>
                   <td style={style.td}>{student.last_sst_date_text}</td>
                 </tr>
@@ -121,7 +127,7 @@ class StudentsTable extends React.Component {
             })}
           </tbody>
           <tfoot style={style.tfoot}>
-            <tr>
+            <tr style={style.tr}>
               <td style={style.td}>{'Total: '}</td>
               <td style={style.td}>{this.totalEvents()}</td>
             </tr>
@@ -190,14 +196,23 @@ const style = {
     borderTop: '1px solid #ccc',
     borderBottom: '1px solid #ccc',
   },
+  tr: {
+    display: 'flex'
+  },
+  name: {
+    flex: 2,
+  },
   td: {
-    width: 150,
+    flex: 1,
+    marginLeft: 5,
     textAlign: 'left',
   },
   th: {
-    width: 150,
+    flex: 1,
+    marginLeft: 5,
     textAlign: 'left',
-    verticalAlign: 'bottom'
+    verticalAlign: 'bottom',
+    marginTop: 'auto'
   }
 };
 

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
@@ -79,57 +79,54 @@ class StudentsTable extends React.Component {
 
   render() {
     return (
-      <div className='StudentsList' style={style.root}>
-        <table className='students-list' style={style.table}>
-          <div style={style.caption}>
+      <div className='StudentsList'>
+        <table className='students-list'>
+          <div className='caption'>
             {this.renderCaption()}
             <DashResetButton clearSelection={this.props.resetFn} selectedCategory={this.props.selectedCategory}/>
           </div>
-          <thead style={style.thead}>
-            <tr style={style.tr}>
-              <th style={{...style.th, ...style.name}}
+          <thead>
+            <tr>
+              <th className='name'
                   onClick={this.onClickHeader.bind(null, 'last_name', 'string')}
                   className={this.headerClassName('last_name')}>
                 Name
               </th>
-              <th style={style.th}
-                  onClick={this.onClickHeader.bind(null, 'grade', 'date')}
+              <th onClick={this.onClickHeader.bind(null, 'grade', 'date')}
                   className={this.headerClassName('grade')}>
                 Grade
               </th>
-              <th style={style.th}
-                  onClick={this.onClickHeader.bind(null, 'events', 'number')}
+              <th onClick={this.onClickHeader.bind(null, 'events', 'number')}
                   className={this.headerClassName('events')}>
                 {this.props.incidentType}
                 {this.renderIncidentTypeSubtitle()}
               </th>
-              <th style={style.th}
-                  onClick={this.onClickHeader.bind(null, 'last_sst_date_text', 'date')}
+              <th onClick={this.onClickHeader.bind(null, 'last_sst_date_text', 'date')}
                   className={this.headerClassName('last_sst_date_text')}>
                 Last SST
               </th>
             </tr>
           </thead>
-          <tbody style={style.tbody}>
+          <tbody>
             {this.orderedRows().map(student => {
               return (
-                <tr key={student.id} style={style.tr}>
-                  <td style={{...style.td, ...style.name}}>
+                <tr key={student.id}>
+                  <td className='name'>
                     <a href={Routes.studentProfile(student.id)}>
                       {student.first_name} {student.last_name}
                     </a>
                   </td>
-                  <td style={style.td}>{student.grade}</td>
-                  <td style={style.td}>{student.events}</td>
-                  <td style={style.td}>{student.last_sst_date_text}</td>
+                  <td>{student.grade}</td>
+                  <td>{student.events}</td>
+                  <td>{student.last_sst_date_text}</td>
                 </tr>
               );
             })}
           </tbody>
-          <tfoot style={style.tfoot}>
-            <tr style={style.tr}>
-              <td style={style.td}>{'Total: '}</td>
-              <td style={style.td}>{this.totalEvents()}</td>
+          <tfoot>
+            <tr>
+              <td>{'Total: '}</td>
+              <td>{this.totalEvents()}</td>
             </tr>
           </tfoot>
         </table>
@@ -166,54 +163,4 @@ StudentsTable.propTypes = {
   incidentSubtitle: PropTypes.string,
   resetFn: PropTypes.func.isRequired, // Function to reset student list to display all students
 };
-
-const style = {
-  root: {
-    marginTop: 20,
-  },
-  caption: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    padding: 5,
-  },
-  table: {
-    width: '100%',
-    border: '1px solid #ccc',
-  },
-  thead: {
-    display: 'block',
-    width: '100%',
-  },
-  tfoot: {
-    display: 'block',
-    width: '100%',
-  },
-  tbody: {
-    display: 'block',
-    width: '100%',
-    height: 480,
-    overflowY: 'scroll',
-    borderTop: '1px solid #ccc',
-    borderBottom: '1px solid #ccc',
-  },
-  tr: {
-    display: 'flex'
-  },
-  name: {
-    flex: 2,
-  },
-  td: {
-    flex: 1,
-    marginLeft: 5,
-    textAlign: 'left',
-  },
-  th: {
-    flex: 1,
-    marginLeft: 5,
-    textAlign: 'left',
-    verticalAlign: 'bottom',
-    marginTop: 'auto'
-  }
-};
-
 export default StudentsTable;

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/StudentsTable.js
@@ -8,6 +8,7 @@ import {
 import * as Routes from '../../helpers/Routes';
 import SharedPropTypes from '../../helpers/prop_types.jsx';
 import DashResetButton from './DashResetButton';
+import { Column, Table } from 'react-virtualized'
 
 class StudentsTable extends React.Component {
 
@@ -22,6 +23,7 @@ class StudentsTable extends React.Component {
     };
 
     this.onClickHeader = this.onClickHeader.bind(this);
+    this.rowStyle = this.rowStyle.bind(this);
   }
 
   //These methods taken directly from school overview students table. TODO, separate into helpers
@@ -78,60 +80,59 @@ class StudentsTable extends React.Component {
   }
 
   render() {
+    const list = this.orderedRows();
+
     return (
       <div className='StudentsList'>
-        <table className='students-list'>
-          <div className='caption'>
-            {this.renderCaption()}
-            <DashResetButton clearSelection={this.props.resetFn} selectedCategory={this.props.selectedCategory}/>
-          </div>
-          <thead>
-            <tr>
-              <th className='name'
-                  onClick={this.onClickHeader.bind(null, 'last_name', 'string')}
-                  className={this.headerClassName('last_name')}>
-                Name
-              </th>
-              <th onClick={this.onClickHeader.bind(null, 'grade', 'date')}
-                  className={this.headerClassName('grade')}>
-                Grade
-              </th>
-              <th onClick={this.onClickHeader.bind(null, 'events', 'number')}
-                  className={this.headerClassName('events')}>
-                {this.props.incidentType}
-                {this.renderIncidentTypeSubtitle()}
-              </th>
-              <th onClick={this.onClickHeader.bind(null, 'last_sst_date_text', 'date')}
-                  className={this.headerClassName('last_sst_date_text')}>
-                Last SST
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {this.orderedRows().map(student => {
-              return (
-                <tr key={student.id}>
-                  <td className='name'>
-                    <a href={Routes.studentProfile(student.id)}>
-                      {student.first_name} {student.last_name}
-                    </a>
-                  </td>
-                  <td>{student.grade}</td>
-                  <td>{student.events}</td>
-                  <td>{student.last_sst_date_text}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-          <tfoot>
-            <tr>
-              <td>{'Total: '}</td>
-              <td>{this.totalEvents()}</td>
-            </tr>
-          </tfoot>
-        </table>
+        <div className='caption'>
+          {this.renderCaption()}
+          <DashResetButton clearSelection={this.props.resetFn} selectedCategory={this.props.selectedCategory}/>
+        </div>
+        <Table
+          width={500}
+          height={500}
+          headerHeight={20}
+          rowHeight={30}
+          rowCount={list.length}
+          rowGetter={({index}) => list[index]}
+          style={{fontSize: 14}}
+          rowStyle={this.rowStyle}
+        >
+          <Column
+            label='Name'
+            dataKey='last_name'
+            width={300}
+          />
+          <Column
+            width={100}
+            label='Grade'
+            dataKey='grade'
+          />
+          <Column
+            width={100}
+            label='Events'
+            dataKey='events'
+          />
+          <Column
+            width={100}
+            label='Last SST'
+            dataKey='last_sst_date_text'
+          />
+        </Table>
+        <div>{'Total: '}</div>
+        <div>{this.totalEvents()}</div>
       </div>
     );
+  }
+
+  rowStyle({index}) {
+    if (index < 0) {
+      return;
+    } else {
+      return index % 2 === 0
+        ? null
+        : { backgroundColor: '#fafafa' };
+    }
   }
 
   renderCaption() {
@@ -145,7 +146,7 @@ class StudentsTable extends React.Component {
     if (!incidentSubtitle) return;
 
     return (
-      <span style={{fontWeight: 'normal'}}><br/>({this.props.incidentSubtitle})</span>
+      <span className='incident_subtitle'><br/>({this.props.incidentSubtitle})</span>
     );
   }
 }

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/absences_dashboard/SchoolAbsenceDashboard.js
@@ -153,7 +153,8 @@ class SchoolAbsenceDashboard extends React.Component {
         first_name: student.first_name,
         last_name: student.last_name,
         last_sst_date_text: latestNoteDateText(300, student.sst_notes),
-        events: studentAbsenceCounts[student.id] || 0
+        events: studentAbsenceCounts[student.id] || 0,
+        grade: student.grade,
       });
     });
 

--- a/app/assets/stylesheets/components/school_dashboard.scss
+++ b/app/assets/stylesheets/components/school_dashboard.scss
@@ -53,6 +53,62 @@
   }
 }
 
+.StudentsList {
+  margin-top: 20px;
+
+  table {
+    width: 100%;
+    border: 1px solid #ccc;
+  }
+
+  thead {
+    display: block;
+    width: 100%;
+  }
+
+  tfoot {
+    display: block;
+    width: 100%;
+  }
+
+  tbody {
+    display: block;
+    width: 100%;
+    height: 480;
+    overflow-y: scroll;
+    border-top: 1px solid #ccc;
+    border-bottom: 1px solid #ccc;
+  }
+
+  tr {
+    display: flex;
+  }
+
+  .caption {
+    display: flex;
+    justify-content: space-between;
+    padding: 5px;
+  }
+
+  .name {
+    flex: 2;
+  }
+
+  td {
+    flex: 1 0 0;
+    margin-left: 5px;
+    text-align: left;
+  }
+
+  th {
+    flex: 1 0 0;
+    margin-left: 5px;
+    text-align: left;
+    vertical-align: bottom;
+    margin-top: auto;
+  }
+}
+
 .ui-datepicker-prev {
   float: left;
 }

--- a/app/assets/stylesheets/components/school_dashboard.scss
+++ b/app/assets/stylesheets/components/school_dashboard.scss
@@ -56,56 +56,15 @@
 .StudentsList {
   margin-top: 20px;
 
-  table {
-    width: 100%;
-    border: 1px solid #ccc;
-  }
-
-  thead {
-    display: block;
-    width: 100%;
-  }
-
-  tfoot {
-    display: block;
-    width: 100%;
-  }
-
-  tbody {
-    display: block;
-    width: 100%;
-    height: 480;
-    overflow-y: scroll;
-    border-top: 1px solid #ccc;
-    border-bottom: 1px solid #ccc;
-  }
-
-  tr {
-    display: flex;
-  }
-
   .caption {
     display: flex;
-    justify-content: space-between;
+    // justify-content: space-between;
     padding: 5px;
   }
 
-  .name {
-    flex: 2;
-  }
-
-  td {
-    flex: 1 0 0;
-    margin-left: 5px;
-    text-align: left;
-  }
-
-  th {
-    flex: 1 0 0;
-    margin-left: 5px;
-    text-align: left;
-    vertical-align: bottom;
-    margin-top: auto;
+  .incident_subtitle {
+    font-weight: normal;
+    font-size: 12px;
   }
 }
 

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -171,6 +171,7 @@ class SchoolsController < ApplicationController
     {
       first_name: student.first_name,
       last_name: student.last_name,
+      grade: student.grade,
       id: student.id,
       homeroom_label: homeroom_label(student.homeroom),
       absences: student.dashboard_absences,
@@ -182,6 +183,7 @@ class SchoolsController < ApplicationController
     {
       first_name: student.first_name,
       last_name: student.last_name,
+      grade: student.grade,
       id: student.id,
       homeroom_label: homeroom_label(student.homeroom),
       tardies: student.dashboard_tardies,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "babel-core": "^6.26.0",
     "babel-runtime": "^6.26.0",
+    "css-loader": "^0.28.11",
     "d3": "3.5.12",
     "es5-shim": "^4.5.9",
     "fetch-mock": "^6.0.1",
@@ -40,6 +41,7 @@
     "react-modal": "^3.0.4",
     "react-router-dom": "^4.2.2",
     "react-test-renderer": "15.4.2",
+    "react-virtualized": "^9.18.5",
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {

--- a/ui/config/webpack.common.js
+++ b/ui/config/webpack.common.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-module.exports = { 
+module.exports = {
   entry: {
     bundle: ['./ui/polyfills.js', './ui/index.js'], // force polyfills to be first
     student_report_pdf: './ui/student_report_pdf.js'
@@ -9,6 +9,7 @@ module.exports = {
       // Process JS with Babel.
       {
         test: /\.(js|jsx)$/,
+
         loader: require.resolve('babel-loader'),
         options: {
           // @remove-on-eject-begin
@@ -20,6 +21,10 @@ module.exports = {
           // directory for faster rebuilds.
           cacheDirectory: true,
         },
+      },
+      {
+        test: /\.css$/,
+        loader: "style-loader!css-loader"
       }
     ]
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1991,7 +1991,7 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@^2.2.5:
+classnames@^2.2.3, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -2624,7 +2624,7 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
-dom-helpers@^3.2.0:
+"dom-helpers@^2.4.0 || ^3.0.0", dom-helpers@^3.2.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
@@ -4878,7 +4878,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -6390,6 +6390,16 @@ react-treebeard@^2.1.0:
     radium "^0.19.0"
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
+
+react-virtualized@^9.18.5:
+  version "9.18.5"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.18.5.tgz#42dd390ebaa7ea809bfcaf775d39872641679b89"
+  dependencies:
+    babel-runtime "^6.26.0"
+    classnames "^2.2.3"
+    dom-helpers "^2.4.0 || ^3.0.0"
+    loose-envify "^1.3.0"
+    prop-types "^15.6.0"
 
 react@15.4.2:
   version "15.4.2"


### PR DESCRIPTION
# What problem does this PR fix?

Educators need to know the grade level of students when using the Absences/Tardies dashboards, because absences mean different things in PK/K than they do in higher level grades.

# What does this PR do?

Attempt to add grade level to the table. Adding another column made the layout cramped and some columns were squeezed up against each other. So I tried a `flex` solution, only to find that it didn't work well in Internet Explorer. I tried moving the styles from JS to CSS thinking that autoprefixer-rails might help (https://github.com/ai/autoprefixer-rails), but it didn't have any effect:

![screen shot 2018-04-25 at 3 26 31 pm](https://user-images.githubusercontent.com/3209501/39270917-0ef8255e-489d-11e8-9140-781f9265333d.png)

Still WIP.