### PR TITLE
Filter to only active students in classroom balancing query

### DIFF
--- a/app/controllers/classroom_balancing_controller.rb
+++ b/app/controllers/classroom_balancing_controller.rb
@@ -127,7 +127,10 @@ class ClassroomBalancingController < ApplicationController
     return [] unless is_authorized_for_grade_level?(educator, grade_level)
 
     # Query for those students (outside normal authorization rules)
-    Student.where(school_id: school_id, grade: grade_level)
+    Student.active.where({
+      school_id: school_id,
+      grade: grade_level
+    })
   end
 
   # Only let educators read their own writes

--- a/spec/controllers/classroom_balancing_controller_spec.rb
+++ b/spec/controllers/classroom_balancing_controller_spec.rb
@@ -133,6 +133,19 @@ describe ClassroomBalancingController, :type => :controller do
       expect(response.status).to eq 200
       expect(json["students"].length).to eq 0
     end
+
+    it 'filters out inactive students' do
+      inactive_student = FactoryBot.create(:student, {
+        grade: '2',
+        enrollment_status: 'Transferred',
+        school: pals.healey,
+        homeroom: pals.healey.homerooms.first
+      })
+      request_students_for_grade_level_next_year_json(pals.uri)
+      json = JSON.parse(response.body)
+      expect(response.status).to eq 200
+      expect(json["students"].map {|s| s['id'] }).not_to include(inactive_student.id)
+    end
   end
 
   describe '#classrooms_for_grade_json' do


### PR DESCRIPTION
Bug fix as part of https://github.com/studentinsights/studentinsights/issues/1659.

# Who is this PR for?
K1-6 educators.

# What problem does this PR fix?
The query for students includes all students and doesn't filter down to just active students.

# What does this PR do?
fixes it!

# Checklists
+ [x] Author included specs for new code

related: https://rollbar.com/somerville-teacher-tool/somerville-teacher-tool/items/118/ and https://rollbar.com/somerville-teacher-tool/somerville-teacher-tool/items/119/