### PR TITLE
Send down proper event fields to discipline dashboard

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -192,7 +192,13 @@ class SchoolsController < ApplicationController
 
   def individual_student_discipline_data(student)
     shared_student_fields(student).merge({
-      discipline_incidents: student.dashboard_absences.as_json(only: [:student_id, :occurred_at])
+      discipline_incidents: student.discipline_incidents.as_json(only: [
+        :student_id,
+        :incident_code,
+        :incident_location,
+        :has_exact_time,
+        :occurred_at
+      ])
     })
   end
 

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -295,6 +295,10 @@ describe SchoolsController, :type => :controller do
     end
 
     it '#individual_student_discipline_data has expected fields' do
+      DisciplineIncident.create!({
+        student_id: student.id,
+        occurred_at: Time.now
+      })
       sign_in(pals.healey_laura_principal)
       json = controller.send(:individual_student_discipline_data, student)
       expect(json.keys.map(&:to_sym)).to contain_exactly(*[
@@ -306,6 +310,13 @@ describe SchoolsController, :type => :controller do
         :homeroom_label,
         :sst_notes
       ])
+      expect(json[:discipline_incidents].first.keys).to contain_exactly *[
+        "student_id",
+        "incident_code",
+        "incident_location",
+        "occurred_at",
+        "has_exact_time"
+      ]
     end
   end
 end


### PR DESCRIPTION
I broke this in https://github.com/studentinsights/studentinsights/pull/1663 this morning and this fixes it.