### PR TITLE
Reducing scope of discipline incidents to one year

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -49,7 +49,8 @@ class SchoolsController < ApplicationController
 
   def discipline_dashboard_data
     student_discipline_data = active_students(@school)
-      .includes([homeroom: :educator], :dashboard_discipline_incidents, :event_notes)
+      .includes([homeroom: :educator], :discipline_incidents, :event_notes)
+      .where('occurred_at >= ?', 1.year.ago).references(:discipline_incidents)
     student_discipline_data_json = student_discipline_data.map do |student|
       individual_student_discipline_data(student)
     end
@@ -192,7 +193,7 @@ class SchoolsController < ApplicationController
 
   def individual_student_discipline_data(student)
     shared_student_fields(student).merge({
-      discipline_incidents: student.dashboard_discipline_incidents.as_json(only: [
+      discipline_incidents: student.discipline_incidents.as_json(only: [
         :student_id,
         :incident_code,
         :incident_location,

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -49,7 +49,7 @@ class SchoolsController < ApplicationController
 
   def discipline_dashboard_data
     student_discipline_data = active_students(@school)
-      .includes([homeroom: :educator], :discipline_incidents, :event_notes)
+      .includes([homeroom: :educator], :dashboard_discipline_incidents, :event_notes)
     student_discipline_data_json = student_discipline_data.map do |student|
       individual_student_discipline_data(student)
     end
@@ -192,7 +192,7 @@ class SchoolsController < ApplicationController
 
   def individual_student_discipline_data(student)
     shared_student_fields(student).merge({
-      discipline_incidents: student.discipline_incidents.as_json(only: [
+      discipline_incidents: student.dashboard_discipline_incidents.as_json(only: [
         :student_id,
         :incident_code,
         :incident_location,

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -26,6 +26,9 @@ class Student < ActiveRecord::Base
   has_many :dashboard_absences, -> {
     where('occurred_at >= ?', 1.year.ago)
   }, class_name: "Absence"
+  has_many :dashboard_discipline_incidents, -> {
+    where('occurred_at >= ?', 1.year.ago)
+  }, class_name: "DisciplineIncident"
 
   has_many :sst_notes, -> { where(event_note_type_id: 300) }, class_name: "EventNote"
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -26,9 +26,6 @@ class Student < ActiveRecord::Base
   has_many :dashboard_absences, -> {
     where('occurred_at >= ?', 1.year.ago)
   }, class_name: "Absence"
-  has_many :dashboard_discipline_incidents, -> {
-    where('occurred_at >= ?', 1.year.ago)
-  }, class_name: "DisciplineIncident"
 
   has_many :sst_notes, -> { where(event_note_type_id: 300) }, class_name: "EventNote"
 


### PR DESCRIPTION
# Who is this PR for?
Discipline dashboard users

# What problem does this PR fix?
The discipline dashboard has some slow load times.

# What does this PR do?
Reduces the discipline incidents handled by the dashboard to those within the last year, in keeping with the absences/tardies dashboard. 


+ [x] Author checked latest in IE - Discipline Dashboard
+ [ ] Reviewer checked latest in IE - Discipline Dashboard