### PR TITLE
Update insights box for high absences to exclude kids younger than KF

### DIFF
--- a/app/lib/insight_students_with_high_absences.rb
+++ b/app/lib/insight_students_with_high_absences.rb
@@ -17,8 +17,12 @@ class InsightStudentsWithHighAbsences
   # This method returns hashes that are the shape of what is needed
   # in the product.
   def students_with_high_absences_json(time_now, time_threshold, absences_threshold)
-    # Include all authorized students
-    students = @authorizer.authorized { Student.all }
+    # Exclude students in younger grades like PreK since attendance isn't mandatory.
+    # This means there's less consistent attendance from families, and it's less
+    # of a priority to follow-up for schools.
+    students = @authorizer.authorized do
+      Student.active.where.not(grade: ['TK', 'PPK', 'PK'])
+    end
     student_ids = students.map(&:id)
 
     # Absences by student in the time period.

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -192,6 +192,15 @@ describe HomeController, :type => :controller do
   end
 
   describe '#students_with_high_absences_json' do
+    before do
+      4.times.each do |index|
+        Absence.create!({
+          occurred_at: time_now - index.days,
+          student: pals.shs_freshman_mari
+        })
+      end
+    end
+
     it 'works end-to-end, using absences for Mari as the test case' do
       sign_in(pals.shs_bill_nye)
       get :students_with_high_absences_json, params: {

--- a/spec/lib/insight_students_with_high_absences_spec.rb
+++ b/spec/lib/insight_students_with_high_absences_spec.rb
@@ -4,8 +4,18 @@ RSpec.describe InsightStudentsWithHighAbsences do
   let!(:pals) { TestPals.create! }
   let!(:time_now) { Time.zone.local(2018, 3, 5, 8, 45) }
 
+  def create_absences(n, student, time_now)
+    n.times do |index|
+      Absence.create!({
+        occurred_at: time_now - index.days,
+        student: student
+      })
+    end
+  end
+
   describe '#students_with_high_absences_json' do
     it 'finds no one for Fatima' do
+      create_absences(4, pals.shs_freshman_mari, time_now)
       time_threshold = time_now - 45.days
       absences_threshold = 4
       insight = InsightStudentsWithHighAbsences.new(pals.shs_fatima_science_teacher)
@@ -14,6 +24,7 @@ RSpec.describe InsightStudentsWithHighAbsences do
     end
 
     it 'finds Mari for Bill when at threshold' do
+      create_absences(4, pals.shs_freshman_mari, time_now)
       time_threshold = time_now - 45.days
       absences_threshold = 4
       insight = InsightStudentsWithHighAbsences.new(pals.shs_bill_nye)
@@ -31,16 +42,23 @@ RSpec.describe InsightStudentsWithHighAbsences do
     end
 
     it 'finds no one for Bill when under threshold' do
-      pals.shs_freshman_mari.absences.destroy_all
-      3.times do |index|
-        Absence.create!({
-          occurred_at: time_now - index.days,
-          student: pals.shs_freshman_mari
-        })
-      end
+      create_absences(3, pals.shs_freshman_mari, time_now)
       time_threshold = time_now - 45.days
       absences_threshold = 4
       insight = InsightStudentsWithHighAbsences.new(pals.shs_bill_nye)
+      students_with_high_absences = insight.students_with_high_absences_json(time_now, time_threshold, absences_threshold)
+      expect(students_with_high_absences).to eq []
+    end
+
+    it 'excludes PreK student for K8 principal' do
+      prek_student = FactoryBot.create(:student, {
+        grade: 'PK',
+        school: pals.healey
+      })
+      create_absences(6, prek_student, time_now)
+      time_threshold = time_now - 45.days
+      absences_threshold = 4
+      insight = InsightStudentsWithHighAbsences.new(pals.healey_laura_principal)
       students_with_high_absences = insight.students_with_high_absences_json(time_now, time_threshold, absences_threshold)
       expect(students_with_high_absences).to eq []
     end

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -311,12 +311,6 @@ class TestPals
       grade_numeric: 67,
       grade_letter: 'D'
     )
-    4.times.each do |index|
-      Absence.create!({
-        occurred_at: time_now - index.days,
-        student: @shs_freshman_mari
-      })
-    end
 
     reindex!
     self


### PR DESCRIPTION
# Who is this PR for?
K8 educators, redirect counselors, APs and principals in particular.

# What problem does this PR fix?
See https://github.com/studentinsights/studentinsights/issues/1656.  Also updates to query only for active students.

# What does this PR do?
Filters out students that are considered for the "high absences" box.  It also moves creating absences out of `TestPals` and into controller specs.

# Screenshot (if adding a client-side feature)
#### before (Snow is PK)
<img width="536" alt="screen shot 2018-05-03 at 5 10 29 pm" src="https://user-images.githubusercontent.com/1056957/39603091-2c022434-4ef5-11e8-886d-84cf20c9191e.png">

#### after
<img width="536" alt="screen shot 2018-05-03 at 5 10 43 pm" src="https://user-images.githubusercontent.com/1056957/39603095-3006e0e2-4ef5-11e8-8c5d-512641f89217.png">
