### PR TITLE
Update queries for Student.all to Student.active

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,7 +56,7 @@ class ApplicationController < ActionController::Base
   # Used to wrap a block with timing measurements and logging, returning the value of the
   # block.
   #
-  # Example: students = log_timing('load students') { Student.all }
+  # Example: students = log_timing('load students') { Student.active }
   # Outputs: log_timing:end [load students] 2998ms
   def log_timing(message)
     return_value = nil

--- a/app/controllers/district_controller.rb
+++ b/app/controllers/district_controller.rb
@@ -3,7 +3,7 @@ class DistrictController < ApplicationController
     raise Exceptions::EducatorNotAuthorized unless current_educator.districtwide_access
 
     # students, grouped by school and grade
-    authorized_students = authorized { Student.all }
+    authorized_students = authorized { Student.active }
     groups = authorized_students.group_by do |student|
       [student.school_id, student.grade]
     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,7 @@ class HomeController < ApplicationController
     time_now = time_now_or_param(params[:time_now])
     limit = params[:limit].to_i
 
-    authorized_students = authorizer.authorized_when_viewing_as(view_as_educator) { Student.all }
+    authorized_students = authorizer.authorized_when_viewing_as(view_as_educator) { Student.active }
     feed = Feed.new(authorized_students)
     feed_cards = feed.all_cards(time_now, limit)
     render json: {

--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -74,7 +74,7 @@ class Authorizer
   # who they are authorized to see themselves.
   #
   # Usage:
-  #  authorized_students = authorized_when_viewing_as(other_educator) { Student.all }
+  #  authorized_students = authorized_when_viewing_as(other_educator) { Student.active }
   def authorized_when_viewing_as(view_as_educator, &block)
     authorized do
       if @educator.can_set_districtwide_access? && view_as_educator.id != @educator.id
@@ -107,7 +107,7 @@ class Authorizer
       return true if @educator.has_access_to_grade_levels? && student.grade.in?(@educator.grade_level_access) # Grade level access
 
       # The next two checks call `#to_a` as a performance optimization.
-      # In loops with `authorized { Student.all }`, without forcing this
+      # In loops with `authorized { Student.active }`, without forcing this
       # to an eagerly evaluated array, repeated calls will keep making the
       # same queries.  This seems unexpected to me, but adding `to_a` at
       # the end results in Rails caching these queries across the repeated

--- a/app/lib/feed.rb
+++ b/app/lib/feed.rb
@@ -2,7 +2,7 @@ class Feed
   # Shortcut for getting feed for all students an educator is authorized to view
   def self.for(educator)
     authorizer = Authorizer.new(educator)
-    authorized_students = authorizer.authorized { Student.all }
+    authorized_students = authorizer.authorized { Student.active }
     self.new(authorized_students)
   end
 

--- a/app/lib/insight_students_with_high_absences.rb
+++ b/app/lib/insight_students_with_high_absences.rb
@@ -17,8 +17,12 @@ class InsightStudentsWithHighAbsences
   # This method returns hashes that are the shape of what is needed
   # in the product.
   def students_with_high_absences_json(time_now, time_threshold, absences_threshold)
-    # Include all authorized students
-    students = @authorizer.authorized { Student.all }
+    # Exclude students in younger grades like PreK since attendance isn't mandatory.
+    # This means there's less consistent attendance from families, and it's less
+    # of a priority to follow-up for schools.
+    students = @authorizer.authorized do
+      Student.active.where.not(grade: ['TK', 'PPK', 'PK'])
+    end
     student_ids = students.map(&:id)
 
     # Absences by student in the time period.

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -192,6 +192,15 @@ describe HomeController, :type => :controller do
   end
 
   describe '#students_with_high_absences_json' do
+    before do
+      4.times.each do |index|
+        Absence.create!({
+          occurred_at: time_now - index.days,
+          student: pals.shs_freshman_mari
+        })
+      end
+    end
+
     it 'works end-to-end, using absences for Mari as the test case' do
       sign_in(pals.shs_bill_nye)
       get :students_with_high_absences_json, params: {

--- a/spec/lib/insight_students_with_high_absences_spec.rb
+++ b/spec/lib/insight_students_with_high_absences_spec.rb
@@ -4,8 +4,18 @@ RSpec.describe InsightStudentsWithHighAbsences do
   let!(:pals) { TestPals.create! }
   let!(:time_now) { Time.zone.local(2018, 3, 5, 8, 45) }
 
+  def create_absences(n, student, time_now)
+    n.times do |index|
+      Absence.create!({
+        occurred_at: time_now - index.days,
+        student: student
+      })
+    end
+  end
+
   describe '#students_with_high_absences_json' do
     it 'finds no one for Fatima' do
+      create_absences(4, pals.shs_freshman_mari, time_now)
       time_threshold = time_now - 45.days
       absences_threshold = 4
       insight = InsightStudentsWithHighAbsences.new(pals.shs_fatima_science_teacher)
@@ -14,6 +24,7 @@ RSpec.describe InsightStudentsWithHighAbsences do
     end
 
     it 'finds Mari for Bill when at threshold' do
+      create_absences(4, pals.shs_freshman_mari, time_now)
       time_threshold = time_now - 45.days
       absences_threshold = 4
       insight = InsightStudentsWithHighAbsences.new(pals.shs_bill_nye)
@@ -31,16 +42,23 @@ RSpec.describe InsightStudentsWithHighAbsences do
     end
 
     it 'finds no one for Bill when under threshold' do
-      pals.shs_freshman_mari.absences.destroy_all
-      3.times do |index|
-        Absence.create!({
-          occurred_at: time_now - index.days,
-          student: pals.shs_freshman_mari
-        })
-      end
+      create_absences(3, pals.shs_freshman_mari, time_now)
       time_threshold = time_now - 45.days
       absences_threshold = 4
       insight = InsightStudentsWithHighAbsences.new(pals.shs_bill_nye)
+      students_with_high_absences = insight.students_with_high_absences_json(time_now, time_threshold, absences_threshold)
+      expect(students_with_high_absences).to eq []
+    end
+
+    it 'excludes PreK student for K8 principal' do
+      prek_student = FactoryBot.create(:student, {
+        grade: 'PK',
+        school: pals.healey
+      })
+      create_absences(6, prek_student, time_now)
+      time_threshold = time_now - 45.days
+      absences_threshold = 4
+      insight = InsightStudentsWithHighAbsences.new(pals.healey_laura_principal)
       students_with_high_absences = insight.students_with_high_absences_json(time_now, time_threshold, absences_threshold)
       expect(students_with_high_absences).to eq []
     end

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -311,12 +311,6 @@ class TestPals
       grade_numeric: 67,
       grade_letter: 'D'
     )
-    4.times.each do |index|
-      Absence.create!({
-        occurred_at: time_now - index.days,
-        student: @shs_freshman_mari
-      })
-    end
 
     reindex!
     self


### PR DESCRIPTION
# Who is this PR for?
All educators

# What problem does this PR fix?
Some queries are for all students instead of just active.  This isn't causing any problems in practice, but I noticed and this fixes it up.
