### PR TITLE
Absences: Update insight box to students without any notes, rather than SST only

### DIFF
--- a/app/assets/javascripts/home/CheckStudentsWithHighAbsences.js
+++ b/app/assets/javascripts/home/CheckStudentsWithHighAbsences.js
@@ -74,7 +74,7 @@ export class CheckStudentsWithHighAbsencesView extends React.Component {
     const truncatedStudentsWithHighAbsences = studentsWithHighAbsences.slice(0, uiLimit);
 
     return (
-      <div className="CheckStudentsWithHighAbsences">
+      <div className="CheckStudentsWithHighAbsencesView">
         <div style={styles.cardTitle}>
           Students missing school
           <HelpBubble
@@ -101,7 +101,7 @@ export class CheckStudentsWithHighAbsencesView extends React.Component {
     } else if (totalStudents === 1) {
       return <div>There is <b>one student</b> missing school recently who {"hasn't"} been mentioned.  {sinceEl}</div>;
     } else {
-      return <div>There are <b>{totalStudents} students</b> missing school who {"haven't"} been mentioned.  {sinceEl}</div>;
+      return <div>There are <b>{totalStudents} students</b> missing school recently who {"haven't"} been mentioned.  {sinceEl}</div>;
     }
   }
 
@@ -144,7 +144,8 @@ export class CheckStudentsWithHighAbsencesView extends React.Component {
   renderHelpContent() {
     return (
       <div>
-        <p style={styles.helpContent}>These are all the students that you have access to who have a high number of absences over the last 45 days, but {"haven't"} been mentioned recently.  This means there aren't any notes about them from SST meetings, parent conversations, or anything else in Student Insights.  The threshold for being included in this list is to have 4 or more absences over the last 45 calendar days.</p>
+        <p style={styles.helpContent}>These are all the students that you have access to who have a high number of absences over the last 45 days, but {"haven't"} been mentioned recently.</p>
+        <p style={styles.helpContent}>This means there aren't any notes about them from SST meetings, parent conversations, or anything else in Student Insights.  The threshold for being included in this list is to have 4 or more absences over the last 45 calendar days.</p>
         <p style={styles.helpContent}>If you work directly with this student, you could talk with them or reach out to the family.  Or you could connect with a colleague providing support services (eg, SST, attendance officers, counselors, redirect).  If the student in still missing school, attendance contracts might be a next step.</p>        
       </div>
     );

--- a/app/assets/javascripts/home/CheckStudentsWithHighAbsences.js
+++ b/app/assets/javascripts/home/CheckStudentsWithHighAbsences.js
@@ -7,7 +7,7 @@ import {apiFetchJson} from '../helpers/apiFetchJson';
 
 
 // Show teachers their students who have high absences
-// but haven't been talked about in SST recently.
+// but don't have any notes in Insights recently (eg, haven't been brought up in SST).
 class CheckStudentsWithHighAbsences extends React.Component {
   constructor(props) {
     super(props);
@@ -97,11 +97,11 @@ export class CheckStudentsWithHighAbsencesView extends React.Component {
     const dateText = now.clone().subtract(45, 'days').format('MMMM Do');
     const sinceEl = <span>Since {dateText}:</span>;
     if (totalStudents === 0) {
-      return <div>There are <b>no students</b> missing school recently who {"haven't"} been mentioned in SST yet.</div>;
+      return <div>There are <b>no students</b> missing school who {"haven't"} been mentioned recently (eg, in SST).</div>;
     } else if (totalStudents === 1) {
-      return <div>There is <b>one student</b> missing school recently who {"hasn't"} been mentioned in SST yet.  {sinceEl}</div>;
+      return <div>There is <b>one student</b> missing school who {"hasn't"} been mentioned recently (eg, in SST).  {sinceEl}</div>;
     } else {
-      return <div>There are <b>{totalStudents} students</b> missing school recently who {"haven't"} been mentioned in SST yet.  {sinceEl}</div>;
+      return <div>There are <b>{totalStudents} students</b> missing school who {"haven't"} been mentioned recently (eg, in SST).  {sinceEl}</div>;
     }
   }
 
@@ -144,8 +144,8 @@ export class CheckStudentsWithHighAbsencesView extends React.Component {
   renderHelpContent() {
     return (
       <div>
-        <p style={styles.helpContent}>These are all the students that you have access to who have a high number of absences over the last 45 days, but {"haven't"} been mentioned yet in SST.  The threshold for being included in this list is to have 4 or more absences over the last 45 calendar days.</p>
-        <p style={styles.helpContent}>If you work directly with this student, you could talk with them or reach out to the family.  Or you could connect with a colleague providing support services (eg, attendance officers, counselors, redirect).  If the student in still missing school, attendance contracts might be a next step.</p>        
+        <p style={styles.helpContent}>These are all the students that you have access to who have a high number of absences over the last 45 days, but {"haven't"} been mentioned recently.  This means there aren't any notes about them from SST meetings, parent conversations, or anything else in Student Insights.  The threshold for being included in this list is to have 4 or more absences over the last 45 calendar days.</p>
+        <p style={styles.helpContent}>If you work directly with this student, you could talk with them or reach out to the family.  Or you could connect with a colleague providing support services (eg, SST, attendance officers, counselors, redirect).  If the student in still missing school, attendance contracts might be a next step.</p>        
       </div>
     );
   }

--- a/app/assets/javascripts/home/CheckStudentsWithHighAbsences.js
+++ b/app/assets/javascripts/home/CheckStudentsWithHighAbsences.js
@@ -97,11 +97,11 @@ export class CheckStudentsWithHighAbsencesView extends React.Component {
     const dateText = now.clone().subtract(45, 'days').format('MMMM Do');
     const sinceEl = <span>Since {dateText}:</span>;
     if (totalStudents === 0) {
-      return <div>There are <b>no students</b> missing school who {"haven't"} been mentioned recently (eg, in SST).</div>;
+      return <div>There are <b>no students</b> missing school recently who {"haven't"} been mentioned.</div>;
     } else if (totalStudents === 1) {
-      return <div>There is <b>one student</b> missing school who {"hasn't"} been mentioned recently (eg, in SST).  {sinceEl}</div>;
+      return <div>There is <b>one student</b> missing school recently who {"hasn't"} been mentioned.  {sinceEl}</div>;
     } else {
-      return <div>There are <b>{totalStudents} students</b> missing school who {"haven't"} been mentioned recently (eg, in SST).  {sinceEl}</div>;
+      return <div>There are <b>{totalStudents} students</b> missing school who {"haven't"} been mentioned.  {sinceEl}</div>;
     }
   }
 

--- a/app/assets/javascripts/home/CheckStudentsWithHighAbsences.story.js
+++ b/app/assets/javascripts/home/CheckStudentsWithHighAbsences.story.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {CheckStudentsWithHighAbsencesView} from './CheckStudentsWithHighAbsences';
+import {pureTestPropsForN} from './CheckStudentsWithHighAbsences.test';
+import {withDefaultNowContext} from '../../../../spec/javascripts/support/NowContainer';
+
+
+storiesOf('home/CheckStudentsWithHighAbsences', module) // eslint-disable-line no-undef
+  .add('different numbers', () => {
+    return (
+      <div>
+        {render(pureTestPropsForN(0))}
+        {render(pureTestPropsForN(1))}
+        {render(pureTestPropsForN(7))}
+      </div>
+    );
+  });
+
+
+function render(props) {
+  return withDefaultNowContext(
+    <div style={{padding: 20}}>
+      <div style={{width: 470, border: '5px solid #333'}}>
+        <CheckStudentsWithHighAbsencesView {...props} />
+      </div>
+    </div>
+  );
+}

--- a/app/assets/javascripts/home/CheckStudentsWithHighAbsences.test.js
+++ b/app/assets/javascripts/home/CheckStudentsWithHighAbsences.test.js
@@ -19,7 +19,7 @@ function testProps() {
   };
 }
 
-function pureTestPropsForN(n) {
+export function pureTestPropsForN(n) {
   return {
     limit: 10,
     totalStudents: n,

--- a/app/assets/javascripts/home/__snapshots__/CheckStudentsWithHighAbsences.test.js.snap
+++ b/app/assets/javascripts/home/__snapshots__/CheckStudentsWithHighAbsences.test.js.snap
@@ -65,9 +65,9 @@ exports[`CheckStudentsWithHighAbsencesView handles when limit reached 1`] = `
         129
          students
       </b>
-       missing school recently who 
+       missing school who 
       haven't
-       been mentioned in SST yet.  
+       been mentioned recently (eg, in SST).  
       <span>
         Since 
         January 27th
@@ -187,9 +187,9 @@ exports[`CheckStudentsWithHighAbsencesView pure component matches snapshot 1`] =
       <b>
         one student
       </b>
-       missing school recently who 
+       missing school who 
       hasn't
-       been mentioned in SST yet.  
+       been mentioned recently (eg, in SST).  
       <span>
         Since 
         January 27th

--- a/app/assets/javascripts/home/__snapshots__/CheckStudentsWithHighAbsences.test.js.snap
+++ b/app/assets/javascripts/home/__snapshots__/CheckStudentsWithHighAbsences.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CheckStudentsWithHighAbsencesView handles when limit reached 1`] = `
 <div
-  className="CheckStudentsWithHighAbsences"
+  className="CheckStudentsWithHighAbsencesView"
 >
   <div
     style={
@@ -65,9 +65,9 @@ exports[`CheckStudentsWithHighAbsencesView handles when limit reached 1`] = `
         129
          students
       </b>
-       missing school who 
+       missing school recently who 
       haven't
-       been mentioned recently (eg, in SST).  
+       been mentioned.  
       <span>
         Since 
         January 27th
@@ -125,7 +125,7 @@ exports[`CheckStudentsWithHighAbsencesView handles when limit reached 1`] = `
 
 exports[`CheckStudentsWithHighAbsencesView pure component matches snapshot 1`] = `
 <div
-  className="CheckStudentsWithHighAbsences"
+  className="CheckStudentsWithHighAbsencesView"
 >
   <div
     style={
@@ -187,9 +187,9 @@ exports[`CheckStudentsWithHighAbsencesView pure component matches snapshot 1`] =
       <b>
         one student
       </b>
-       missing school who 
+       missing school recently who 
       hasn't
-       been mentioned recently (eg, in SST).  
+       been mentioned.  
       <span>
         Since 
         January 27th

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,7 +56,7 @@ class ApplicationController < ActionController::Base
   # Used to wrap a block with timing measurements and logging, returning the value of the
   # block.
   #
-  # Example: students = log_timing('load students') { Student.all }
+  # Example: students = log_timing('load students') { Student.active }
   # Outputs: log_timing:end [load students] 2998ms
   def log_timing(message)
     return_value = nil

--- a/app/controllers/district_controller.rb
+++ b/app/controllers/district_controller.rb
@@ -3,7 +3,7 @@ class DistrictController < ApplicationController
     raise Exceptions::EducatorNotAuthorized unless current_educator.districtwide_access
 
     # students, grouped by school and grade
-    authorized_students = authorized { Student.all }
+    authorized_students = authorized { Student.active }
     groups = authorized_students.group_by do |student|
       [student.school_id, student.grade]
     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,7 @@ class HomeController < ApplicationController
     time_now = time_now_or_param(params[:time_now])
     limit = params[:limit].to_i
 
-    authorized_students = authorizer.authorized_when_viewing_as(view_as_educator) { Student.all }
+    authorized_students = authorizer.authorized_when_viewing_as(view_as_educator) { Student.active }
     feed = Feed.new(authorized_students)
     feed_cards = feed.all_cards(time_now, limit)
     render json: {

--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -74,7 +74,7 @@ class Authorizer
   # who they are authorized to see themselves.
   #
   # Usage:
-  #  authorized_students = authorized_when_viewing_as(other_educator) { Student.all }
+  #  authorized_students = authorized_when_viewing_as(other_educator) { Student.active }
   def authorized_when_viewing_as(view_as_educator, &block)
     authorized do
       if @educator.can_set_districtwide_access? && view_as_educator.id != @educator.id
@@ -107,7 +107,7 @@ class Authorizer
       return true if @educator.has_access_to_grade_levels? && student.grade.in?(@educator.grade_level_access) # Grade level access
 
       # The next two checks call `#to_a` as a performance optimization.
-      # In loops with `authorized { Student.all }`, without forcing this
+      # In loops with `authorized { Student.active }`, without forcing this
       # to an eagerly evaluated array, repeated calls will keep making the
       # same queries.  This seems unexpected to me, but adding `to_a` at
       # the end results in Rails caching these queries across the repeated

--- a/app/lib/feed.rb
+++ b/app/lib/feed.rb
@@ -2,7 +2,7 @@ class Feed
   # Shortcut for getting feed for all students an educator is authorized to view
   def self.for(educator)
     authorizer = Authorizer.new(educator)
-    authorized_students = authorizer.authorized { Student.all }
+    authorized_students = authorizer.authorized { Student.active }
     self.new(authorized_students)
   end
 

--- a/app/lib/insight_students_with_high_absences.rb
+++ b/app/lib/insight_students_with_high_absences.rb
@@ -6,7 +6,7 @@ class InsightStudentsWithHighAbsences
 
   # Returns a list of all students that the educator has access
   # to that have a high number of absences, but haven't been
-  # commented on in SST yet.  This information may not be directly
+  # commented on in Insights yet.  This information may not be directly
   # actionable for all teachers (eg, ninth grade math teachers) but
   # for SST team members, principals and APs, redirect, and K8
   # classroom teachers, the intended actions are to talk with
@@ -56,13 +56,15 @@ class InsightStudentsWithHighAbsences
     end
   end
 
-  # Students who've been commented on in SST recently
+  # Students who've been commented on in Insights recently (for any reason)
+  # This includes any kind of comment since we don't want folks to
+  # enter notes inaccurately as "SST Meetings" when they aren't really, just to
+  # make this list seem in better shape.
   def recently_commented_student_ids(student_ids, time_threshold)
     recent_notes = EventNote
       .where(is_restricted: false)
       .where(student_id: student_ids)
       .where('recorded_at > ?', time_threshold)
-      .where(event_note_type_id: [300])
     recent_notes.map(&:student_id).uniq
   end
 

--- a/app/lib/insight_students_with_high_absences.rb
+++ b/app/lib/insight_students_with_high_absences.rb
@@ -17,8 +17,12 @@ class InsightStudentsWithHighAbsences
   # This method returns hashes that are the shape of what is needed
   # in the product.
   def students_with_high_absences_json(time_now, time_threshold, absences_threshold)
-    # Include all authorized students
-    students = @authorizer.authorized { Student.all }
+    # Exclude students in younger grades like PreK since attendance isn't mandatory.
+    # This means there's less consistent attendance from families, and it's less
+    # of a priority to follow-up for schools.
+    students = @authorizer.authorized do
+      Student.active.where.not(grade: ['TK', 'PPK', 'PK'])
+    end
     student_ids = students.map(&:id)
 
     # Absences by student in the time period.

--- a/app/models/event_note_type.rb
+++ b/app/models/event_note_type.rb
@@ -15,4 +15,12 @@ class EventNoteType < ActiveRecord::Base
   def self.SST
     EventNoteType.find(300)
   end
+
+  def self.NGE
+    EventNoteType.find(305)
+  end
+
+  def self.TENGE
+    EventNoteType.find(306)
+  end
 end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -192,6 +192,15 @@ describe HomeController, :type => :controller do
   end
 
   describe '#students_with_high_absences_json' do
+    before do
+      4.times.each do |index|
+        Absence.create!({
+          occurred_at: time_now - index.days,
+          student: pals.shs_freshman_mari
+        })
+      end
+    end
+
     it 'works end-to-end, using absences for Mari as the test case' do
       sign_in(pals.shs_bill_nye)
       get :students_with_high_absences_json, params: {

--- a/spec/lib/insight_students_with_high_absences_spec.rb
+++ b/spec/lib/insight_students_with_high_absences_spec.rb
@@ -68,17 +68,29 @@ RSpec.describe InsightStudentsWithHighAbsences do
     let!(:insight) { InsightStudentsWithHighAbsences.new(pals.shs_bill_nye) }
     let!(:time_threshold) { time_now - 45.days }
     let!(:student_ids) { [pals.shs_freshman_mari] }
-    let!(:sst_event_note_type) { EventNoteType.find(300) }
 
     it 'with no comment' do
       expect(insight.send(:recently_commented_student_ids, student_ids, time_threshold)).to eq []
+    end
+
+    it 'with NGE' do
+      EventNote.create!(
+        student: pals.shs_freshman_mari,
+        educator: pals.uri,
+        event_note_type: EventNoteType.NGE,
+        text: 'blah',
+        recorded_at: time_now
+      )
+      expect(insight.send(:recently_commented_student_ids, student_ids, time_threshold)).to eq [
+        pals.shs_freshman_mari.id
+      ]
     end
 
     it 'with SST comment' do
       EventNote.create!(
         student: pals.shs_freshman_mari,
         educator: pals.uri,
-        event_note_type: sst_event_note_type,
+        event_note_type: EventNoteType.SST,
         text: 'blah',
         recorded_at: time_now
       )
@@ -91,7 +103,7 @@ RSpec.describe InsightStudentsWithHighAbsences do
       EventNote.create!(
         student: pals.shs_freshman_mari,
         educator: pals.uri,
-        event_note_type: sst_event_note_type,
+        event_note_type: EventNoteType.SST,
         is_restricted: true,
         text: 'blah',
         recorded_at: time_now
@@ -103,7 +115,7 @@ RSpec.describe InsightStudentsWithHighAbsences do
       EventNote.create!(
         student: pals.shs_freshman_mari,
         educator: pals.uri,
-        event_note_type: sst_event_note_type,
+        event_note_type: EventNoteType.SST,
         text: 'blah',
         recorded_at: time_now - 50.days
       )

--- a/spec/lib/insight_students_with_high_absences_spec.rb
+++ b/spec/lib/insight_students_with_high_absences_spec.rb
@@ -4,8 +4,18 @@ RSpec.describe InsightStudentsWithHighAbsences do
   let!(:pals) { TestPals.create! }
   let!(:time_now) { Time.zone.local(2018, 3, 5, 8, 45) }
 
+  def create_absences(n, student, time_now)
+    n.times do |index|
+      Absence.create!({
+        occurred_at: time_now - index.days,
+        student: student
+      })
+    end
+  end
+
   describe '#students_with_high_absences_json' do
     it 'finds no one for Fatima' do
+      create_absences(4, pals.shs_freshman_mari, time_now)
       time_threshold = time_now - 45.days
       absences_threshold = 4
       insight = InsightStudentsWithHighAbsences.new(pals.shs_fatima_science_teacher)
@@ -14,6 +24,7 @@ RSpec.describe InsightStudentsWithHighAbsences do
     end
 
     it 'finds Mari for Bill when at threshold' do
+      create_absences(4, pals.shs_freshman_mari, time_now)
       time_threshold = time_now - 45.days
       absences_threshold = 4
       insight = InsightStudentsWithHighAbsences.new(pals.shs_bill_nye)
@@ -31,16 +42,23 @@ RSpec.describe InsightStudentsWithHighAbsences do
     end
 
     it 'finds no one for Bill when under threshold' do
-      pals.shs_freshman_mari.absences.destroy_all
-      3.times do |index|
-        Absence.create!({
-          occurred_at: time_now - index.days,
-          student: pals.shs_freshman_mari
-        })
-      end
+      create_absences(3, pals.shs_freshman_mari, time_now)
       time_threshold = time_now - 45.days
       absences_threshold = 4
       insight = InsightStudentsWithHighAbsences.new(pals.shs_bill_nye)
+      students_with_high_absences = insight.students_with_high_absences_json(time_now, time_threshold, absences_threshold)
+      expect(students_with_high_absences).to eq []
+    end
+
+    it 'excludes PreK student for K8 principal' do
+      prek_student = FactoryBot.create(:student, {
+        grade: 'PK',
+        school: pals.healey
+      })
+      create_absences(6, prek_student, time_now)
+      time_threshold = time_now - 45.days
+      absences_threshold = 4
+      insight = InsightStudentsWithHighAbsences.new(pals.healey_laura_principal)
       students_with_high_absences = insight.students_with_high_absences_json(time_now, time_threshold, absences_threshold)
       expect(students_with_high_absences).to eq []
     end

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -311,12 +311,6 @@ class TestPals
       grade_numeric: 67,
       grade_letter: 'D'
     )
-    4.times.each do |index|
-      Absence.create!({
-        occurred_at: time_now - index.days,
-        student: @shs_freshman_mari
-      })
-    end
 
     reindex!
     self

--- a/ui/config/.storybook/config.js
+++ b/ui/config/.storybook/config.js
@@ -14,6 +14,9 @@ function loadStories() {
   require('../../../app/assets/javascripts/components/DibelsBreakdownBar.story.js');
   require('../../../app/assets/javascripts/components/ReactSelect.story.js');
 
+  // home
+  require('../../../app/assets/javascripts/home/CheckStudentsWithHighAbsences.story.js');
+
   // student profile
   require('../../../app/assets/javascripts/student_profile/RiskBubble.story.js');
   


### PR DESCRIPTION
# Who is this PR for?
All educators, K8 principals and redirect counselors in particular.

# What problem does this PR fix?
See https://github.com/studentinsights/studentinsights/issues/1655.

# What does this PR do?
Updates the query for recent notes to look for any note, not just SST and updates the copy.

# Screenshot (if adding a client-side feature)
Note that Storybook doesn't yet load fonts etc. so the styling isn't exactly accurate, but this new story shows all copy variations at once:

<img width="483" alt="screen shot 2018-05-03 at 6 01 57 pm" src="https://user-images.githubusercontent.com/1056957/39604920-3354210e-4efc-11e8-89b1-26d360d79979.png">


# Checklists
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code
