### PR TITLE
Classrooms: Revisions to definitions and comparisons, counts instead of percents

### DIFF
--- a/app/assets/javascripts/components/DibelsBreakdownBar.js
+++ b/app/assets/javascripts/components/DibelsBreakdownBar.js
@@ -2,60 +2,77 @@ import React from 'react';
 
 // Visual component showing a horizontal bar broken down into three colors
 // showing percent of students at different DIBELS levels.
-export default function DibelsBreakdownBar(props) {
-  const {height, coreCount, strategicCount, intensiveCount, style = {}} = props;
-  const totalCount = coreCount + strategicCount + intensiveCount;
-  const opacity = 0.5;
-  const fontSize = 10;
-  const scale = (value) => `${Math.ceil(100 * value)}%`;
+export default class DibelsBreakdownBar extends React.Component {
+  totalCount() {
+    const {coreCount, strategicCount, intensiveCount} = this.props;
+    return coreCount + strategicCount + intensiveCount;
+  }
 
-  if (totalCount === 0) return null;
-  return (
-    <div className="DibelsBreakdownBar" style={{height, ...style}}>
-      <div style={{position: 'relative', width: '100%', height}}>
-        <div style={{
-          position: 'absolute',
-          background: 'green',
-          opacity,
-          fontSize,
-          left: scale(0),
-          width: scale(coreCount / totalCount),
-          height
-        }}>{'\u00A0'}</div>
-        <div style={{
-          position: 'absolute',
-          background: 'orange',
-          opacity,
-          fontSize,
-          left: scale(coreCount / totalCount),
-          width: scale(strategicCount / totalCount),
-          height
-        }}>{'\u00A0'}</div>
-        <div style={{
-          position: 'absolute',
-          background: 'red',
-          opacity,
-          fontSize,
-          left: scale((coreCount + strategicCount) / totalCount),
-          width: scale(intensiveCount / totalCount),
-          height
-        }}>{'\u00A0'}</div>
+  scale(count) {
+    const totalCount = this.totalCount();
+    return `${Math.ceil(100 * count / totalCount)}%`;
+  }
 
-        {coreCount > 0 && 
+  render() {
+    const {height, coreCount, strategicCount, intensiveCount, style = {}} = this.props;    
+    return (
+      <div className="DibelsBreakdownBar" style={{height, ...style}}>
+        <div style={{position: 'relative', width: '100%', height}}>
+          {this.renderBarAndLabel({
+            left: 0,
+            width: coreCount,
+            color: 'green'
+          })}
+          {this.renderBarAndLabel({
+            left: coreCount,
+            width: strategicCount,
+            color: 'orange'
+          })}
+          {this.renderBarAndLabel({
+            left: coreCount + strategicCount,
+            width: intensiveCount,
+            color: 'red'
+          })}
+        </div>
+      </div>
+    );
+  }
+
+
+  renderBarAndLabel({left, width, color}) {
+    const {height} = this.props;
+    const opacity = 0.5;
+    const fontSize = 10;
+
+    if (width === 0) return;
+    return (
+      <div>
+        <div style={{
+          opacity,
+          fontSize,
+          position: 'absolute',
+          background: color,
+          left: this.scale(left),
+          width: this.scale(width),
+          height
+        }}>{'\u00A0'}</div>
+        {width > 0 && 
           <div style={{
-            position: 'absolute',
-            textAlign: 'right',
             opacity,
             fontSize,
-            left: scale(0),
-            width: scale(coreCount / totalCount),
+            color,
+            position: 'absolute',
+            textAlign: 'right',
+            left: this.scale(left),
+            width: this.scale(width),
             top: height/2  + 1, // padding
-            color: 'green'
-          }}>{coreCount}</div>}
+            paddingRight: 1
+          }}>{width}</div>}
       </div>
-    </div>
-  );
+    );
+  }
 }
+
 DibelsBreakdownBar.propTypes = {
   coreCount: React.PropTypes.number.isRequired,
   strategicCount: React.PropTypes.number.isRequired,

--- a/app/assets/javascripts/components/DibelsBreakdownBar.js
+++ b/app/assets/javascripts/components/DibelsBreakdownBar.js
@@ -7,7 +7,7 @@ export default function DibelsBreakdownBar(props) {
   const totalCount = coreCount + strategicCount + intensiveCount;
   const opacity = 0.5;
   const fontSize = 10;
-  const scale = (value) => `${Math.round(100 * value)}%`;
+  const scale = (value) => `${Math.ceil(100 * value)}%`;
 
   if (totalCount === 0) return null;
   return (
@@ -44,14 +44,14 @@ export default function DibelsBreakdownBar(props) {
         {coreCount > 0 && 
           <div style={{
             position: 'absolute',
-            textAlign: 'left',
+            textAlign: 'right',
             opacity,
             fontSize,
             left: scale(0),
             width: scale(coreCount / totalCount),
             top: height/2  + 1, // padding
             color: 'green'
-          }}>{Math.round(100 * coreCount / totalCount)}%</div>}
+          }}>{coreCount}</div>}
       </div>
     </div>
   );

--- a/app/assets/javascripts/components/DibelsBreakdownBar.js
+++ b/app/assets/javascripts/components/DibelsBreakdownBar.js
@@ -40,7 +40,7 @@ export default class DibelsBreakdownBar extends React.Component {
 
 
   renderBarAndLabel({left, width, color}) {
-    const {height} = this.props;
+    const {height, labelTop} = this.props;
     const opacity = 0.5;
     const fontSize = 10;
 
@@ -65,7 +65,7 @@ export default class DibelsBreakdownBar extends React.Component {
             textAlign: 'right',
             left: this.scale(left),
             width: this.scale(width),
-            top: height/2  + 1, // padding
+            top: labelTop,
             paddingRight: 1
           }}>{width}</div>}
       </div>
@@ -78,5 +78,6 @@ DibelsBreakdownBar.propTypes = {
   strategicCount: React.PropTypes.number.isRequired,
   intensiveCount: React.PropTypes.number.isRequired,
   height: React.PropTypes.number.isRequired,
+  labelTop: React.PropTypes.number.isRequired,
   style: React.PropTypes.object
 };

--- a/app/assets/javascripts/components/DibelsBreakdownBar.story.js
+++ b/app/assets/javascripts/components/DibelsBreakdownBar.story.js
@@ -5,12 +5,16 @@ import DibelsBreakdownBar from './DibelsBreakdownBar';
 
 storiesOf('components/DibelsBreakdownBar', module) // eslint-disable-line no-undef
   .add('all', () => {
+    const style = {
+      margin: 20,
+      width: 300
+    };
     return (
       <div style={{display: 'flex', flexDirection: 'column', margin: 20, background: '3px solid black'}}>
-       <DibelsBreakdownBar height={20} style={{margin: 20, width: 300}} strategicCount={3} coreCount={2} intensiveCount={7} />
-       <DibelsBreakdownBar height={20} style={{margin: 20, width: 300}} strategicCount={13} coreCount={12} intensiveCount={17} />
-       <DibelsBreakdownBar height={20} style={{margin: 20, width: 300}} strategicCount={8} coreCount={4} intensiveCount={2} />
-       <DibelsBreakdownBar height={20} style={{margin: 20, width: 300}} strategicCount={0} coreCount={0} intensiveCount={0} />
+       <DibelsBreakdownBar height={20} labelTop={23} style={style} strategicCount={3} coreCount={2} intensiveCount={7} />
+       <DibelsBreakdownBar height={20} labelTop={23} style={style} strategicCount={13} coreCount={12} intensiveCount={17} />
+       <DibelsBreakdownBar height={20} labelTop={23} style={style} strategicCount={0} coreCount={0} intensiveCount={0} />
+       <DibelsBreakdownBar height={40} labelTop={43} style={style} strategicCount={8} coreCount={4} intensiveCount={2} />
       </div>
     );
   });

--- a/app/assets/javascripts/components/DibelsBreakdownBar.test.js
+++ b/app/assets/javascripts/components/DibelsBreakdownBar.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import renderer from 'react-test-renderer';
+import DibelsBreakdownBar from './DibelsBreakdownBar';
+
+
+export function testProps(props) {
+  return {
+    coreCount: 7,
+    strategicCount: 3,
+    intensiveCount: 2,
+    height: 50,
+    ...props
+  };
+}
+
+it('renders without crashing', () => {
+  const el = document.createElement('div');
+  const props = testProps();
+  ReactDOM.render(<DibelsBreakdownBar {...props} />, el);
+});
+
+it('snapshots', () => {
+  const props = testProps();
+  const tree = renderer
+    .create(<DibelsBreakdownBar {...props} />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/assets/javascripts/components/Stack.js
+++ b/app/assets/javascripts/components/Stack.js
@@ -1,0 +1,62 @@
+import React from 'react';
+
+// Render a horizontal Stack that is filled in order, with each bar
+// having a {`color`, `count`} and an overall `scaleFn`.
+export default class Stack extends React.Component {
+
+  render() {
+    const {style, barStyle, labelStyle, stacks, scaleFn, labelFn} = this.props;
+
+    return (
+      <div style={{
+        color: 'black',
+        cursor: 'default',
+        display: 'inline-block',
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        ...style
+      }}>
+        {stacks.map((stack, index) => {
+          const sum = stacks.slice(0, index).reduce((count, stack) => count + stack.count, 0);
+          const {key, color, count} = stack;
+          const label = labelFn(count, stack, index);
+          function toScreen(count) {
+            return `${Math.round(100*scaleFn(count))}%`;
+          }
+          return (
+            <div
+              key={key === undefined ? index : key}>
+              <div style={{
+                position: 'absolute',
+                left: toScreen(sum),
+                backgroundColor: color,
+                width: toScreen(count),
+                height: '100%',
+                ...barStyle
+              }} />
+              <div style={{
+                position: 'absolute',
+                left: toScreen(sum),
+                width: toScreen(count),
+                height: '100%',
+                ...labelStyle
+              }}>{label}</div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+}
+
+Stack.propTypes = {
+  stacks: React.PropTypes.array.isRequired,
+  scaleFn: React.PropTypes.func.isRequired,
+  labelFn: React.PropTypes.func.isRequired,
+  style: React.PropTypes.object,
+  barStyle: React.PropTypes.object,
+  labelStyle: React.PropTypes.object,
+  title: React.PropTypes.string
+};

--- a/app/assets/javascripts/components/Stack.js
+++ b/app/assets/javascripts/components/Stack.js
@@ -26,7 +26,8 @@ export default class Stack extends React.Component {
           }
           return (
             <div
-              key={key === undefined ? index : key}>
+              key={key === undefined ? index : key}
+              style={{width: '100%'}}>
               <div style={{
                 position: 'absolute',
                 left: toScreen(sum),

--- a/app/assets/javascripts/components/Stack.story.js
+++ b/app/assets/javascripts/components/Stack.story.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import Stack from './Stack';
+
+
+storiesOf('components/Stack', module) // eslint-disable-line no-undef
+  .add('all', () => {
+    return (
+      <div>
+        <div style={{display: 'flex', flexDirection: 'column', margin: 20, width: 300, height: 30, border: '1px solid #333'}}>
+          <Stack
+            stacks={[
+              {count: 18, color: 'red'},
+              {count: 8, color: 'orange'}
+            ]}
+            scaleFn={count => count / (18+8)}
+            labelFn={count => count}
+          />
+        </div>
+        <div style={{display: 'flex', flexDirection: 'column', margin: 20, width: 300, height: 20, border: '1px solid #eee'}}>
+          <Stack
+            barStyle={{
+              height: 6
+            }}
+            labelStyle={{
+              fontSize: 10,
+              display: 'flex',
+              alignItems: 'flex-end'
+            }}
+            stacks={[
+              {count: 18, color: 'red'},
+              {count: 8, color: 'orange'}
+            ]}
+            scaleFn={count => count / (18+8)}
+            labelFn={(count, stack, index) => index === 0 ? count : null}
+          />
+        </div>
+      </div>
+    );
+  });

--- a/app/assets/javascripts/components/Stack.test.js
+++ b/app/assets/javascripts/components/Stack.test.js
@@ -1,16 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import renderer from 'react-test-renderer';
-import DibelsBreakdownBar from './DibelsBreakdownBar';
+import Stack from './Stack';
 
 
 export function testProps(props) {
   return {
-    coreCount: 7,
-    strategicCount: 3,
-    intensiveCount: 2,
-    height: 50,
-    labelTop: 55,
+    stacks: [
+      {count: 18, color: 'red'},
+      {count: 8, color: 'orange'}
+    ],
+    scaleFn(count) { return count / (18+8); },
+    labelFn(count) { return count; },
     ...props
   };
 }
@@ -18,13 +19,13 @@ export function testProps(props) {
 it('renders without crashing', () => {
   const el = document.createElement('div');
   const props = testProps();
-  ReactDOM.render(<DibelsBreakdownBar {...props} />, el);
+  ReactDOM.render(<Stack {...props} />, el);
 });
 
 it('snapshots', () => {
   const props = testProps();
   const tree = renderer
-    .create(<DibelsBreakdownBar {...props} />)
+    .create(<Stack {...props} />)
     .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/assets/javascripts/components/TinyBar.js
+++ b/app/assets/javascripts/components/TinyBar.js
@@ -1,0 +1,63 @@
+import React from 'react';
+
+// Render a horizontal Stack that is filled in order, with each bar
+// having a {`color`, `count`} and an overall `scaleFn`.
+export default class Stack extends React.Component {
+
+  render() {
+    const {style, barStyle, labelStyle, stacks, scaleFn, labelFn} = this.props;
+
+    return (
+      <div style={{
+        color: 'black',
+        cursor: 'default',
+        display: 'inline-block',
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        ...style
+      }}>
+        {stacks.map((stack, index) => {
+          const sum = stacks.slice(0, index).reduce((count, stack) => count + stack.count, 0);
+          const {key, color, count} = stack;
+          const label = labelFn(count, stack, index);
+          function toScreen(count) {
+            return `${Math.round(100*scaleFn(count))}%`;
+          }
+          return (
+            <div
+              key={key === undefined ? index : key}
+              style={{width: '100%'}}>
+              <div style={{
+                position: 'absolute',
+                left: toScreen(sum),
+                backgroundColor: color,
+                width: toScreen(count),
+                height: '100%',
+                ...barStyle
+              }} />
+              <div style={{
+                position: 'absolute',
+                left: toScreen(sum),
+                width: toScreen(count),
+                height: '100%',
+                ...labelStyle
+              }}>{label}</div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+}
+
+Stack.propTypes = {
+  stacks: React.PropTypes.array.isRequired,
+  scaleFn: React.PropTypes.func.isRequired,
+  labelFn: React.PropTypes.func.isRequired,
+  style: React.PropTypes.object,
+  barStyle: React.PropTypes.object,
+  labelStyle: React.PropTypes.object,
+  title: React.PropTypes.string
+};

--- a/app/assets/javascripts/components/__snapshots__/DibelsBreakdownBar.test.js.snap
+++ b/app/assets/javascripts/components/__snapshots__/DibelsBreakdownBar.test.js.snap
@@ -44,7 +44,7 @@ exports[`snapshots 1`] = `
             "paddingRight": 1,
             "position": "absolute",
             "textAlign": "right",
-            "top": 26,
+            "top": 55,
             "width": "59%",
           }
         }
@@ -78,7 +78,7 @@ exports[`snapshots 1`] = `
             "paddingRight": 1,
             "position": "absolute",
             "textAlign": "right",
-            "top": 26,
+            "top": 55,
             "width": "25%",
           }
         }
@@ -112,7 +112,7 @@ exports[`snapshots 1`] = `
             "paddingRight": 1,
             "position": "absolute",
             "textAlign": "right",
-            "top": 26,
+            "top": 55,
             "width": "17%",
           }
         }

--- a/app/assets/javascripts/components/__snapshots__/DibelsBreakdownBar.test.js.snap
+++ b/app/assets/javascripts/components/__snapshots__/DibelsBreakdownBar.test.js.snap
@@ -1,0 +1,84 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshots 1`] = `
+<div
+  className="DibelsBreakdownBar"
+  style={
+    Object {
+      "height": 50,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "height": 50,
+        "position": "relative",
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "green",
+          "fontSize": 10,
+          "height": 50,
+          "left": "0%",
+          "opacity": 0.5,
+          "position": "absolute",
+          "width": "59%",
+        }
+      }
+    >
+       
+    </div>
+    <div
+      style={
+        Object {
+          "background": "orange",
+          "fontSize": 10,
+          "height": 50,
+          "left": "59%",
+          "opacity": 0.5,
+          "position": "absolute",
+          "width": "25%",
+        }
+      }
+    >
+       
+    </div>
+    <div
+      style={
+        Object {
+          "background": "red",
+          "fontSize": 10,
+          "height": 50,
+          "left": "84%",
+          "opacity": 0.5,
+          "position": "absolute",
+          "width": "17%",
+        }
+      }
+    >
+       
+    </div>
+    <div
+      style={
+        Object {
+          "color": "green",
+          "fontSize": 10,
+          "left": "0%",
+          "opacity": 0.5,
+          "position": "absolute",
+          "textAlign": "right",
+          "top": 26,
+          "width": "59%",
+        }
+      }
+    >
+      7
+    </div>
+  </div>
+</div>
+`;

--- a/app/assets/javascripts/components/__snapshots__/DibelsBreakdownBar.test.js.snap
+++ b/app/assets/javascripts/components/__snapshots__/DibelsBreakdownBar.test.js.snap
@@ -18,66 +18,107 @@ exports[`snapshots 1`] = `
       }
     }
   >
-    <div
-      style={
-        Object {
-          "background": "green",
-          "fontSize": 10,
-          "height": 50,
-          "left": "0%",
-          "opacity": 0.5,
-          "position": "absolute",
-          "width": "59%",
+    <div>
+      <div
+        style={
+          Object {
+            "background": "green",
+            "fontSize": 10,
+            "height": 50,
+            "left": "0%",
+            "opacity": 0.5,
+            "position": "absolute",
+            "width": "59%",
+          }
         }
-      }
-    >
-       
+      >
+         
+      </div>
+      <div
+        style={
+          Object {
+            "color": "green",
+            "fontSize": 10,
+            "left": "0%",
+            "opacity": 0.5,
+            "paddingRight": 1,
+            "position": "absolute",
+            "textAlign": "right",
+            "top": 26,
+            "width": "59%",
+          }
+        }
+      >
+        7
+      </div>
     </div>
-    <div
-      style={
-        Object {
-          "background": "orange",
-          "fontSize": 10,
-          "height": 50,
-          "left": "59%",
-          "opacity": 0.5,
-          "position": "absolute",
-          "width": "25%",
+    <div>
+      <div
+        style={
+          Object {
+            "background": "orange",
+            "fontSize": 10,
+            "height": 50,
+            "left": "59%",
+            "opacity": 0.5,
+            "position": "absolute",
+            "width": "25%",
+          }
         }
-      }
-    >
-       
+      >
+         
+      </div>
+      <div
+        style={
+          Object {
+            "color": "orange",
+            "fontSize": 10,
+            "left": "59%",
+            "opacity": 0.5,
+            "paddingRight": 1,
+            "position": "absolute",
+            "textAlign": "right",
+            "top": 26,
+            "width": "25%",
+          }
+        }
+      >
+        3
+      </div>
     </div>
-    <div
-      style={
-        Object {
-          "background": "red",
-          "fontSize": 10,
-          "height": 50,
-          "left": "84%",
-          "opacity": 0.5,
-          "position": "absolute",
-          "width": "17%",
+    <div>
+      <div
+        style={
+          Object {
+            "background": "red",
+            "fontSize": 10,
+            "height": 50,
+            "left": "84%",
+            "opacity": 0.5,
+            "position": "absolute",
+            "width": "17%",
+          }
         }
-      }
-    >
-       
-    </div>
-    <div
-      style={
-        Object {
-          "color": "green",
-          "fontSize": 10,
-          "left": "0%",
-          "opacity": 0.5,
-          "position": "absolute",
-          "textAlign": "right",
-          "top": 26,
-          "width": "59%",
+      >
+         
+      </div>
+      <div
+        style={
+          Object {
+            "color": "red",
+            "fontSize": 10,
+            "left": "84%",
+            "opacity": 0.5,
+            "paddingRight": 1,
+            "position": "absolute",
+            "textAlign": "right",
+            "top": 26,
+            "width": "17%",
+          }
         }
-      }
-    >
-      7
+      >
+        2
+      </div>
     </div>
   </div>
 </div>

--- a/app/assets/javascripts/components/__snapshots__/Stack.test.js.snap
+++ b/app/assets/javascripts/components/__snapshots__/Stack.test.js.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshots 1`] = `
+<div
+  style={
+    Object {
+      "color": "black",
+      "cursor": "default",
+      "display": "inline-block",
+      "height": "100%",
+      "position": "relative",
+      "width": "100%",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "backgroundColor": "red",
+          "height": "100%",
+          "left": "0%",
+          "position": "absolute",
+          "width": "69%",
+        }
+      }
+    />
+    <div
+      style={
+        Object {
+          "height": "100%",
+          "left": "0%",
+          "position": "absolute",
+          "width": "69%",
+        }
+      }
+    >
+      18
+    </div>
+  </div>
+  <div
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "backgroundColor": "orange",
+          "height": "100%",
+          "left": "69%",
+          "position": "absolute",
+          "width": "31%",
+        }
+      }
+    />
+    <div
+      style={
+        Object {
+          "height": "100%",
+          "left": "69%",
+          "position": "absolute",
+          "width": "31%",
+        }
+      }
+    >
+      8
+    </div>
+  </div>
+</div>
+`;

--- a/app/assets/javascripts/equity/ClassroomListCreatorPage.js
+++ b/app/assets/javascripts/equity/ClassroomListCreatorPage.js
@@ -70,6 +70,7 @@ export default class ClassroomListCreatorPage extends React.Component {
     this.doReplaceState();
     window.addEventListener('beforeunload', this.onBeforeUnload);
     this.triggerFetches();
+    this.installDebugHook();
   }
 
   componentDidUpdate() {
@@ -80,6 +81,12 @@ export default class ClassroomListCreatorPage extends React.Component {
   componentWillUnmount() {
     if (this.doSaveChanges.flush) this.doSaveChanges.flush(); // flush any queued changes
     window.removeEventListener('beforeunload', this.onBeforeUnload);
+  }
+
+  // This is a debug hook for iterating on particular production data sets locally
+  // during development.
+  installDebugHook() {
+    window.forceDebug = this.onForceDebug.bind(this);
   }
 
   doSizePage() {
@@ -202,6 +209,11 @@ export default class ClassroomListCreatorPage extends React.Component {
     return (isDirty)
       ? 'You have unsaved changes.'
       : undefined;
+  }
+
+  onForceDebug(nextState) {
+    const {gradeLevelNextYear, students, studentIdsByRoom} = nextState;
+    this.setState({gradeLevelNextYear, students, studentIdsByRoom, stepIndex: 2});
   }
 
   onFetchedGradeLevels(json) {

--- a/app/assets/javascripts/equity/ClassroomListCreatorPage.js
+++ b/app/assets/javascripts/equity/ClassroomListCreatorPage.js
@@ -18,7 +18,18 @@ export const STEPS = [
   'Submit to principal'
 ];
 
-// Entry point for grade-level teaching teams to create classroom lists.
+// Entry point for grade-level teaching teams to create classroom lists,
+// which creates a new client-side `balanceId`.
+export function ClassroomListCreatorPageEntryPoint({disableHistory}) {
+  return <ClassroomListCreatorPage
+    balanceId={uuidv4()}
+    disableHistory={disableHistory} />;
+}
+ClassroomListCreatorPageEntryPoint.propTypes = {
+  disableHistory: React.PropTypes.bool
+};
+
+// Root page component.
 // This component manages state transitions and hands off requests to the server
 // and rendering to other components.  On state changes, it saves to the server
 // with some throttling to prevent too much server communication.
@@ -27,7 +38,6 @@ export default class ClassroomListCreatorPage extends React.Component {
     super(props);
 
     this.state = {
-      balanceId: props.balanceId || uuidv4(),
       stepIndex: 0,
 
       // first
@@ -94,8 +104,8 @@ export default class ClassroomListCreatorPage extends React.Component {
   }
   
   doReplaceState() {
-    const {balanceId} = this.state;
-    const path = `/balancing/${balanceId}`;
+    const {balanceId} = this.props;
+    const path = `/classlists/${balanceId}`;
     if (!this.props.disableHistory) {
       window.history.replaceState({}, null, path);
     }
@@ -103,8 +113,8 @@ export default class ClassroomListCreatorPage extends React.Component {
 
   // This method is throttled.
   doSaveChanges() {
+    const {balanceId} = this.props;
     const {
-      balanceId,
       stepIndex,
       schoolId,
       gradeLevelNextYear,
@@ -162,12 +172,13 @@ export default class ClassroomListCreatorPage extends React.Component {
   }
 
   fetchGradeLevels() {
-    const {balanceId} = this.state;
+    const {balanceId} = this.props;
     return fetchGradeLevelsJson(balanceId);
   }
 
   fetchStudents() {
-    const {balanceId, gradeLevelNextYear, schoolId} = this.state;
+    const {balanceId} = this.props;
+    const {gradeLevelNextYear, schoolId} = this.state;
     return fetchStudentsJson({balanceId, gradeLevelNextYear, schoolId});
   }
 
@@ -275,10 +286,12 @@ export default class ClassroomListCreatorPage extends React.Component {
   }
 
   render() {
+    const {balanceId} = this.props;
     const availableSteps = this.availableSteps();
     return (
       <ClassroomListCreatorWorkflow
         {...this.state}
+        balanceId={balanceId}
         steps={STEPS}
         availableSteps={availableSteps}
         onStepChanged={this.onStepChanged}
@@ -294,7 +307,7 @@ export default class ClassroomListCreatorPage extends React.Component {
   }
 }
 ClassroomListCreatorPage.propTypes = {
-  balanceId: React.PropTypes.string,
+  balanceId: React.PropTypes.string.isRequired,
   disableHistory: React.PropTypes.bool
 };
 

--- a/app/assets/javascripts/equity/ClassroomListCreatorPage.story.js
+++ b/app/assets/javascripts/equity/ClassroomListCreatorPage.story.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {MemoryRouter} from 'react-router-dom';
 import {storiesOf} from '@storybook/react';
-import ClassroomListCreatorPage from './ClassroomListCreatorPage';
+import {ClassroomListCreatorPageEntryPoint} from './ClassroomListCreatorPage';
 import mockWithFixtures from './fixtures/mockWithFixtures';
 import storybookFrame from './storybookFrame';
 
@@ -10,7 +10,7 @@ storiesOf('equity/ClassroomListCreatorPage', module) // eslint-disable-line no-u
     mockWithFixtures();
     return storybookFrame(
       <MemoryRouter initialEntries={['/balancing']}>
-        <ClassroomListCreatorPage disableHistory={true} />
+        <ClassroomListCreatorPageEntryPoint disableHistory={true} />
       </MemoryRouter>
     );
   });

--- a/app/assets/javascripts/equity/ClassroomListCreatorPage.test.js
+++ b/app/assets/javascripts/equity/ClassroomListCreatorPage.test.js
@@ -2,15 +2,24 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {MemoryRouter} from 'react-router-dom';
 import mockWithFixtures from './fixtures/mockWithFixtures';
-import ClassroomListCreatorPage from './ClassroomListCreatorPage';
+import ClassroomListCreatorPage, {ClassroomListCreatorPageEntryPoint} from './ClassroomListCreatorPage';
 
 beforeEach(() => mockWithFixtures());
 
-it('renders without crashing', () => {
+it('renders without crashing on entrypoint', () => {
   const el = document.createElement('div');
   ReactDOM.render(
     <MemoryRouter initialEntries={['/balancing']}>
-      <ClassroomListCreatorPage disableHistory={true} />
+      <ClassroomListCreatorPageEntryPoint disableHistory={true} />
+    </MemoryRouter>
+  , el);
+});
+
+it('renders without crashing with balanceId', () => {
+  const el = document.createElement('div');
+  ReactDOM.render(
+    <MemoryRouter initialEntries={['/balancing/foo-id']}>
+      <ClassroomListCreatorPage balanceId="foo-id" disableHistory={true} />
     </MemoryRouter>
   , el);
 });

--- a/app/assets/javascripts/equity/ClassroomStats.js
+++ b/app/assets/javascripts/equity/ClassroomStats.js
@@ -29,7 +29,7 @@ export default class ClassroomStats extends React.Component {
     const showStar = (['1', '2'].indexOf(gradeLevelNextYear) === -1);
     const showDibels = !showStar;
     return (
-      <div>
+      <div className="ClassroomStats" style={styles.root}>
         <table style={styles.table}>
           <thead>
             <tr>
@@ -156,7 +156,7 @@ export default class ClassroomStats extends React.Component {
         stacks={stacks}
         style={{
           paddingTop: 5,
-          height: 10,
+          height: 18,
           marginBottom: 1
         }}
         barStyle={{
@@ -187,13 +187,17 @@ ClassroomStats.propTypes = {
 };
 
 const styles = {
+  root: {
+    padding: 20,
+    paddingBottom: 15,
+    borderBottom: '1px solid #eee'
+  },
   table: {
     width: '100%',
     textAlign: 'left',
     fontSize: 12,
-    borderBottom: '1px solid #eee',
-    padding: 20,
-    tableLayout: 'fixed'
+    tableLayout: 'fixed',
+    borderCollapse: 'collapsed'
   },
   cell: { /* overridding some global CSS */
     textAlign: 'left',

--- a/app/assets/javascripts/equity/ClassroomStats.js
+++ b/app/assets/javascripts/equity/ClassroomStats.js
@@ -9,17 +9,14 @@ import {studentsInRoom} from './studentIdsByRoomFunctions';
 // This component is written particularly for Somerville and it's likely this would require factoring out
 // into `PerDistrict` to respect the way this data is stored across districts.
 export default class ClassroomStats extends React.Component {
+  constructor(props) {
+    super(props);
+    this.renderLabelFn = this.renderLabelFn.bind(this);
+  }
+
   studentsInRoom(room) {
     const {students, studentIdsByRoom} = this.props;
     return studentsInRoom(students, studentIdsByRoom, room.roomKey);
-  }
-
-  percentageInRoom(room, filterFn) {
-    const students = this.studentsInRoom(room);
-    const count = students.filter(filterFn).length;
-    return count === 0
-      ? 0 
-      : Math.round(100 * count / students.length);
   }
 
   render() {
@@ -34,38 +31,58 @@ export default class ClassroomStats extends React.Component {
           <thead>
             <tr>
               <th style={styles.cell}></th>
-              <th style={styles.bar}></th>
-              <th style={{...styles.cell, ...styles.hover}} title="Students who have an IEP or 504 plan">IEP or 504</th>
-              <th style={{...styles.cell, ...styles.hover}} title="Students receiving English Learning Services or who have in the past (FLEP)">Limited or FLEP</th>
-              <th style={styles.bar}></th>
-              <th style={{...styles.cell, ...styles.hover}} title="Students who identify their gender as male and not female, nonbinary or transgendered.  One gender is chosen here to simplify the visual representation, not to imply a preference or hierarchy.">Gender, male</th>
-              <th style={{...styles.cell, ...styles.hover}} title="Students whose are enrolled in the free or reduced lunch program">Low income</th>
-              <th style={styles.bar}></th>
-              <th style={{...styles.cell, ...styles.hover}} title="Students who had three or more discipline incidents of any kind during this past school year.  Discipline incidents vary in severity; click on the student's name to see more in their profile.">Discipline, 3+</th>
+              <th style={styles.spacer}></th>
+              <th style={{...styles.cell, ...styles.heading}}
+                title="Students who have an IEP or 504 plan">IEP or 504</th>
+              <th style={{...styles.cell, ...styles.heading}}
+                title="Students receiving English Learning Services or who have in the past (FLEP)">Limited or FLEP</th>
+              <th style={styles.spacer}></th>
+              <th style={{...styles.cell, ...styles.heading}}
+                title="Students who identify their gender as male and not female, nonbinary or transgendered.  One gender is chosen here to simplify the visual representation, not to imply a preference or hierarchy.">
+                Gender, male</th>
+              <th style={{...styles.cell, ...styles.heading}}
+                title="Students whose are enrolled in the free or reduced lunch program">
+                Low income
+              </th>
+              <th style={styles.spacer}></th>
+              <th style={{...styles.cell, ...styles.heading}}
+                title="Students who had three or more discipline incidents of any kind during this past school year.  Discipline incidents vary in severity; click on the student's name to see more in their profile.">
+                Discipline, 3+
+              </th>
               {showDibels &&
-                <th style={{...styles.cell, ...styles.hover}} title="Students' latest DIBELS scores, broken down into Core (green), Strategic (orange) and Itensive (red)">Dibels CORE</th>}
+                <th style={{...styles.cell, ...styles.heading}}
+                  title="Students' latest DIBELS scores, broken down into Core (green), Strategic (orange) and Itensive (red)">
+                  Dibels CORE
+                </th>}
               {showStar &&
-                <th style={{...styles.cell, ...styles.hover}} title="A boxplot showing the range of students' latest STAR Math percentile scores.  The number represents the median score.">STAR Math</th>}
+                <th style={{...styles.cell, ...styles.heading}}
+                  title="A boxplot showing the range of students' latest STAR Math percentile scores.  The number represents the median score.">
+                  STAR Math
+                </th>}
               {showStar &&
-                <th style={{...styles.cell, ...styles.hover}} title="A boxplot showing the range of students' latest STAR Reading percentile scores.  The number represents the median score.">STAR Reading</th>}
+                <th style={{...styles.cell, ...styles.heading}}
+                  title="A boxplot showing the range of students' latest STAR Reading percentile scores.  The number represents the median score.">
+                  STAR Reading
+                </th>}
             </tr>
           </thead>
           <tbody>
             {rooms.map(room => {  
+              const studentsInRoom = this.studentsInRoom(room);
               return (
                 <tr key={room.roomKey}>
                   <td style={styles.cell}>{room.roomName}</td>
-                  <th style={styles.bar}></th>
-                  <td style={styles.cell}>{this.renderIepOr504(room)}</td>
-                  <td style={styles.cell}>{this.renderEnglishLearners(room)}</td>
-                  <td style={styles.bar}></td>
-                  <td style={styles.cell}>{this.renderGender(room)}</td>
-                  <td style={styles.cell}>{this.renderLowIncome(room)}</td>
-                  <td style={styles.bar}></td>
-                  <td style={styles.cell}>{this.renderDiscipline(room)}</td>
-                  {showDibels && <td style={styles.cell}>{this.renderDibelsBreakdown(room)}</td>}
-                  {showStar && <td style={styles.cell}>{this.renderMath(room)}</td>}
-                  {showStar && <td style={styles.cell}>{this.renderReading(room)}</td>}
+                  <th style={styles.spacer}></th>
+                  <td style={styles.cell}>{this.renderIepOr504(studentsInRoom)}</td>
+                  <td style={styles.cell}>{this.renderEnglishLearners(studentsInRoom)}</td>
+                  <td style={styles.spacer}></td>
+                  <td style={styles.cell}>{this.renderGender(studentsInRoom)}</td>
+                  <td style={styles.cell}>{this.renderLowIncome(studentsInRoom)}</td>
+                  <td style={styles.spacer}></td>
+                  <td style={styles.cell}>{this.renderDiscipline(studentsInRoom)}</td>
+                  {showDibels && <td style={styles.cell}>{this.renderDibelsBreakdown(studentsInRoom)}</td>}
+                  {showStar && <td style={styles.cell}>{this.renderMath(studentsInRoom)}</td>}
+                  {showStar && <td style={styles.cell}>{this.renderReading(studentsInRoom)}</td>}
                 </tr>
               );
             })}
@@ -75,36 +92,41 @@ export default class ClassroomStats extends React.Component {
     );
   }
 
-  renderMath(room) {
-    return this.renderStar(room, student => student.most_recent_star_math_percentile);
+  renderIepOr504(studentsInRoom) {
+    const count = studentsInRoom.filter(student => {
+      return (student.disability !== null || student.plan_504 !== 'Not 504');
+    }).length;
+    return this.renderStackSimple(count);
   }
 
-
-  renderReading(room) {
-    return this.renderStar(room, student => student.most_recent_star_reading_percentile);
+  renderEnglishLearners(studentsInRoom) {
+    const count = studentsInRoom.filter(student => {
+      return ['Limited', 'FLEP'].indexOf(student.limited_english_proficiency !== -1);
+    }).length;
+    return this.renderStackSimple(count);
   }
 
-  renderStar(room, accessor) {
-    const students = this.studentsInRoom(room);
-    const values = _.compact(students.map(accessor));
-    return (
-      <div>
-        {(values.length === 0)
-          ? null
-          : <BoxAndWhisker values={values} style={{width: 100, marginLeft: 'auto', marginRight: 'auto'}} />}
-      </div>
-    );
+  renderGender(studentsInRoom) {
+    const count = studentsInRoom.filter(student => student.gender === 'M').length;
+    return this.renderStackSimple(count);
   }
 
-  renderDiscipline(room) {
-    const count = this.studentsInRoom(room).filter(student => {
+  renderLowIncome(studentsInRoom) {
+    const count = studentsInRoom.filter(student => {
+      return ['Free Lunch', 'Reduced Lunch'].indexOf(student.free_reduced_lunch) !== -1;
+    }).length;
+    return this.renderStackSimple(count);
+  }
+
+  renderDiscipline(studentsInRoom) {
+    const count = studentsInRoom.filter(student => {
       return (student.most_recent_school_year_discipline_incidents_count >= 3);
     }).length;
     return this.renderStackSimple(count);
   }
 
-  renderDibelsBreakdown(room) {
-    const students = this.studentsInRoom(room);
+  renderDibelsBreakdown(studentsInRoom) {
+    const students = studentsInRoom;
     const dibelsCounts = {
       strategic: 0,
       intensive: 0,
@@ -125,67 +147,48 @@ export default class ClassroomStats extends React.Component {
     );
   }
 
-  renderGender(room) {
-    const count = this.studentsInRoom(room).filter(student => student.gender === 'M').length;
-    return this.renderStackSimple(count);
+  renderMath(studentsInRoom) {
+    return this.renderStar(studentsInRoom, student => student.most_recent_star_math_percentile);
   }
 
-  renderLowIncome(room) {
-    const count = this.studentsInRoom(room).filter(student => {
-      return ['Free Lunch', 'Reduced Lunch'].indexOf(student.free_reduced_lunch) !== -1;
-    }).length;
-    return this.renderStackSimple(count);
+
+  renderReading(studentsInRoom) {
+    return this.renderStar(studentsInRoom, student => student.most_recent_star_reading_percentile);
   }
 
-  renderIepOr504(room) {
-    const count = this.studentsInRoom(room).filter(student => {
-      return (student.disability !== null || student.plan_504 !== 'Not 504');
-    }).length;
-    return this.renderStackSimple(count);
+  renderStar(studentsInRoom, accessor) {
+    const values = _.compact(studentsInRoom.map(accessor));
+    return (
+      <div>
+        {(values.length === 0)
+          ? null
+          : <BoxAndWhisker values={values} style={{width: 100, marginLeft: 'auto', marginRight: 'auto'}} />}
+      </div>
+    );
   }
 
-  renderDisability(room) {
-    const count = this.studentsInRoom(room).filter(student => student.disability !== null).length;
-    return this.renderStackSimple(count);
-  }
-
-  renderEnglishLearners(room) {
-    const limitedCount = this.studentsInRoom(room).filter(student => student.limited_english_proficiency === 'Limited').length;
-    const flepCount = this.studentsInRoom(room).filter(student => student.limited_english_proficiency === 'FLEP').length;
-    return this.renderStackSimple(limitedCount + flepCount);
-  }
-
+  // This uses <Stack /> in a way different than intended, where it only
+  // shows one bar, and positions the label to the right versus underneath.
   renderStackSimple(count) {
     const {students, rooms} = this.props;
-    const magicScale = (students.length / rooms.length) * 1.5; // multiplier over even split
+    
+    // tunable, this is a multiplier above the space an even split would take
+    const scaleTuningFactor = (students.length / rooms.length) * 1.5;
     const stacks = [{ count, color: 'rgb(137, 175, 202)' }];
-
     return (
       <Stack
         stacks={stacks}
-        style={{
-          paddingTop: 5,
-          height: 20,
-          marginBottom: 1
-        }}
-        barStyle={{
-          height: 3
-        }} 
-        labelStyle={{
-          fontSize: 10,
-          display: 'flex',
-          alignItems: 'flex-end',
-          justifyContent: 'flex-end',
-          position: 'relative',
-          top: -5,
-          left: 12
-        }}
-        scaleFn={count => count / magicScale}
-        labelFn={(count, stack, index) => {
-          if (count === 0) return '\u00A0';
-          return <span style={{color: '#333'}}>{count}</span>;
-        }} />
+        style={styles.stackStyle}
+        barStyle={styles.stackBarStyle} 
+        labelStyle={styles.stackLabelStyle}
+        scaleFn={count => count / scaleTuningFactor}
+        labelFn={this.renderLabelFn} />
     );
+  }
+
+  renderLabelFn(count, stack, index) {
+    if (count === 0) return '\u00A0';
+    return <span style={{color: '#333'}}>{count}</span>;
   }
 }
 ClassroomStats.propTypes = {
@@ -215,25 +218,31 @@ const styles = {
     verticalAlign: 'top',
     overflow: 'hidden'
   },
-  hover: {
+  heading: {
     textDecoration: 'dashed #ccc underline',
-    cursor: 'help'
+    cursor: 'help',
+    paddingBottom: 5
   },
-  bar: {
+  spacer: {
     width: 1
   },
-  barStyle: {
-    background: 'white',
-    fontSize: 10,
-    position: 'relative',
-    top: 4,
-    borderTop: '2px solid #999'
+  stackStyle: {
+    paddingTop: 5,
+    height: 20,
+    marginBottom: 1
   },
-  barInnerStyle:{
-    justifyContent: 'flex-start',
-    padding: 1,
-    paddingBottom: 3,
-    color: '#ccc'
+  stackBarStyle: {
+    height: 3
+  },
+  // Positions label to the right of bar
+  stackLabelStyle: {
+    fontSize: 10,
+    display: 'flex',
+    alignItems: 'flex-end',
+    justifyContent: 'flex-end',
+    position: 'relative',
+    top: -5,
+    left: 12
   }
 };
 

--- a/app/assets/javascripts/equity/ClassroomStats.js
+++ b/app/assets/javascripts/equity/ClassroomStats.js
@@ -34,14 +34,20 @@ export default class ClassroomStats extends React.Component {
           <thead>
             <tr>
               <th style={styles.cell}></th>
-              <th style={styles.cell}>IEP or 504</th>
-              <th style={styles.cell}>Limited or FLEP</th>
-              <th style={styles.cell}>Gender, male</th>
-              <th style={styles.cell}>Low income</th>
-              <th style={styles.cell}>Discipline, 3+</th>
-              {showDibels && <th style={styles.cell}>Dibels CORE</th>}
-              {showStar && <th style={styles.cell}>STAR Math</th>}
-              {showStar && <th style={styles.cell}>STAR Reading</th>}
+              <th style={styles.bar}></th>
+              <th style={{...styles.cell, ...styles.hover}} title="Students who have an IEP or 504 plan">IEP or 504</th>
+              <th style={{...styles.cell, ...styles.hover}} title="Students receiving English Learning Services or who have in the past (FLEP)">Limited or FLEP</th>
+              <th style={styles.bar}></th>
+              <th style={{...styles.cell, ...styles.hover}} title="Students who identify their gender as male and not female, nonbinary or transgendered.  One gender is chosen here to simplify the visual representation, not to imply a preference or hierarchy.">Gender, male</th>
+              <th style={{...styles.cell, ...styles.hover}} title="Students whose are enrolled in the free or reduced lunch program">Low income</th>
+              <th style={styles.bar}></th>
+              <th style={{...styles.cell, ...styles.hover}} title="Students who had three or more discipline incidents of any kind during this past school year.  Discipline incidents vary in severity; click on the student's name to see more in their profile.">Discipline, 3+</th>
+              {showDibels &&
+                <th style={{...styles.cell, ...styles.hover}} title="Students' latest DIBELS scores, broken down into Core (green), Strategic (orange) and Itensive (red)">Dibels CORE</th>}
+              {showStar &&
+                <th style={{...styles.cell, ...styles.hover}} title="A boxplot showing the range of students' latest STAR Math percentile scores.  The number represents the median score.">STAR Math</th>}
+              {showStar &&
+                <th style={{...styles.cell, ...styles.hover}} title="A boxplot showing the range of students' latest STAR Reading percentile scores.  The number represents the median score.">STAR Reading</th>}
             </tr>
           </thead>
           <tbody>
@@ -49,10 +55,13 @@ export default class ClassroomStats extends React.Component {
               return (
                 <tr key={room.roomKey}>
                   <td style={styles.cell}>{room.roomName}</td>
+                  <th style={styles.bar}></th>
                   <td style={styles.cell}>{this.renderIepOr504(room)}</td>
                   <td style={styles.cell}>{this.renderEnglishLearners(room)}</td>
+                  <td style={styles.bar}></td>
                   <td style={styles.cell}>{this.renderGender(room)}</td>
                   <td style={styles.cell}>{this.renderLowIncome(room)}</td>
+                  <td style={styles.bar}></td>
                   <td style={styles.cell}>{this.renderDiscipline(room)}</td>
                   {showDibels && <td style={styles.cell}>{this.renderDibelsBreakdown(room)}</td>}
                   {showStar && <td style={styles.cell}>{this.renderMath(room)}</td>}
@@ -156,7 +165,7 @@ export default class ClassroomStats extends React.Component {
         stacks={stacks}
         style={{
           paddingTop: 5,
-          height: 18,
+          height: 20,
           marginBottom: 1
         }}
         barStyle={{
@@ -197,7 +206,7 @@ const styles = {
     textAlign: 'left',
     fontSize: 12,
     tableLayout: 'fixed',
-    borderCollapse: 'collapsed'
+    borderCollapse: 'collapse'
   },
   cell: { /* overridding some global CSS */
     textAlign: 'left',
@@ -205,6 +214,13 @@ const styles = {
     fontSize: 12,
     verticalAlign: 'top',
     overflow: 'hidden'
+  },
+  hover: {
+    textDecoration: 'dashed #ccc underline',
+    cursor: 'help'
+  },
+  bar: {
+    width: 1
   },
   barStyle: {
     background: 'white',

--- a/app/assets/javascripts/equity/ClassroomStats.js
+++ b/app/assets/javascripts/equity/ClassroomStats.js
@@ -143,6 +143,7 @@ export default class ClassroomStats extends React.Component {
         coreCount={dibelsCounts.core}
         intensiveCount={dibelsCounts.intensive}
         strategicCount={dibelsCounts.strategic}
+        style={{paddingTop: 2}}
         height={5}
         labelTop={5} />
     );

--- a/app/assets/javascripts/equity/ClassroomStats.js
+++ b/app/assets/javascripts/equity/ClassroomStats.js
@@ -143,7 +143,8 @@ export default class ClassroomStats extends React.Component {
         coreCount={dibelsCounts.core}
         intensiveCount={dibelsCounts.intensive}
         strategicCount={dibelsCounts.strategic}
-        height={5} />
+        height={5}
+        labelTop={5} />
     );
   }
 

--- a/app/assets/javascripts/equity/ClassroomStats.js
+++ b/app/assets/javascripts/equity/ClassroomStats.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import _ from 'lodash';
-import Bar from '../components/Bar';
 import Stack from '../components/Stack';
 import BoxAndWhisker from '../components/BoxAndWhisker';
 import DibelsBreakdownBar from '../components/DibelsBreakdownBar';
@@ -37,9 +36,9 @@ export default class ClassroomStats extends React.Component {
               <th style={styles.cell}></th>
               <th style={styles.cell}>IEP or 504</th>
               <th style={styles.cell}>Limited or FLEP</th>
-              <th style={styles.cell}>Gender (male)</th>
+              <th style={styles.cell}>Gender, male</th>
               <th style={styles.cell}>Low income</th>
-              <th style={styles.cell}>Discipline (>=3)</th>
+              <th style={styles.cell}>Discipline, 3+</th>
               {showDibels && <th style={styles.cell}>Dibels CORE</th>}
               {showStar && <th style={styles.cell}>STAR Math</th>}
               {showStar && <th style={styles.cell}>STAR Reading</th>}
@@ -117,15 +116,6 @@ export default class ClassroomStats extends React.Component {
     );
   }
 
-  // If no score, consider them not core.
-  renderDibelsCore(room) {
-    return this.renderBarFor(room, student => {
-      return (student.latest_dibels)
-        ? student.latest_dibels.performance_level.toLowerCase().indexOf('core') !== -1
-        : false;
-    });
-  }
-
   renderGender(room) {
     const count = this.studentsInRoom(room).filter(student => student.gender === 'M').length;
     return this.renderStackSimple(count);
@@ -154,99 +144,40 @@ export default class ClassroomStats extends React.Component {
     const limitedCount = this.studentsInRoom(room).filter(student => student.limited_english_proficiency === 'Limited').length;
     const flepCount = this.studentsInRoom(room).filter(student => student.limited_english_proficiency === 'FLEP').length;
     return this.renderStackSimple(limitedCount + flepCount);
-
-    // const stacks = [
-    //   { count: limitedCount, color: '#999', key: 'limited' },
-    //   { count: flepCount, color: '#ccc', key: 'flep' }
-    // ];
-    // return this.renderStackReal(stacks, {
-    //   labelStyle: {
-    //     width: 'auto'
-    //   },
-    //   labelFn(count, stack, index) {
-    //     if (count === 0 || index !== 1) return '\u00A0';
-    //     return (
-    //        <span style={{position: 'relative', top: -8, paddingLeft: 15, color: 'red', opacity: 1.0}}>{limitedCount} + {flepCount}</span>
-    //     );
-
-
-    //     //       <span> + </span>
-    //     //       <span style={{color: stack.color, opacity: 0.8}}>{flepCount}</span>
-    //       // : <span style={{color: 'red', opacity: 1.0}}>{limitedCount} + {flepCount}</span>
-
-
-
-    //     //       <span> + </span>
-    //     //       <span style={{color: stack.color, opacity: 0.8}}>{flepCount}</span>
-
-
-    //                   // : <span style={{color: stack.color, opacity: 0.8}}>{count}</span>;
-
-    //     // return (count === 0 || index < stacks.length - 1)
-    //     //   ? '\u00A0'
-    //     //   : <span style={{
-    //     //     // position: 'relative',
-    //     //     // top: -5,
-    //     //     // left: 12
-    //     //   }}>
-    //     //       <span style={{color: 'red', opacity: 1.0}}>{limitedCount} + {flepCount}</span>
-    //     //       <span> + </span>
-    //     //       <span style={{color: stack.color, opacity: 0.8}}>{flepCount}</span>
-    //     //     </span>;
-    //   }
-    // });
   }
 
   renderStackSimple(count) {
-    const stacks = [{ count, color: '#aaa' }];
-    return this.renderStackReal(stacks, {
-      labelStyle: {
-        position: 'relative',
-        top: -5,
-        left: 12
-      }
-    });
-  }
+    const {students, rooms} = this.props;
+    const magicScale = (students.length / rooms.length) * 1.5; // multiplier over even split
+    const stacks = [{ count, color: 'rgb(137, 175, 202)' }];
 
-  renderStackReal(stacks, options = {}) {
-    const magicScale = (this.props.students.length / this.props.rooms.length) * 1.5; // multiplier of even split
     return (
       <Stack
         stacks={stacks}
-        style={{paddingTop: 5, height: 10, marginBottom: 1}}
-        barStyle={{height: 3}} 
+        style={{
+          paddingTop: 5,
+          height: 10,
+          marginBottom: 1
+        }}
+        barStyle={{
+          height: 3
+        }} 
         labelStyle={{
           fontSize: 10,
           display: 'flex',
           alignItems: 'flex-end',
           justifyContent: 'flex-end',
-          ...(options.labelStyle || {})
+          position: 'relative',
+          top: -5,
+          left: 12
         }}
         scaleFn={count => count / magicScale}
-        labelFn={options.labelFn || function(count, stack, index) {
+        labelFn={(count, stack, index) => {
           if (count === 0) return '\u00A0';
-          const color = (count / magicScale > 1) ? 'red' : '#333';
-          return <span style={{color}}>{count}</span>;
+          return <span style={{color: '#333'}}>{count}</span>;
         }} />
     );
   }
-
-  renderBarFor(room, filterFn) {
-    const students = this.studentsInRoom(room);
-    const count = students.filter(filterFn).length;
-    const percent = count === 0
-      ? 0 
-      : Math.round(100 * count / students.length);
-
-    return (
-      <Bar
-        percent={percent}
-        threshold={5}
-        style={styles.barStyle}
-        innerStyle={styles.barInnerStyle} />
-    );
-  }
-
 }
 ClassroomStats.propTypes = {
   students: React.PropTypes.array.isRequired,

--- a/app/assets/javascripts/equity/ClassroomStats.test.js
+++ b/app/assets/javascripts/equity/ClassroomStats.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import renderer from 'react-test-renderer';
+import {withDefaultNowContext} from '../../../../spec/javascripts/support/NowContainer';
+import ClassroomStats from './ClassroomStats';
+import students_for_grade_level_next_year_json from './fixtures/students_for_grade_level_next_year_json';
+import {
+  createRooms,
+  roomKeyFromIndex,
+  initialStudentIdsByRoom
+} from './studentIdsByRoomFunctions';
+
+export function testProps(props = {}) {
+  const rooms = createRooms(4);
+  const {students} = students_for_grade_level_next_year_json;
+  return {
+    rooms,
+    students,
+    gradeLevelNextYear: '5',
+    studentIdsByRoom: initialStudentIdsByRoom(rooms.length, students, {
+      placementFn(studentIdsByRoom, student) {
+        const roomIndex = JSON.stringify(student).length % rooms.length; // consistent hash
+        return roomKeyFromIndex(roomIndex);
+      }
+    }),
+    ...props
+  };
+}
+
+it('renders without crashing', () => {
+  const el = document.createElement('div');
+  const props = testProps();
+  ReactDOM.render(withDefaultNowContext(<ClassroomStats {...props} />), el);
+});
+
+
+it('snapshots', () => {
+  const props = testProps();
+  const tree = renderer
+    .create(withDefaultNowContext(<ClassroomStats {...props} />))
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/assets/javascripts/equity/CreateYourClassroomsView.js
+++ b/app/assets/javascripts/equity/CreateYourClassroomsView.js
@@ -25,7 +25,12 @@ export default class CreateYourClassroomsView extends React.Component {
   onDragEnd(dragEndResult) {
     const {onClassroomListsChanged, studentIdsByRoom} = this.props;
     const updatedStudentIdsByRoom = studentIdsByRoomAfterDrag(studentIdsByRoom, dragEndResult);
+
+    // Debugging hack
+    const before = performance.now();
     onClassroomListsChanged(updatedStudentIdsByRoom);
+    const after = performance.now();
+    document.querySelectorAll('.ClassroomStats tr th')[0].innerHTML = `${Math.round(after - before)}ms`;
   }
 
   render() {

--- a/app/assets/javascripts/equity/CreateYourClassroomsView.story.js
+++ b/app/assets/javascripts/equity/CreateYourClassroomsView.story.js
@@ -9,6 +9,9 @@ import {testProps} from './CreateYourClassroomsView.test';
 
 
 storiesOf('equity/CreateYourClassroomsView', module) // eslint-disable-line no-undef
+  .add("Next 2rd grade, empty", () => {
+    return testRender(testProps({ forceUnplaced: true }));
+  })
   .add("Next 2rd grade", () => {
     return testRender(testProps());
   })
@@ -34,10 +37,12 @@ function testRender(props = {}) {
 class Container extends React.Component {
   constructor(props) {
     super(props);
-    const {classroomsCount, students} = props;
+    const {classroomsCount, students, forceUnplaced} = props;
     const studentIdsByRoom = initialStudentIdsByRoom(classroomsCount, students, {
       placementFn(studentIdsByRoom, student) {
-        return _.sample(Object.keys(studentIdsByRoom));
+        return (forceUnplaced)
+          ? 'room:unplaced'
+          : _.sample(Object.keys(studentIdsByRoom));
       }
     });
 
@@ -60,5 +65,6 @@ class Container extends React.Component {
 }
 Container.propTypes = {
   classroomsCount: React.PropTypes.number.isRequired,
-  students: React.PropTypes.array.isRequired
+  students: React.PropTypes.array.isRequired,
+  forceUnplaced: React.PropTypes.bool
 };

--- a/app/assets/javascripts/equity/CreateYourClassroomsView.story.js
+++ b/app/assets/javascripts/equity/CreateYourClassroomsView.story.js
@@ -9,7 +9,7 @@ import {testProps} from './CreateYourClassroomsView.test';
 
 
 storiesOf('equity/CreateYourClassroomsView', module) // eslint-disable-line no-undef
-  .add("Next 2rd grade, empty", () => {
+  .add("empty", () => {
     return testRender(testProps({ forceUnplaced: true }));
   })
   .add("Next 2rd grade", () => {

--- a/app/assets/javascripts/equity/CreateYourClassroomsView.story.js
+++ b/app/assets/javascripts/equity/CreateYourClassroomsView.story.js
@@ -1,10 +1,13 @@
 import React from 'react';
-import _ from 'lodash';
 import {storiesOf} from '@storybook/react';
 import storybookFrame from './storybookFrame';
 import {withDefaultNowContext} from '../../../../spec/javascripts/support/NowContainer';
 import CreateYourClassroomsView from './CreateYourClassroomsView';
-import {initialStudentIdsByRoom} from './studentIdsByRoomFunctions';
+import {
+  UNPLACED_ROOM_KEY,
+  roomKeyFromIndex,
+  initialStudentIdsByRoom
+} from './studentIdsByRoomFunctions';
 import {testProps} from './CreateYourClassroomsView.test';
 
 
@@ -17,6 +20,7 @@ storiesOf('equity/CreateYourClassroomsView', module) // eslint-disable-line no-u
   })
   .add("Next 5th grade", () => {
     return testRender(testProps({
+      classroomsCount: 4,
       gradeLevelNextYear: '5'
     }));
   })
@@ -41,8 +45,8 @@ class Container extends React.Component {
     const studentIdsByRoom = initialStudentIdsByRoom(classroomsCount, students, {
       placementFn(studentIdsByRoom, student) {
         return (forceUnplaced)
-          ? 'room:unplaced'
-          : _.sample(Object.keys(studentIdsByRoom));
+          ? UNPLACED_ROOM_KEY
+          : roomKeyFromIndex(JSON.stringify(student).length % classroomsCount);
       }
     });
 

--- a/app/assets/javascripts/equity/CreateYourClassroomsView.test.js
+++ b/app/assets/javascripts/equity/CreateYourClassroomsView.test.js
@@ -10,7 +10,7 @@ beforeEach(() => mockWithFixtures());
 export function testProps(props = {}) {
   return {
     classroomsCount: 3,
-    gradeLevelNextYear: '3',
+    gradeLevelNextYear: '2',
     students: students_for_grade_level_next_year_json.students,
     studentIdsByRoom: {},
     fetchProfile(studentId) { return Promise.resolve(profile_json); },

--- a/app/assets/javascripts/equity/InlineStudentProfile.js
+++ b/app/assets/javascripts/equity/InlineStudentProfile.js
@@ -26,9 +26,8 @@ export default class InlineStudentProfile extends React.Component {
               </Card>
               <Card style={styles.card}>
                 <div style={styles.header}>Learning English</div>
-                <div>Learning English: {student.limited_english_proficiency}</div>
+                {student.limited_english_proficiency !== 'Fluent' && <div>Learning English: {student.limited_english_proficiency}</div>}
                 {student.latest_access_results && <div>ACCESS Composite: {student.latest_access_results.composite}</div>}
-                <div>Home language: {student.home_language}</div>
               </Card>
             </div>
             <div style={{display: 'flex'}}>
@@ -68,7 +67,7 @@ export default class InlineStudentProfile extends React.Component {
   renderFeed() {
     const {student, fetchProfile} = this.props;
     return (
-      <div>
+      <div style={styles.feed}>
         <SectionHeading>Notes for {student.first_name}</SectionHeading>
         <GenericLoader
           promiseFn={() => fetchProfile(student.id)}
@@ -103,5 +102,8 @@ const styles = {
   card: {
     flex: 1,
     margin: 5
+  },
+  feed: {
+    paddingTop: 20
   }
 };

--- a/app/assets/javascripts/equity/SimpleStudentCard.js
+++ b/app/assets/javascripts/equity/SimpleStudentCard.js
@@ -100,11 +100,13 @@ const styles = {
     backgroundColor: 'white'
   },
   modalOverlay: {
-    backgroundColor: 'rgba(128, 128, 128, 0.75)'
+    backgroundColor: 'rgba(128, 128, 128, 0.75)',
+    zIndex: 10
   },
   modalContent: {
     left: 200,
     right: 200,
-    padding: 0
+    padding: 0,
+    zIndex: 20
   }
 };

--- a/app/assets/javascripts/equity/SimpleStudentCard.js
+++ b/app/assets/javascripts/equity/SimpleStudentCard.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {Draggable} from 'react-beautiful-dnd';
 import Modal from 'react-modal';
 import MoreDots from '../components/MoreDots';
-import Hover from '../components/Hover';
 import InlineStudentProfile from './InlineStudentProfile';
 
 
@@ -56,20 +55,10 @@ export default class SimpleStudentCard extends React.Component {
 
   renderStudentCard(student) {
     return (
-      <Hover>
-        {isHovering => {
-          const style = {
-            ...styles.studentCard,
-            ...(isHovering ? styles.hovering : {})
-          };
-          return (
-            <div style={style} onClick={this.onClick}>
-              <span>{student.first_name} {student.last_name}</span>
-              <MoreDots />
-            </div>
-          );
-        }}
-      </Hover>
+      <div style={styles.studentCard} onClick={this.onClick}>
+        <span>{student.first_name} {student.last_name}</span>
+        <MoreDots />
+      </div>
     );
   }
 
@@ -109,9 +98,6 @@ const styles = {
     cursor: 'pointer',
     borderRadius: 3,
     backgroundColor: 'white'
-  },
-  hovering: {
-    
   },
   modalOverlay: {
     backgroundColor: 'rgba(128, 128, 128, 0.75)'

--- a/app/assets/javascripts/equity/SimpleStudentCard.js
+++ b/app/assets/javascripts/equity/SimpleStudentCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {Draggable} from 'react-beautiful-dnd';
 import Modal from 'react-modal';
 import MoreDots from '../components/MoreDots';
+import Hover from '../components/Hover';
 import InlineStudentProfile from './InlineStudentProfile';
 
 
@@ -35,16 +36,32 @@ export default class SimpleStudentCard extends React.Component {
             <div>
               {this.renderModal()}
               <div ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
-                <div style={styles.studentCard} onClick={this.onClick}>
-                  <span>{student.first_name} {student.last_name}</span>
-                  <MoreDots />
-                </div>
+                {this.renderStudentCard(student)}
               </div>
               {provided.placeholder /* this preserves space when dragging */}
             </div>
           );
         }}
       </Draggable>
+    );
+  }
+
+  renderStudentCard(student) {
+    return (
+      <Hover>
+        {isHovering => {
+          const style = {
+            ...styles.studentCard,
+            ...(isHovering ? styles.hovering : {})
+          };
+          return (
+            <div style={style} onClick={this.onClick}>
+              <span>{student.first_name} {student.last_name}</span>
+              <MoreDots />
+            </div>
+          );
+        }}
+      </Hover>
     );
   }
 
@@ -55,7 +72,7 @@ export default class SimpleStudentCard extends React.Component {
       <Modal
         style={{
           overlay: styles.modalOverlay,
-          context: styles.modalContent
+          content: styles.modalContent
         }}
         isOpen={modalIsOpen}
         onRequestClose={this.onClose}
@@ -83,14 +100,17 @@ const styles = {
     padding: 6,
     cursor: 'pointer',
     borderRadius: 3,
-    background: 'white'
+    backgroundColor: 'white'
+  },
+  hovering: {
+    
   },
   modalOverlay: {
     backgroundColor: 'rgba(128, 128, 128, 0.75)'
   },
   modalContent: {
-    left: 180,
-    right: 180,
+    left: 200,
+    right: 200,
     padding: 0
   }
 };

--- a/app/assets/javascripts/equity/SimpleStudentCard.js
+++ b/app/assets/javascripts/equity/SimpleStudentCard.js
@@ -19,10 +19,12 @@ export default class SimpleStudentCard extends React.Component {
     this.onClose = this.onClose.bind(this);
   }
 
+  // This is an optimization that in particular is trying to avoid
+  // unnecessary renders of <Draggable />.
   shouldComponentUpdate(nextProps, nextState) {
-    if (this.props.index !== nextProps.index) return false;
-    if (this.state.modalIsOpen !== nextProps.modalIsOpen) return false;
-    return true;
+    if (this.props.index !== nextProps.index) return true;
+    if (this.state.modalIsOpen !== nextState.modalIsOpen) return true;
+    return false;
   }
 
   onClick() {

--- a/app/assets/javascripts/equity/SimpleStudentCard.js
+++ b/app/assets/javascripts/equity/SimpleStudentCard.js
@@ -19,6 +19,12 @@ export default class SimpleStudentCard extends React.Component {
     this.onClose = this.onClose.bind(this);
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    if (this.props.index !== nextProps.index) return false;
+    if (this.state.modalIsOpen !== nextProps.modalIsOpen) return false;
+    return true;
+  }
+
   onClick() {
     this.setState({modalIsOpen: true});
   }

--- a/app/assets/javascripts/equity/__snapshots__/ClassroomStats.test.js.snap
+++ b/app/assets/javascripts/equity/__snapshots__/ClassroomStats.test.js.snap
@@ -49,6 +49,7 @@ exports[`snapshots 1`] = `
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
+              "paddingBottom": 5,
               "textAlign": "left",
               "textDecoration": "dashed #ccc underline",
               "verticalAlign": "top",
@@ -65,6 +66,7 @@ exports[`snapshots 1`] = `
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
+              "paddingBottom": 5,
               "textAlign": "left",
               "textDecoration": "dashed #ccc underline",
               "verticalAlign": "top",
@@ -88,6 +90,7 @@ exports[`snapshots 1`] = `
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
+              "paddingBottom": 5,
               "textAlign": "left",
               "textDecoration": "dashed #ccc underline",
               "verticalAlign": "top",
@@ -104,6 +107,7 @@ exports[`snapshots 1`] = `
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
+              "paddingBottom": 5,
               "textAlign": "left",
               "textDecoration": "dashed #ccc underline",
               "verticalAlign": "top",
@@ -127,6 +131,7 @@ exports[`snapshots 1`] = `
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
+              "paddingBottom": 5,
               "textAlign": "left",
               "textDecoration": "dashed #ccc underline",
               "verticalAlign": "top",
@@ -143,6 +148,7 @@ exports[`snapshots 1`] = `
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
+              "paddingBottom": 5,
               "textAlign": "left",
               "textDecoration": "dashed #ccc underline",
               "verticalAlign": "top",
@@ -159,6 +165,7 @@ exports[`snapshots 1`] = `
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
+              "paddingBottom": 5,
               "textAlign": "left",
               "textDecoration": "dashed #ccc underline",
               "verticalAlign": "top",
@@ -679,7 +686,7 @@ exports[`snapshots 1`] = `
                     "height": 3,
                     "left": "0%",
                     "position": "absolute",
-                    "width": "23%",
+                    "width": "46%",
                   }
                 }
               />
@@ -694,7 +701,7 @@ exports[`snapshots 1`] = `
                     "left": 12,
                     "position": "relative",
                     "top": -5,
-                    "width": "23%",
+                    "width": "46%",
                   }
                 }
               >
@@ -705,7 +712,7 @@ exports[`snapshots 1`] = `
                     }
                   }
                 >
-                  5
+                  10
                 </span>
               </div>
             </div>
@@ -1264,7 +1271,7 @@ exports[`snapshots 1`] = `
                     "height": 3,
                     "left": "0%",
                     "position": "absolute",
-                    "width": "32%",
+                    "width": "79%",
                   }
                 }
               />
@@ -1279,7 +1286,7 @@ exports[`snapshots 1`] = `
                     "left": 12,
                     "position": "relative",
                     "top": -5,
-                    "width": "32%",
+                    "width": "79%",
                   }
                 }
               >
@@ -1290,7 +1297,7 @@ exports[`snapshots 1`] = `
                     }
                   }
                 >
-                  7
+                  17
                 </span>
               </div>
             </div>
@@ -1857,7 +1864,7 @@ exports[`snapshots 1`] = `
                     "height": 3,
                     "left": "0%",
                     "position": "absolute",
-                    "width": "9%",
+                    "width": "37%",
                   }
                 }
               />
@@ -1872,7 +1879,7 @@ exports[`snapshots 1`] = `
                     "left": 12,
                     "position": "relative",
                     "top": -5,
-                    "width": "9%",
+                    "width": "37%",
                   }
                 }
               >
@@ -1883,7 +1890,7 @@ exports[`snapshots 1`] = `
                     }
                   }
                 >
-                  2
+                  8
                 </span>
               </div>
             </div>
@@ -2442,7 +2449,7 @@ exports[`snapshots 1`] = `
                     "height": 3,
                     "left": "0%",
                     "position": "absolute",
-                    "width": "28%",
+                    "width": "88%",
                   }
                 }
               />
@@ -2457,7 +2464,7 @@ exports[`snapshots 1`] = `
                     "left": 12,
                     "position": "relative",
                     "top": -5,
-                    "width": "28%",
+                    "width": "88%",
                   }
                 }
               >
@@ -2468,7 +2475,7 @@ exports[`snapshots 1`] = `
                     }
                   }
                 >
-                  6
+                  19
                 </span>
               </div>
             </div>

--- a/app/assets/javascripts/equity/__snapshots__/ClassroomStats.test.js.snap
+++ b/app/assets/javascripts/equity/__snapshots__/ClassroomStats.test.js.snap
@@ -14,7 +14,7 @@ exports[`snapshots 1`] = `
   <table
     style={
       Object {
-        "borderCollapse": "collapsed",
+        "borderCollapse": "collapse",
         "fontSize": 12,
         "tableLayout": "fixed",
         "textAlign": "left",
@@ -38,91 +38,133 @@ exports[`snapshots 1`] = `
         <th
           style={
             Object {
+              "width": 1,
+            }
+          }
+        />
+        <th
+          style={
+            Object {
+              "cursor": "help",
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
               "textAlign": "left",
+              "textDecoration": "dashed #ccc underline",
               "verticalAlign": "top",
             }
           }
+          title="Students who have an IEP or 504 plan"
         >
           IEP or 504
         </th>
         <th
           style={
             Object {
+              "cursor": "help",
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
               "textAlign": "left",
+              "textDecoration": "dashed #ccc underline",
               "verticalAlign": "top",
             }
           }
+          title="Students receiving English Learning Services or who have in the past (FLEP)"
         >
           Limited or FLEP
         </th>
         <th
           style={
             Object {
+              "width": 1,
+            }
+          }
+        />
+        <th
+          style={
+            Object {
+              "cursor": "help",
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
               "textAlign": "left",
+              "textDecoration": "dashed #ccc underline",
               "verticalAlign": "top",
             }
           }
+          title="Students who identify their gender as male and not female, nonbinary or transgendered.  One gender is chosen here to simplify the visual representation, not to imply a preference or hierarchy."
         >
           Gender, male
         </th>
         <th
           style={
             Object {
+              "cursor": "help",
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
               "textAlign": "left",
+              "textDecoration": "dashed #ccc underline",
               "verticalAlign": "top",
             }
           }
+          title="Students whose are enrolled in the free or reduced lunch program"
         >
           Low income
         </th>
         <th
           style={
             Object {
+              "width": 1,
+            }
+          }
+        />
+        <th
+          style={
+            Object {
+              "cursor": "help",
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
               "textAlign": "left",
+              "textDecoration": "dashed #ccc underline",
               "verticalAlign": "top",
             }
           }
+          title="Students who had three or more discipline incidents of any kind during this past school year.  Discipline incidents vary in severity; click on the student's name to see more in their profile."
         >
           Discipline, 3+
         </th>
         <th
           style={
             Object {
+              "cursor": "help",
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
               "textAlign": "left",
+              "textDecoration": "dashed #ccc underline",
               "verticalAlign": "top",
             }
           }
+          title="A boxplot showing the range of students' latest STAR Math percentile scores.  The number represents the median score."
         >
           STAR Math
         </th>
         <th
           style={
             Object {
+              "cursor": "help",
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
               "textAlign": "left",
+              "textDecoration": "dashed #ccc underline",
               "verticalAlign": "top",
             }
           }
+          title="A boxplot showing the range of students' latest STAR Reading percentile scores.  The number represents the median score."
         >
           STAR Reading
         </th>
@@ -143,6 +185,13 @@ exports[`snapshots 1`] = `
         >
           Not placed
         </td>
+        <th
+          style={
+            Object {
+              "width": 1,
+            }
+          }
+        />
         <td
           style={
             Object {
@@ -160,7 +209,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -223,7 +272,77 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "0%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "0%",
+                  }
+                }
+              >
+                 
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "width": 1,
+            }
+          }
+        />
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -286,7 +405,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -335,66 +454,10 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
-              "fontSize": 12,
-              "fontWeight": "normal",
-              "overflow": "hidden",
-              "textAlign": "left",
-              "verticalAlign": "top",
+              "width": 1,
             }
           }
-        >
-          <div
-            style={
-              Object {
-                "color": "black",
-                "cursor": "default",
-                "display": "inline-block",
-                "height": 18,
-                "marginBottom": 1,
-                "paddingTop": 5,
-                "position": "relative",
-                "width": "100%",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "width": "100%",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "backgroundColor": "rgb(137, 175, 202)",
-                    "height": 3,
-                    "left": "0%",
-                    "position": "absolute",
-                    "width": "0%",
-                  }
-                }
-              />
-              <div
-                style={
-                  Object {
-                    "alignItems": "flex-end",
-                    "display": "flex",
-                    "fontSize": 10,
-                    "height": "100%",
-                    "justifyContent": "flex-end",
-                    "left": 12,
-                    "position": "relative",
-                    "top": -5,
-                    "width": "0%",
-                  }
-                }
-              >
-                 
-              </div>
-            </div>
-          </div>
-        </td>
+        />
         <td
           style={
             Object {
@@ -412,7 +475,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -499,6 +562,13 @@ exports[`snapshots 1`] = `
         >
           Room A
         </td>
+        <th
+          style={
+            Object {
+              "width": 1,
+            }
+          }
+        />
         <td
           style={
             Object {
@@ -516,7 +586,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -587,7 +657,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -644,6 +714,13 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "width": 1,
+            }
+          }
+        />
+        <td
+          style={
+            Object {
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
@@ -658,7 +735,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -729,7 +806,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -786,6 +863,13 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "width": 1,
+            }
+          }
+        />
+        <td
+          style={
+            Object {
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
@@ -800,7 +884,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -1063,6 +1147,13 @@ exports[`snapshots 1`] = `
         >
           Room B
         </td>
+        <th
+          style={
+            Object {
+              "width": 1,
+            }
+          }
+        />
         <td
           style={
             Object {
@@ -1080,7 +1171,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -1151,7 +1242,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -1208,6 +1299,13 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "width": 1,
+            }
+          }
+        />
+        <td
+          style={
+            Object {
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
@@ -1222,7 +1320,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -1293,7 +1391,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -1350,6 +1448,13 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "width": 1,
+            }
+          }
+        />
+        <td
+          style={
+            Object {
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
@@ -1364,7 +1469,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -1635,6 +1740,13 @@ exports[`snapshots 1`] = `
         >
           Room C
         </td>
+        <th
+          style={
+            Object {
+              "width": 1,
+            }
+          }
+        />
         <td
           style={
             Object {
@@ -1652,7 +1764,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -1723,7 +1835,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -1780,6 +1892,13 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "width": 1,
+            }
+          }
+        />
+        <td
+          style={
+            Object {
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
@@ -1794,7 +1913,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -1865,7 +1984,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -1922,6 +2041,13 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "width": 1,
+            }
+          }
+        />
+        <td
+          style={
+            Object {
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
@@ -1936,7 +2062,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -2199,6 +2325,13 @@ exports[`snapshots 1`] = `
         >
           Room D
         </td>
+        <th
+          style={
+            Object {
+              "width": 1,
+            }
+          }
+        />
         <td
           style={
             Object {
@@ -2216,7 +2349,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -2287,7 +2420,85 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "28%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "28%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  6
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "width": 1,
+            }
+          }
+        />
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -2358,78 +2569,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
-                "marginBottom": 1,
-                "paddingTop": 5,
-                "position": "relative",
-                "width": "100%",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "width": "100%",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "backgroundColor": "rgb(137, 175, 202)",
-                    "height": 3,
-                    "left": "0%",
-                    "position": "absolute",
-                    "width": "28%",
-                  }
-                }
-              />
-              <div
-                style={
-                  Object {
-                    "alignItems": "flex-end",
-                    "display": "flex",
-                    "fontSize": 10,
-                    "height": "100%",
-                    "justifyContent": "flex-end",
-                    "left": 12,
-                    "position": "relative",
-                    "top": -5,
-                    "width": "28%",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#333",
-                    }
-                  }
-                >
-                  6
-                </span>
-              </div>
-            </div>
-          </div>
-        </td>
-        <td
-          style={
-            Object {
-              "fontSize": 12,
-              "fontWeight": "normal",
-              "overflow": "hidden",
-              "textAlign": "left",
-              "verticalAlign": "top",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "color": "black",
-                "cursor": "default",
-                "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",
@@ -2486,6 +2626,13 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "width": 1,
+            }
+          }
+        />
+        <td
+          style={
+            Object {
               "fontSize": 12,
               "fontWeight": "normal",
               "overflow": "hidden",
@@ -2500,7 +2647,7 @@ exports[`snapshots 1`] = `
                 "color": "black",
                 "cursor": "default",
                 "display": "inline-block",
-                "height": 18,
+                "height": 20,
                 "marginBottom": 1,
                 "paddingTop": 5,
                 "position": "relative",

--- a/app/assets/javascripts/equity/__snapshots__/ClassroomStats.test.js.snap
+++ b/app/assets/javascripts/equity/__snapshots__/ClassroomStats.test.js.snap
@@ -1,0 +1,2763 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshots 1`] = `
+<div
+  className="ClassroomStats"
+  style={
+    Object {
+      "borderBottom": "1px solid #eee",
+      "padding": 20,
+      "paddingBottom": 15,
+    }
+  }
+>
+  <table
+    style={
+      Object {
+        "borderCollapse": "collapsed",
+        "fontSize": 12,
+        "tableLayout": "fixed",
+        "textAlign": "left",
+        "width": "100%",
+      }
+    }
+  >
+    <thead>
+      <tr>
+        <th
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        />
+        <th
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          IEP or 504
+        </th>
+        <th
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          Limited or FLEP
+        </th>
+        <th
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          Gender, male
+        </th>
+        <th
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          Low income
+        </th>
+        <th
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          Discipline, 3+
+        </th>
+        <th
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          STAR Math
+        </th>
+        <th
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          STAR Reading
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          Not placed
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "0%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "0%",
+                  }
+                }
+              >
+                 
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "0%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "0%",
+                  }
+                }
+              >
+                 
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "0%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "0%",
+                  }
+                }
+              >
+                 
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "0%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "0%",
+                  }
+                }
+              >
+                 
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "0%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "0%",
+                  }
+                }
+              >
+                 
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div />
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div />
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          Room A
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "19%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "19%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  4
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "23%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "23%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  5
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "14%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "14%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  3
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "14%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "14%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  3
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "0%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "0%",
+                  }
+                }
+              >
+                 
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div>
+            <div
+              className="BoxAndWhisker"
+              style={
+                Object {
+                  "height": 18,
+                  "marginLeft": "auto",
+                  "marginRight": "auto",
+                  "width": 100,
+                }
+              }
+              title="{\\"min\\":2,\\"p25\\":44,\\"p50\\":63,\\"p75\\":78,\\"max\\":90}"
+            >
+              <div
+                style={
+                  Object {
+                    "height": "100%",
+                    "position": "relative",
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "backgroundColor": "#999",
+                      "height": 1,
+                      "left": "2%",
+                      "position": "absolute",
+                      "top": 5,
+                      "width": "88%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "borderRight": 0,
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "44%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "19%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "63%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "15%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "color": "#333",
+                      "fontSize": 10,
+                      "left": "38%",
+                      "position": "absolute",
+                      "textAlign": "center",
+                      "top": 8.5,
+                      "width": "50%",
+                    }
+                  }
+                >
+                  63
+                </div>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div>
+            <div
+              className="BoxAndWhisker"
+              style={
+                Object {
+                  "height": 18,
+                  "marginLeft": "auto",
+                  "marginRight": "auto",
+                  "width": 100,
+                }
+              }
+              title="{\\"min\\":18,\\"p25\\":24,\\"p50\\":41,\\"p75\\":63,\\"max\\":100}"
+            >
+              <div
+                style={
+                  Object {
+                    "height": "100%",
+                    "position": "relative",
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "backgroundColor": "#999",
+                      "height": 1,
+                      "left": "18%",
+                      "position": "absolute",
+                      "top": 5,
+                      "width": "82%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "borderRight": 0,
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "24%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "17%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "41%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "22%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "color": "#333",
+                      "fontSize": 10,
+                      "left": "16%",
+                      "position": "absolute",
+                      "textAlign": "center",
+                      "top": 8.5,
+                      "width": "50%",
+                    }
+                  }
+                >
+                  41
+                </div>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          Room B
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "28%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "28%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  6
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "32%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "32%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  7
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "46%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "46%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  10
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "56%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "56%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  12
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "5%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "5%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  1
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div>
+            <div
+              className="BoxAndWhisker"
+              style={
+                Object {
+                  "height": 18,
+                  "marginLeft": "auto",
+                  "marginRight": "auto",
+                  "width": 100,
+                }
+              }
+              title="{\\"min\\":5,\\"p25\\":22,\\"p50\\":45,\\"p75\\":60,\\"max\\":100}"
+            >
+              <div
+                style={
+                  Object {
+                    "height": "100%",
+                    "position": "relative",
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "backgroundColor": "#999",
+                      "height": 1,
+                      "left": "5%",
+                      "position": "absolute",
+                      "top": 5,
+                      "width": "95%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "borderRight": 0,
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "22%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "23%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "45%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "15%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "color": "#333",
+                      "fontSize": 10,
+                      "left": "20%",
+                      "position": "absolute",
+                      "textAlign": "center",
+                      "top": 8.5,
+                      "width": "50%",
+                    }
+                  }
+                >
+                  45
+                </div>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div>
+            <div
+              className="BoxAndWhisker"
+              style={
+                Object {
+                  "height": 18,
+                  "marginLeft": "auto",
+                  "marginRight": "auto",
+                  "width": 100,
+                }
+              }
+              title="{\\"min\\":4,\\"p25\\":28,\\"p50\\":58,\\"p75\\":73,\\"max\\":91}"
+            >
+              <div
+                style={
+                  Object {
+                    "height": "100%",
+                    "position": "relative",
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "backgroundColor": "#999",
+                      "height": 1,
+                      "left": "4%",
+                      "position": "absolute",
+                      "top": 5,
+                      "width": "87%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "borderRight": 0,
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "28%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "30%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "58%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "15%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "color": "#333",
+                      "fontSize": 10,
+                      "left": "33%",
+                      "position": "absolute",
+                      "textAlign": "center",
+                      "top": 8.5,
+                      "width": "50%",
+                    }
+                  }
+                >
+                  58
+                </div>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          Room C
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "9%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "9%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  2
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "9%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "9%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  2
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "19%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "19%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  4
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "19%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "19%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  4
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "0%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "0%",
+                  }
+                }
+              >
+                 
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div>
+            <div
+              className="BoxAndWhisker"
+              style={
+                Object {
+                  "height": 18,
+                  "marginLeft": "auto",
+                  "marginRight": "auto",
+                  "width": 100,
+                }
+              }
+              title="{\\"min\\":3,\\"p25\\":42,\\"p50\\":60,\\"p75\\":68,\\"max\\":100}"
+            >
+              <div
+                style={
+                  Object {
+                    "height": "100%",
+                    "position": "relative",
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "backgroundColor": "#999",
+                      "height": 1,
+                      "left": "3%",
+                      "position": "absolute",
+                      "top": 5,
+                      "width": "97%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "borderRight": 0,
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "42%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "18%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "60%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "8%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "color": "#333",
+                      "fontSize": 10,
+                      "left": "35%",
+                      "position": "absolute",
+                      "textAlign": "center",
+                      "top": 8.5,
+                      "width": "50%",
+                    }
+                  }
+                >
+                  60
+                </div>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div>
+            <div
+              className="BoxAndWhisker"
+              style={
+                Object {
+                  "height": 18,
+                  "marginLeft": "auto",
+                  "marginRight": "auto",
+                  "width": 100,
+                }
+              }
+              title="{\\"min\\":39,\\"p25\\":43,\\"p50\\":69,\\"p75\\":100,\\"max\\":100}"
+            >
+              <div
+                style={
+                  Object {
+                    "height": "100%",
+                    "position": "relative",
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "backgroundColor": "#999",
+                      "height": 1,
+                      "left": "39%",
+                      "position": "absolute",
+                      "top": 5,
+                      "width": "61%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "borderRight": 0,
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "43%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "26%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "69%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "31%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "color": "#333",
+                      "fontSize": 10,
+                      "left": "44%",
+                      "position": "absolute",
+                      "textAlign": "center",
+                      "top": 8.5,
+                      "width": "50%",
+                    }
+                  }
+                >
+                  69
+                </div>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          Room D
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "32%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "32%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  7
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "28%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "28%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  6
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "28%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "28%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  6
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "37%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "37%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  8
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "color": "black",
+                "cursor": "default",
+                "display": "inline-block",
+                "height": 18,
+                "marginBottom": 1,
+                "paddingTop": 5,
+                "position": "relative",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "rgb(137, 175, 202)",
+                    "height": 3,
+                    "left": "0%",
+                    "position": "absolute",
+                    "width": "5%",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 10,
+                    "height": "100%",
+                    "justifyContent": "flex-end",
+                    "left": 12,
+                    "position": "relative",
+                    "top": -5,
+                    "width": "5%",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#333",
+                    }
+                  }
+                >
+                  1
+                </span>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div>
+            <div
+              className="BoxAndWhisker"
+              style={
+                Object {
+                  "height": 18,
+                  "marginLeft": "auto",
+                  "marginRight": "auto",
+                  "width": 100,
+                }
+              }
+              title="{\\"min\\":1,\\"p25\\":24,\\"p50\\":59,\\"p75\\":90,\\"max\\":100}"
+            >
+              <div
+                style={
+                  Object {
+                    "height": "100%",
+                    "position": "relative",
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "backgroundColor": "#999",
+                      "height": 1,
+                      "left": "1%",
+                      "position": "absolute",
+                      "top": 5,
+                      "width": "99%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "borderRight": 0,
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "24%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "35%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "59%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "31%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "color": "#333",
+                      "fontSize": 10,
+                      "left": "34%",
+                      "position": "absolute",
+                      "textAlign": "center",
+                      "top": 8.5,
+                      "width": "50%",
+                    }
+                  }
+                >
+                  59
+                </div>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div>
+            <div
+              className="BoxAndWhisker"
+              style={
+                Object {
+                  "height": 18,
+                  "marginLeft": "auto",
+                  "marginRight": "auto",
+                  "width": 100,
+                }
+              }
+              title="{\\"min\\":6,\\"p25\\":35,\\"p50\\":60,\\"p75\\":72,\\"max\\":100}"
+            >
+              <div
+                style={
+                  Object {
+                    "height": "100%",
+                    "position": "relative",
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "backgroundColor": "#999",
+                      "height": 1,
+                      "left": "6%",
+                      "position": "absolute",
+                      "top": 5,
+                      "width": "94%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "borderRight": 0,
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "35%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "25%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "border": "1px solid #999",
+                      "fontSize": 10,
+                      "height": 7,
+                      "left": "60%",
+                      "paddingLeft": 3,
+                      "position": "absolute",
+                      "top": 1.5,
+                      "width": "12%",
+                    }
+                  }
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "color": "#333",
+                      "fontSize": 10,
+                      "left": "35%",
+                      "position": "absolute",
+                      "textAlign": "center",
+                      "top": 8.5,
+                      "width": "50%",
+                    }
+                  }
+                >
+                  60
+                </div>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/app/assets/javascripts/equity/__snapshots__/InlineStudentProfile.test.js.snap
+++ b/app/assets/javascripts/equity/__snapshots__/InlineStudentProfile.test.js.snap
@@ -104,16 +104,8 @@ exports[`snapshots 1`] = `
             Learning English
           </div>
           <div>
-            Learning English: 
-            Fluent
-          </div>
-          <div>
             ACCESS Composite: 
             1
-          </div>
-          <div>
-            Home language: 
-            Portuguese
           </div>
         </div>
       </div>
@@ -269,7 +261,13 @@ exports[`snapshots 1`] = `
     <div
       style={Object {}}
     >
-      <div>
+      <div
+        style={
+          Object {
+            "paddingTop": 20,
+          }
+        }
+      >
         <div
           className="SectionHeading"
           style={

--- a/app/assets/javascripts/equity/studentIdsByRoomFunctions.js
+++ b/app/assets/javascripts/equity/studentIdsByRoomFunctions.js
@@ -45,7 +45,7 @@ export function insertedInto(items, insertIndex, itemToInsert) {
 
 // Returns array with items swapped locations.
 export function reordered(items, fromIndex, toIndex) {
-  const result = Array.from(items);
+  const result = items.slice();
   const [removed] = result.splice(fromIndex, 1);
   result.splice(toIndex, 0, removed);
   return result;

--- a/app/assets/javascripts/equity/studentIdsByRoomFunctions.js
+++ b/app/assets/javascripts/equity/studentIdsByRoomFunctions.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 
-// Place the students into their initial state (eg, all unsorted).
+// Place the students into their initial state (eg, all unplaced, sorted alphabetically).
 // {[roomKey]: [studentId]}
 // Allow another placementFn to be passed.
 export function initialStudentIdsByRoom(roomsCount, students, options = {}) {
@@ -15,7 +15,8 @@ export function initialStudentIdsByRoom(roomsCount, students, options = {}) {
     };
   }, initialMap);
 
-  students.forEach(student => {
+  const sortedStudents = _.sortBy(students, student => `${student.first_name}, ${student.last_name}`);
+  sortedStudents.forEach(student => {
     const roomKey = (options.placementFn)
       ? options.placementFn(studentIdsByRoom, student)
       : UNPLACED_ROOM_KEY;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,7 +78,7 @@ Rails.application.routes.draw do
   resources :sections, only: [:index, :show]
   resources :iep_documents, only: [:show]
 
-  resource :balancing, only: [] do
+  resource :classlists, only: [] do
     member do
       get '' => 'ui#ui'
       get '/:balance_id' => 'ui#ui'

--- a/ui/App.js
+++ b/ui/App.js
@@ -11,7 +11,7 @@ import SchoolCoursesPage from '../app/assets/javascripts/school_courses/SchoolCo
 import MountTimer from '../app/assets/javascripts/components/MountTimer';
 import measurePageLoad from '../app/assets/javascripts/helpers/measurePageLoad';
 import ExploreSchoolEquityPage from '../app/assets/javascripts/equity/ExploreSchoolEquityPage';
-import ClassroomListCreatorPage from '../app/assets/javascripts/equity/ClassroomListCreatorPage';
+import ClassroomListCreatorPage, {ClassroomListCreatorPageEntryPoint} from '../app/assets/javascripts/equity/ClassroomListCreatorPage';
 import DistrictEnrollmentPage from '../app/assets/javascripts/district_enrollment/DistrictEnrollmentPage';
 import ImportRecordsPage from '../app/assets/javascripts/import_records/ImportRecordsPage';
 
@@ -57,7 +57,7 @@ class App extends React.Component {
           <Route exact path="/schools/:id/tardies" render={this.renderTardiesDashboard.bind(this)}/>
           <Route exact path="/schools/:id/discipline" render={this.renderDisciplineDashboard.bind(this)}/>
           <Route exact path="/schools/:id/equity/explore" render={this.renderExploreSchoolEquityPage.bind(this)}/>
-          <Route exact path="/balancing/:balance_id?" render={this.renderClassroomListCreator.bind(this)}/>
+          <Route exact path="/classlists/:balance_id?" render={this.renderClassroomListCreator.bind(this)}/>
           <Route exact path="/district/enrollment" render={this.renderDistrictEnrollmentPage.bind(this)}/>
           <Route render={() => this.renderNotFound()} />
         </Switch>
@@ -83,7 +83,9 @@ class App extends React.Component {
   renderClassroomListCreator(routeProps) {
     const balanceId = routeProps.match.params.balance_id;
     this.trackVisit(routeProps, 'CLASSROOM_LIST_CREATOR_PAGE');
-    return <ClassroomListCreatorPage balanceId={balanceId} />;
+    return (balanceId)
+      ? <ClassroomListCreatorPage balanceId={balanceId} />
+      : <ClassroomListCreatorPageEntryPoint />;
   }
 
   renderSchoolCoursesPage(routeProps) {

--- a/ui/App.test.js
+++ b/ui/App.test.js
@@ -6,6 +6,7 @@ import EducatorPage from '../app/assets/javascripts/educator/EducatorPage';
 import SchoolCoursesPage from '../app/assets/javascripts/school_courses/SchoolCoursesPage';
 import DashboardLoader from '../app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashboardLoader';
 import DistrictEnrollmentPage from '../app/assets/javascripts/district_enrollment/DistrictEnrollmentPage';
+import ClassroomListCreatorPage from '../app/assets/javascripts/equity/ClassroomListCreatorPage';
 import {MemoryRouter} from 'react-router-dom';
 
 
@@ -24,6 +25,7 @@ jest.mock('../app/assets/javascripts/educator/EducatorPage');
 jest.mock('../app/assets/javascripts/school_courses/SchoolCoursesPage');
 jest.mock('../app/assets/javascripts/school_administrator_dashboard/dashboard_components/DashboardLoader');
 jest.mock('../app/assets/javascripts/district_enrollment/DistrictEnrollmentPage');
+jest.mock('../app/assets/javascripts/equity/ClassroomListCreatorPage');
 
 // For testing, which mirrors the output of ui_controller#ui on the
 // server.
@@ -77,6 +79,13 @@ it('renders district enrollment', () => {
   const wrapper = mount(renderPath('/district/enrollment'));
   expect(wrapper.contains(
     <DistrictEnrollmentPage />
+  )).toEqual(true);
+});
+
+it('renders /classlists page', () => {
+  const wrapper = mount(renderPath('/classlists/foo-id'));
+  expect(wrapper.contains(
+    <ClassroomListCreatorPage balanceId="foo-id" />
   )).toEqual(true);
 });
 

--- a/ui/config/.storybook/config.js
+++ b/ui/config/.storybook/config.js
@@ -13,6 +13,7 @@ function loadStories() {
   require('../../../app/assets/javascripts/components/Circle.story.js');
   require('../../../app/assets/javascripts/components/DibelsBreakdownBar.story.js');
   require('../../../app/assets/javascripts/components/ReactSelect.story.js');
+  require('../../../app/assets/javascripts/components/Stack.story.js');
 
   // home
   require('../../../app/assets/javascripts/home/CheckStudentsWithHighAbsences.story.js');
@@ -40,4 +41,7 @@ function mockJestFns() {
   global.describe = function() {}
   global.beforeEach = function() {}
   global.it = function() {}
+  global.jest = {
+    fn() {}
+  };
 }


### PR DESCRIPTION
# Who is this PR for?
K1-6 teachers, part of https://github.com/studentinsights/studentinsights/issues/1659.

# What problem does this PR fix?
Makes a set of improvements for pilot sessions.

# What does this PR do?
Changes some definitions for how classrooms are compared, changes the comparison from using percents to counts of students, makes some other visual changes like adding tooltips to explain the categories and sorting student names on load.  It also makes a few optimizations to reduce the work done when dragging cards.  It also changes the entrypoint to `/classlists` but doesn't do any other internal renaming.

# Screenshot (if adding a client-side feature)
### screenshot, STAR, tooltips, counts instead of percents
<img width="865" alt="screen shot 2018-05-05 at 7 49 57 am" src="https://user-images.githubusercontent.com/1056957/39662994-f0e58dba-5038-11e8-84c0-7eb1cb05d574.png">

### screenshot, DIBELS
<img width="1003" alt="screen shot 2018-05-05 at 7 49 29 am" src="https://user-images.githubusercontent.com/1056957/39662996-f4141088-5038-11e8-8551-431ee5995c50.png">


### while dragging, counting renders before adding shouldComponentUpdate on SimpleStudentCard
<img width="826" alt="screen shot 2018-05-04 at 6 43 14 pm" src="https://user-images.githubusercontent.com/1056957/39662819-ce314b2c-5035-11e8-928f-e61e01e49a2f.png">

# Checklists
+ [ ] Author checked latest in IE - Classroom list creator
+ [ ] Author improved specs for code in need of better test coverage
+ [ ] Author included specs for new code