### PR TITLE
Factor out Timestamp component from feed cards

### DIFF
--- a/app/assets/javascripts/components/Timestamp.js
+++ b/app/assets/javascripts/components/Timestamp.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import {toMomentFromTime} from '../helpers/toMoment';
+
+
+// Render a timestamp with "from" and short date
+export default class Timestamp extends React.Component {
+  render() {
+    const {nowFn} = this.context;
+    const now = nowFn();
+    const {railsTimestamp, style} = this.props;
+    const momentTimestamp = toMomentFromTime(railsTimestamp);
+
+    return (
+      <div className="Timestamp" style={style || {}}>
+        {momentTimestamp.from(now)} on {momentTimestamp.format('M/D')}
+      </div>
+    );
+  }
+}
+Timestamp.contextTypes = {
+  nowFn: React.PropTypes.func.isRequired
+};
+Timestamp.propTypes = {
+  railsTimestamp: React.PropTypes.string.isRequired,
+  style: React.PropTypes.object
+};

--- a/app/assets/javascripts/components/Timestamp.test.js
+++ b/app/assets/javascripts/components/Timestamp.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Timestamp from './Timestamp';
+import {withDefaultNowContext} from '../../../../spec/javascripts/support/NowContainer';
+
+it('renders without crashing', () => {
+  const el = document.createElement('div');
+  ReactDOM.render(withDefaultNowContext(<Timestamp railsTimestamp="2018-02-09T12:03:26.664Z" />), el);
+  expect($(el).text()).toContain('a month ago on 2/9');
+});

--- a/app/assets/javascripts/feed/EventNoteCard.js
+++ b/app/assets/javascripts/feed/EventNoteCard.js
@@ -4,15 +4,13 @@ import Educator from '../components/Educator';
 import NoteText from '../components/NoteText';
 import HouseBadge from '../components/HouseBadge';
 import NoteBadge from '../components/NoteBadge';
-import {toMomentFromTime} from '../helpers/toMoment';
+import Timestamp from '../components/Timestamp';
 import {eventNoteTypeText} from '../components/eventNoteType';
 
 
 // Render a card in the feed for an EventNote
 class EventNoteCard extends React.Component {
   render() {
-    const {nowFn} = this.context;
-    const now = nowFn();
     const {eventNoteCardJson, style} = this.props;
     const {student, educator} = eventNoteCardJson;
 
@@ -30,7 +28,7 @@ class EventNoteCard extends React.Component {
             </div>
           }
           whereEl={<div>in {eventNoteTypeText(eventNoteCardJson.event_note_type_id)}</div>}
-          whenEl={<div>{toMomentFromTime(eventNoteCardJson.recorded_at).from(now)} on {toMomentFromTime(eventNoteCardJson.recorded_at).format('M/D')}</div>}
+          whenEl={<Timestamp railsTimestamp={eventNoteCardJson.recorded_at} />}
           badgesEl={<div>
             {student.house && <HouseBadge style={styles.footerBadge} house={student.house} />}
             <NoteBadge style={styles.footerBadge} eventNoteTypeId={eventNoteCardJson.event_note_type_id} />
@@ -42,9 +40,6 @@ class EventNoteCard extends React.Component {
     );
   }
 }
-EventNoteCard.contextTypes = {
-  nowFn: React.PropTypes.func.isRequired
-};
 EventNoteCard.propTypes = {
   eventNoteCardJson: React.PropTypes.shape({
     recorded_at: React.PropTypes.string.isRequired,

--- a/app/assets/javascripts/feed/IncidentCard.js
+++ b/app/assets/javascripts/feed/IncidentCard.js
@@ -1,15 +1,13 @@
 import React from 'react';
-import {toMomentFromTime} from '../helpers/toMoment';
 import FeedCardFrame from './FeedCardFrame';
 import HouseBadge from '../components/HouseBadge';
 import Badge from '../components/Badge';
+import Timestamp from '../components/Timestamp';
 
 
 // Render a card in the feed for a discipline incident
 class IncidentCard extends React.Component {
   render() {
-    const {nowFn} = this.context;
-    const now = nowFn();
     const {style, incidentCard} = this.props;
     const {student} = incidentCard;
 
@@ -19,7 +17,7 @@ class IncidentCard extends React.Component {
           style={style}
           student={student}
           whereEl={<div>in {incidentCard.incident_location}</div>}
-          whenEl={<div>{toMomentFromTime(incidentCard.occurred_at).from(now)} on {toMomentFromTime(incidentCard.occurred_at).format('M/D')}</div>}
+          whenEl={<Timestamp railsTimestamp={incidentCard.occurred_at} />}
           badgesEl={<div>
             {student.house && <HouseBadge style={styles.footerBadge} house={student.house} />}
             <Badge style={styles.footerBadge} text="Incident" backgroundColor="rgb(255, 140, 0)" />
@@ -31,9 +29,6 @@ class IncidentCard extends React.Component {
     );
   }
 }
-IncidentCard.contextTypes = {
-  nowFn: React.PropTypes.func.isRequired
-};
 IncidentCard.propTypes = {
   incidentCard: React.PropTypes.shape({
     id: React.PropTypes.number.isRequired,

--- a/app/assets/javascripts/feed/__snapshots__/EventNoteCard.test.js.snap
+++ b/app/assets/javascripts/feed/__snapshots__/EventNoteCard.test.js.snap
@@ -111,7 +111,10 @@ exports[`matches snapshot 1`] = `
           </div>
         </div>
         <div>
-          <div>
+          <div
+            className="Timestamp"
+            style={Object {}}
+          >
             14 years ago
              on 
             3/5

--- a/app/assets/javascripts/feed/__snapshots__/FeedView.test.js.snap
+++ b/app/assets/javascripts/feed/__snapshots__/FeedView.test.js.snap
@@ -149,7 +149,10 @@ exports[`FeedView pure component matches snapshot 1`] = `
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               12 days ago
                on 
               3/1
@@ -309,7 +312,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               6 years ago
                on 
               12/2
@@ -481,7 +487,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               6 years ago
                on 
               11/5
@@ -666,7 +675,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               6 years ago
                on 
               10/28
@@ -824,7 +836,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               6 years ago
                on 
               10/25
@@ -996,7 +1011,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               6 years ago
                on 
               10/24
@@ -1181,7 +1199,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               6 years ago
                on 
               10/16
@@ -1366,7 +1387,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               6 years ago
                on 
               10/16
@@ -1537,7 +1561,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               6 years ago
                on 
               10/4
@@ -1695,7 +1722,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               6 years ago
                on 
               10/4
@@ -1880,7 +1910,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               6 years ago
                on 
               10/3
@@ -2065,7 +2098,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               6 years ago
                on 
               9/30
@@ -2250,7 +2286,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               6 years ago
                on 
               9/23
@@ -2408,7 +2447,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               6 years ago
                on 
               9/22
@@ -2580,7 +2622,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               6 years ago
                on 
               9/22
@@ -2752,7 +2797,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               6 years ago
                on 
               9/17
@@ -2924,7 +2972,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               7 years ago
                on 
               9/11
@@ -3109,7 +3160,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               7 years ago
                on 
               9/9
@@ -3267,7 +3321,10 @@ Philis is meeting with parent next week and will present an attendance contract.
             </div>
           </div>
           <div>
-            <div>
+            <div
+              className="Timestamp"
+              style={Object {}}
+            >
               7 years ago
                on 
               9/8

--- a/app/assets/javascripts/feed/__snapshots__/IncidentCard.test.js.snap
+++ b/app/assets/javascripts/feed/__snapshots__/IncidentCard.test.js.snap
@@ -81,7 +81,10 @@ exports[`matches snapshot 1`] = `
           </div>
         </div>
         <div>
-          <div>
+          <div
+            className="Timestamp"
+            style={Object {}}
+          >
             13 days ago
              on 
             2/28


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
In working on https://github.com/studentinsights/studentinsights/pull/1683, I initially wanted to use the same timestamp rendering (days ago plus the date) so factored this out.  I ended up removing that from https://github.com/studentinsights/studentinsights/pull/1683, but this seems useful to keep anyway since it's duplicated in two feed components now.

# What does this PR do?
Factors out `<Timestamp />` from two feed cards.

# Checklists
+ [x] Author included specs for new code
