### PR TITLE
Classrooms: Vertically scroll each list independently

### DIFF
--- a/app/assets/javascripts/class_lists/ClassListCreatorPage.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorPage.js
@@ -109,16 +109,16 @@ export default class ClassListCreatorPage extends React.Component {
   }
 
   doSizePage() {
-    // Size to entire vertical height
+    // Reach outside component to change styles for page and conatiner, to take up
+    // the entire vertical height.
     window.document.documentElement.style.height = '100%';
     window.document.body.style.height = '100%';
     window.document.body.style.display = 'flex';
     window.document.body.style['flex-direction'] = 'column';
-
     window.document.getElementById('main').style.flex = 1;
     window.document.getElementById('main').style.display = 'flex';
     
-    // Prevent horizontal scrollbar
+    // Prevent horizontal scrollbar from showing.
     window.document.body.style['min-width'] = '1000px';
   }
   

--- a/app/assets/javascripts/class_lists/ClassListCreatorPage.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorPage.js
@@ -109,6 +109,16 @@ export default class ClassListCreatorPage extends React.Component {
   }
 
   doSizePage() {
+    // Size to entire vertical height
+    window.document.documentElement.style.height = '100%';
+    window.document.body.style.height = '100%';
+    window.document.body.style.display = 'flex';
+    window.document.body.style['flex-direction'] = 'column';
+
+    window.document.getElementById('main').style.flex = 1;
+    window.document.getElementById('main').style.display = 'flex';
+    
+    // Prevent horizontal scrollbar
     window.document.body.style['min-width'] = '1000px';
   }
   

--- a/app/assets/javascripts/class_lists/ClassListCreatorPage.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorPage.js
@@ -109,6 +109,9 @@ export default class ClassListCreatorPage extends React.Component {
   }
 
   doSizePage() {
+    const {disableSizing} = this.props;
+    if (disableSizing) return;
+    
     // Reach outside component to change styles for page and conatiner, to take up
     // the entire vertical height.
     window.document.documentElement.style.height = '100%';
@@ -366,7 +369,8 @@ export default class ClassListCreatorPage extends React.Component {
 }
 ClassListCreatorPage.propTypes = {
   defaultWorkspaceId: React.PropTypes.string,
-  disableHistory: React.PropTypes.bool
+  disableHistory: React.PropTypes.bool,
+  disableSizing: React.PropTypes.bool
 };
 
 

--- a/app/assets/javascripts/class_lists/ClassListCreatorPage.test.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorPage.test.js
@@ -6,20 +6,30 @@ import ClassListCreatorPage from './ClassListCreatorPage';
 
 beforeEach(() => mockWithFixtures());
 
+function testProps(props) {
+  return {
+    disableHistory: true,
+    disableSizing: true,
+    ...props
+  };
+}
+
 it('renders without crashing on entrypoint', () => {
+  const props = testProps();
   const el = document.createElement('div');
   ReactDOM.render(
     <MemoryRouter initialEntries={['/classlists']}>
-      <ClassListCreatorPage disableHistory={true} />
+      <ClassListCreatorPage {...props} />
     </MemoryRouter>
   , el);
 });
 
 it('renders without crashing with balanceId', () => {
+  const props = testProps({defaultWorkspaceId: 'foo-id'});
   const el = document.createElement('div');
   ReactDOM.render(
     <MemoryRouter initialEntries={['/classlists/foo-id']}>
-      <ClassListCreatorPage defaultWorkspaceId="foo-id" disableHistory={true} />
+      <ClassListCreatorPage {...props} />
     </MemoryRouter>
   , el);
 });

--- a/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
@@ -161,7 +161,7 @@ export default class ClassListCreatorWorkflow extends React.Component {
             <textarea
               style={styles.textarea}
               disabled={!isEditable}
-              rows={12}
+              rows={8}
               value={planText}
               onChange={event => onPlanTextChanged(event.target.value)} />
           </div>

--- a/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
@@ -157,12 +157,14 @@ export default class ClassListCreatorWorkflow extends React.Component {
           <div style={{fontSize: 12, padding: 10, paddingLeft: 0, paddingTop: 3}}>
             Some teams start with considering social dynamics, splitting up students who are leaders or who don't work well together.  Others start creating groups with diverse academic strengths.
           </div>
-          <textarea
-            style={styles.textarea}
-            disabled={!isEditable}
-            rows={12}
-            value={planText}
-            onChange={event => onPlanTextChanged(event.target.value)} />
+          <div>
+            <textarea
+              style={styles.textarea}
+              disabled={!isEditable}
+              rows={12}
+              value={planText}
+              onChange={event => onPlanTextChanged(event.target.value)} />
+          </div>
         </div>
       </div>
     );
@@ -254,7 +256,8 @@ ClassListCreatorWorkflow.propTypes = {
 
 const styles = {
   root: {
-    fontSize: 14
+    fontSize: 14,
+    width: '100%'
   },
   heading: {
     marginTop: 20

--- a/app/assets/javascripts/class_lists/ClassroomStats.js
+++ b/app/assets/javascripts/class_lists/ClassroomStats.js
@@ -69,6 +69,7 @@ export default class ClassroomStats extends React.Component {
                   title="A boxplot showing the range of students' latest STAR Reading percentile scores.  The number represents the median score.">
                   STAR Reading
                 </th>}
+              <th style={{...styles.cell, width: 50}}>Total</th>
             </tr>
           </thead>
           <tbody>
@@ -88,6 +89,9 @@ export default class ClassroomStats extends React.Component {
                   {showDibels && <td style={styles.cell}>{this.renderDibelsBreakdown(studentsInRoom)}</td>}
                   {showStar && <td style={styles.cell}>{this.renderMath(studentsInRoom)}</td>}
                   {showStar && <td style={styles.cell}>{this.renderReading(studentsInRoom)}</td>}
+                  <td style={styles.cell}>{studentsInRoom.length > 0 &&
+                    <span style={styles.total}>{studentsInRoom.length}</span>}
+                  </td>
                 </tr>
               );
             })}
@@ -260,7 +264,7 @@ const styles = {
     justifyContent: 'flex-end',
     position: 'relative',
     top: -6,
-    left: 13
+    left: 14
   },
   breakdownBar: {
     paddingTop: 4,
@@ -277,6 +281,12 @@ const styles = {
   },
   boxAndWhiskerLabel: {
     fontSize: 12
+  },
+  total: {
+    color: '#999',
+    float: 'right',
+    fontSize: 12,
+    paddingRight: 20
   }
 };
 

--- a/app/assets/javascripts/class_lists/CreateYourLists.js
+++ b/app/assets/javascripts/class_lists/CreateYourLists.js
@@ -148,8 +148,8 @@ const styles = {
   },
   classroomListColumn: {
     padding: 20,
-    paddingLeft: 10,
-    paddingRight: 10,
+    paddingLeft: 5,
+    paddingRight: 5,
     display: 'flex',
     flex: 1,
     flexDirection: 'column'

--- a/app/assets/javascripts/class_lists/CreateYourLists.js
+++ b/app/assets/javascripts/class_lists/CreateYourLists.js
@@ -148,8 +148,8 @@ const styles = {
   },
   classroomListColumn: {
     padding: 20,
-    paddingLeft: 5,
-    paddingRight: 5,
+    paddingLeft: 10,
+    paddingRight: 10,
     display: 'flex',
     flex: 1,
     flexDirection: 'column'

--- a/app/assets/javascripts/class_lists/CreateYourLists.js
+++ b/app/assets/javascripts/class_lists/CreateYourLists.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
+import {AutoSizer} from 'react-virtualized';
 import SimpleStudentCard from './SimpleStudentCard';
 import ClassroomStats from './ClassroomStats';
 import {studentsInRoom} from './studentIdsByRoomFunctions';
@@ -58,17 +59,21 @@ export default class CreateYourListsView extends React.Component {
                       <span style={styles.roomStudentCount}>({classroomStudents.length})</span>
                     </div>
                   </div>
-                  <Droppable
-                    droppableId={roomKey}
-                    type="CLASSROOM_LIST"
-                    isDropDisabled={!isEditable}>
-                    {(provided, snapshot) => (
-                      <div ref={provided.innerRef} style={styles.droppable}>
-                        <div>{classroomStudents.map(this.renderStudentCard, this)}</div>
-                        <div>{provided.placeholder}</div>
-                      </div>
-                    )}
-                  </Droppable>
+                  <div style={{flex: 1}}>
+                    <AutoSizer disableWidth>{({height}) => (
+                      <Droppable
+                        droppableId={roomKey}
+                        type="CLASSROOM_LIST"
+                        isDropDisabled={!isEditable}>
+                        {(provided, snapshot) => (
+                          <div ref={provided.innerRef} style={{...styles.droppable, height}}>
+                            <div>{classroomStudents.map(this.renderStudentCard, this)}</div>
+                            <div>{provided.placeholder}</div>
+                          </div>
+                        )}
+                      </Droppable>
+                    )}</AutoSizer>
+                  </div>
                 </div>
               );
             })}
@@ -132,10 +137,14 @@ export function studentIdsByRoomAfterDrag(studentIdsByRoom, dragEndResult) {
 const styles = {
   root: {
     userSelect: 'none',
-    msUserSelect: 'none'
+    msUserSelect: 'none',
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%'
   },
   listsContainer: {
-    display: 'flex'
+    display: 'flex',
+    flex: 1
   },
   classroomListColumn: {
     padding: 20,
@@ -152,7 +161,8 @@ const styles = {
     borderRadius: 3,
     paddingTop: 10,
     paddingBottom: 10,
-    minHeight: 150
+    minHeight: 150,
+    overflowY: 'scroll'
   },
   roomTitle: {
     border: '1px solid #aaa',

--- a/app/assets/javascripts/class_lists/HorizontalStepper.js
+++ b/app/assets/javascripts/class_lists/HorizontalStepper.js
@@ -113,14 +113,12 @@ const styles = {
     paddingTop: 15,
     height: '100%',
     display: 'flex',
-    flexDirection: 'column',
-    border: '1px solid red'
+    flexDirection: 'column'
   },
   content: {
     borderTop: '1px solid #ccc',
     marginTop: 10,
-    flex: 1,
-    border: '1px solid green'
+    flex: 1
   },
   bannerContainer: {
     display: 'flex',

--- a/app/assets/javascripts/class_lists/HorizontalStepper.js
+++ b/app/assets/javascripts/class_lists/HorizontalStepper.js
@@ -110,11 +110,17 @@ HorizontalStepper.propTypes = {
 
 const styles = {
   root: {
-    paddingTop: 15
+    paddingTop: 15,
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    border: '1px solid red'
   },
   content: {
     borderTop: '1px solid #ccc',
-    marginTop: 10
+    marginTop: 10,
+    flex: 1,
+    border: '1px solid green'
   },
   bannerContainer: {
     display: 'flex',

--- a/app/assets/javascripts/class_lists/__snapshots__/ClassListCreatorWorkflow.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ClassListCreatorWorkflow.test.js.snap
@@ -6,6 +6,7 @@ exports[`chooseYourGradeProps 1`] = `
   style={
     Object {
       "fontSize": 14,
+      "width": "100%",
     }
   }
 >
@@ -13,6 +14,9 @@ exports[`chooseYourGradeProps 1`] = `
     className="HorizontalStepper"
     style={
       Object {
+        "display": "flex",
+        "flexDirection": "column",
+        "height": "100%",
         "paddingTop": 15,
       }
     }
@@ -231,6 +235,7 @@ exports[`chooseYourGradeProps 1`] = `
       style={
         Object {
           "borderTop": "1px solid #ccc",
+          "flex": 1,
           "marginTop": 10,
         }
       }
@@ -570,6 +575,7 @@ exports[`chooseYourGradeProps 2`] = `
   style={
     Object {
       "fontSize": 14,
+      "width": "100%",
     }
   }
 >
@@ -577,6 +583,9 @@ exports[`chooseYourGradeProps 2`] = `
     className="HorizontalStepper"
     style={
       Object {
+        "display": "flex",
+        "flexDirection": "column",
+        "height": "100%",
         "paddingTop": 15,
       }
     }
@@ -811,6 +820,7 @@ exports[`chooseYourGradeProps 2`] = `
       style={
         Object {
           "borderTop": "1px solid #ccc",
+          "flex": 1,
           "marginTop": 10,
         }
       }
@@ -1058,6 +1068,7 @@ exports[`makeAPlanProps 1`] = `
   style={
     Object {
       "fontSize": 14,
+      "width": "100%",
     }
   }
 >
@@ -1065,6 +1076,9 @@ exports[`makeAPlanProps 1`] = `
     className="HorizontalStepper"
     style={
       Object {
+        "display": "flex",
+        "flexDirection": "column",
+        "height": "100%",
         "paddingTop": 15,
       }
     }
@@ -1283,6 +1297,7 @@ exports[`makeAPlanProps 1`] = `
       style={
         Object {
           "borderTop": "1px solid #ccc",
+          "flex": 1,
           "marginTop": 10,
         }
       }
@@ -1539,18 +1554,20 @@ exports[`makeAPlanProps 1`] = `
           >
             Some teams start with considering social dynamics, splitting up students who are leaders or who don't work well together.  Others start creating groups with diverse academic strengths.
           </div>
-          <textarea
-            disabled={false}
-            onChange={[Function]}
-            rows={12}
-            style={
-              Object {
-                "border": "1px solid #ccc",
-                "width": "100%",
+          <div>
+            <textarea
+              disabled={false}
+              onChange={[Function]}
+              rows={8}
+              style={
+                Object {
+                  "border": "1px solid #ccc",
+                  "width": "100%",
+                }
               }
-            }
-            value=""
-          />
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -1624,6 +1641,7 @@ exports[`makeAPlanProps 2`] = `
   style={
     Object {
       "fontSize": 14,
+      "width": "100%",
     }
   }
 >
@@ -1631,6 +1649,9 @@ exports[`makeAPlanProps 2`] = `
     className="HorizontalStepper"
     style={
       Object {
+        "display": "flex",
+        "flexDirection": "column",
+        "height": "100%",
         "paddingTop": 15,
       }
     }
@@ -1865,6 +1886,7 @@ exports[`makeAPlanProps 2`] = `
       style={
         Object {
           "borderTop": "1px solid #ccc",
+          "flex": 1,
           "marginTop": 10,
         }
       }
@@ -2065,18 +2087,20 @@ exports[`makeAPlanProps 2`] = `
           >
             Some teams start with considering social dynamics, splitting up students who are leaders or who don't work well together.  Others start creating groups with diverse academic strengths.
           </div>
-          <textarea
-            disabled={true}
-            onChange={[Function]}
-            rows={12}
-            style={
-              Object {
-                "border": "1px solid #ccc",
-                "width": "100%",
+          <div>
+            <textarea
+              disabled={true}
+              onChange={[Function]}
+              rows={8}
+              style={
+                Object {
+                  "border": "1px solid #ccc",
+                  "width": "100%",
+                }
               }
-            }
-            value=""
-          />
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/app/assets/javascripts/class_lists/__snapshots__/ClassroomStats.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ClassroomStats.test.js.snap
@@ -167,6 +167,19 @@ exports[`snapshots 1`] = `
         >
           STAR Reading
         </th>
+        <th
+          style={
+            Object {
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+              "width": 50,
+            }
+          }
+        >
+          Total
+        </th>
       </tr>
     </thead>
     <tbody>
@@ -240,7 +253,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "0%",
@@ -302,7 +315,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "0%",
@@ -402,7 +415,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "0%",
@@ -471,7 +484,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "0%",
@@ -507,6 +520,16 @@ exports[`snapshots 1`] = `
         >
           <div />
         </td>
+        <td
+          style={
+            Object {
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        />
       </tr>
       <tr>
         <td
@@ -578,7 +601,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "12%",
@@ -648,7 +671,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "23%",
@@ -825,7 +848,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "29%",
@@ -902,7 +925,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "0%",
@@ -1114,6 +1137,29 @@ exports[`snapshots 1`] = `
             </div>
           </div>
         </td>
+        <td
+          style={
+            Object {
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <span
+            style={
+              Object {
+                "color": "#999",
+                "float": "right",
+                "fontSize": 12,
+                "paddingRight": 20,
+              }
+            }
+          >
+            8
+          </span>
+        </td>
       </tr>
       <tr>
         <td
@@ -1185,7 +1231,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "18%",
@@ -1255,7 +1301,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "58%",
@@ -1432,7 +1478,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "47%",
@@ -1509,7 +1555,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "0%",
@@ -1721,6 +1767,29 @@ exports[`snapshots 1`] = `
             </div>
           </div>
         </td>
+        <td
+          style={
+            Object {
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <span
+            style={
+              Object {
+                "color": "#999",
+                "float": "right",
+                "fontSize": 12,
+                "paddingRight": 20,
+              }
+            }
+          >
+            14
+          </span>
+        </td>
       </tr>
       <tr>
         <td
@@ -1792,7 +1861,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "18%",
@@ -1862,7 +1931,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "29%",
@@ -2039,7 +2108,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "41%",
@@ -2116,7 +2185,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "0%",
@@ -2328,6 +2397,29 @@ exports[`snapshots 1`] = `
             </div>
           </div>
         </td>
+        <td
+          style={
+            Object {
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <span
+            style={
+              Object {
+                "color": "#999",
+                "float": "right",
+                "fontSize": 12,
+                "paddingRight": 20,
+              }
+            }
+          >
+            9
+          </span>
+        </td>
       </tr>
       <tr>
         <td
@@ -2399,7 +2491,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "18%",
@@ -2469,7 +2561,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "58%",
@@ -2646,7 +2738,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "41%",
@@ -2723,7 +2815,7 @@ exports[`snapshots 1`] = `
                     "fontSize": 12,
                     "height": "100%",
                     "justifyContent": "flex-end",
-                    "left": 13,
+                    "left": 14,
                     "position": "relative",
                     "top": -6,
                     "width": "0%",
@@ -2934,6 +3026,29 @@ exports[`snapshots 1`] = `
               </div>
             </div>
           </div>
+        </td>
+        <td
+          style={
+            Object {
+              "fontWeight": "normal",
+              "overflow": "hidden",
+              "textAlign": "left",
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <span
+            style={
+              Object {
+                "color": "#999",
+                "float": "right",
+                "fontSize": 12,
+                "paddingRight": 20,
+              }
+            }
+          >
+            15
+          </span>
         </td>
       </tr>
     </tbody>

--- a/app/assets/javascripts/class_lists/__snapshots__/HorizontalStepper.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/HorizontalStepper.test.js.snap
@@ -5,6 +5,9 @@ exports[`snapshots 1`] = `
   className="HorizontalStepper"
   style={
     Object {
+      "display": "flex",
+      "flexDirection": "column",
+      "height": "100%",
       "paddingTop": 15,
     }
   }
@@ -223,6 +226,7 @@ exports[`snapshots 1`] = `
     style={
       Object {
         "borderTop": "1px solid #ccc",
+        "flex": 1,
         "marginTop": 10,
       }
     }
@@ -307,6 +311,9 @@ exports[`snapshots when readonly 1`] = `
   className="HorizontalStepper"
   style={
     Object {
+      "display": "flex",
+      "flexDirection": "column",
+      "height": "100%",
       "paddingTop": 15,
     }
   }
@@ -541,6 +548,7 @@ exports[`snapshots when readonly 1`] = `
     style={
       Object {
         "borderTop": "1px solid #ccc",
+        "flex": 1,
         "marginTop": 10,
       }
     }

--- a/app/assets/javascripts/class_lists/storybookFrame.js
+++ b/app/assets/javascripts/class_lists/storybookFrame.js
@@ -3,7 +3,7 @@ export default function storybookFrame(children) {
   return (
     <div style={{width: '100%', background: '#333'}}>
       <div style={{height: 216}} />
-      <div style={{width: 1024, border: '5px solid #333', background: 'white'}}>
+      <div style={{width: 1024, border: '5px solid #333', background: 'white', height: 460}}>
       {children}
       </div>
     </div>


### PR DESCRIPTION
# Who is this PR for?
K1-6 educator teams, part of https://github.com/studentinsights/studentinsights/pull/1683.

# What problem does this PR fix?
This reduces scrolling especially on first placements, trading off hiding the full set of students in the workspace.

# What does this PR do?
Adds some styling hacks to the container to allow the page to resize to full height.  And then adds `<AutoSizer />` to the droppable lists and sets them to `overflowY: scroll`.  Also adds a total column.

# Screenshot (if adding a client-side feature)
These show sizing guidelines (not present in final PR):
<img width="1020" alt="screen shot 2018-05-10 at 1 55 29 pm" src="https://user-images.githubusercontent.com/1056957/39886167-9fb42d20-545c-11e8-9bbc-eabbef7dae8c.png">
<img width="1022" alt="screen shot 2018-05-10 at 1 55 19 pm" src="https://user-images.githubusercontent.com/1056957/39886168-9fc44458-545c-11e8-89a7-c6506dbbeeca.png">

Total column:
<img width="1013" alt="screen shot 2018-05-10 at 2 08 50 pm" src="https://user-images.githubusercontent.com/1056957/39886203-bdf39f46-545c-11e8-83a3-bc3ec68a9d81.png">

# Checklists
+ [x] Author checked latest in IE - Class lists
+ [x] Author included specs for new code
