### PR TITLE
Classrooms: Replace box-and-whiskers with breakdown into three buckets

### DIFF
--- a/app/assets/javascripts/class_lists/ClassroomStats.js
+++ b/app/assets/javascripts/class_lists/ClassroomStats.js
@@ -1,13 +1,14 @@
 import React from 'react';
-import _ from 'lodash';
 import Hover from '../components/Hover';
 import Stack from '../components/Stack';
-import BoxAndWhisker from '../components/BoxAndWhisker';
 import DibelsBreakdownBar from '../components/DibelsBreakdownBar';
 import BreakdownBar from '../components/BreakdownBar';
 import {
   selection,
   steelBlue,
+  high,
+  medium,
+  low,
   male,
   female,
   nonBinary
@@ -234,17 +235,33 @@ export default class ClassroomStats extends React.Component {
     return this.renderStar(studentsInRoom, student => student.most_recent_star_reading_percentile);
   }
 
+  // Ignore students without scores
   renderStar(studentsInRoom, accessor) {
-    const values = _.compact(studentsInRoom.map(accessor));
+    const lowCount = studentsInRoom.filter(student => {
+      const percentile = accessor(student);
+      return (percentile && percentile < 30);
+    }).length;
+    const mediumCount = studentsInRoom.filter(student => {
+      const percentile = accessor(student);
+      return (percentile && percentile >= 30 && percentile <= 70);
+    }).length;
+    const highCount = studentsInRoom.filter(student => {
+      const percentile = accessor(student);
+      return (percentile && percentile > 70);
+    }).length;
+
+    const items = [
+      { left: 0, width: highCount, color: high, key: 'high' },
+      { left: highCount, width: mediumCount, color: medium, key: 'medium' },
+      { left: highCount + mediumCount, width: lowCount, color: low, key: 'low' }
+    ];
     return (
-      <div>
-        {(values.length === 0)
-          ? null
-          : <BoxAndWhisker
-              values={values}
-              style={styles.boxAndWhisker}
-              labelStyle={styles.boxAndWhiskerLabel} />}
-      </div>
+      <BreakdownBar
+        items={items}
+        style={styles.breakdownBar}
+        innerStyle={styles.breakdownBarInner}
+        height={5}
+        labelTop={5} />
     );
   }
 

--- a/app/assets/javascripts/class_lists/ClassroomStats.js
+++ b/app/assets/javascripts/class_lists/ClassroomStats.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Hover from '../components/Hover';
 import Stack from '../components/Stack';
+import BoxAndWhisker from '../components/BoxAndWhisker';
 import DibelsBreakdownBar from '../components/DibelsBreakdownBar';
 import BreakdownBar from '../components/BreakdownBar';
 import {
@@ -31,6 +32,10 @@ export default class ClassroomStats extends React.Component {
     super(props);
     this.renderLabelFn = this.renderLabelFn.bind(this);
     this.onKeyPress = this.onKeyPress.bind(this);
+  }
+
+  isFlagSet(flagKey) {
+    return (window.location.search.indexOf(flagKey) !== -1);
   }
 
   studentsInRoom(room) {
@@ -235,8 +240,14 @@ export default class ClassroomStats extends React.Component {
     return this.renderStar(studentsInRoom, student => student.most_recent_star_reading_percentile);
   }
 
-  // Ignore students without scores
   renderStar(studentsInRoom, accessor) {
+    return (this.isFlagSet('box-and-whisker'))
+      ? this.renderStarWithBoxAndWhisker(studentsInRoom, accessor)
+      : this.renderStarWithBreakdown(studentsInRoom, accessor);
+  }
+
+  // Ignore students without scores
+  renderStarWithBreakdown(studentsInRoom, accessor) {
     const lowCount = studentsInRoom.filter(student => {
       const percentile = accessor(student);
       return (percentile && percentile < 30);
@@ -262,6 +273,20 @@ export default class ClassroomStats extends React.Component {
         innerStyle={styles.breakdownBarInner}
         height={5}
         labelTop={5} />
+    );
+  }
+
+  renderStarWithBoxAndWhisker(studentsInRoom, accessor) {
+    const values = _.compact(studentsInRoom.map(accessor));
+    return (
+      <div>
+        {(values.length === 0)
+          ? null
+          : <BoxAndWhisker
+              values={values}
+              style={styles.boxAndWhisker}
+              labelStyle={styles.boxAndWhiskerLabel} />}
+      </div>
     );
   }
 

--- a/app/assets/javascripts/class_lists/__snapshots__/ClassroomStats.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ClassroomStats.test.js.snap
@@ -629,7 +629,26 @@ exports[`snapshots 1`] = `
               }
             }
           >
-            <div />
+            <div
+              className="BreakdownBar"
+              style={
+                Object {
+                  "height": 5,
+                  "paddingRight": 10,
+                  "paddingTop": 4,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "height": 5,
+                    "position": "relative",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
           </td>
           <td
             style={
@@ -641,7 +660,26 @@ exports[`snapshots 1`] = `
               }
             }
           >
-            <div />
+            <div
+              className="BreakdownBar"
+              style={
+                Object {
+                  "height": 5,
+                  "paddingRight": 10,
+                  "paddingTop": 4,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "height": 5,
+                    "position": "relative",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
           </td>
           <td
             style={
@@ -1045,90 +1083,119 @@ exports[`snapshots 1`] = `
               }
             }
           >
-            <div>
+            <div
+              className="BreakdownBar"
+              style={
+                Object {
+                  "height": 5,
+                  "paddingRight": 10,
+                  "paddingTop": 4,
+                }
+              }
+            >
               <div
-                className="BoxAndWhisker"
                 style={
                   Object {
-                    "height": 18,
-                    "marginLeft": "auto",
-                    "marginRight": "auto",
-                    "width": 100,
+                    "height": 5,
+                    "position": "relative",
+                    "width": "100%",
                   }
                 }
               >
-                <div
-                  style={
-                    Object {
-                      "height": "100%",
-                      "position": "relative",
-                      "width": "100%",
-                    }
-                  }
-                >
+                <div>
                   <div
                     style={
                       Object {
-                        "backgroundColor": "#999",
-                        "height": 1,
-                        "left": "3%",
-                        "position": "absolute",
-                        "top": 5,
-                        "width": "97%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "borderRight": 0,
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "5%",
-                        "paddingLeft": 3,
-                        "position": "absolute",
-                        "top": 1.5,
-                        "width": "10%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "15%",
-                        "paddingLeft": 3,
-                        "position": "absolute",
-                        "top": 1.5,
-                        "width": "26%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "color": "#333",
+                        "background": "rgba(0,128,0,0.5)",
                         "fontSize": 12,
-                        "left": "-10%",
+                        "height": 5,
+                        "left": "0%",
                         "position": "absolute",
-                        "textAlign": "center",
-                        "top": 8.5,
-                        "width": "50%",
+                        "width": "13%",
                       }
                     }
                   >
-                    15
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(0,128,0,0.5)",
+                        "fontSize": 12,
+                        "left": "0%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "13%",
+                      }
+                    }
+                  >
+                    1
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "13%",
+                        "position": "absolute",
+                        "width": "25%",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "left": "13%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "25%",
+                      }
+                    }
+                  >
+                    2
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,0,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "38%",
+                        "position": "absolute",
+                        "width": "63%",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(255,0,0,0.5)",
+                        "fontSize": 12,
+                        "left": "38%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "63%",
+                      }
+                    }
+                  >
+                    5
                   </div>
                 </div>
               </div>
@@ -1144,90 +1211,119 @@ exports[`snapshots 1`] = `
               }
             }
           >
-            <div>
+            <div
+              className="BreakdownBar"
+              style={
+                Object {
+                  "height": 5,
+                  "paddingRight": 10,
+                  "paddingTop": 4,
+                }
+              }
+            >
               <div
-                className="BoxAndWhisker"
                 style={
                   Object {
-                    "height": 18,
-                    "marginLeft": "auto",
-                    "marginRight": "auto",
-                    "width": 100,
+                    "height": 5,
+                    "position": "relative",
+                    "width": "100%",
                   }
                 }
               >
-                <div
-                  style={
-                    Object {
-                      "height": "100%",
-                      "position": "relative",
-                      "width": "100%",
-                    }
-                  }
-                >
+                <div>
                   <div
                     style={
                       Object {
-                        "backgroundColor": "#999",
-                        "height": 1,
-                        "left": "14%",
-                        "position": "absolute",
-                        "top": 5,
-                        "width": "77%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "borderRight": 0,
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "17%",
-                        "paddingLeft": 3,
-                        "position": "absolute",
-                        "top": 1.5,
-                        "width": "32%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "49%",
-                        "paddingLeft": 3,
-                        "position": "absolute",
-                        "top": 1.5,
-                        "width": "19%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "color": "#333",
+                        "background": "rgba(0,128,0,0.5)",
                         "fontSize": 12,
-                        "left": "24%",
+                        "height": 5,
+                        "left": "0%",
                         "position": "absolute",
-                        "textAlign": "center",
-                        "top": 8.5,
-                        "width": "50%",
+                        "width": "25%",
                       }
                     }
                   >
-                    49
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(0,128,0,0.5)",
+                        "fontSize": 12,
+                        "left": "0%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "25%",
+                      }
+                    }
+                  >
+                    2
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "25%",
+                        "position": "absolute",
+                        "width": "38%",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "left": "25%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "38%",
+                      }
+                    }
+                  >
+                    3
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,0,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "63%",
+                        "position": "absolute",
+                        "width": "38%",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(255,0,0,0.5)",
+                        "fontSize": 12,
+                        "left": "63%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "38%",
+                      }
+                    }
+                  >
+                    3
                   </div>
                 </div>
               </div>
@@ -1648,36 +1744,35 @@ exports[`snapshots 1`] = `
               }
             }
           >
-            <div>
+            <div
+              className="BreakdownBar"
+              style={
+                Object {
+                  "height": 5,
+                  "paddingRight": 10,
+                  "paddingTop": 4,
+                }
+              }
+            >
               <div
-                className="BoxAndWhisker"
                 style={
                   Object {
-                    "height": 18,
-                    "marginLeft": "auto",
-                    "marginRight": "auto",
-                    "width": 100,
+                    "height": 5,
+                    "position": "relative",
+                    "width": "100%",
                   }
                 }
               >
-                <div
-                  style={
-                    Object {
-                      "height": "100%",
-                      "position": "relative",
-                      "width": "100%",
-                    }
-                  }
-                >
+                <div>
                   <div
                     style={
                       Object {
-                        "backgroundColor": "#999",
-                        "height": 1,
-                        "left": "1%",
+                        "background": "rgba(0,128,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "0%",
                         "position": "absolute",
-                        "top": 5,
-                        "width": "95%",
+                        "width": "42%",
                       }
                     }
                   >
@@ -1686,15 +1781,61 @@ exports[`snapshots 1`] = `
                   <div
                     style={
                       Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "borderRight": 0,
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "16%",
-                        "paddingLeft": 3,
+                        "color": "rgba(0,128,0,0.5)",
+                        "fontSize": 12,
+                        "left": "0%",
+                        "paddingRight": 1,
                         "position": "absolute",
-                        "top": 1.5,
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "42%",
+                      }
+                    }
+                  >
+                    5
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "42%",
+                        "position": "absolute",
+                        "width": "25%",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "left": "42%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "25%",
+                      }
+                    }
+                  >
+                    3
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,0,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "67%",
+                        "position": "absolute",
                         "width": "34%",
                       }
                     }
@@ -1704,34 +1845,18 @@ exports[`snapshots 1`] = `
                   <div
                     style={
                       Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "50%",
-                        "paddingLeft": 3,
-                        "position": "absolute",
-                        "top": 1.5,
-                        "width": "27%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "color": "#333",
+                        "color": "rgba(255,0,0,0.5)",
                         "fontSize": 12,
-                        "left": "25%",
+                        "left": "67%",
+                        "paddingRight": 1,
                         "position": "absolute",
-                        "textAlign": "center",
-                        "top": 8.5,
-                        "width": "50%",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "34%",
                       }
                     }
                   >
-                    50
+                    4
                   </div>
                 </div>
               </div>
@@ -1747,90 +1872,119 @@ exports[`snapshots 1`] = `
               }
             }
           >
-            <div>
+            <div
+              className="BreakdownBar"
+              style={
+                Object {
+                  "height": 5,
+                  "paddingRight": 10,
+                  "paddingTop": 4,
+                }
+              }
+            >
               <div
-                className="BoxAndWhisker"
                 style={
                   Object {
-                    "height": 18,
-                    "marginLeft": "auto",
-                    "marginRight": "auto",
-                    "width": 100,
+                    "height": 5,
+                    "position": "relative",
+                    "width": "100%",
                   }
                 }
               >
-                <div
-                  style={
-                    Object {
-                      "height": "100%",
-                      "position": "relative",
-                      "width": "100%",
-                    }
-                  }
-                >
+                <div>
                   <div
                     style={
                       Object {
-                        "backgroundColor": "#999",
-                        "height": 1,
-                        "left": "12%",
-                        "position": "absolute",
-                        "top": 5,
-                        "width": "65%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "borderRight": 0,
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "26%",
-                        "paddingLeft": 3,
-                        "position": "absolute",
-                        "top": 1.5,
-                        "width": "14%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "40%",
-                        "paddingLeft": 3,
-                        "position": "absolute",
-                        "top": 1.5,
-                        "width": "26%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "color": "#333",
+                        "background": "rgba(0,128,0,0.5)",
                         "fontSize": 12,
-                        "left": "15%",
+                        "height": 5,
+                        "left": "0%",
                         "position": "absolute",
-                        "textAlign": "center",
-                        "top": 8.5,
-                        "width": "50%",
+                        "width": "19%",
                       }
                     }
                   >
-                    40
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(0,128,0,0.5)",
+                        "fontSize": 12,
+                        "left": "0%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "19%",
+                      }
+                    }
+                  >
+                    2
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "19%",
+                        "position": "absolute",
+                        "width": "55%",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "left": "19%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "55%",
+                      }
+                    }
+                  >
+                    6
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,0,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "73%",
+                        "position": "absolute",
+                        "width": "28%",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(255,0,0,0.5)",
+                        "fontSize": 12,
+                        "left": "73%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "28%",
+                      }
+                    }
+                  >
+                    3
                   </div>
                 </div>
               </div>
@@ -2251,90 +2405,119 @@ exports[`snapshots 1`] = `
               }
             }
           >
-            <div>
+            <div
+              className="BreakdownBar"
+              style={
+                Object {
+                  "height": 5,
+                  "paddingRight": 10,
+                  "paddingTop": 4,
+                }
+              }
+            >
               <div
-                className="BoxAndWhisker"
                 style={
                   Object {
-                    "height": 18,
-                    "marginLeft": "auto",
-                    "marginRight": "auto",
-                    "width": 100,
+                    "height": 5,
+                    "position": "relative",
+                    "width": "100%",
                   }
                 }
               >
-                <div
-                  style={
-                    Object {
-                      "height": "100%",
-                      "position": "relative",
-                      "width": "100%",
-                    }
-                  }
-                >
+                <div>
                   <div
                     style={
                       Object {
-                        "backgroundColor": "#999",
-                        "height": 1,
-                        "left": "11%",
-                        "position": "absolute",
-                        "top": 5,
-                        "width": "84%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "borderRight": 0,
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "29%",
-                        "paddingLeft": 3,
-                        "position": "absolute",
-                        "top": 1.5,
-                        "width": "23%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "52%",
-                        "paddingLeft": 3,
-                        "position": "absolute",
-                        "top": 1.5,
-                        "width": "43%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "color": "#333",
+                        "background": "rgba(0,128,0,0.5)",
                         "fontSize": 12,
-                        "left": "27%",
+                        "height": 5,
+                        "left": "0%",
                         "position": "absolute",
-                        "textAlign": "center",
-                        "top": 8.5,
-                        "width": "50%",
+                        "width": "34%",
                       }
                     }
                   >
-                    52
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(0,128,0,0.5)",
+                        "fontSize": 12,
+                        "left": "0%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "34%",
+                      }
+                    }
+                  >
+                    3
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "34%",
+                        "position": "absolute",
+                        "width": "34%",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "left": "34%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "34%",
+                      }
+                    }
+                  >
+                    3
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,0,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "67%",
+                        "position": "absolute",
+                        "width": "34%",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(255,0,0,0.5)",
+                        "fontSize": 12,
+                        "left": "67%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "34%",
+                      }
+                    }
+                  >
+                    3
                   </div>
                 </div>
               </div>
@@ -2350,90 +2533,119 @@ exports[`snapshots 1`] = `
               }
             }
           >
-            <div>
+            <div
+              className="BreakdownBar"
+              style={
+                Object {
+                  "height": 5,
+                  "paddingRight": 10,
+                  "paddingTop": 4,
+                }
+              }
+            >
               <div
-                className="BoxAndWhisker"
                 style={
                   Object {
-                    "height": 18,
-                    "marginLeft": "auto",
-                    "marginRight": "auto",
-                    "width": 100,
+                    "height": 5,
+                    "position": "relative",
+                    "width": "100%",
                   }
                 }
               >
-                <div
-                  style={
-                    Object {
-                      "height": "100%",
-                      "position": "relative",
-                      "width": "100%",
-                    }
-                  }
-                >
+                <div>
                   <div
                     style={
                       Object {
-                        "backgroundColor": "#999",
-                        "height": 1,
-                        "left": "19%",
-                        "position": "absolute",
-                        "top": 5,
-                        "width": "71%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "borderRight": 0,
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "28%",
-                        "paddingLeft": 3,
-                        "position": "absolute",
-                        "top": 1.5,
-                        "width": "41%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "69%",
-                        "paddingLeft": 3,
-                        "position": "absolute",
-                        "top": 1.5,
-                        "width": "10%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "color": "#333",
+                        "background": "rgba(0,128,0,0.5)",
                         "fontSize": 12,
-                        "left": "44%",
+                        "height": 5,
+                        "left": "0%",
                         "position": "absolute",
-                        "textAlign": "center",
-                        "top": 8.5,
-                        "width": "50%",
+                        "width": "45%",
                       }
                     }
                   >
-                    69
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(0,128,0,0.5)",
+                        "fontSize": 12,
+                        "left": "0%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "45%",
+                      }
+                    }
+                  >
+                    4
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "45%",
+                        "position": "absolute",
+                        "width": "23%",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "left": "45%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "23%",
+                      }
+                    }
+                  >
+                    2
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,0,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "67%",
+                        "position": "absolute",
+                        "width": "34%",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(255,0,0,0.5)",
+                        "fontSize": 12,
+                        "left": "67%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "34%",
+                      }
+                    }
+                  >
+                    3
                   </div>
                 </div>
               </div>
@@ -2854,90 +3066,119 @@ exports[`snapshots 1`] = `
               }
             }
           >
-            <div>
+            <div
+              className="BreakdownBar"
+              style={
+                Object {
+                  "height": 5,
+                  "paddingRight": 10,
+                  "paddingTop": 4,
+                }
+              }
+            >
               <div
-                className="BoxAndWhisker"
                 style={
                   Object {
-                    "height": 18,
-                    "marginLeft": "auto",
-                    "marginRight": "auto",
-                    "width": 100,
+                    "height": 5,
+                    "position": "relative",
+                    "width": "100%",
                   }
                 }
               >
-                <div
-                  style={
-                    Object {
-                      "height": "100%",
-                      "position": "relative",
-                      "width": "100%",
-                    }
-                  }
-                >
+                <div>
                   <div
                     style={
                       Object {
-                        "backgroundColor": "#999",
-                        "height": 1,
-                        "left": "2%",
-                        "position": "absolute",
-                        "top": 5,
-                        "width": "88%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "borderRight": 0,
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "14%",
-                        "paddingLeft": 3,
-                        "position": "absolute",
-                        "top": 1.5,
-                        "width": "54%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "68%",
-                        "paddingLeft": 3,
-                        "position": "absolute",
-                        "top": 1.5,
-                        "width": "14%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "color": "#333",
+                        "background": "rgba(0,128,0,0.5)",
                         "fontSize": 12,
-                        "left": "43%",
+                        "height": 5,
+                        "left": "0%",
                         "position": "absolute",
-                        "textAlign": "center",
-                        "top": 8.5,
-                        "width": "50%",
+                        "width": "46%",
                       }
                     }
                   >
-                    68
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(0,128,0,0.5)",
+                        "fontSize": 12,
+                        "left": "0%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "46%",
+                      }
+                    }
+                  >
+                    5
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "46%",
+                        "position": "absolute",
+                        "width": "28%",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "left": "46%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "28%",
+                      }
+                    }
+                  >
+                    3
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,0,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "73%",
+                        "position": "absolute",
+                        "width": "28%",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(255,0,0,0.5)",
+                        "fontSize": 12,
+                        "left": "73%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "28%",
+                      }
+                    }
+                  >
+                    3
                   </div>
                 </div>
               </div>
@@ -2953,90 +3194,119 @@ exports[`snapshots 1`] = `
               }
             }
           >
-            <div>
+            <div
+              className="BreakdownBar"
+              style={
+                Object {
+                  "height": 5,
+                  "paddingRight": 10,
+                  "paddingTop": 4,
+                }
+              }
+            >
               <div
-                className="BoxAndWhisker"
                 style={
                   Object {
-                    "height": 18,
-                    "marginLeft": "auto",
-                    "marginRight": "auto",
-                    "width": 100,
+                    "height": 5,
+                    "position": "relative",
+                    "width": "100%",
                   }
                 }
               >
-                <div
-                  style={
-                    Object {
-                      "height": "100%",
-                      "position": "relative",
-                      "width": "100%",
-                    }
-                  }
-                >
+                <div>
                   <div
                     style={
                       Object {
-                        "backgroundColor": "#999",
-                        "height": 1,
-                        "left": "4%",
-                        "position": "absolute",
-                        "top": 5,
-                        "width": "96%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "borderRight": 0,
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "47%",
-                        "paddingLeft": 3,
-                        "position": "absolute",
-                        "top": 1.5,
-                        "width": "10%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "background": "#ccc",
-                        "border": "1px solid #999",
-                        "fontSize": 10,
-                        "height": 7,
-                        "left": "57%",
-                        "paddingLeft": 3,
-                        "position": "absolute",
-                        "top": 1.5,
-                        "width": "33%",
-                      }
-                    }
-                  >
-                     
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "color": "#333",
+                        "background": "rgba(0,128,0,0.5)",
                         "fontSize": 12,
-                        "left": "32%",
+                        "height": 5,
+                        "left": "0%",
                         "position": "absolute",
-                        "textAlign": "center",
-                        "top": 8.5,
-                        "width": "50%",
+                        "width": "46%",
                       }
                     }
                   >
-                    57
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(0,128,0,0.5)",
+                        "fontSize": 12,
+                        "left": "0%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "46%",
+                      }
+                    }
+                  >
+                    5
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "46%",
+                        "position": "absolute",
+                        "width": "37%",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(255,165,0,0.5)",
+                        "fontSize": 12,
+                        "left": "46%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "37%",
+                      }
+                    }
+                  >
+                    4
+                  </div>
+                </div>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "background": "rgba(255,0,0,0.5)",
+                        "fontSize": 12,
+                        "height": 5,
+                        "left": "82%",
+                        "position": "absolute",
+                        "width": "19%",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "rgba(255,0,0,0.5)",
+                        "fontSize": 12,
+                        "left": "82%",
+                        "paddingRight": 1,
+                        "position": "absolute",
+                        "textAlign": "right",
+                        "top": 5,
+                        "width": "19%",
+                      }
+                    }
+                  >
+                    2
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
# Who is this PR for?
K1-6 educator teams, part of https://github.com/studentinsights/studentinsights/issues/1659.

# What problem does this PR fix?
Box and whisker plots are good for summarizing distributions but all teachers might not read these fluently.  The numbers also introduce multiple distributions for each classroom separate from the distribution of scores for the whole grade and the distribution of scores within the STAR norming cohort.  This means there's no natural correspondence between the chart and highlighting individual students like with other charts in https://github.com/studentinsights/studentinsights/pull/1686.

# What does this PR do?
This changes the STAR charts to breakdown charts with cutoffs at the 30th percentile and 70th percentile.  This maps roughly to how teachers have talked about this in pilot sessions - low, medium, high and this makes the correspondence between the chart and highlighting more direct.  This PR also adds a magic query string `?box-and-whisker` to show those charts too so we can compare while looking at this change for various grades.

# Screenshot (if adding a client-side feature)
<img width="1014" alt="screen shot 2018-05-11 at 11 39 18 am" src="https://user-images.githubusercontent.com/1056957/39933559-55f41d16-5511-11e8-802b-8fe6a76aab57.png">

# Checklists
+ [x] Author included specs for new code
