### PR TITLE
Classrooms: Enable expanding to see full class lists

### DIFF
--- a/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
@@ -18,13 +18,22 @@ import {fetchProfile} from './api';
 export default class ClassListCreatorWorkflow extends React.Component {
   constructor(props) {
     super(props);
-
+    this.state = {
+      isExpandedVertically: false
+    };
     this.renderStepContents = this.renderStepContents.bind(this);
+    this.onExpandVerticallyToggled = this.onExpandVerticallyToggled.bind(this);
+  }
+
+  onExpandVerticallyToggled() {
+    const {isExpandedVertically} = this.state;
+    this.setState({isExpandedVertically: !isExpandedVertically});
   }
 
   render() {
     const {steps, stepIndex, availableSteps, onStepChanged, isEditable} = this.props;
-
+    const {isExpandedVertically} = this.state;
+    const expandedVerticallyStyles = (isExpandedVertically) ? {} : { height: '100%' };
     return (
       <div className="ClassListCreatorView" style={styles.root}>
         <HorizontalStepper
@@ -34,7 +43,7 @@ export default class ClassListCreatorWorkflow extends React.Component {
           stepIndex={stepIndex}
           onStepChanged={onStepChanged}
           renderFn={this.renderStepContents}
-          style={styles.horizontalStepper}
+          style={{...styles.horizontalStepper, ...expandedVerticallyStyles}}
           contentStyle={styles.horizontalStepperContent} />
       </div>
     );
@@ -180,6 +189,7 @@ export default class ClassListCreatorWorkflow extends React.Component {
       studentIdsByRoom,
       gradeLevelNextYear
     } = this.props;
+    const {isExpandedVertically} = this.state;
 
     if (students === null || studentIdsByRoom === null) return <Loading />;
     return (
@@ -190,6 +200,8 @@ export default class ClassListCreatorWorkflow extends React.Component {
         studentIdsByRoom={studentIdsByRoom}
         fetchProfile={studentId => fetchProfile(workspaceId, studentId)}
         isEditable={isEditable}
+        isExpandedVertically={isExpandedVertically}
+        onExpandVerticallyToggled={this.onExpandVerticallyToggled}
         onClassListsChanged={onClassListsChanged}/>
     );
   }

--- a/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
@@ -33,7 +33,9 @@ export default class ClassListCreatorWorkflow extends React.Component {
   render() {
     const {steps, stepIndex, availableSteps, onStepChanged, isEditable} = this.props;
     const {isExpandedVertically} = this.state;
-    const expandedVerticallyStyles = (isExpandedVertically) ? {} : { height: '100%' };
+    const expandedOrCollapsedStyles = (isExpandedVertically)
+      ? styles.horizontalStepperExpanded 
+      : styles.horizontalStepperCollapsed;
     return (
       <div className="ClassListCreatorView" style={styles.root}>
         <HorizontalStepper
@@ -43,7 +45,7 @@ export default class ClassListCreatorWorkflow extends React.Component {
           stepIndex={stepIndex}
           onStepChanged={onStepChanged}
           renderFn={this.renderStepContents}
-          style={{...styles.horizontalStepper, ...expandedVerticallyStyles}}
+          style={{...styles.horizontalStepper, ...expandedOrCollapsedStyles}}
           contentStyle={styles.horizontalStepperContent} />
       </div>
     );
@@ -295,6 +297,14 @@ const styles = {
   },
   horizontalStepper: {
     paddingTop: 15
+  },
+  horizontalStepperCollapsed: {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  horizontalStepperExpanded: {
+    
   },
   horizontalStepperContent: {
     borderTop: '1px solid #ccc',

--- a/app/assets/javascripts/class_lists/ClassroomStats.js
+++ b/app/assets/javascripts/class_lists/ClassroomStats.js
@@ -85,7 +85,7 @@ export default class ClassroomStats extends React.Component {
                 {this.renderHeaderCell({
                   label: 'Discipline, 3+',
                   columnHighlightKey: HighlightKeys.HIGH_DISCIPLINE,
-                  title: 'Students whose are enrolled in the free or reduced lunch program.'
+                  title: 'Students who had three or more discipline incidents of any kind during this past school year.  Discipline incidents vary in severity; click on the student\'s name to see more in their profile.'
                 })}
                 {showDibels && this.renderHeaderCell({
                   label: 'Dibels CORE',

--- a/app/assets/javascripts/class_lists/CreateYourLists.js
+++ b/app/assets/javascripts/class_lists/CreateYourLists.js
@@ -68,7 +68,7 @@ export default class CreateYourListsView extends React.Component {
 
   renderLists(rooms) {
     const {isEditable, students, studentIdsByRoom, isExpandedVertically} = this.props;
-    const expandedStyles = isExpandedVertically ? { height: '90em' } : {}; // estimating 30 students with 3em per card
+    const expandedStyles = isExpandedVertically ? { height: '90em' } : { flex: 1 }; // estimating 30 students with 3em per card
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
         <div style={{...styles.listsContainer, ...expandedStyles}}>
@@ -171,8 +171,7 @@ const styles = {
     position: 'relative' // for expandLink
   },
   listsContainer: {
-    display: 'flex',
-    flex: 1
+    display: 'flex'
   },
   classroomListColumn: {
     padding: 20,

--- a/app/assets/javascripts/class_lists/CreateYourLists.js
+++ b/app/assets/javascripts/class_lists/CreateYourLists.js
@@ -39,17 +39,21 @@ export default class CreateYourListsView extends React.Component {
 
   render() {
     const {
-      isEditable,
       students,
       classroomsCount,
       studentIdsByRoom,
-      gradeLevelNextYear
+      gradeLevelNextYear,
+      isExpandedVertically,
+      onExpandVerticallyToggled
     } = this.props;
     const {highlightKey} = this.state;
     const rooms = createRooms(classroomsCount);
 
     return (
       <div className="CreateYourListsView" style={styles.root}>
+        <div style={styles.expandLink} onClick={onExpandVerticallyToggled}>
+          {isExpandedVertically ? '▴ Collapse ▴' : '▾ Expand ▾'}
+        </div>
         <ClassroomStats
           students={students}
           gradeLevelNextYear={gradeLevelNextYear}
@@ -57,40 +61,48 @@ export default class CreateYourListsView extends React.Component {
           studentIdsByRoom={studentIdsByRoom}
           highlightKey={highlightKey}
           onCategorySelected={this.onCategorySelected}/>
-        <DragDropContext onDragEnd={this.onDragEnd}>
-          <div style={styles.listsContainer}>
-            {rooms.map(room => {
-              const {roomKey, roomName} = room;
-              const classroomStudents = studentsInRoom(students, studentIdsByRoom, roomKey);
-              return (
-                <div key={roomKey} style={styles.classroomListColumn}>
-                  <div>
-                    <div style={styles.roomTitle}>
-                      <span style={{fontWeight: 'bold'}}>{roomName}</span>
-                      <span style={styles.roomStudentCount}>({classroomStudents.length})</span>
-                    </div>
-                  </div>
-                  <div style={{flex: 1}}>
-                    <AutoSizer disableWidth>{({height}) => (
-                      <Droppable
-                        droppableId={roomKey}
-                        type="CLASSROOM_LIST"
-                        isDropDisabled={!isEditable}>
-                        {(provided, snapshot) => (
-                          <div ref={provided.innerRef} style={{...styles.droppable, height}}>
-                            <div>{classroomStudents.map(this.renderStudentCard, this)}</div>
-                            <div>{provided.placeholder}</div>
-                          </div>
-                        )}
-                      </Droppable>
-                    )}</AutoSizer>
+        {this.renderLists(rooms)}
+      </div>
+    );
+  }
+
+  renderLists(rooms) {
+    const {isEditable, students, studentIdsByRoom, isExpandedVertically} = this.props;
+    const expandedStyles = isExpandedVertically ? { height: '90em' } : {}; // estimating 30 students with 3em per card
+    return (
+      <DragDropContext onDragEnd={this.onDragEnd}>
+        <div style={{...styles.listsContainer, ...expandedStyles}}>
+          {rooms.map(room => {
+            const {roomKey, roomName} = room;
+            const classroomStudents = studentsInRoom(students, studentIdsByRoom, roomKey);
+            return (
+              <div key={roomKey} style={styles.classroomListColumn}>
+                <div>
+                  <div style={styles.roomTitle}>
+                    <span style={{fontWeight: 'bold'}}>{roomName}</span>
+                    <span style={styles.roomStudentCount}>({classroomStudents.length})</span>
                   </div>
                 </div>
-              );
-            })}
-          </div>
-        </DragDropContext>
-      </div>
+                <div style={{flex: 1}}>
+                  <AutoSizer disableWidth>{({height}) => (
+                    <Droppable
+                      droppableId={roomKey}
+                      type="CLASSROOM_LIST"
+                      isDropDisabled={!isEditable}>
+                      {(provided, snapshot) => (
+                        <div ref={provided.innerRef} style={{...styles.droppable, height}}>
+                          <div>{classroomStudents.map(this.renderStudentCard, this)}</div>
+                          <div>{provided.placeholder}</div>
+                        </div>
+                      )}
+                    </Droppable>
+                  )}</AutoSizer>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </DragDropContext>
     );
   }
 
@@ -108,12 +120,14 @@ export default class CreateYourListsView extends React.Component {
 }
 CreateYourListsView.propTypes = {
   isEditable: React.PropTypes.bool.isRequired,
+  isExpandedVertically: React.PropTypes.bool.isRequired,
   classroomsCount: React.PropTypes.number.isRequired,
   gradeLevelNextYear: React.PropTypes.string.isRequired,
   students: React.PropTypes.array.isRequired,
   studentIdsByRoom: React.PropTypes.object.isRequired,
   fetchProfile: React.PropTypes.func.isRequired,
-  onClassListsChanged: React.PropTypes.func.isRequired
+  onClassListsChanged: React.PropTypes.func.isRequired,
+  onExpandVerticallyToggled: React.PropTypes.func.isRequired,
 };
 
 
@@ -153,7 +167,8 @@ const styles = {
     msUserSelect: 'none',
     display: 'flex',
     flexDirection: 'column',
-    height: '100%'
+    height: '100%',
+    position: 'relative' // for expandLink
   },
   listsContainer: {
     display: 'flex',
@@ -192,5 +207,14 @@ const styles = {
     float: 'right',
     color: '#666',
     fontSize: 12
+  },
+  expandLink: {
+    position: 'absolute',
+    padding: 10,
+    left: 0,
+    right: 0,
+    textAlign: 'center',
+    bottom: -20,
+    cursor: 'pointer'
   }
 };

--- a/app/assets/javascripts/class_lists/CreateYourLists.story.js
+++ b/app/assets/javascripts/class_lists/CreateYourLists.story.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {widthFrame} from './storybookFrame';
+import {action} from '@storybook/addon-actions';
+import storybookFrame from './storybookFrame';
 import {withDefaultNowContext} from '../../../../spec/javascripts/support/NowContainer';
 import CreateYourLists from './CreateYourLists';
 import {
@@ -11,26 +12,35 @@ import {
 import {testProps} from './CreateYourLists.test';
 
 
-function testRender(props = {}) {
-  return widthFrame(withDefaultNowContext(<Container {...props} />));
+function storyProps(props = {}) {
+  return {
+    ...testProps(),
+    onClassListsChanged: action('onClassListsChanged'),
+    onExpandVerticallyToggled: action('onExpandVerticallyToggled'),
+    ...props
+  };
+}
+
+function storyRender(props = {}) {
+  return storybookFrame(withDefaultNowContext(<Container {...props} />));
 }
 
 storiesOf('classlists/CreateYourLists', module) // eslint-disable-line no-undef
-  .add("empty", () => testRender(testProps({ forceUnplaced: true })))
-  .add("Next 2rd grade", () => testRender(testProps()))
+  .add("empty", () => storyRender(storyProps({ forceUnplaced: true })))
+  .add("Next 2rd grade", () => storyRender(storyProps()))
   .add("Next 5th grade", () => {
-    return testRender(testProps({
+    return storyRender(storyProps({
       classroomsCount: 4,
       gradeLevelNextYear: '5'
     }));
   })
   .add("Many classrooms", () => {
-    return testRender(testProps({
+    return storyRender(storyProps({
       classroomsCount: 5,
       gradeLevelNextYear: '5'
     }));
   })
-  .add("readonly", () => testRender(testProps({ isEditable: false })));
+  .add("readonly", () => storyRender(storyProps({ isEditable: false })));
 
 
 // Container for tracking state changes

--- a/app/assets/javascripts/class_lists/CreateYourLists.test.js
+++ b/app/assets/javascripts/class_lists/CreateYourLists.test.js
@@ -10,12 +10,14 @@ beforeEach(() => mockWithFixtures());
 export function testProps(props = {}) {
   return {
     isEditable: true,
+    isExpandedVertically: false,
     classroomsCount: 3,
     gradeLevelNextYear: '2',
     students: students_for_grade_level_next_year_json.students,
     studentIdsByRoom: {},
     fetchProfile(studentId) { return Promise.resolve(profile_json); },
     onClassListsChanged: jest.fn(),
+    onExpandVerticallyToggled: jest.fn(),
     ...props
   };
 }

--- a/app/assets/javascripts/class_lists/HorizontalStepper.js
+++ b/app/assets/javascripts/class_lists/HorizontalStepper.js
@@ -111,7 +111,6 @@ HorizontalStepper.propTypes = {
 const styles = {
   root: {
     paddingTop: 15,
-    height: '100%',
     display: 'flex',
     flexDirection: 'column'
   },

--- a/app/assets/javascripts/class_lists/HorizontalStepper.js
+++ b/app/assets/javascripts/class_lists/HorizontalStepper.js
@@ -110,9 +110,7 @@ HorizontalStepper.propTypes = {
 
 const styles = {
   root: {
-    paddingTop: 15,
-    display: 'flex',
-    flexDirection: 'column'
+    paddingTop: 15
   },
   content: {
     borderTop: '1px solid #ccc',

--- a/app/assets/javascripts/class_lists/__snapshots__/ClassroomStats.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ClassroomStats.test.js.snap
@@ -211,7 +211,7 @@ exports[`snapshots 1`] = `
                 "verticalAlign": "top",
               }
             }
-            title="Students whose are enrolled in the free or reduced lunch program."
+            title="Students who had three or more discipline incidents of any kind during this past school year.  Discipline incidents vary in severity; click on the student's name to see more in their profile."
           >
             <div
               className="Hover"

--- a/app/assets/javascripts/class_lists/__snapshots__/HorizontalStepper.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/HorizontalStepper.test.js.snap
@@ -7,7 +7,6 @@ exports[`snapshots 1`] = `
     Object {
       "display": "flex",
       "flexDirection": "column",
-      "height": "100%",
       "paddingTop": 15,
     }
   }
@@ -313,7 +312,6 @@ exports[`snapshots when readonly 1`] = `
     Object {
       "display": "flex",
       "flexDirection": "column",
-      "height": "100%",
       "paddingTop": 15,
     }
   }

--- a/app/assets/javascripts/class_lists/__snapshots__/HorizontalStepper.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/HorizontalStepper.test.js.snap
@@ -5,8 +5,6 @@ exports[`snapshots 1`] = `
   className="HorizontalStepper"
   style={
     Object {
-      "display": "flex",
-      "flexDirection": "column",
       "paddingTop": 15,
     }
   }
@@ -310,8 +308,6 @@ exports[`snapshots when readonly 1`] = `
   className="HorizontalStepper"
   style={
     Object {
-      "display": "flex",
-      "flexDirection": "column",
       "paddingTop": 15,
     }
   }


### PR DESCRIPTION
# Who is this PR for?
Grade 1-6 educator teams, part of https://github.com/studentinsights/studentinsights/issues/1659.

# What problem does this PR fix?
Using vertical scrolls in https://github.com/studentinsights/studentinsights/pull/1685 helps a lot with reducing scrolling and especially with making the initial class list creation process easier and faster.  But it trades off being able to see and scan more of the lists, especially for teaching teams with more classrooms using larger screens or higher pixel ratios (eg, like Argenziano teams with Smart Boards).  This becomes even more desirable with https://github.com/studentinsights/studentinsights/pull/1686, where in the final revision and balancing phase you can't scan all students quickly and visually with the vertical scrollbars and have to scroll each list independently to find highlighted students.

# What does this PR do?
Adds an "expand" button to break out of the vertical scrolling and just show everything on the screen.

# Screenshot (if adding a client-side feature)
### default
<img width="1304" alt="screen shot 2018-05-11 at 12 40 52 pm" src="https://user-images.githubusercontent.com/1056957/39936537-c5b72b08-551a-11e8-8c02-c3cbbdce062d.png">

### when expanded, scrolling to see as much as possible
<img width="1301" alt="screen shot 2018-05-11 at 12 56 59 pm" src="https://user-images.githubusercontent.com/1056957/39936555-da69356e-551a-11e8-929b-8645b6b816c4.png">

# Checklists
+ [ ] Author checked latest in IE - Class lists
+ [ ] Author included specs for new code
