### PR TITLE
Remove code from Let's Encrypt SSL installation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,8 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-  unless Rails.env.development?
-    force_ssl except: [:lets_encrypt_endpoint]
-  end
+
+  force_ssl unless Rails.env.development?
 
   before_action :redirect_domain!
   before_action :authenticate_educator!  # Devise method, applies to all controllers (in this app 'users' are 'educators')

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,14 +1,10 @@
 class PagesController < ApplicationController
 
-  skip_before_action :authenticate_educator!, only: [:about, :lets_encrypt_endpoint]  # Inherited from ApplicationController
+  skip_before_action :authenticate_educator!, only: [:about]  # Inherited from ApplicationController
 
   def no_default_page
   end
 
   def not_authorized
-  end
-
-  def lets_encrypt_endpoint
-    render text: ENV['LETS_ENCRYPT_STRING']
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,10 +52,6 @@ Rails.application.routes.draw do
   get 'no_default_page' => 'pages#no_default_page'
   get 'not_authorized' => 'pages#not_authorized'
 
-  if ENV['LETS_ENCRYPT_ENDPOINT']
-    get ENV['LETS_ENCRYPT_ENDPOINT'] => 'pages#lets_encrypt_endpoint'
-  end
-
   get '/students/names' => 'students#names'
   get '/students/lasids' => 'students#lasids'
   resources :students, only: [:show] do


### PR DESCRIPTION
# Who is this PR for?

Developers; cleaning up old code.

# What problem does this PR fix?

Our SSL isn't managed by Let's Encrypt anymore, so let's clean out the code related to installing Let's Encrypt. The code added a special, unauthenticated endpoint that sent down a secret string so that Let's Encrypt could verify our ownership of the domain.

# What does this PR do?

Removes Let's Encrypt endpoint. 