### PR TITLE
Classrooms: Handle changing number of rooms after students have been assigned

### DIFF
--- a/app/assets/javascripts/class_lists/ClassListCreatorPage.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorPage.js
@@ -8,7 +8,10 @@ import {
   postClassList
 } from './api';
 import Loading from '../components/Loading';
-import {initialStudentIdsByRoom} from './studentIdsByRoomFunctions';
+import {
+  initialStudentIdsByRoom,
+  studentIdsByRoomAfterRoomsCountChanged
+} from './studentIdsByRoomFunctions';
 import ClassListCreatorWorkflow from './ClassListCreatorWorkflow';
 import uuidv4 from 'uuid/v4';
 
@@ -328,9 +331,13 @@ export default class ClassListCreatorPage extends React.Component {
 
   // TODO(kr) warn about resetting students?
   onClassroomsCountIncremented(delta) {
-    const {classroomsCount} = this.state;
-    const updatedClassroomsCount = classroomsCount + delta;
-    this.setState({classroomsCount: updatedClassroomsCount});
+    const classroomsCount = this.state.classroomsCount + delta;
+    if (this.state.studentIdsByRoom === null) {
+      this.setState({classroomsCount});
+    } else {
+      const studentIdsByRoom = studentIdsByRoomAfterRoomsCountChanged(this.state.studentIdsByRoom, classroomsCount);
+      this.setState({classroomsCount, studentIdsByRoom});
+    }
   }
 
   onPlanTextChanged(planText) {

--- a/app/assets/javascripts/class_lists/studentIdsByRoomFunctions.test.js
+++ b/app/assets/javascripts/class_lists/studentIdsByRoomFunctions.test.js
@@ -1,4 +1,9 @@
-import {reordered, studentsInRoom} from './studentIdsByRoomFunctions';
+import {
+  reordered,
+  studentsInRoom,
+  studentIdsByRoomAfterRoomsCountChanged,
+  UNPLACED_ROOM_KEY
+} from './studentIdsByRoomFunctions';
 import students_for_grade_level_next_year_json from './fixtures/students_for_grade_level_next_year_json';
 
 it('#reordered', () => {
@@ -16,4 +21,36 @@ it('#studentsInRoom', () => {
   };
   expect(studentsInRoom(students, studentIdsByRoom, 'room:3')).toEqual([b, a]);
   expect(studentsInRoom(students, studentIdsByRoom, 'room:4')).toEqual([c]);
+});
+
+
+describe('#studentIdsByRoomAfterRoomsCountChanged', () => {
+  it('remove a room', () => {
+    expect(studentIdsByRoomAfterRoomsCountChanged({
+      [UNPLACED_ROOM_KEY]: [6, 7],
+      "room:0": [1, 2],
+      "room:1": [3],
+      "room:2": [4, 5]
+    }, 2)).toEqual({
+      [UNPLACED_ROOM_KEY]: [6, 7, 4, 5],
+      "room:0": [1, 2],
+      "room:1": [3]
+    });
+  });
+
+  it('add rooms', () => {
+    expect(studentIdsByRoomAfterRoomsCountChanged({
+      [UNPLACED_ROOM_KEY]: [6, 7],
+      "room:0": [1, 2],
+      "room:1": [3],
+      "room:2": [4, 5]
+    }, 5)).toEqual({
+      [UNPLACED_ROOM_KEY]: [6, 7],
+      "room:0": [1, 2],
+      "room:1": [3],
+      "room:2": [4, 5],
+      "room:3": [],
+      "room:4": []
+    });
+  });
 });


### PR DESCRIPTION
# Who is this PR for?
Grade 1-6 educator teams.  This is part of https://github.com/studentinsights/studentinsights/issues/1659.

# What problem does this PR fix?
This came up in feedback from an AP who triggered https://rollbar.com/somerville-teacher-tool/somerville-teacher-tool/items/120/.

# What does this PR do?
Fixes the bug.  Previously the code assumed that the order of these operations was fixed; with relaxing some of the navigation this isn't fixed anymore, so this updates the code to handle when this event happens after students have been placed.

# Checklists
+ [x] Author checked latest in IE - Class lists
+ [x] Author included specs for new code
