### PR TITLE
Add brakeman to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,6 @@ script:
   - bundle exec rake immigrant:check_keys
   - ./scripts/ci/detect_package_lock.sh
   - rubocop
+  - bundle exec brakeman -z
   - bundle exec rspec spec
   - yarn test-cli

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'simplecov'
   gem 'timecop'
+  gem 'brakeman'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     bourbon (4.3.4)
       sass (~> 3.4)
       thor (~> 0.19)
+    brakeman (4.3.0)
     builder (3.2.3)
     capybara (3.0.1)
       addressable
@@ -323,6 +324,7 @@ DEPENDENCIES
   aws-sdk (~> 2)
   better_errors
   bourbon (~> 4.3.2)
+  brakeman
   capybara
   database_cleaner
   delayed_job_active_record

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,7 @@
+{
+  "ignored_warnings": [
+
+  ],
+  "updated": "2018-05-17 08:09:31 -0400",
+  "brakeman_version": "4.3.0"
+}


### PR DESCRIPTION
# Who is this PR for?
developers

# What does this PR do?
Adding Brakeman as a layer of static analysis checking for recent CVEs and other potential security vulnerabilities.  Adds this to the Travis build.
