### PR TITLE
Classrooms: Allow enabling class lists in demo site

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -28,6 +28,14 @@ class PerDistrict
     ENV['DISTRICT_NAME']
   end
 
+  def enabled_class_lists?
+    if @district_key == SOMERVILLE || @district_key == DEMO
+      EnvironmentVariable.is_true('ENABLE_CLASS_LISTS')
+    else
+      false
+    end
+  end
+
   def include_incident_cards?
     EnvironmentVariable.is_true('FEED_INCLUDE_INCIDENT_CARDS') || false
   end

--- a/app/controllers/class_lists_controller.rb
+++ b/app/controllers/class_lists_controller.rb
@@ -1,6 +1,5 @@
 class ClassListsController < ApplicationController
-  # This entire feature is Somerville-specific
-  before_action :ensure_somerville_only!
+  before_action :ensure_feature_enabled_for_district!
 
   # For showing the list of all workspaces that the user can read
   def workspaces_json
@@ -224,8 +223,7 @@ class ClassListsController < ApplicationController
     end
   end
 
-  def ensure_somerville_only!
-    district_key = PerDistrict.new.district_key
-    raise Exceptions::EducatorNotAuthorized unless district_key == PerDistrict::SOMERVILLE
+  def ensure_feature_enabled_for_district!
+    raise Exceptions::EducatorNotAuthorized unless PerDistrict.new.enabled_class_lists?
   end
 end

--- a/spec/controllers/class_lists_controller_spec.rb
+++ b/spec/controllers/class_lists_controller_spec.rb
@@ -10,10 +10,48 @@ describe ClassListsController, :type => :controller do
     }.merge(params))
   end
 
+  # enable feature
+  before { @ENABLE_CLASS_LISTS = ENV['ENABLE_CLASS_LISTS'] }
+  before { ENV['ENABLE_CLASS_LISTS'] = 'true' }
+  after { ENV['ENABLE_CLASS_LISTS'] = @ENABLE_CLASS_LISTS }
+
   before { request.env['HTTPS'] = 'on' }
   before { request.env['HTTP_ACCEPT'] = 'application/json' }
   let!(:pals) { TestPals.create! }
   let!(:time_now) { pals.time_now }
+
+  describe 'env ENABLE_CLASS_LISTS can disable feature' do
+    before do
+      ENV['ENABLE_CLASS_LISTS'] = 'false'
+      sign_in(pals.healey_sarah_teacher)
+    end
+
+    it 'guards writing to update_class_list_json' do
+      post :update_class_list_json, params: {
+        format: :json,
+        workspace_id: 'foo-workspace-id',
+        school_id: pals.healey.id,
+        grade_level_next_year: '6',
+        json: { foo: 'bazzzzz' }
+      }
+      expect(response.status).to eq 403
+    end
+
+    it 'guards workspaces_json as an example' do
+      get :workspaces_json, params: { format: :json }
+      expect(response.status).to eq 403
+    end
+
+    it 'guards students_for_grade_level_next_year_json as an example' do
+      get :students_for_grade_level_next_year_json, params: {
+        format: :json,
+        workspace_id: 'foo-workspace-id',
+        school_id: pals.healey.id,
+        grade_level_next_year: '6'
+      }
+      expect(response.status).to eq 403
+    end
+  end
 
   describe '#workspaces_json' do
     it 'shows Sarah her classlist' do


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Enables doing some simplistic load testing on the demo site, which isn't a perfect proxy for any production site but can help get some ballpark figures.

# What does this PR do?
Adds an ENV variable for controlling the class lists feature, and allows it to be set in the demo environment.

# Checklists
+ [x] Author included specs for new code
