### PR TITLE
Sorting discipline events correctly in all date ranges

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
@@ -21,17 +21,11 @@ class SchoolDisciplineDashboard extends React.Component {
       selectedChart: 'location',
       selectedCategory: null
     };
-    this.setDate = this.setDate.bind(this);
     this.setStudentList = this.setStudentList.bind(this);
     this.resetStudentList = this.resetStudentList.bind(this);
     this.selectChart = this.selectChart.bind(this);
   }
 
-  setDate(range) {
-    this.setState({
-      startDate: moment.unix(range[0]).format("YYYY-MM-DD")
-    });
-  }
   setStudentList(highchartsEvent) {
     this.setState({selectedCategory: highchartsEvent.point.category});
   }
@@ -42,8 +36,8 @@ class SchoolDisciplineDashboard extends React.Component {
     this.setState({selectedChart: selection.value, selectedCategory: null});
   }
 
-  filterIncidentDates(incidents) {
-    return incidents.filter((incident) => {
+  filterIncidentDates(incidentsArray) {
+    return incidentsArray.filter((incident) => {
       return moment.utc(incident.occurred_at).isSameOrAfter(moment.utc(this.state.startDate));
     });
   }
@@ -60,9 +54,10 @@ class SchoolDisciplineDashboard extends React.Component {
   }
 
   getChartData(selectedChart) {
+    const filteredEvents = this.filterIncidentDates(this.props.schoolDisciplineEvents);
     return {
       type: selectedChart,
-      disciplineIncidents: _.groupBy(this.props.schoolDisciplineEvents, selectedChart),
+      disciplineIncidents: _.groupBy(filteredEvents, selectedChart),
       title: "Incidents by " + selectedChart};
   }
 
@@ -91,7 +86,6 @@ class SchoolDisciplineDashboard extends React.Component {
 
   sortedGrades(chartKeys) {
     return chartKeys.sort((a,b) => sortByGrade(a,b));
-
   }
 
   sortedClassrooms(chartKeys) {

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
@@ -46,7 +46,7 @@ class SchoolDisciplineDashboard extends React.Component {
     let studentDisciplineIncidentCounts = {};
     const selectedChartData = this.getChartData(this.state.selectedChart);
     const incidents = incidentCategory ? selectedChartData.disciplineIncidents[incidentCategory] : this.props.schoolDisciplineEvents;
-    this.filterIncidentDates(incidents).forEach((incident) => {
+    incidents.forEach((incident) => {
       studentDisciplineIncidentCounts[incident.student_id] = studentDisciplineIncidentCounts[incident.student_id] || 0;
       studentDisciplineIncidentCounts[incident.student_id]++;
     });
@@ -54,6 +54,8 @@ class SchoolDisciplineDashboard extends React.Component {
   }
 
   getChartData(selectedChart) {
+    //This chart data is filtered based on the date selection and passed to the
+    //student table and chart renders below
     const filteredEvents = this.filterIncidentDates(this.props.schoolDisciplineEvents);
     return {
       type: selectedChart,

--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
@@ -137,7 +137,7 @@ class SchoolDisciplineDashboard extends React.Component {
     const categories = this.sortChartKeys(Object.keys(selectedChart.disciplineIncidents));
     const seriesData = categories.map((type) => {
       if (!selectedChart.disciplineIncidents[type]) return [];
-      const incidents = this.filterIncidentDates(selectedChart.disciplineIncidents[type]);
+      const incidents = selectedChart.disciplineIncidents[type];
       return [type, incidents.length];
     });
 


### PR DESCRIPTION
# Who is this PR for?
Dashboard users

# What problem does this PR fix?
Charts were sorted by number of events, but only for the school year

# What does this PR do?
Sorts charts by number of events within the selected date range

# Screenshot (if adding a client-side feature)
Broken
![sortingold](https://user-images.githubusercontent.com/638809/40336982-d943fdea-5d3a-11e8-9247-b5b67861ea7e.gif)

Fixed
![sortingnew](https://user-images.githubusercontent.com/638809/40336993-e2f19f78-5d3a-11e8-83ef-6858fb1ecfa5.gif)



+ [x] Author checked latest in IE - Discipline Dashboard
+ [x] Reviewer checked latest in IE - Discipline Dashboard
