### PR TITLE
restrict student table to selected category

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/dashboard_components/discipline_dashboard/SchoolDisciplineDashboard.js
@@ -101,6 +101,15 @@ class SchoolDisciplineDashboard extends React.Component {
     });
   }
 
+  //For grades and classrooms, the students table should only show the relevant students
+  groupStudents() {
+    if (this.state.selectedChart === 'grade' && this.state.selectedCategory) {
+      return this.props.dashboardStudents.filter(student => student.grade === this.state.selectedCategory);
+    } else if (this.state.selectedChart === 'classroom' && this.state.selectedCategory) {
+      return this.props.dashboardStudents.filter(student => student.homeroom_label === this.state.selectedCategory);
+    } else return this.props.dashboardStudents;
+  }
+
   render() {
     const selectedChart = this.getChartData(this.state.selectedChart);
     const chartOptions = [
@@ -162,7 +171,7 @@ class SchoolDisciplineDashboard extends React.Component {
   }
 
   renderStudentDisciplineTable() {
-    const students = this.props.dashboardStudents;
+    const students = this.groupStudents();
     const studentDisciplineIncidentCounts = this.studentDisciplineIncidentCounts(this.state.selectedCategory);
     let rows =[];
     students.forEach((student) => {


### PR DESCRIPTION
# Who is this PR for?
Dashboard users

# What problem does this PR fix?
students table doesn't restrict the students based on selection cf #1708 

# What does this PR do?
Properly restricts students in the table like so:

![goodfilter](https://user-images.githubusercontent.com/638809/40337624-94fb7c86-5d3e-11e8-8e05-e2ca6c034522.gif)

# Checklists

## Javascript QA

+ [x] Author checked latest in IE - Discipline Dashboard
+ [x] Reviewer checked latest in IE - Discipline Dashboard
