### PR TITLE
Classrooms: Add links to video walkthrough and quick guide

### DIFF
--- a/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
@@ -76,7 +76,7 @@ export default class ClassListCreatorWorkflow extends React.Component {
     return (
       <div style={styles.stepContent}>
         <div>
-          <div style={styles.heading}>Class List Maker Tool</div>
+          <div style={{...styles.heading, fontWeight: 'bold'}}>Class List Maker Tool</div>
           <IntroCopy />
         </div>
         <div>

--- a/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
@@ -76,7 +76,7 @@ export default class ClassListCreatorWorkflow extends React.Component {
     return (
       <div style={styles.stepContent}>
         <div>
-          <div style={{...styles.heading, fontWeight: 'bold'}}>Class List Maker Tool</div>
+          <div style={styles.titleHeading}>Class List Creator</div>
           <IntroCopy />
         </div>
         <div>
@@ -313,6 +313,12 @@ const styles = {
   },
   heading: {
     marginTop: 20
+  },
+  titleHeading: {
+    fontSize: 20,
+    fontWeight: 300,
+    marginTop: 20,
+    marginBottom: 10
   },
   button: {
     display: 'inline-block',

--- a/app/assets/javascripts/class_lists/ClassListsViewPage.js
+++ b/app/assets/javascripts/class_lists/ClassListsViewPage.js
@@ -53,7 +53,7 @@ export class ClassListsViewPageView extends React.Component {
   render() {
     return (
       <div>
-        <SectionHeading>Class lists</SectionHeading>
+        <SectionHeading>Class List Maker Tool</SectionHeading>
         {this.renderTable()}
       </div>
     );
@@ -144,7 +144,7 @@ const styles = {
   },
   newButton: {
     display: 'block',
-    margin: 10
+    marginTop: 10
   },
   overview: {
     margin: 10

--- a/app/assets/javascripts/class_lists/ClassListsViewPage.js
+++ b/app/assets/javascripts/class_lists/ClassListsViewPage.js
@@ -53,7 +53,7 @@ export class ClassListsViewPageView extends React.Component {
   render() {
     return (
       <div>
-        <SectionHeading>Class List Maker Tool</SectionHeading>
+        <SectionHeading>Class List Creator</SectionHeading>
         {this.renderTable()}
       </div>
     );

--- a/app/assets/javascripts/class_lists/IntroCopy.js
+++ b/app/assets/javascripts/class_lists/IntroCopy.js
@@ -4,16 +4,19 @@ When Student Insights was being developed, some teachers started asking whether 
 
 
 export default function IntroCopy() {
+  const videoUrl = 'https://drive.google.com/file/d/1OmsB-9K1cgo1g6l21rnu0xL8H4KDyVAk/view';
+  const onePageGuideUrl = 'https://drive.google.com/file/d/1NHztne6tGz16qbIIeoeL8aNvTLQ0UTHj/view';
   return (
     <div style={styles.introCopy}>
       {text}
+      <div style={{marginTop: 20}}>This <a href={videoUrl} target="_blank">Video Walkthrough</a> and a <a href={onePageGuideUrl} target="_blank">Quick Guide</a> show the steps to use this tool.</div>
     </div>
   );
 }
 
 const styles = {
   introCopy: {
-    fontSize: 12,
+    fontSize: 14,
     padding: 10,
     paddingLeft: 0,
     whiteSpace: 'pre-wrap'

--- a/app/assets/javascripts/class_lists/__snapshots__/ClassListCreatorWorkflow.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ClassListCreatorWorkflow.test.js.snap
@@ -251,12 +251,14 @@ exports[`chooseYourGradeProps 1`] = `
           <div
             style={
               Object {
-                "fontWeight": "bold",
+                "fontSize": 20,
+                "fontWeight": 300,
+                "marginBottom": 10,
                 "marginTop": 20,
               }
             }
           >
-            Class List Maker Tool
+            Class List Creator
           </div>
           <div
             style={
@@ -859,12 +861,14 @@ exports[`chooseYourGradeProps 2`] = `
           <div
             style={
               Object {
-                "fontWeight": "bold",
+                "fontSize": 20,
+                "fontWeight": 300,
+                "marginBottom": 10,
                 "marginTop": 20,
               }
             }
           >
-            Class List Maker Tool
+            Class List Creator
           </div>
           <div
             style={

--- a/app/assets/javascripts/class_lists/__snapshots__/ClassListCreatorWorkflow.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ClassListCreatorWorkflow.test.js.snap
@@ -251,6 +251,7 @@ exports[`chooseYourGradeProps 1`] = `
           <div
             style={
               Object {
+                "fontWeight": "bold",
                 "marginTop": 20,
               }
             }
@@ -260,7 +261,7 @@ exports[`chooseYourGradeProps 1`] = `
           <div
             style={
               Object {
-                "fontSize": 12,
+                "fontSize": 14,
                 "padding": 10,
                 "paddingLeft": 0,
                 "whiteSpace": "pre-wrap",
@@ -270,6 +271,29 @@ exports[`chooseYourGradeProps 1`] = `
             Over the last few years, we've been hearing from teachers and principals and how complex and time-consuming the class assignment process is, including the moving of sticky notes, looking up information and lists of tally marks.
 
 When Student Insights was being developed, some teachers started asking whether we could use it to make the class list creation process easier and more efficient.
+            <div
+              style={
+                Object {
+                  "marginTop": 20,
+                }
+              }
+            >
+              This 
+              <a
+                href="https://drive.google.com/file/d/1OmsB-9K1cgo1g6l21rnu0xL8H4KDyVAk/view"
+                target="_blank"
+              >
+                Video Walkthrough
+              </a>
+               and a 
+              <a
+                href="https://drive.google.com/file/d/1NHztne6tGz16qbIIeoeL8aNvTLQ0UTHj/view"
+                target="_blank"
+              >
+                Quick Guide
+              </a>
+               show the steps to use this tool.
+            </div>
           </div>
         </div>
         <div>
@@ -835,6 +859,7 @@ exports[`chooseYourGradeProps 2`] = `
           <div
             style={
               Object {
+                "fontWeight": "bold",
                 "marginTop": 20,
               }
             }
@@ -844,7 +869,7 @@ exports[`chooseYourGradeProps 2`] = `
           <div
             style={
               Object {
-                "fontSize": 12,
+                "fontSize": 14,
                 "padding": 10,
                 "paddingLeft": 0,
                 "whiteSpace": "pre-wrap",
@@ -854,6 +879,29 @@ exports[`chooseYourGradeProps 2`] = `
             Over the last few years, we've been hearing from teachers and principals and how complex and time-consuming the class assignment process is, including the moving of sticky notes, looking up information and lists of tally marks.
 
 When Student Insights was being developed, some teachers started asking whether we could use it to make the class list creation process easier and more efficient.
+            <div
+              style={
+                Object {
+                  "marginTop": 20,
+                }
+              }
+            >
+              This 
+              <a
+                href="https://drive.google.com/file/d/1OmsB-9K1cgo1g6l21rnu0xL8H4KDyVAk/view"
+                target="_blank"
+              >
+                Video Walkthrough
+              </a>
+               and a 
+              <a
+                href="https://drive.google.com/file/d/1NHztne6tGz16qbIIeoeL8aNvTLQ0UTHj/view"
+                target="_blank"
+              >
+                Quick Guide
+              </a>
+               show the steps to use this tool.
+            </div>
           </div>
         </div>
         <div>

--- a/app/assets/javascripts/class_lists/__snapshots__/ClassListsViewPage.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ClassListsViewPage.test.js.snap
@@ -19,7 +19,7 @@ exports[`snapshots view 1`] = `
         }
       }
     >
-      Class lists
+      Class List Maker Tool
     </h4>
   </div>
   <div>
@@ -40,7 +40,7 @@ exports[`snapshots view 1`] = `
             "cursor": "pointer",
             "display": "block",
             "fontSize": 14,
-            "margin": 10,
+            "marginTop": 10,
             "padding": "8px 25px",
             "textDecoration": "none",
           }

--- a/app/assets/javascripts/class_lists/__snapshots__/ClassListsViewPage.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ClassListsViewPage.test.js.snap
@@ -19,7 +19,7 @@ exports[`snapshots view 1`] = `
         }
       }
     >
-      Class List Maker Tool
+      Class List Creator
     </h4>
   </div>
   <div>


### PR DESCRIPTION
# Who is this PR for?
K-5 teaching teams, part of https://github.com/studentinsights/studentinsights/issues/1696.

# What does this PR do?
Adds links to the video walkthrough and quick guide, both stored behind Google Drive authorization.

# Screenshot (if adding a client-side feature)
<img width="1017" alt="screen shot 2018-05-22 at 11 25 23 am" src="https://user-images.githubusercontent.com/1056957/40372654-26c04808-5db3-11e8-99aa-54038c9907e4.png">
<img width="1024" alt="screen shot 2018-05-22 at 11 26 46 am" src="https://user-images.githubusercontent.com/1056957/40372662-27f78196-5db3-11e8-8804-4c2c31316959.png">


# Checklists
+ [x] Author checked latest in IE - Class list creator
+ [x] Author included specs for new code
