### PR TITLE
Classrooms: Tighten param log scrubbing a bit more

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,7 +1,14 @@
 # Configure sensitive parameters which will be filtered from the log file.
+# This functions as a regex, not a whitelist of keys.
 Rails.application.config.filter_parameters += [
   :password,
-  :text, # Filtering this one out because the `text` field in the event_notes and
-         # event_note_revisions tables can contain sensitive information about
-         # students that we want to keep out of logs.
+
+  # Filtering this one out because the `text` field in the event_notes and
+  # event_note_revisions tables can contain sensitive information about
+  # students that we want to keep out of logs.
+  :text,
+
+  # This is a good filter in general, but was added specifically for
+  # class_lists_controller.
+  :name
 ]


### PR DESCRIPTION
Part of https://github.com/studentinsights/studentinsights/issues/1696, removing educator names from logging as well.

Example locally:
<img width="667" alt="screen shot 2018-05-22 at 11 43 19 am" src="https://user-images.githubusercontent.com/1056957/40373651-5b319ea0-5db5-11e8-9c48-d9204688dbaf.png">
