### PR TITLE
Add ClassList index for (workspace_id, created_at)

### DIFF
--- a/db/migrate/20180523030653_add_class_list_indexes.rb
+++ b/db/migrate/20180523030653_add_class_list_indexes.rb
@@ -1,0 +1,8 @@
+class AddClassListIndexes < ActiveRecord::Migration[5.1]
+  def change
+    add_index(:class_lists, [:workspace_id, :created_at], order: {
+      workspace_id: :asc,
+      created_at: :desc
+    })
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180507124415) do
+ActiveRecord::Schema.define(version: 20180523030653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20180507124415) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "submitted", default: false
+    t.index ["workspace_id", "created_at"], name: "index_class_lists_on_workspace_id_and_created_at", order: { created_at: :desc }
   end
 
   create_table "courses", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
# Who is this PR for?
K-5 teaching teams, part of https://github.com/studentinsights/studentinsights/issues/1696.

# What problem does this PR fix?
Speeds up queries doing scans and sorts.

# What does this PR do?
Adds an index, verified this works as expected locally:

```
> ClassList.all.where(workspace_id: workspace_id).order(created_at: :desc).limit(1).explain
 Limit  (cost=0.27..4.40 rows=1 width=350)
   ->  Index Scan using index_class_lists_on_workspace_id_and_created_at on class_lists  (cost=0.27..20.90 rows=5 width=350)
         Index Cond: ((workspace_id)::text = '8f6aa764-4ca9-441c-9e1f-99b0d7c1cfa6'::text)
```