### PR TITLE
Classrooms: Add restrictions on when users can change school and grade

### DIFF
--- a/app/assets/javascripts/class_lists/ClassListCreatorPage.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorPage.js
@@ -52,7 +52,7 @@ export default class ClassListCreatorPage extends React.Component {
       // workspace
       educators: null, // from server
       students: null, // from server
-      classroomsCount: 4,
+      classroomsCount: 2,
       authors: [],
       planText: '',
       studentIdsByRoom: null,
@@ -137,6 +137,13 @@ export default class ClassListCreatorPage extends React.Component {
     return (schoolId === null || gradeLevelNextYear === null)
       ? [0]
       : [0, 1, 2, 3];
+  }
+
+  canChangeSchoolOrGrade() {
+    const {studentIdsByRoom, students, hasFetchedStudents, hasFetchedClassList} = this.state;
+    if (students !== null || hasFetchedStudents) return false;
+    if (studentIdsByRoom !== null || hasFetchedClassList) return false;
+    return true;
   }
 
   // This is a debug hook for iterating on particular production data sets locally
@@ -435,11 +442,13 @@ export default class ClassListCreatorPage extends React.Component {
 
     const availableSteps = this.availableSteps();
     const isDirty = this.isDirty();
+    const canChangeSchoolOrGrade = this.canChangeSchoolOrGrade();
     return (
       <ClassListCreatorWorkflow
         {...this.state}
         isDirty={isDirty}
         steps={STEPS}
+        canChangeSchoolOrGrade={canChangeSchoolOrGrade}
         availableSteps={availableSteps}
         onStepChanged={this.onStepChanged}
         onSchoolIdChanged={this.onSchoolIdChanged}

--- a/app/assets/javascripts/class_lists/ClassListCreatorPage.test.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorPage.test.js
@@ -41,10 +41,11 @@ it('integration test for state changes, server requests and autosave', done => {
   wrapper.instance().onSchoolIdChanged(4);
   wrapper.instance().onGradeLevelNextYearChanged('6');
   wrapper.instance().onStepChanged(2);
+  wrapper.instance().onClassroomsCountIncremented(2);
 
   // This should update component state, but also trigger server
   // requests and other state changes too.
-  setTimeout(() => {    
+  setTimeout(() => { 
     expect(wrapper.state().schoolId).toEqual(4);
     expect(wrapper.state().gradeLevelNextYear).toEqual('6');
     expect(wrapper.state().stepIndex).toEqual(2);

--- a/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
@@ -77,10 +77,12 @@ export default class ClassListCreatorWorkflow extends React.Component {
       schoolId,
       gradeLevelNextYear,
       onSchoolIdChanged,
+      canChangeSchoolOrGrade,
       onGradeLevelNextYearChanged
     } = this.props;
 
     if (schools === null || gradeLevelsNextYear === null) return <Loading />;
+
     return (
       <div style={styles.stepContent}>
         <div>
@@ -94,7 +96,7 @@ export default class ClassListCreatorWorkflow extends React.Component {
                 name="select-school-name"
                 value={schoolId}
                 onChange={item => onSchoolIdChanged(item.value)}
-                disabled={!isEditable}
+                disabled={!isEditable || !canChangeSchoolOrGrade}
                 options={_.sortBy(schools, s => s.name).map(school => {
                   return {
                     value: school.id,
@@ -109,7 +111,7 @@ export default class ClassListCreatorWorkflow extends React.Component {
                 name="select-grade-level"
                 value={gradeLevelNextYear}
                 onChange={item => onGradeLevelNextYearChanged(item.value)}
-                disabled={!isEditable}
+                disabled={!isEditable || !canChangeSchoolOrGrade}
                 options={gradeLevelsNextYear.map(gradeLevelNextYear => {
                   return {
                     value: gradeLevelNextYear,
@@ -118,6 +120,9 @@ export default class ClassListCreatorWorkflow extends React.Component {
                 })}
               />
           </div>
+          {!canChangeSchoolOrGrade &&
+            <div style={{marginTop: 20}}>You can't change the school or grade level once you've moved forward.  If you need to change this, <a href="/classlists">create a new class list</a> instead.</div>
+          }
         </div>
       </div>
     );
@@ -293,6 +298,7 @@ ClassListCreatorWorkflow.propTypes = {
 
   // state
   isDirty: React.PropTypes.bool.isRequired,
+  canChangeSchoolOrGrade: React.PropTypes.bool.isRequired,
   stepIndex: React.PropTypes.number.isRequired,
   workspaceId: React.PropTypes.string.isRequired,
   schoolId: React.PropTypes.number,

--- a/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.story.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.story.js
@@ -32,6 +32,7 @@ function render(props) {
 
 storiesOf('classlists/ClassListCreatorWorkflow', module) // eslint-disable-line no-undef
   .add('Choose your grade', () => render(withStoryProps(chooseYourGradeProps())))
+  .add('Choose your grade, already done', () => render(withStoryProps(chooseYourGradeProps({ canChangeSchoolOrGrade: false }))))
   .add('Choose your grade, readonly', () => render(withStoryProps(chooseYourGradeProps({ isEditable: false }))))
   .add('Make a plan', () => render(withStoryProps(makeAPlanProps())))
   .add('Make a plan, readonly', () => render(withStoryProps(makeAPlanProps({ isEditable: false }))))

--- a/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.test.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.test.js
@@ -21,6 +21,7 @@ export function testProps(props = {}) {
     isEditable: true,
     isSubmitted: false,
     isDirty: false,
+    canChangeSchoolOrGrade: true,
 
     // state
     stepIndex: 0,

--- a/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.test.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.test.js
@@ -99,6 +99,7 @@ it('renders without crashing', () => {
 it('chooseYourGradeProps', () => {
   expect(snapshotRender(chooseYourGradeProps())).toMatchSnapshot();
   expect(snapshotRender(chooseYourGradeProps({ isEditable: false }))).toMatchSnapshot();
+  expect(snapshotRender(chooseYourGradeProps({ canChangeSchoolOrGrade: false }))).toMatchSnapshot();
 });
 
 it('makeAPlanProps', () => {

--- a/app/assets/javascripts/class_lists/__snapshots__/ClassListCreatorWorkflow.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ClassListCreatorWorkflow.test.js.snap
@@ -1056,6 +1056,504 @@ When Student Insights was being developed, some teachers started asking whether 
 </div>
 `;
 
+exports[`chooseYourGradeProps 3`] = `
+<div
+  className="ClassListCreatorView"
+  style={
+    Object {
+      "fontSize": 14,
+      "width": "100%",
+    }
+  }
+>
+  <div
+    className="HorizontalStepper"
+    style={
+      Object {
+        "display": "flex",
+        "flexDirection": "column",
+        "height": "100%",
+        "paddingTop": 15,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "fontSize": 12,
+          "justifyContent": "space-between",
+          "marginLeft": 15,
+          "marginRight": 15,
+        }
+      }
+    >
+      <div>
+        <span
+          onClick={[Function]}
+          style={
+            Object {
+              "backgroundColor": "rgba(49, 119, 201, 0.25)",
+              "border": "1px solid white",
+              "borderColor": "#3177c9",
+              "borderRadius": 3,
+              "cursor": "pointer",
+              "marginLeft": 5,
+              "marginRight": 10,
+              "padding": 8,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<svg viewBox=\\"0 0 24 24\\" style=\\"display: inline-block; color: #3177c9; fill: #3177c9; height: 24px; width: 24px; user-select: none; transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms; font-size: 24px;\\"><circle cx=\\"12\\" cy=\\"12\\" r=\\"10\\"></circle><text x=\\"12\\" y=\\"16\\" text-anchor=\\"middle\\" font-size=\\"12\\" fill=\\"#fff\\">1</text></svg>",
+              }
+            }
+            style={
+              Object {
+                "display": "inline-block",
+                "verticalAlign": "middle",
+              }
+            }
+          />
+          <span
+            style={
+              Object {
+                "paddingLeft": 5,
+              }
+            }
+          >
+            Choose your grade
+          </span>
+        </span>
+        <span
+          onClick={[Function]}
+          style={
+            Object {
+              "border": "1px solid white",
+              "borderColor": "white",
+              "borderRadius": 3,
+              "cursor": "pointer",
+              "marginLeft": 5,
+              "marginRight": 10,
+              "padding": 8,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<svg viewBox=\\"0 0 24 24\\" style=\\"display: inline-block; color: #3177c9; fill: #3177c9; height: 24px; width: 24px; user-select: none; transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms; font-size: 24px;\\"><circle cx=\\"12\\" cy=\\"12\\" r=\\"10\\"></circle><text x=\\"12\\" y=\\"16\\" text-anchor=\\"middle\\" font-size=\\"12\\" fill=\\"#fff\\">2</text></svg>",
+              }
+            }
+            style={
+              Object {
+                "display": "inline-block",
+                "verticalAlign": "middle",
+              }
+            }
+          />
+          <span
+            style={
+              Object {
+                "paddingLeft": 5,
+              }
+            }
+          >
+            Make a plan
+          </span>
+        </span>
+        <span
+          onClick={[Function]}
+          style={
+            Object {
+              "border": "1px solid white",
+              "borderColor": "white",
+              "borderRadius": 3,
+              "cursor": "pointer",
+              "marginLeft": 5,
+              "marginRight": 10,
+              "padding": 8,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<svg viewBox=\\"0 0 24 24\\" style=\\"display: inline-block; color: #3177c9; fill: #3177c9; height: 24px; width: 24px; user-select: none; transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms; font-size: 24px;\\"><circle cx=\\"12\\" cy=\\"12\\" r=\\"10\\"></circle><text x=\\"12\\" y=\\"16\\" text-anchor=\\"middle\\" font-size=\\"12\\" fill=\\"#fff\\">3</text></svg>",
+              }
+            }
+            style={
+              Object {
+                "display": "inline-block",
+                "verticalAlign": "middle",
+              }
+            }
+          />
+          <span
+            style={
+              Object {
+                "paddingLeft": 5,
+              }
+            }
+          >
+            Create your classrooms
+          </span>
+        </span>
+        <span
+          onClick={[Function]}
+          style={
+            Object {
+              "border": "1px solid white",
+              "borderColor": "white",
+              "borderRadius": 3,
+              "cursor": "pointer",
+              "marginLeft": 5,
+              "marginRight": 10,
+              "padding": 8,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<svg viewBox=\\"0 0 24 24\\" style=\\"display: inline-block; color: #3177c9; fill: #3177c9; height: 24px; width: 24px; user-select: none; transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms; font-size: 24px;\\"><circle cx=\\"12\\" cy=\\"12\\" r=\\"10\\"></circle><text x=\\"12\\" y=\\"16\\" text-anchor=\\"middle\\" font-size=\\"12\\" fill=\\"#fff\\">4</text></svg>",
+              }
+            }
+            style={
+              Object {
+                "display": "inline-block",
+                "verticalAlign": "middle",
+              }
+            }
+          />
+          <span
+            style={
+              Object {
+                "paddingLeft": 5,
+              }
+            }
+          >
+            Share with principal
+          </span>
+        </span>
+        <span
+          onClick={[Function]}
+          style={
+            Object {
+              "border": "1px solid white",
+              "borderColor": "white",
+              "borderRadius": 3,
+              "cursor": "pointer",
+              "marginLeft": 5,
+              "marginRight": 10,
+              "padding": 8,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<svg viewBox=\\"0 0 24 24\\" style=\\"display: inline-block; color: #3177c9; fill: #3177c9; height: 24px; width: 24px; user-select: none; transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms; font-size: 24px;\\"><circle cx=\\"12\\" cy=\\"12\\" r=\\"10\\"></circle><text x=\\"12\\" y=\\"16\\" text-anchor=\\"middle\\" font-size=\\"12\\" fill=\\"#fff\\">5</text></svg>",
+              }
+            }
+            style={
+              Object {
+                "display": "inline-block",
+                "verticalAlign": "middle",
+              }
+            }
+          />
+          <span
+            style={
+              Object {
+                "paddingLeft": 5,
+              }
+            }
+          >
+            Principal finalizes
+          </span>
+        </span>
+      </div>
+    </div>
+    <div
+      style={
+        Object {
+          "borderTop": "1px solid #ccc",
+          "flex": 1,
+          "marginTop": 10,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "margin": 20,
+          }
+        }
+      >
+        <div>
+          <div
+            style={
+              Object {
+                "fontSize": 20,
+                "fontWeight": 300,
+                "marginBottom": 10,
+                "marginTop": 20,
+              }
+            }
+          >
+            Class List Creator
+          </div>
+          <div
+            style={
+              Object {
+                "fontSize": 14,
+                "padding": 10,
+                "paddingLeft": 0,
+                "whiteSpace": "pre-wrap",
+              }
+            }
+          >
+            Over the last few years, we've been hearing from teachers and principals and how complex and time-consuming the class assignment process is, including the moving of sticky notes, looking up information and lists of tally marks.
+
+When Student Insights was being developed, some teachers started asking whether we could use it to make the class list creation process easier and more efficient.
+            <div
+              style={
+                Object {
+                  "marginTop": 20,
+                }
+              }
+            >
+              This 
+              <a
+                href="https://drive.google.com/file/d/1OmsB-9K1cgo1g6l21rnu0xL8H4KDyVAk/view"
+                target="_blank"
+              >
+                Video Walkthrough
+              </a>
+               and a 
+              <a
+                href="https://drive.google.com/file/d/1NHztne6tGz16qbIIeoeL8aNvTLQ0UTHj/view"
+                target="_blank"
+              >
+                Quick Guide
+              </a>
+               show the steps to use this tool.
+            </div>
+          </div>
+        </div>
+        <div>
+          <div>
+            <div
+              style={
+                Object {
+                  "marginTop": 20,
+                }
+              }
+            >
+              What school?
+            </div>
+            <div
+              className="Select has-value is-clearable is-disabled is-searchable Select--single"
+              style={undefined}
+            >
+              <input
+                disabled={true}
+                name="select-school-name"
+                type="hidden"
+                value="5"
+              />
+              <div
+                className="Select-control"
+                onKeyDown={[Function]}
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={undefined}
+              >
+                <span
+                  className="Select-multi-value-wrapper"
+                  id="react-select-6--value"
+                >
+                  <div
+                    className="Select-value"
+                    style={undefined}
+                    title={undefined}
+                  >
+                    <span
+                      aria-selected="true"
+                      className="Select-value-label"
+                      id="react-select-6--value-item"
+                      role="option"
+                    >
+                      E Somerville Community
+                    </span>
+                  </div>
+                  <div
+                    aria-activedescendant="react-select-6--value"
+                    aria-disabled="true"
+                    aria-expanded={false}
+                    aria-label={undefined}
+                    aria-labelledby={undefined}
+                    aria-owns=""
+                    className="Select-input"
+                    onBlur={[Function]}
+                    onFocus={[Function]}
+                    role="combobox"
+                    style={
+                      Object {
+                        "border": 0,
+                        "display": "inline-block",
+                        "width": 1,
+                      }
+                    }
+                    tabIndex={0}
+                  />
+                </span>
+                <span
+                  className="Select-arrow-zone"
+                  onMouseDown={[Function]}
+                >
+                  <span
+                    className="Select-arrow"
+                    onMouseDown={[Function]}
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div
+              style={
+                Object {
+                  "marginTop": 20,
+                }
+              }
+            >
+              What grade level are you creating?
+            </div>
+            <div
+              className="Select is-clearable is-disabled is-searchable Select--single"
+              style={undefined}
+            >
+              <div
+                className="Select-control"
+                onKeyDown={[Function]}
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={undefined}
+              >
+                <span
+                  className="Select-multi-value-wrapper"
+                  id="react-select-7--value"
+                >
+                  <div
+                    className="Select-placeholder"
+                  >
+                    Select...
+                  </div>
+                  <div
+                    aria-activedescendant="react-select-7--value"
+                    aria-disabled="true"
+                    aria-expanded={false}
+                    aria-label={undefined}
+                    aria-labelledby={undefined}
+                    aria-owns=""
+                    className="Select-input"
+                    onBlur={[Function]}
+                    onFocus={[Function]}
+                    role="combobox"
+                    style={
+                      Object {
+                        "border": 0,
+                        "display": "inline-block",
+                        "width": 1,
+                      }
+                    }
+                    tabIndex={0}
+                  />
+                </span>
+                <span
+                  className="Select-arrow-zone"
+                  onMouseDown={[Function]}
+                >
+                  <span
+                    className="Select-arrow"
+                    onMouseDown={[Function]}
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "marginTop": 20,
+              }
+            }
+          >
+            You can't change the school or grade level once you've moved forward.  If you need to change this, 
+            <a
+              href="/classlists"
+            >
+              create a new class list
+            </a>
+             instead.
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      style={
+        Object {
+          "display": "flex",
+          "justifyContent": "space-between",
+          "margin": 10,
+        }
+      }
+    >
+      <div />
+      <div
+        className="Hover"
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={undefined}
+      >
+        <button
+          onClick={[Function]}
+          style={
+            Object {
+              "background": "#4A90E2",
+              "border": "none",
+              "borderRadius": 28,
+              "color": "white",
+              "cursor": "pointer",
+              "fontSize": 14,
+              "margin": 10,
+              "padding": "8px 25px",
+              "textDecoration": "none",
+            }
+          }
+        >
+          Next &gt;
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`makeAPlanProps 1`] = `
 <div
   className="ClassListCreatorView"
@@ -1330,7 +1828,7 @@ exports[`makeAPlanProps 1`] = `
             >
               <span
                 className="Select-multi-value-wrapper"
-                id="react-select-6--value"
+                id="react-select-8--value"
               >
                 <div
                   className="Select-value"
@@ -1350,7 +1848,7 @@ exports[`makeAPlanProps 1`] = `
                   <span
                     aria-selected="true"
                     className="Select-value-label"
-                    id="react-select-6--value-0"
+                    id="react-select-8--value-0"
                     role="option"
                   >
                     Districtwide, Rich
@@ -1370,7 +1868,7 @@ exports[`makeAPlanProps 1`] = `
                   }
                 >
                   <input
-                    aria-activedescendant="react-select-6--value"
+                    aria-activedescendant="react-select-8--value"
                     aria-describedby={undefined}
                     aria-expanded="false"
                     aria-haspopup="false"
@@ -1915,7 +2413,7 @@ exports[`makeAPlanProps 2`] = `
             >
               <span
                 className="Select-multi-value-wrapper"
-                id="react-select-7--value"
+                id="react-select-9--value"
               >
                 <div
                   className="Select-value"
@@ -1925,7 +2423,7 @@ exports[`makeAPlanProps 2`] = `
                   <span
                     aria-selected="true"
                     className="Select-value-label"
-                    id="react-select-7--value-0"
+                    id="react-select-9--value-0"
                     role="option"
                   >
                     Districtwide, Rich
@@ -1937,7 +2435,7 @@ exports[`makeAPlanProps 2`] = `
                   </span>
                 </div>
                 <div
-                  aria-activedescendant="react-select-7--value"
+                  aria-activedescendant="react-select-9--value"
                   aria-disabled="true"
                   aria-expanded={false}
                   aria-label={undefined}


### PR DESCRIPTION
# Who is this PR for?
K-5 teaching teams, part of https://github.com/studentinsights/studentinsights/issues/1696.

# What problem does this PR fix?
When this was first made, the sequence was linear and users could move back and forth freely.  Changing that made the state transitions more complicated, and a scenario that wasn't handled was if a user changed the school or grade after either the list of students or the existing class list had been loaded (or requested).  @alexsoble ran into this right away in helpful testing things out yesterday.

# What does this PR do?
This restricts when users can change those values.  An assumption is that folks will proceed linearly, but if not and they do want to go back to change this, there's a message telling them to just go create a new class list instead.

# Screenshot (if adding a client-side feature)
<img width="1016" alt="screen shot 2018-05-23 at 9 47 07 am" src="https://user-images.githubusercontent.com/1056957/40428896-5a0929ac-5e6f-11e8-9236-e8fc04f213b9.png">

# Checklists
+ [x] Author checked latest in IE - Class lists
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code