### PR TITLE
Classrooms: Fix DibelsBreakdown chart bug

### DIFF
--- a/app/assets/javascripts/components/DibelsBreakdownBar.js
+++ b/app/assets/javascripts/components/DibelsBreakdownBar.js
@@ -13,8 +13,8 @@ export default class DibelsBreakdownBar extends React.Component {
     const {coreCount, strategicCount, intensiveCount} = this.props;
     const items = [
       { left: 0, width: coreCount, color: high, key: 'core' },
-      { left: coreCount, width: intensiveCount, color: medium, key: 'strategic' },
-      { left: coreCount + intensiveCount, width: strategicCount, color: low, key: 'intensive' }
+      { left: coreCount, width: strategicCount, color: medium, key: 'strategic' },
+      { left: coreCount + strategicCount, width: intensiveCount, color: low, key: 'intensive' }
     ];
 
     return <BreakdownBar items={items} {...this.props} />;

--- a/app/assets/javascripts/components/DibelsBreakdownBar.story.js
+++ b/app/assets/javascripts/components/DibelsBreakdownBar.story.js
@@ -11,10 +11,10 @@ storiesOf('components/DibelsBreakdownBar', module) // eslint-disable-line no-und
     };
     return (
       <div style={{display: 'flex', flexDirection: 'column', margin: 20, background: '3px solid black'}}>
-       <DibelsBreakdownBar height={20} labelTop={23} style={style} strategicCount={3} coreCount={2} intensiveCount={7} />
-       <DibelsBreakdownBar height={20} labelTop={23} style={style} strategicCount={13} coreCount={12} intensiveCount={17} />
-       <DibelsBreakdownBar height={20} labelTop={23} style={style} strategicCount={0} coreCount={0} intensiveCount={0} />
-       <DibelsBreakdownBar height={40} labelTop={43} style={style} strategicCount={8} coreCount={4} intensiveCount={2} />
+       <DibelsBreakdownBar height={20} labelTop={23} style={style} coreCount={2} strategicCount={3} intensiveCount={7} />
+       <DibelsBreakdownBar height={20} labelTop={23} style={style} coreCount={12} strategicCount={13} intensiveCount={17} />
+       <DibelsBreakdownBar height={20} labelTop={23} style={style} coreCount={0} strategicCount={0} intensiveCount={0} />
+       <DibelsBreakdownBar height={40} labelTop={43} style={style} coreCount={4} strategicCount={8} intensiveCount={2} />
       </div>
     );
   });

--- a/app/assets/javascripts/components/__snapshots__/DibelsBreakdownBar.test.js.snap
+++ b/app/assets/javascripts/components/__snapshots__/DibelsBreakdownBar.test.js.snap
@@ -56,7 +56,7 @@ exports[`snapshots 1`] = `
             "height": 50,
             "left": "59%",
             "position": "absolute",
-            "width": "17%",
+            "width": "25%",
           }
         }
       >
@@ -71,11 +71,11 @@ exports[`snapshots 1`] = `
             "position": "absolute",
             "textAlign": "right",
             "top": 55,
-            "width": "17%",
+            "width": "25%",
           }
         }
       >
-        2
+        3
       </div>
     </div>
     <div>
@@ -84,9 +84,9 @@ exports[`snapshots 1`] = `
           Object {
             "background": "rgba(255,0,0,0.5)",
             "height": 50,
-            "left": "75%",
+            "left": "84%",
             "position": "absolute",
-            "width": "25%",
+            "width": "17%",
           }
         }
       >
@@ -96,16 +96,16 @@ exports[`snapshots 1`] = `
         style={
           Object {
             "color": "rgba(255,0,0,0.5)",
-            "left": "75%",
+            "left": "84%",
             "paddingRight": 1,
             "position": "absolute",
             "textAlign": "right",
             "top": 55,
-            "width": "25%",
+            "width": "17%",
           }
         }
       >
-        3
+        2
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Who is this PR for?
K-2 teaching teams, part of https://github.com/studentinsights/studentinsights/issues/1696.  Follow-up fix for https://github.com/studentinsights/studentinsights/pull/1729.

# What problem does this PR fix?
`DibelsBreakdownChart` mixed up the intensive and strategic values.

# What does this PR do?
Fixes it and updates snapshot.

# Screenshot (if adding a client-side feature)
<img width="757" alt="screen shot 2018-05-23 at 4 45 20 pm" src="https://user-images.githubusercontent.com/1056957/40450130-b5ea7bd4-5ea8-11e8-8546-99f4a2c14dfe.png">


# Checklists
+ [x] Author checked latest in IE - Class list
+ [x] Author included specs for new code
