### PR TITLE
Fix timezone in display of times in class lists"

### DIFF
--- a/app/assets/javascripts/class_lists/ClassListsViewPage.js
+++ b/app/assets/javascripts/class_lists/ClassListsViewPage.js
@@ -90,7 +90,7 @@ export class ClassListsViewPageView extends React.Component {
           </thead>
           <tbody>{sortedWorkspaces.map(workspace => {
             const classList = workspace.class_list;
-            const createdAtMoment = toMomentFromTime(classList.created_at);
+            const createdAtMoment = toMomentFromTime(classList.created_at).local();
             const educatorStyle = (classList.created_by_educator.id === currentEducatorId)
               ? { fontWeight: 'bold' }
               : {};

--- a/app/assets/javascripts/class_lists/__snapshots__/ClassListsViewPage.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ClassListsViewPage.test.js.snap
@@ -217,7 +217,7 @@ exports[`snapshots view 1`] = `
             }
             title="Revisions: 17"
           >
-            Wednesday 5/9, 12:03pm
+            Wednesday 5/9, 8:03am
           </td>
           <td
             style={
@@ -315,7 +315,7 @@ exports[`snapshots view 1`] = `
             }
             title="Revisions: 7"
           >
-            Tuesday 5/8, 3:26pm
+            Tuesday 5/8, 11:26am
           </td>
           <td
             style={
@@ -413,7 +413,7 @@ exports[`snapshots view 1`] = `
             }
             title="Revisions: 26"
           >
-            Monday 5/7, 6:12pm
+            Monday 5/7, 2:12pm
           </td>
           <td
             style={
@@ -511,7 +511,7 @@ exports[`snapshots view 1`] = `
             }
             title="Revisions: 7"
           >
-            Monday 5/7, 10:54pm
+            Monday 5/7, 6:54pm
           </td>
           <td
             style={
@@ -625,7 +625,7 @@ exports[`snapshots view 1`] = `
             }
             title="Revisions: 6"
           >
-            Monday 5/7, 6:20pm
+            Monday 5/7, 2:20pm
           </td>
           <td
             style={
@@ -739,7 +739,7 @@ exports[`snapshots view 1`] = `
             }
             title="Revisions: 9"
           >
-            Tuesday 5/8, 4:33pm
+            Tuesday 5/8, 12:33pm
           </td>
           <td
             style={
@@ -833,7 +833,7 @@ exports[`snapshots view 1`] = `
             }
             title="Revisions: 26"
           >
-            Tuesday 5/8, 4:08pm
+            Tuesday 5/8, 12:08pm
           </td>
           <td
             style={
@@ -931,7 +931,7 @@ exports[`snapshots view 1`] = `
             }
             title="Revisions: 4"
           >
-            Tuesday 5/8, 3:26pm
+            Tuesday 5/8, 11:26am
           </td>
           <td
             style={
@@ -1025,7 +1025,7 @@ exports[`snapshots view 1`] = `
             }
             title="Revisions: 3"
           >
-            Monday 5/7, 10:55pm
+            Monday 5/7, 6:55pm
           </td>
           <td
             style={


### PR DESCRIPTION
# Who is this PR for?
K-5 teaching teams, part of https://github.com/studentinsights/studentinsights/issues/1695.

# What problem does this PR fix?
Times are displayed in UTC time rather than local time.  This is an issue throughout the JS code and I tried to fix this more holistically in https://github.com/studentinsights/studentinsights/tree/patch/utc-time-for-class-lists but am tabling that for now to get this change out first.

# What does this PR do?
Expresses the time in local time.
