### PR TITLE
Update sign-in feature spec name and copy

### DIFF
--- a/spec/features/sign_in_feature_spec.rb
+++ b/spec/features/sign_in_feature_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'capybara/rspec'
 
-describe 'educator sign in using database_authenticatable not LDAP', type: :feature do
+describe 'educator sign in using Mock LDAP', type: :feature do
   let!(:pals) { TestPals.create! }
 
   context 'teacher signs in' do


### PR DESCRIPTION
# Who is this PR for?

Developers.

# What problem does this PR fix?

Misleading file name and description in spec; should have been caught and fixed as part of #1701.

# What does this PR do?

We're using Mock LDAP and not database_authenticable in the test environment now (we don't even have the encrypted password fields in the database to support database_authenticable anymore). Update the name of the sign-in feature spec to reflect this and update the description copy in the spec so as not to confuse other developers. 