### PR TITLE
Classrooms: Fix coloring bug with medium STAR scores

### DIFF
--- a/app/assets/javascripts/class_lists/ClassroomStats.js
+++ b/app/assets/javascripts/class_lists/ClassroomStats.js
@@ -22,6 +22,7 @@ import {
   isLowIncome,
   isHighDiscipline,
   dibelsLevel,
+  starBucket,
   HighlightKeys
 } from './studentFilters';
 
@@ -249,18 +250,10 @@ export default class ClassroomStats extends React.Component {
 
   // Ignore students without scores
   renderStarWithBreakdown(studentsInRoom, accessor) {
-    const lowCount = studentsInRoom.filter(student => {
-      const percentile = accessor(student);
-      return (percentile && percentile < 30);
-    }).length;
-    const mediumCount = studentsInRoom.filter(student => {
-      const percentile = accessor(student);
-      return (percentile && percentile >= 30 && percentile <= 70);
-    }).length;
-    const highCount = studentsInRoom.filter(student => {
-      const percentile = accessor(student);
-      return (percentile && percentile > 70);
-    }).length;
+    const counts = _.countBy(studentsInRoom, student => starBucket(accessor(student)));
+    const lowCount = counts.low || 0;
+    const mediumCount = counts.medium || 0;
+    const highCount = counts.high || 0;
 
     const items = [
       { left: 0, width: highCount, color: high, key: 'high' },

--- a/app/assets/javascripts/class_lists/StudentCard.js
+++ b/app/assets/javascripts/class_lists/StudentCard.js
@@ -18,6 +18,7 @@ import {
   isLowIncome,
   isHighDiscipline,
   dibelsLevel,
+  starBucketThresholds,
   HighlightKeys
 } from './studentFilters';
 
@@ -178,7 +179,7 @@ const highlightFns = {
 // Perform color operation for STAR percentile scores, calling out high and low only
 // Missing scores aren't called out.
 function starStyles(maybePercentile) {
-  const starScale = chroma.scale([low, 'white', high]).classes([0, 0.3, 0.7, 1]);
+  const starScale = chroma.scale([low, medium, high]).classes(starBucketThresholds);
   const hasScore = _.isNumber(maybePercentile);
   if (!hasScore) return styles.none;
   const fraction = maybePercentile / 100;

--- a/app/assets/javascripts/class_lists/__snapshots__/ClassroomStats.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ClassroomStats.test.js.snap
@@ -1772,7 +1772,7 @@ exports[`snapshots 1`] = `
                         "height": 5,
                         "left": "0%",
                         "position": "absolute",
-                        "width": "42%",
+                        "width": "39%",
                       }
                     }
                   >
@@ -1788,7 +1788,7 @@ exports[`snapshots 1`] = `
                         "position": "absolute",
                         "textAlign": "right",
                         "top": 5,
-                        "width": "42%",
+                        "width": "39%",
                       }
                     }
                   >
@@ -1802,9 +1802,9 @@ exports[`snapshots 1`] = `
                         "background": "rgba(255,165,0,0.5)",
                         "fontSize": 12,
                         "height": 5,
-                        "left": "42%",
+                        "left": "39%",
                         "position": "absolute",
-                        "width": "25%",
+                        "width": "24%",
                       }
                     }
                   >
@@ -1815,12 +1815,12 @@ exports[`snapshots 1`] = `
                       Object {
                         "color": "rgba(255,165,0,0.5)",
                         "fontSize": 12,
-                        "left": "42%",
+                        "left": "39%",
                         "paddingRight": 1,
                         "position": "absolute",
                         "textAlign": "right",
                         "top": 5,
-                        "width": "25%",
+                        "width": "24%",
                       }
                     }
                   >
@@ -1834,9 +1834,9 @@ exports[`snapshots 1`] = `
                         "background": "rgba(255,0,0,0.5)",
                         "fontSize": 12,
                         "height": 5,
-                        "left": "67%",
+                        "left": "62%",
                         "position": "absolute",
-                        "width": "34%",
+                        "width": "39%",
                       }
                     }
                   >
@@ -1847,16 +1847,16 @@ exports[`snapshots 1`] = `
                       Object {
                         "color": "rgba(255,0,0,0.5)",
                         "fontSize": 12,
-                        "left": "67%",
+                        "left": "62%",
                         "paddingRight": 1,
                         "position": "absolute",
                         "textAlign": "right",
                         "top": 5,
-                        "width": "34%",
+                        "width": "39%",
                       }
                     }
                   >
-                    4
+                    5
                   </div>
                 </div>
               </div>
@@ -1900,7 +1900,7 @@ exports[`snapshots 1`] = `
                         "height": 5,
                         "left": "0%",
                         "position": "absolute",
-                        "width": "19%",
+                        "width": "16%",
                       }
                     }
                   >
@@ -1916,7 +1916,7 @@ exports[`snapshots 1`] = `
                         "position": "absolute",
                         "textAlign": "right",
                         "top": 5,
-                        "width": "19%",
+                        "width": "16%",
                       }
                     }
                   >
@@ -1930,9 +1930,9 @@ exports[`snapshots 1`] = `
                         "background": "rgba(255,165,0,0.5)",
                         "fontSize": 12,
                         "height": 5,
-                        "left": "19%",
+                        "left": "16%",
                         "position": "absolute",
-                        "width": "55%",
+                        "width": "47%",
                       }
                     }
                   >
@@ -1943,12 +1943,12 @@ exports[`snapshots 1`] = `
                       Object {
                         "color": "rgba(255,165,0,0.5)",
                         "fontSize": 12,
-                        "left": "19%",
+                        "left": "16%",
                         "paddingRight": 1,
                         "position": "absolute",
                         "textAlign": "right",
                         "top": 5,
-                        "width": "55%",
+                        "width": "47%",
                       }
                     }
                   >
@@ -1962,9 +1962,9 @@ exports[`snapshots 1`] = `
                         "background": "rgba(255,0,0,0.5)",
                         "fontSize": 12,
                         "height": 5,
-                        "left": "73%",
+                        "left": "62%",
                         "position": "absolute",
-                        "width": "28%",
+                        "width": "39%",
                       }
                     }
                   >
@@ -1975,16 +1975,16 @@ exports[`snapshots 1`] = `
                       Object {
                         "color": "rgba(255,0,0,0.5)",
                         "fontSize": 12,
-                        "left": "73%",
+                        "left": "62%",
                         "paddingRight": 1,
                         "position": "absolute",
                         "textAlign": "right",
                         "top": 5,
-                        "width": "28%",
+                        "width": "39%",
                       }
                     }
                   >
-                    3
+                    5
                   </div>
                 </div>
               </div>
@@ -3094,7 +3094,7 @@ exports[`snapshots 1`] = `
                         "height": 5,
                         "left": "0%",
                         "position": "absolute",
-                        "width": "46%",
+                        "width": "39%",
                       }
                     }
                   >
@@ -3110,7 +3110,7 @@ exports[`snapshots 1`] = `
                         "position": "absolute",
                         "textAlign": "right",
                         "top": 5,
-                        "width": "46%",
+                        "width": "39%",
                       }
                     }
                   >
@@ -3124,9 +3124,9 @@ exports[`snapshots 1`] = `
                         "background": "rgba(255,165,0,0.5)",
                         "fontSize": 12,
                         "height": 5,
-                        "left": "46%",
+                        "left": "39%",
                         "position": "absolute",
-                        "width": "28%",
+                        "width": "24%",
                       }
                     }
                   >
@@ -3137,12 +3137,12 @@ exports[`snapshots 1`] = `
                       Object {
                         "color": "rgba(255,165,0,0.5)",
                         "fontSize": 12,
-                        "left": "46%",
+                        "left": "39%",
                         "paddingRight": 1,
                         "position": "absolute",
                         "textAlign": "right",
                         "top": 5,
-                        "width": "28%",
+                        "width": "24%",
                       }
                     }
                   >
@@ -3156,9 +3156,9 @@ exports[`snapshots 1`] = `
                         "background": "rgba(255,0,0,0.5)",
                         "fontSize": 12,
                         "height": 5,
-                        "left": "73%",
+                        "left": "62%",
                         "position": "absolute",
-                        "width": "28%",
+                        "width": "39%",
                       }
                     }
                   >
@@ -3169,16 +3169,16 @@ exports[`snapshots 1`] = `
                       Object {
                         "color": "rgba(255,0,0,0.5)",
                         "fontSize": 12,
-                        "left": "73%",
+                        "left": "62%",
                         "paddingRight": 1,
                         "position": "absolute",
                         "textAlign": "right",
                         "top": 5,
-                        "width": "28%",
+                        "width": "39%",
                       }
                     }
                   >
-                    3
+                    5
                   </div>
                 </div>
               </div>
@@ -3222,7 +3222,7 @@ exports[`snapshots 1`] = `
                         "height": 5,
                         "left": "0%",
                         "position": "absolute",
-                        "width": "46%",
+                        "width": "39%",
                       }
                     }
                   >
@@ -3238,7 +3238,7 @@ exports[`snapshots 1`] = `
                         "position": "absolute",
                         "textAlign": "right",
                         "top": 5,
-                        "width": "46%",
+                        "width": "39%",
                       }
                     }
                   >
@@ -3252,9 +3252,9 @@ exports[`snapshots 1`] = `
                         "background": "rgba(255,165,0,0.5)",
                         "fontSize": 12,
                         "height": 5,
-                        "left": "46%",
+                        "left": "39%",
                         "position": "absolute",
-                        "width": "37%",
+                        "width": "31%",
                       }
                     }
                   >
@@ -3265,12 +3265,12 @@ exports[`snapshots 1`] = `
                       Object {
                         "color": "rgba(255,165,0,0.5)",
                         "fontSize": 12,
-                        "left": "46%",
+                        "left": "39%",
                         "paddingRight": 1,
                         "position": "absolute",
                         "textAlign": "right",
                         "top": 5,
-                        "width": "37%",
+                        "width": "31%",
                       }
                     }
                   >
@@ -3284,9 +3284,9 @@ exports[`snapshots 1`] = `
                         "background": "rgba(255,0,0,0.5)",
                         "fontSize": 12,
                         "height": 5,
-                        "left": "82%",
+                        "left": "70%",
                         "position": "absolute",
-                        "width": "19%",
+                        "width": "31%",
                       }
                     }
                   >
@@ -3297,16 +3297,16 @@ exports[`snapshots 1`] = `
                       Object {
                         "color": "rgba(255,0,0,0.5)",
                         "fontSize": 12,
-                        "left": "82%",
+                        "left": "70%",
                         "paddingRight": 1,
                         "position": "absolute",
                         "textAlign": "right",
                         "top": 5,
-                        "width": "19%",
+                        "width": "31%",
                       }
                     }
                   >
-                    2
+                    4
                   </div>
                 </div>
               </div>

--- a/app/assets/javascripts/class_lists/studentFilters.js
+++ b/app/assets/javascripts/class_lists/studentFilters.js
@@ -34,3 +34,15 @@ export function dibelsLevel(dibels) {
   if (performanceLevel.indexOf('int') !== -1) return 'intensive';
   return null;
 }
+
+// Bucket STAR percentiles into high/medium/low
+export const starBucketThresholds = [0, 0.30, 0.70, 1];
+export function starBucket(percentile) {
+  if (percentile == null) return null;
+
+  const lowThreshold = 100 * starBucketThresholds[1];
+  const highThreshold = 100 * starBucketThresholds[2];
+  if (percentile < lowThreshold) return 'low';
+  if (percentile > highThreshold) return 'high';
+  return 'medium';
+}

--- a/ui/config/setupTests.js
+++ b/ui/config/setupTests.js
@@ -20,7 +20,12 @@ global.fetch = require('jest-fetch-mock'); // eslint-disable-line no-undef
 console.error = jest.fn(error => { throw new Error(error); }); //eslint-disable-line no-console
 console.warn = jest.fn(warn => { throw new Error(warn); }); //eslint-disable-line no-console
 
-// flag for GenericLoader
+// Make test fail if code is reporting errors to Rollbar
+window.Rollbar = {
+  error: jest.fn(error => { throw new Error(error); }) //eslint-disable-line no-console
+};
+
+// flag for GenericLoader to handle failure differently in test
 global.GENERIC_LOADER_THROW_ON_REJECT_IN_TEST = true;
 
 // Unhandled promise rejections should fail tests


### PR DESCRIPTION
# Who is this PR for?
K-5 teaching teams, part of https://github.com/studentinsights/studentinsights/issues/1696.

# What problem does this PR fix?
STAR colors aren't the same for the chart up top and student cards.  Cards don't color medium, and they should be yellow.

# What does this PR do?
Also removes some duplication and factors it out.  Also fixes a bug where one place was calculating "greater than" and the other was calculating "greater than or equal."

# Screenshot (if adding a client-side feature)
### before
<img width="212" alt="screen shot 2018-05-25 at 5 47 46 pm" src="https://user-images.githubusercontent.com/1056957/40567543-cb4a00ca-6043-11e8-8f39-be5f638bb1a4.png">

### after
<img width="223" alt="screen shot 2018-05-25 at 5 47 58 pm" src="https://user-images.githubusercontent.com/1056957/40567545-cf39d26e-6043-11e8-9985-c305e3df9cb4.png">


# Checklists
+ [x] Author included specs for new code
