### PR TITLE
Add code comments for iep import

### DIFF
--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -25,6 +25,17 @@ class IepPdfImportJob
     import_ieps!(remote_filenames)
   end
 
+  # Each ZIP file sent down from EasyIEP has a number at the end, the number
+  # indicates that the ZIP contains a set of changed IEPs from `n` days ago.
+  #
+  # If there are no IEPs on any given day, that number may be missing from the
+  # sequence.
+  #
+  # The most recent change set (student-documents-1.zip), is the only one we really
+  # need to import, but the rest are sent down in case the import job fails
+  # and we need to catch up on missed change sets.
+  #
+  # Order is important here.
   def nightly_import!
     remote_filenames = [
       'student-documents-6.zip',

--- a/app/jobs/iep_pdf_import_job.rb
+++ b/app/jobs/iep_pdf_import_job.rb
@@ -20,7 +20,7 @@ class IepPdfImportJob
   # contains several older documents (ie., for a first-time import).
   # It will fail on any errors, log to the console and won't retry.
   def bulk_import!
-    remote_filenames = [ENV['BULK_IEP_IMPORT_TARGET']]
+    remote_filenames = [ENV.fetch('BULK_IEP_IMPORT_TARGET')]
 
     import_ieps!(remote_filenames)
   end


### PR DESCRIPTION
# Who is this PR for?

Developers. 

# What problem does this PR fix?

Lack of clear code comments around IEP import job.

# What does this PR do?

Clarifies how IEP ZIP files flow into the SFTP site from Somerville's IEP system; ensure that bulk IEP upload ENV variable is set before we call the `bulk_import!` method. 