### PR TITLE
Autosave High School Transition notes as user types; fix bug with saving

### DIFF
--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -58,11 +58,14 @@ class TransitionNotes extends React.Component {
       restrictedNoteId: (restrictedNote ? restrictedNote.id : null)
     };
 
-    this.onClickSave = this.onClickSave.bind(this);
-    this.onClickSaveRestricted = this.onClickSaveRestricted.bind(this);
+    this.autosaveRegularNote = _.throttle(this.autosaveRegularNote.bind(this), 5000);
+    this.autosaveRestrictedNote = _.throttle(this.autosaveRestrictedNote.bind(this), 5000);
+
+    this.onChangeRegularNote = this.onChangeRegularNote.bind(this);
+    this.onChangeRestrictedNote = this.onChangeRestrictedNote.bind(this);
   }
 
-  onClickSave() {
+  autosaveRegularNote() {
     const params = {
       is_restricted: false,
       text: this.state.noteText
@@ -75,7 +78,7 @@ class TransitionNotes extends React.Component {
     this.props.onSave(params);
   }
 
-  onClickSaveRestricted() {
+  autosaveRestrictedNote() {
     const params = {
       is_restricted: true,
       text: this.state.restrictedNoteText
@@ -86,6 +89,15 @@ class TransitionNotes extends React.Component {
     }
 
     this.props.onSave(params);
+  }
+
+
+  onChangeRegularNote(e) {
+    this.setState({noteText: e.target.value}, () => {this.autosaveRegularNote()});
+  }
+
+  onChangeRestrictedNote(e) {
+    this.setState({restrictedNoteText: e.target.value}, () => {this.autosaveRestrictedNote()});
   }
 
   render() {
@@ -101,7 +113,7 @@ class TransitionNotes extends React.Component {
             rows={10}
             style={styles.textarea}
             value={noteText}
-            onChange={(e) => this.setState({noteText: e.target.value})}
+            onChange={this.onChangeRegularNote}
             readOnly={readOnly} />
           <div style={{color: 'gray'}}>This note will autosave as you type.</div>
         </div>
@@ -113,7 +125,7 @@ class TransitionNotes extends React.Component {
             rows={10}
             style={styles.textarea}
             value={restrictedNoteText}
-            onChange={(e) => this.setState({restrictedNoteText: e.target.value})}
+            onChange={this.onChangeRestrictedNote}
             readOnly={readOnly} />
           <div style={{color: 'gray'}}>This note will autosave as you type.</div>
         </div>

--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -85,23 +85,23 @@ class TransitionNotes extends React.Component {
   // is like.
   componentWillReceiveProps(newProps) {
     if (newProps.requestState !== this.props.requestState) {
-      if (this.props.requestState === 'pending') {
-        setTimeout(() => {
-          this.setState({regularNoteAutosaveStatus: newProps.requestState})
-        }, 2000);
-      } else {
-        this.setState({regularNoteAutosaveStatus: newProps.requestState});
-      }
+      this.setState({regularNoteAutosaveStatus: newProps.requestState});
+      // if (this.props.requestState === 'pending') {
+      //   setTimeout(() => {
+      //     this.setState({regularNoteAutosaveStatus: newProps.requestState})
+      //   }, 2000);
+      // } else {
+      // }
     }
 
     if (newProps.requestStateRestricted !== this.props.requestStateRestricted) {
-      if (this.props.requestStateRestricted == 'pending') {
-        setTimeout(() => {
-          this.setState({restrictedNoteAutosaveStatus: newProps.requestStateRestricted})
-        },2000);
-      } else {
-        this.setState({restrictedNoteAutosaveStatus: newProps.requestStateRestricted});
-      }
+      this.setState({restrictedNoteAutosaveStatus: newProps.requestStateRestricted});
+      // if (this.props.requestStateRestricted == 'pending') {
+      //   setTimeout(() => {
+      //     this.setState({restrictedNoteAutosaveStatus: newProps.requestStateRestricted})
+      //   },2000);
+      // } else {
+      // }
     }
   }
 

--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -60,28 +60,6 @@ class TransitionNotes extends React.Component {
 
     this.onClickSave = this.onClickSave.bind(this);
     this.onClickSaveRestricted = this.onClickSaveRestricted.bind(this);
-    this.buttonText = this.buttonText.bind(this);
-    this.buttonTextRestricted = this.buttonTextRestricted.bind(this);
-  }
-
-  buttonText() {
-    const {requestState} = this.props;
-
-    if (requestState === 'pending') return 'Saving ...';
-
-    if (requestState === 'error') return 'Error ...';
-
-    return 'Save Note';
-  }
-
-  buttonTextRestricted() {
-    const {requestStateRestricted} = this.props;
-
-    if (requestStateRestricted === 'pending') return 'Saving ...';
-
-    if (requestStateRestricted === 'error') return 'Error ...';
-
-    return 'Save Note';
   }
 
   onClickSave() {
@@ -125,7 +103,7 @@ class TransitionNotes extends React.Component {
             value={noteText}
             onChange={(e) => this.setState({noteText: e.target.value})}
             readOnly={readOnly} />
-          {this.renderButton(this.onClickSave, this.buttonText)}
+          <div style={{color: 'gray'}}>This note will autosave as you type.</div>
         </div>
         <div style={{flex: 1, margin: 30}}>
           <SectionHeading>
@@ -137,21 +115,9 @@ class TransitionNotes extends React.Component {
             value={restrictedNoteText}
             onChange={(e) => this.setState({restrictedNoteText: e.target.value})}
             readOnly={readOnly} />
-          {this.renderButton(this.onClickSaveRestricted, this.buttonTextRestricted)}
+          <div style={{color: 'gray'}}>This note will autosave as you type.</div>
         </div>
       </div>
-    );
-  }
-
-  renderButton(onClickFn, buttonTextFn) {
-    const {readOnly} = this.props;
-
-    if (readOnly) return null;
-
-    return (
-      <button onClick={onClickFn} className='btn save'>
-        {buttonTextFn()}
-      </button>
     );
   }
 

--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -72,36 +72,31 @@ class TransitionNotes extends React.Component {
   // React 15.4 in Insights, and have some legacy-cleanup work to finish
   // til we can migrate to 16. Noting that this func will have to be refactored.
 
-  // In my local environment, when I type into the Transition Note textarea,
-  // the server responds with "saved!" so fast that the status text is barely
-  // readable when it's supposed to say "Autosaving..."
+  // When the user types into the Transition Note textarea, the server
+  // handles autosaving very quickly. In fact, so fast that in the "pending" state,
+  // the status text is barely readable when it's supposed to say "Autosaving..."
 
-  // This code adds an artificial delay so that the text that says "Autosaving..."
-  // can hang for around 2 seconds to let the user read it.
-
-  // It occurred to me that the server might respond more slowly on the Heroku app,
-  // which would make this code unnecessary. So I'm going to try commenting it out,
-  // deploying up to the Heroku demo site, and seeing what the user experience
-  // is like.
+  // This code adds a delay so that the text that says "Autosaving..."
+  // can hang for  2 seconds to let the user read it.
   componentWillReceiveProps(newProps) {
     if (newProps.requestState !== this.props.requestState) {
-      this.setState({regularNoteAutosaveStatus: newProps.requestState});
-      // if (this.props.requestState === 'pending') {
-      //   setTimeout(() => {
-      //     this.setState({regularNoteAutosaveStatus: newProps.requestState})
-      //   }, 2000);
-      // } else {
-      // }
+      if (this.props.requestState === 'pending') {
+        setTimeout(() => {
+          this.setState({regularNoteAutosaveStatus: newProps.requestState})
+        }, 2000);
+      } else {
+        this.setState({regularNoteAutosaveStatus: newProps.requestState});
+      }
     }
 
     if (newProps.requestStateRestricted !== this.props.requestStateRestricted) {
-      this.setState({restrictedNoteAutosaveStatus: newProps.requestStateRestricted});
-      // if (this.props.requestStateRestricted == 'pending') {
-      //   setTimeout(() => {
-      //     this.setState({restrictedNoteAutosaveStatus: newProps.requestStateRestricted})
-      //   },2000);
-      // } else {
-      // }
+      if (this.props.requestStateRestricted == 'pending') {
+        setTimeout(() => {
+          this.setState({restrictedNoteAutosaveStatus: newProps.requestStateRestricted})
+        }, 2000);
+      } else {
+        this.setState({restrictedNoteAutosaveStatus: newProps.requestStateRestricted});
+      }
     }
   }
 

--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -47,15 +47,13 @@ class TransitionNotes extends React.Component {
   constructor(props) {
     super(props);
 
-    const transitionNotes = props.transitionNotes;
+    const {transitionNotes} = props;
     const regularNote = _.find(transitionNotes, {is_restricted: false});
     const restrictedNote = _.find(transitionNotes, {is_restricted: true});
 
     this.state = {
       noteText: (regularNote ? regularNote.text : notePrompts),
       restrictedNoteText: (restrictedNote ? restrictedNote.text : restrictedNotePrompts),
-      regularNoteId: (regularNote ? regularNote.id : null),
-      restrictedNoteId: (restrictedNote ? restrictedNote.id : null),
       regularNoteAutosaveStatus: null,
       restrictedNoteAutosaveStatus: null,
     };
@@ -68,7 +66,6 @@ class TransitionNotes extends React.Component {
     this.onChangeRegularNote = this.onChangeRegularNote.bind(this);
     this.onChangeRestrictedNote = this.onChangeRestrictedNote.bind(this);
   }
-
 
   // This method will be deprecated in React 16.3. But we're still using
   // React 15.4 and have some migration work to finish up til we can migrate to
@@ -88,36 +85,40 @@ class TransitionNotes extends React.Component {
     if (newProps.requestStateRestricted !== this.props.requestStateRestricted) {
       if (this.props.requestStateRestricted == 'pending') {
         setTimeout(() => {
-          this.setState({restrictedNoteAutosaveStatus: newProps.requestState})
+          this.setState({restrictedNoteAutosaveStatus: newProps.requestStateRestricted})
         },2000);
       } else {
-        this.setState({restrictedNoteAutosaveStatus: newProps.requestState});
+        this.setState({restrictedNoteAutosaveStatus: newProps.requestStateRestricted});
       }
     }
   }
 
   autosaveRegularNote() {
+    const {transitionNotes} = this.props;
+    const regularNote = _.find(transitionNotes, {is_restricted: false});
+    const regularNoteId = (regularNote) ? regularNote.id : null;
+
     const params = {
       is_restricted: false,
       text: this.state.noteText
     };
 
-    if (this.state.regularNoteId) {
-      _.merge(params, {id: this.state.regularNoteId});
-    }
+    if (regularNoteId) { _.merge(params, {id: regularNoteId}); }
 
     this.props.onSave(params);
   }
 
   autosaveRestrictedNote() {
+    const {transitionNotes} = this.props;
+    const restrictedNote = _.find(transitionNotes, {is_restricted: true});
+    const restrictedNoteId = (restrictedNote) ? restrictedNote.id : null;
+
     const params = {
       is_restricted: true,
       text: this.state.restrictedNoteText
     };
 
-    if (this.state.restrictedNoteId) {
-      _.merge(params, {id: this.state.restrictedNoteId});
-    }
+    if (restrictedNoteId) { _.merge(params, {id: restrictedNoteId}); }
 
     this.props.onSave(params);
   }
@@ -141,6 +142,7 @@ class TransitionNotes extends React.Component {
   }
 
   render() {
+    console.log('this.props', this.props);
     const {noteText, restrictedNoteText, readOnly} = this.state;
 
     return (

--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -67,10 +67,22 @@ class TransitionNotes extends React.Component {
     this.onChangeRestrictedNote = this.onChangeRestrictedNote.bind(this);
   }
 
+  // Note on componentWillReceiveProps:
   // This method will be deprecated in React 16.3. But we're still using
-  // React 15.4 and have some migration work to finish up til we can migrate to
-  // React 16. Just noting that this will eventually have to be refactored
-  // eventually.
+  // React 15.4 in Insights, and have some legacy-cleanup work to finish
+  // til we can migrate to 16. Noting that this func will have to be refactored.
+
+  // In my local environment, when I type into the Transition Note textarea,
+  // the server responds with "saved!" so fast that the status text is barely
+  // readable when it's supposed to say "Autosaving..."
+
+  // This code adds an artificial delay so that the text that says "Autosaving..."
+  // can hang for around 2 seconds to let the user read it.
+
+  // It occurred to me that the server might respond more slowly on the Heroku app,
+  // which would make this code unnecessary. So I'm going to try commenting it out,
+  // deploying up to the Heroku demo site, and seeing what the user experience
+  // is like.
   componentWillReceiveProps(newProps) {
     if (newProps.requestState !== this.props.requestState) {
       if (this.props.requestState === 'pending') {

--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -82,7 +82,7 @@ class TransitionNotes extends React.Component {
     if (newProps.requestState !== this.props.requestState) {
       if (this.props.requestState === 'pending') {
         setTimeout(() => {
-          this.setState({regularNoteAutosaveStatus: newProps.requestState})
+          this.setState({regularNoteAutosaveStatus: newProps.requestState});
         }, 2000);
       } else {
         this.setState({regularNoteAutosaveStatus: newProps.requestState});
@@ -92,7 +92,7 @@ class TransitionNotes extends React.Component {
     if (newProps.requestStateRestricted !== this.props.requestStateRestricted) {
       if (this.props.requestStateRestricted == 'pending') {
         setTimeout(() => {
-          this.setState({restrictedNoteAutosaveStatus: newProps.requestStateRestricted})
+          this.setState({restrictedNoteAutosaveStatus: newProps.requestStateRestricted});
         }, 2000);
       } else {
         this.setState({restrictedNoteAutosaveStatus: newProps.requestStateRestricted});

--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -58,7 +58,7 @@ class TransitionNotes extends React.Component {
       restrictedNoteAutosaveStatus: null,
     };
 
-    const throttleOptions = {leading: true, trailing: false};
+    const throttleOptions = {leading: true, trailing: true};
 
     this.autosaveRegularNote = _.throttle(this.autosaveRegularNote.bind(this), 3000, throttleOptions);
     this.autosaveRestrictedNote = _.throttle(this.autosaveRestrictedNote.bind(this), 3000, throttleOptions);

--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -146,15 +146,14 @@ class TransitionNotes extends React.Component {
   }
 
   onChangeRegularNote(e) {
-    this.setState({noteText: e.target.value}, () => {this.autosaveRegularNote()});
+    this.setState({noteText: e.target.value}, () => {this.autosaveRegularNote();});
   }
 
   onChangeRestrictedNote(e) {
-    this.setState({restrictedNoteText: e.target.value}, () => {this.autosaveRestrictedNote()});
+    this.setState({restrictedNoteText: e.target.value}, () => {this.autosaveRestrictedNote();});
   }
 
   render() {
-    console.log('this.props', this.props);
     const {noteText, restrictedNoteText, readOnly} = this.state;
 
     return (

--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -91,6 +91,25 @@ class TransitionNotes extends React.Component {
     this.props.onSave(params);
   }
 
+  regularNoteAutosaveStatus() {
+    const {requestState} = this.props;
+
+    if (requestState === 'pending') return 'Autosaving ...';
+
+    if (requestState === 'error') return 'There was an error autosaving this note.';
+
+    return 'This note will autosave as you type.';
+  }
+
+  restrictedNoteAutosaveStatus() {
+    const {requestStateRestricted} = this.props;
+
+    if (requestStateRestricted === 'pending') return 'Autosaving ...';
+
+    if (requestStateRestricted === 'error') return 'There was an error autosaving this note.';
+
+    return 'This note will autosave as you type.';
+  }
 
   onChangeRegularNote(e) {
     this.setState({noteText: e.target.value}, () => {this.autosaveRegularNote()});
@@ -115,7 +134,7 @@ class TransitionNotes extends React.Component {
             value={noteText}
             onChange={this.onChangeRegularNote}
             readOnly={readOnly} />
-          <div style={{color: 'gray'}}>This note will autosave as you type.</div>
+          <div style={{color: 'gray'}}>{this.regularNoteAutosaveStatus()}</div>
         </div>
         <div style={{flex: 1, margin: 30}}>
           <SectionHeading>
@@ -127,7 +146,7 @@ class TransitionNotes extends React.Component {
             value={restrictedNoteText}
             onChange={this.onChangeRestrictedNote}
             readOnly={readOnly} />
-          <div style={{color: 'gray'}}>This note will autosave as you type.</div>
+          <div style={{color: 'gray'}}>{this.restrictedNoteAutosaveStatus()}</div>
         </div>
       </div>
     );

--- a/app/assets/javascripts/student_profile/page_container.jsx
+++ b/app/assets/javascripts/student_profile/page_container.jsx
@@ -169,7 +169,10 @@ function fromPair(key, value) {
         ? { saveRestrictedTransitionNote: 'saved' }
         : { saveTransitionNote: 'saved' };
 
-      this.setState({ requests: merge(this.state.requests, requestState) });
+      this.setState({
+        requests: merge(this.state.requests, requestState),
+        transitionNotes: response.transition_notes
+      });
     },
 
     onSaveTransitionNoteFail: function(request, status, message) {

--- a/app/assets/javascripts/student_profile/page_container.jsx
+++ b/app/assets/javascripts/student_profile/page_container.jsx
@@ -166,8 +166,8 @@ function fromPair(key, value) {
 
     onSaveTransitionNoteDone: function(response) {
       const requestState = (response.is_restricted)
-        ? { saveRestrictedTransitionNote: null }
-        : { saveTransitionNote: null };
+        ? { saveRestrictedTransitionNote: 'saved' }
+        : { saveTransitionNote: 'saved' };
 
       this.setState({ requests: merge(this.state.requests, requestState) });
     },

--- a/app/controllers/transition_notes_controller.rb
+++ b/app/controllers/transition_notes_controller.rb
@@ -16,7 +16,10 @@ class TransitionNotesController < ApplicationController
     }))
 
     if transition_note.save
-      render json: { result: 'ok', is_restricted: transition_note.is_restricted }
+      render json: {
+        is_restricted: transition_note.is_restricted,
+        transition_notes: transition_note.student.transition_notes,
+      }
     else
       render json: { errors: transition_note.errors.full_messages }, status: 422
     end
@@ -28,7 +31,10 @@ class TransitionNotesController < ApplicationController
     transition_note.text = transition_note_params[:text]
 
     if transition_note.save
-      render json: { result: 'ok', is_restricted: transition_note.is_restricted }
+      render json: {
+        is_restricted: transition_note.is_restricted,
+        transition_notes: transition_note.student.transition_notes,
+      }
     else
       render json: { errors: transition_note.errors.full_messages }, status: 422
     end

--- a/app/models/transition_note.rb
+++ b/app/models/transition_note.rb
@@ -5,7 +5,7 @@ class TransitionNote < ApplicationRecord
   validates :educator, presence: true
   validates :student, presence: true
 
-  validate :just_two_per_student
+  validate :just_two_per_student, on: :create
 
   def just_two_per_student
     if student.transition_notes.count > 1

--- a/app/models/transition_note.rb
+++ b/app/models/transition_note.rb
@@ -4,4 +4,15 @@ class TransitionNote < ApplicationRecord
 
   validates :educator, presence: true
   validates :student, presence: true
+
+  validate :just_two_per_student
+
+  def just_two_per_student
+    if student.transition_notes.count > 1
+      errors.add(
+        :student, 'cannot have more than two transition notes (one regular, one restricted)'
+      )
+    end
+  end
+
 end


### PR DESCRIPTION
# Who is this PR for?

K-8 Counselors taking transition notes. 

# What problem does this PR fix?

During user feedback, Les mentioned that he'd have to remind some of the counselors to "hit" save, otherwise they'd lose all their work. He suggested that autosaving would make the process easier. 

# What does this PR do?

+ Implements autosaving for the Transition Note typing flow.
+ Fixes bug with saving

# GIF 

![current-code](https://user-images.githubusercontent.com/3209501/40863136-69da8424-65b4-11e8-8837-6de7b3d1c993.gif)
