### PR TITLE
Performance optimizations for querying for educator authorizations

### DIFF
--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -20,17 +20,19 @@ module Admin
     end
 
     def authorization
+      @all_educators = Educator.all
+      
       @districtwide_educators = []
       @can_set_educators = []
       @admin_educators = []
       @restricted_notes_educators = []
-      Educator.all.each do |educator|
+    
+      @all_educators.each do |educator|
         @districtwide_educators << educator if educator.districtwide_access
         @can_set_educators << educator if educator.can_set_districtwide_access
         @admin_educators << educator if educator.admin
         @restricted_notes_educators << educator if educator.can_view_restricted_notes
       end
-      @all_educators = Educator.all
       render layout: false
     end
 

--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -21,12 +21,12 @@ module Admin
 
     def authorization
       @all_educators = Educator.all
-      
+
       @districtwide_educators = []
       @can_set_educators = []
       @admin_educators = []
       @restricted_notes_educators = []
-    
+
       @all_educators.each do |educator|
         @districtwide_educators << educator if educator.districtwide_access
         @can_set_educators << educator if educator.can_set_districtwide_access

--- a/app/lib/class_list_queries.rb
+++ b/app/lib/class_list_queries.rb
@@ -50,10 +50,7 @@ class ClassListQueries
 
   # Is this feature relevant for them at all?
   def is_relevant_for_educator?
-    supported_schools.each do |school|
-      return true if authorized_grade_levels(school.id).size > 0
-    end
-    false
+    supported_schools.any? {|school| authorized_grade_levels(school.id).size > 0 }
   end
 
   # At a school, what grade levels are they authorized for?
@@ -71,7 +68,7 @@ class ClassListQueries
 
   # What schools are supported?
   def supported_schools
-    School.where(school_type: ['ESMS', 'ES', 'MS'])
+    @supported_schools ||= School.where(school_type: ['ESMS', 'ES', 'MS'])
   end
 
   # This is authorization-aware, and checks authorization for the grade level

--- a/app/lib/perf_test.rb
+++ b/app/lib/perf_test.rb
@@ -1,4 +1,15 @@
 class PerfTest
+  # See ClassListQueries.  This was driven by the view in admin/authorization, running this
+  # across all educators.
+  def self.is_relevant_for_educator?(percentage, options = {})
+    timer = PerfTest.new.run(percentage) do |t, educator|
+      ClassListQueries.new(educator).is_relevant_for_educator?
+    end
+    pp timer.report
+    pp PerfTest::Reporter.new.report(timer.report.group_by {|tuple| tuple[0] })
+    timer
+  end
+
   # For testing the high absences insight
   def self.high_absences(percentage, options = {})
     timer = PerfTest.new.run(percentage) do |t, educator|

--- a/app/views/admin/educators/authorization.html.erb
+++ b/app/views/admin/educators/authorization.html.erb
@@ -51,8 +51,11 @@
       </thead>
       <tbody>
         <%
+          @navbar_links_map = {}
           sorted_educators = @all_educators.sort_by do |educator|
-            PathsForEducator.new(educator).navbar_links.keys
+            navbar_links = PathsForEducator.new(educator).navbar_links
+            @navbar_links_map[educator.id] = navbar_links
+            navbar_links.keys
           end
         %>
         <% sorted_educators.map do |educator| %>
@@ -87,7 +90,7 @@
             <td style="padding: 5px;"><%= link_to educator.full_name, "/educators/view/#{educator.id}" %></td>
             <td style="padding: 5px;"><%= educator.school.try(:name) %></td>
             <td>
-              <% PathsForEducator.new(educator).navbar_links.map do |path, key| %>
+              <% @navbar_links_map[educator.id].map do |path, key| %>
                 <%= link_to path, key %>
               <% end %>
             </td>


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
The "Educator permissions: overview" link has been broken since shipping the class list links.  This is because this page sorts based on the navbar links shown to each user, and the change to check whether to show the class list link made this significantly slower to do across all users.

# What does this PR do?
Speeds this up.  This is the data on the new `PerfTest` method here, running on 1% of educators:

```
# before
ALL_FOR_EDUCATOR, sample size: 98
  all_for_educator          median: 137ms   p95: 201ms

# after
ALL_FOR_EDUCATOR, sample size: 98
  all_for_educator          median: 6ms   p95: 36ms
```