### PR TITLE
Add invalid grade to student grade validation

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -322,6 +322,6 @@ class Student < ActiveRecord::Base
   end
 
   def validate_grade
-    errors.add(:grade, "must be a valid grade") unless grade.in?(VALID_GRADES)
+    errors.add(:grade, "invalid grade: #{grade}") unless grade.in?(VALID_GRADES)
   end
 end

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -285,4 +285,14 @@ RSpec.describe Student do
 
   end
 
+  describe '#validate_grade' do
+    it 'prevents and prints out invalid grades' do
+      student = FactoryBot.create(:student)
+      was_successful = student.update(grade: 'foo')
+      expect(was_successful).to eq false
+      expect(student.errors.details).to eq({
+        grade: [{:error=>"invalid grade: foo"}]
+      })
+    end
+  end
 end


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Make it easier to see why a grade validation fails.

# What does this PR do?
Adds in the invalid grade value to the validation error message.
