### PR TITLE
Improve Transition Note autosaving UX

### DIFF
--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -58,7 +58,7 @@ class TransitionNotes extends React.Component {
       restrictedNoteAutosaveStatus: null,
     };
 
-    const throttleOptions = {leading: true, trailing: true};
+    const throttleOptions = {leading: false, trailing: true};
 
     this.autosaveRegularNote = _.throttle(this.autosaveRegularNote.bind(this), 3000, throttleOptions);
     this.autosaveRestrictedNote = _.throttle(this.autosaveRestrictedNote.bind(this), 3000, throttleOptions);

--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -60,8 +60,8 @@ class TransitionNotes extends React.Component {
 
     const throttleOptions = {leading: false, trailing: true};
 
-    this.autosaveRegularNote = _.throttle(this.autosaveRegularNote.bind(this), 3000, throttleOptions);
-    this.autosaveRestrictedNote = _.throttle(this.autosaveRestrictedNote.bind(this), 3000, throttleOptions);
+    this.autosaveRegularNote = _.throttle(this.autosaveRegularNote.bind(this), 1000, throttleOptions);
+    this.autosaveRestrictedNote = _.throttle(this.autosaveRestrictedNote.bind(this), 1000, throttleOptions);
 
     this.onChangeRegularNote = this.onChangeRegularNote.bind(this);
     this.onChangeRestrictedNote = this.onChangeRestrictedNote.bind(this);

--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -54,8 +54,6 @@ class TransitionNotes extends React.Component {
     this.state = {
       noteText: (regularNote ? regularNote.text : notePrompts),
       restrictedNoteText: (restrictedNote ? restrictedNote.text : restrictedNotePrompts),
-      regularNoteAutosaveStatus: null,
-      restrictedNoteAutosaveStatus: null,
     };
 
     const throttleOptions = {leading: false, trailing: true};
@@ -65,39 +63,6 @@ class TransitionNotes extends React.Component {
 
     this.onChangeRegularNote = this.onChangeRegularNote.bind(this);
     this.onChangeRestrictedNote = this.onChangeRestrictedNote.bind(this);
-  }
-
-  // Note on componentWillReceiveProps:
-  // This method will be deprecated in React 16.3. But we're still using
-  // React 15.4 in Insights, and have some legacy-cleanup work to finish
-  // til we can migrate to 16. Noting that this func will have to be refactored.
-
-  // When the user types into the Transition Note textarea, the server
-  // handles autosaving very quickly. In fact, so fast that in the "pending" state,
-  // the status text is barely readable when it's supposed to say "Autosaving..."
-
-  // This code adds a delay so that the text that says "Autosaving..."
-  // can hang for  2 seconds to let the user read it.
-  componentWillReceiveProps(newProps) {
-    if (newProps.requestState !== this.props.requestState) {
-      if (this.props.requestState === 'pending') {
-        setTimeout(() => {
-          this.setState({regularNoteAutosaveStatus: newProps.requestState});
-        }, 2000);
-      } else {
-        this.setState({regularNoteAutosaveStatus: newProps.requestState});
-      }
-    }
-
-    if (newProps.requestStateRestricted !== this.props.requestStateRestricted) {
-      if (this.props.requestStateRestricted == 'pending') {
-        setTimeout(() => {
-          this.setState({restrictedNoteAutosaveStatus: newProps.requestStateRestricted});
-        }, 2000);
-      } else {
-        this.setState({restrictedNoteAutosaveStatus: newProps.requestStateRestricted});
-      }
-    }
   }
 
   autosaveRegularNote() {
@@ -133,7 +98,7 @@ class TransitionNotes extends React.Component {
   autosaveStatusText(status) {
     if (status === 'saved') return 'Saved.';
 
-    if (status === 'pending') return 'Autosaving ...';
+    if (status === 'pending') return 'Saving...';
 
     if (status === 'error') return 'There was an error autosaving this note.';
 
@@ -164,7 +129,7 @@ class TransitionNotes extends React.Component {
             onChange={this.onChangeRegularNote}
             readOnly={readOnly} />
           <div style={{color: 'gray'}}>
-            {this.autosaveStatusText(this.state.regularNoteAutosaveStatus)}
+            {this.autosaveStatusText(this.props.requestState)}
           </div>
         </div>
         <div style={{flex: 1, margin: 30}}>
@@ -178,7 +143,7 @@ class TransitionNotes extends React.Component {
             onChange={this.onChangeRestrictedNote}
             readOnly={readOnly} />
           <div style={{color: 'gray'}}>
-            {this.autosaveStatusText(this.state.restrictedNoteAutosaveStatus)}
+            {this.autosaveStatusText(this.props.requestStateRestricted)}
           </div>
         </div>
       </div>

--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -115,6 +115,7 @@ class TransitionNotes extends React.Component {
 
   render() {
     const {noteText, restrictedNoteText, readOnly} = this.state;
+    const {requestState, requestStateRestricted} = this.props;
 
     return (
       <div style={{display: 'flex'}}>
@@ -129,7 +130,7 @@ class TransitionNotes extends React.Component {
             onChange={this.onChangeRegularNote}
             readOnly={readOnly} />
           <div style={{color: 'gray'}}>
-            {this.autosaveStatusText(this.props.requestState)}
+            {this.autosaveStatusText(requestState)}
           </div>
         </div>
         <div style={{flex: 1, margin: 30}}>
@@ -143,7 +144,7 @@ class TransitionNotes extends React.Component {
             onChange={this.onChangeRestrictedNote}
             readOnly={readOnly} />
           <div style={{color: 'gray'}}>
-            {this.autosaveStatusText(this.props.requestStateRestricted)}
+            {this.autosaveStatusText(requestStateRestricted)}
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Who is this PR for?

Les and the other K8 Counselor-Educators who will use the transition note feature. 

# What problem does this PR fix?

Current autosave feature has a bug. Bug report from Les: 

> "Noticed that the AutoSave (Caching/Refresh Rates) has a small glitch. When typing a more rapid rate keystrokes are being missed as the auto save is happening. The little message/indicator is how I noticed this."

Here's a GIF where I reproduce my interpretation of this bug report locally: 

![the-bug](https://user-images.githubusercontent.com/3209501/40931535-0d6f851a-67f1-11e8-96ef-b117602e816d.gif)

Here's my understanding of this bug: the autosaving user interface shows "Saved!" at the same time as requests are being sent off to the server to save the rest of a user's input. So the user feels free to exit, but some of their work remains unsaved.

Why does this happen? The current code sets both `{leading: true, trailing: true}` for the lodash `_.throttle`. This means  that API requests are being fired off as soon as the user types the first letter into the `<textarea>`. This causes something like this to happen:

```
- user presses key: "A"
- send request out to the network with body: "A"
- user presses keys: "bracadbra!"
- network responds to the original request, says "Saved!"
- user thinks that the network is saying "Saved! to "Abracadbra!", but network only processed "A"
```

This kind of mis-syncing between UI and server states is exacerbated by two other choices I made:

+ Delaying the text status to make it hang on "Autosaving..." for a longer amount of time, in order to make transitions appear smoother for the user
+ Setting a high throttle wait period of 3 seconds in order to make things easier on the serve

# What does this PR do?

+ Changes lodash options to `{leading: false, trailing: true}`
+ Reduces throttle wait timing to 1000ms (1 second)
+ Removes the custom "delay" code I wrote
+ Make the status text say `"Saving..."` instead of `"Autosaving..."` when in a pending state; this reduces the amount of visual "jumping" when the request is handled quickly, since most of the letters in the status text stay the same.

# GIF

![the-fix](https://user-images.githubusercontent.com/3209501/40932187-20bff6ca-67f3-11e8-98a0-3c15a47885d4.gif)
