### PR TITLE
Fix cursor jumping bug by wrapping Transition Note textarea

### DIFF
--- a/app/assets/javascripts/student_profile/TransitionNoteTextbox.js
+++ b/app/assets/javascripts/student_profile/TransitionNoteTextbox.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const styles = {
+  textarea: {
+    marginTop: 20,
+    fontSize: 14,
+    border: '4px solid rgba(153,117,185, 0.4)',
+    width: '100%'
+  }
+};
+
+class TransitionNoteTextbox extends React.Component {
+
+  render() {
+    const {value, onChange, readOnly} = this.props;
+
+    return (
+      <textarea
+        rows={10}
+        style={styles.textarea}
+        value={value}
+        onChange={onChange}
+        readOnly={readOnly}
+      />
+    );
+  }
+
+}
+
+TransitionNoteTextbox.propTypes = {
+  readOnly: PropTypes.bool.isRequired,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+export default TransitionNoteTextbox;
+

--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -2,15 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import SectionHeading from '../components/SectionHeading';
 import _ from 'lodash';
-
-const styles = {
-  textarea: {
-    marginTop: 20,
-    fontSize: 14,
-    border: '4px solid rgba(153,117,185, 0.4)',
-    width: '100%'
-  }
-};
+import TransitionNoteTextbox from './TransitionNoteTextbox';
 
 const notePrompts = `What are this student's strengths?
 ——————————
@@ -114,8 +106,8 @@ class TransitionNotes extends React.Component {
   }
 
   render() {
-    const {noteText, restrictedNoteText, readOnly} = this.state;
-    const {requestState, requestStateRestricted} = this.props;
+    const {noteText, restrictedNoteText} = this.state;
+    const {requestState, requestStateRestricted, readOnly} = this.props;
 
     return (
       <div style={{display: 'flex'}}>
@@ -123,12 +115,11 @@ class TransitionNotes extends React.Component {
           <SectionHeading>
             High School Transition Note
           </SectionHeading>
-          <textarea
-            rows={10}
-            style={styles.textarea}
+          <TransitionNoteTextbox
             value={noteText}
             onChange={this.onChangeRegularNote}
-            readOnly={readOnly} />
+            readOnly={readOnly}
+          />
           <div style={{color: 'gray'}}>
             {this.autosaveStatusText(requestState)}
           </div>
@@ -137,12 +128,11 @@ class TransitionNotes extends React.Component {
           <SectionHeading>
             High School Transition Note (Restricted)
           </SectionHeading>
-          <textarea
-            rows={10}
-            style={styles.textarea}
+          <TransitionNoteTextbox
             value={restrictedNoteText}
             onChange={this.onChangeRestrictedNote}
-            readOnly={readOnly} />
+            readOnly={readOnly}
+          />
           <div style={{color: 'gray'}}>
             {this.autosaveStatusText(requestStateRestricted)}
           </div>


### PR DESCRIPTION
# Who is this PR for?

Les and the other K8 Counselor-Educators who will use the transition note feature.

# What problem does this PR fix?

Cursor jumps to the end of the Transition Note textbox while user typing. 

My theory is that this happens when the server responds to a POST request from the client, updating its props. This forces re-render, which loses cursor position of inputs. 

# What does this PR do?

Wraps the textarea in question in its own component. My theory here is that the textarea inputs won't lose their cursor position if they're wrapped in a component this way. 

Why? The TransitionNoteTextbox.js component has three props. Two of them should never change (`readOnly` and `onChange`). The `value` prop is governed by the state of the parent component, which in turn is governed by user input. 

None of these props change when the server responds to the client's POST request: the state and props values that change, like `requestState`, and `requestStateRestricted`, aren't passed down to this lower-level component. 