### PR TITLE
Back out autosaving feature from Transition Notes

### DIFF
--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -124,7 +124,6 @@ class TransitionNotes extends React.Component {
 
   render() {
     const {noteText, restrictedNoteText, readOnly} = this.state;
-    const {requestState, requestStateRestricted} = this.props;
 
     return (
       <div style={{display: 'flex'}}>

--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -56,16 +56,33 @@ class TransitionNotes extends React.Component {
       restrictedNoteText: (restrictedNote ? restrictedNote.text : restrictedNotePrompts),
     };
 
-    const throttleOptions = {leading: false, trailing: true};
-
-    this.autosaveRegularNote = _.throttle(this.autosaveRegularNote.bind(this), 1000, throttleOptions);
-    this.autosaveRestrictedNote = _.throttle(this.autosaveRestrictedNote.bind(this), 1000, throttleOptions);
-
-    this.onChangeRegularNote = this.onChangeRegularNote.bind(this);
-    this.onChangeRestrictedNote = this.onChangeRestrictedNote.bind(this);
+    this.onClickSave = this.onClickSave.bind(this);
+    this.onClickSaveRestricted = this.onClickSaveRestricted.bind(this);
+    this.buttonText = this.buttonText.bind(this);
+    this.buttonTextRestricted = this.buttonTextRestricted.bind(this);
   }
 
-  autosaveRegularNote() {
+  buttonText() {
+    const {requestState} = this.props;
+
+    if (requestState === 'pending') return 'Saving ...';
+
+    if (requestState === 'error') return 'Error ...';
+
+    return 'Save Note';
+  }
+
+  buttonTextRestricted() {
+    const {requestStateRestricted} = this.props;
+
+    if (requestStateRestricted === 'pending') return 'Saving ...';
+
+    if (requestStateRestricted === 'error') return 'Error ...';
+
+    return 'Save Note';
+  }
+
+  onClickSave() {
     const {transitionNotes} = this.props;
     const regularNote = _.find(transitionNotes, {is_restricted: false});
     const regularNoteId = (regularNote) ? regularNote.id : null;
@@ -80,7 +97,7 @@ class TransitionNotes extends React.Component {
     this.props.onSave(params);
   }
 
-  autosaveRestrictedNote() {
+  onClickSaveRestricted() {
     const {transitionNotes} = this.props;
     const restrictedNote = _.find(transitionNotes, {is_restricted: true});
     const restrictedNoteId = (restrictedNote) ? restrictedNote.id : null;
@@ -95,22 +112,12 @@ class TransitionNotes extends React.Component {
     this.props.onSave(params);
   }
 
-  autosaveStatusText(status) {
-    if (status === 'saved') return 'Saved.';
-
-    if (status === 'pending') return 'Saving...';
-
-    if (status === 'error') return 'There was an error autosaving this note.';
-
-    return 'This note will autosave as you type.';
-  }
-
   onChangeRegularNote(e) {
-    this.setState({noteText: e.target.value}, () => {this.autosaveRegularNote();});
+    this.setState({noteText: e.target.value});
   }
 
   onChangeRestrictedNote(e) {
-    this.setState({restrictedNoteText: e.target.value}, () => {this.autosaveRestrictedNote();});
+    this.setState({restrictedNoteText: e.target.value});
   }
 
   render() {
@@ -129,9 +136,7 @@ class TransitionNotes extends React.Component {
             value={noteText}
             onChange={this.onChangeRegularNote}
             readOnly={readOnly} />
-          <div style={{color: 'gray'}}>
-            {this.autosaveStatusText(requestState)}
-          </div>
+          {this.renderButton(this.onClickSave, this.buttonText)}
         </div>
         <div style={{flex: 1, margin: 30}}>
           <SectionHeading>
@@ -143,9 +148,7 @@ class TransitionNotes extends React.Component {
             value={restrictedNoteText}
             onChange={this.onChangeRestrictedNote}
             readOnly={readOnly} />
-          <div style={{color: 'gray'}}>
-            {this.autosaveStatusText(requestStateRestricted)}
-          </div>
+          {this.renderButton(this.onClickSaveRestricted, this.buttonTextRestricted)}
         </div>
       </div>
     );

--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -58,6 +58,8 @@ class TransitionNotes extends React.Component {
 
     this.onClickSave = this.onClickSave.bind(this);
     this.onClickSaveRestricted = this.onClickSaveRestricted.bind(this);
+    this.onChangeRegularNote = this.onChangeRegularNote.bind(this);
+    this.onChangeRestrictedNote = this.onChangeRestrictedNote.bind(this);
     this.buttonText = this.buttonText.bind(this);
     this.buttonTextRestricted = this.buttonTextRestricted.bind(this);
   }
@@ -151,6 +153,18 @@ class TransitionNotes extends React.Component {
           {this.renderButton(this.onClickSaveRestricted, this.buttonTextRestricted)}
         </div>
       </div>
+    );
+  }
+
+  renderButton(onClickFn, buttonTextFn) {
+    const {readOnly} = this.props;
+
+    if (readOnly) return null;
+
+    return (
+      <button onClick={onClickFn} className='btn save'>
+        {buttonTextFn()}
+      </button>
     );
   }
 


### PR DESCRIPTION
# Who is this PR for?

K8-Counselors. 

# What problem does this PR fix?

Autosaving was not good/usable in Internet Explorer; see #1762. Reverting back to a healthy state.

# What does this PR do?

Removes the autosaving.

# Screenshot (if adding a client-side feature)

![saving](https://user-images.githubusercontent.com/3209501/41001026-ce30e32e-68dd-11e8-8545-5330f3ce4e14.gif)
