### PR TITLE
Remove line breaks from transition note prompts

### DIFF
--- a/app/assets/javascripts/student_profile/TransitionNotes.js
+++ b/app/assets/javascripts/student_profile/TransitionNotes.js
@@ -13,34 +13,18 @@ const styles = {
 };
 
 const notePrompts = `What are this student's strengths?
-——————————
-
 
 What is this student's involvement in the school community like?
-——————————
-
 
 How does this student relate to their peers?
-——————————
-
 
 Who is the student's primary guardian?
-——————————
 
-
-Any additional comments or good things to know about this student?
-——————————
-
-
-`;
+Any additional comments or good things to know about this student?`;
 
 const restrictedNotePrompts = `Is this student receiving Social Services and if so, what is the name and contact info of their social worker?
-——————————
 
-
-Is this student receiving mental health supports?
-——————————
-  `;
+Is this student receiving mental health supports?`;
 
 class TransitionNotes extends React.Component {
 


### PR DESCRIPTION
# Who is this PR for?

K8 Counselor Educators.

# What problem does this PR fix?

The manual line breaks I added between prompts are confusing and ugly for users. 

# What does this PR do?

Removes the line breaks so that we see only the prompts. 

# Screenshot (if adding a client-side feature)
![screen shot 2018-06-06 at 10 36 51 am](https://user-images.githubusercontent.com/3209501/41045133-bb769718-6975-11e8-802c-e0c36110f353.png)
