### PR TITLE
Classrooms: Add validation check for duplicate teacher names when exporting

### DIFF
--- a/app/assets/javascripts/class_lists/ExportList.js
+++ b/app/assets/javascripts/class_lists/ExportList.js
@@ -54,9 +54,13 @@ export default class ExportList extends React.Component {
 
   onRoomTeacherChanged(roomKey, option) {
     const {principalTeacherNamesByRoom, onPrincipalTeacherNamesByRoomChanged} = this.props;
+    const teacherName = (option === null) ? '' : option.name;
+    if ((teacherName !== '') && _.include(principalTeacherNamesByRoom, teacherName)) {
+      return alert('Duplicate teacher name.');
+    }
     onPrincipalTeacherNamesByRoomChanged({
       ...principalTeacherNamesByRoom,
-      [roomKey]: (option === null) ? '' : option.name
+      [roomKey]: (option === null) ? '' : teacherName
     });
   }
 


### PR DESCRIPTION
# Who is this PR for?
K-5 principals, part of https://github.com/studentinsights/studentinsights/issues/1722.

# What problem does this PR fix?
Adds validation if duplicate teacher names on export.
