### PR TITLE
Remove educator full_name validation

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -14,7 +14,6 @@ class Educator < ActiveRecord::Base
   has_many    :educator_labels
 
   validates :email, presence: true, uniqueness: true, case_sensitive: false
-  validates :full_name, presence: true, uniqueness: true, case_sensitive: false
 
   validate :validate_has_school_unless_districtwide,
            :validate_admin_gets_access_to_all_students,


### PR DESCRIPTION
# Who is this PR for?
developers, follow-on to https://github.com/studentinsights/studentinsights/pull/1755

# What problem does this PR fix?
There are several duplicates for Somerville, all related to name changes and revealing that we don't handle this during import.  Backing out the validation for now, since it's not as trivial to patch manually and it's not helpful to alert on this every night until we improve this.

# What does this PR do?
Removes the validation