### PR TITLE
Add additional steps for character encoding and escaping in CSV files

### DIFF
--- a/app/importers/data_transformers/csv_transformer.rb
+++ b/app/importers/data_transformers/csv_transformer.rb
@@ -11,7 +11,7 @@ class CsvTransformer
 
   # Performs whole-file transformations first
   def transform(csv_string)
-    cleaned_contents = ParseableCsvString.new(@log).parseable_string_from_string(csv_string)
+    cleaned_contents = ParseableCsvString.new(@log).from_string(csv_string)
 
     csv = CSV.parse(cleaned_contents, headers: @headers,
                           header_converters: :symbol,

--- a/app/importers/data_transformers/csv_transformer.rb
+++ b/app/importers/data_transformers/csv_transformer.rb
@@ -4,19 +4,14 @@ class CsvTransformer
 
   attr_accessor :pre_cleanup_csv_size
 
-  def initialize(options={})
+  def initialize(log, options={})
+    @log = log
     @headers=options.key?(:headers) ? options[:headers] : true
   end
 
   # Performs whole-file transformations first
-  # Enforce UTF8 encoding and
-  # Replace \" within fields to just ", to satisfy the strict Ruby CSV parser
   def transform(csv_string)
-    cleaned_contents = csv_string.encode('UTF-8', 'binary', {
-      invalid: :replace,
-      undef: :replace,
-      replace: ''
-    }).gsub("\\\"", "")
+    cleaned_contents = ParseableCsvString.new(@log).parseable_string_from_string(csv_string)
 
     csv = CSV.parse(cleaned_contents, headers: @headers,
                           header_converters: :symbol,

--- a/app/importers/data_transformers/parseable_csv_string.rb
+++ b/app/importers/data_transformers/parseable_csv_string.rb
@@ -1,0 +1,98 @@
+require 'csv'
+
+# This class handles encoding issues with CSV strings, and other
+# character translations, returning a UTF-8 string that should
+# be able to be parsed by CSV#parse.
+class ParseableCsvString
+  def initialize(log)
+    @log = log
+  end
+
+  def from_filename(filename)
+    parseable_string_from_string(read(filename))
+  end
+
+  def from_string(raw_file_contents)
+    raw_file_contents = read(filename)
+    encoded_string = encode_as_utf8(raw_file_contents)
+    string_without_quotes = convert_quotes(encoded_string)
+    strip_inline_newlines(string_without_quotes)
+  end
+
+  private
+  # Read as a raw binary encoded string
+  def read(filename)
+    @log.puts '#read...'
+    File.open(filename, 'r:ASCII-8BIT', &:read)
+  end
+
+  # Encode as UTF-8 and handle invalid character encodings
+  def encode_as_utf8(raw_file_contents)
+    @log.puts '#encode_as_utf8...'
+
+    # track encoding failures and handle some
+    failed_encoding_count = 0
+    replaced_encoding_count = 0
+    failed_encodings = []
+    encoding_fallback = Proc.new do |invalid|
+      converted_value = map_invalid_encoding(invalid)
+      if converted_value.nil?
+        failed_encodings << invalid
+        failed_encoding_count = failed_encoding_count + 1
+        ''
+      else
+        replaced_encoding_count = replaced_encoding_count + 1
+        converted_value
+      end
+    end
+
+    # do the encoding
+    encoded = raw_file_contents.encode('UTF-8', 'binary', fallback: encoding_fallback)
+    if replaced_encoding_count > 0
+      @log.puts "  converted #{replaced_encoding_count} known invalid character encodings"
+    end
+    if failed_encoding_count > 0
+      @log.puts "  failed to convert #{failed_encoding_count} unexpected invalid character encodings for #{failed_encodings.uniq}"
+    end
+
+    encoded
+  end
+
+  # These are the known invalid encodings, and manual translations to UTF-8 encodings.
+  def map_invalid_encoding(invalid_encoding)
+    {
+      "\xE9".force_encoding('ASCII-8BIT') => 'é',
+      "\x92".force_encoding('ASCII-8BIT') => '’'
+    }[invalid_encoding]
+  end
+
+  # Replace \" within fields to just ", to satisfy the strict Ruby CSV parser
+  def convert_quotes(string)
+    @log.puts '#convert_quotes...'
+
+    quotes_converted_count = 0
+    string_without_quotes = string.gsub("\\\"") do |match|
+      quotes_converted_count = quotes_converted_count + 1
+       '""'
+    end
+
+    @log.puts "  stripped #{quotes_converted_count} quotes."
+    string_without_quotes
+  end
+
+  # Find newlines within quotes fields (\\\r\n) and replace them with spaces, since
+  # the Ruby CSV class can't understand that they're within the field and interpret them as a
+  # broken line that hasn't close the quote.
+  def strip_inline_newlines(string)
+    @log.puts '#strip_inline_newlines...'
+
+    newlines_stripped_count = 0
+    string_without_inline_newlines = string.gsub(/\\\r\n/) do |match|
+      newlines_stripped_count = newlines_stripped_count + 1
+      " "
+    end
+
+    @log.puts "  stripped #{newlines_stripped_count} newlines."
+    string_without_inline_newlines
+  end
+end

--- a/app/importers/data_transformers/parseable_csv_string.rb
+++ b/app/importers/data_transformers/parseable_csv_string.rb
@@ -9,11 +9,10 @@ class ParseableCsvString
   end
 
   def from_filename(filename)
-    parseable_string_from_string(read(filename))
+    from_string(read(filename))
   end
 
   def from_string(raw_file_contents)
-    raw_file_contents = read(filename)
     encoded_string = encode_as_utf8(raw_file_contents)
     string_without_quotes = convert_quotes(encoded_string)
     strip_inline_newlines(string_without_quotes)

--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -38,7 +38,7 @@ class AttendanceImporter
   end
 
   def data_transformer
-    StreamingCsvTransformer.new
+    StreamingCsvTransformer.new(@log)
   end
 
   def filter

--- a/app/importers/file_importers/behavior_importer.rb
+++ b/app/importers/file_importers/behavior_importer.rb
@@ -37,7 +37,7 @@ class BehaviorImporter
   end
 
   def data_transformer
-    CsvTransformer.new
+    CsvTransformer.new(@log)
   end
 
   def filter

--- a/app/importers/file_importers/courses_sections_importer.rb
+++ b/app/importers/file_importers/courses_sections_importer.rb
@@ -26,7 +26,7 @@ class CoursesSectionsImporter
   end
 
   def data_transformer
-    CsvTransformer.new
+    CsvTransformer.new(@log)
   end
 
   def filter

--- a/app/importers/file_importers/educator_section_assignments_importer.rb
+++ b/app/importers/file_importers/educator_section_assignments_importer.rb
@@ -31,7 +31,7 @@ class EducatorSectionAssignmentsImporter
   end
 
   def data_transformer
-    CsvTransformer.new
+    CsvTransformer.new(@log)
   end
 
   def filter

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -26,7 +26,7 @@ class EducatorsImporter
   end
 
   def data_transformer
-    CsvTransformer.new
+    CsvTransformer.new(@log)
   end
 
   def filter

--- a/app/importers/file_importers/streaming_csv_transformer.rb
+++ b/app/importers/file_importers/streaming_csv_transformer.rb
@@ -6,23 +6,18 @@ require 'csv'
 class StreamingCsvTransformer
   NIL_CODE = '\N'
 
-  def initialize(options = {})
+  def initialize(log, options = {})
+    @log = log
     @headers = options.key?(:headers) ? options[:headers] : true
     @total_rows_count = nil
     @processed_rows_count = nil
   end
 
   # Performs whole-file transformations first
-  # Enforce UTF8 encoding and
-  # Replace \" within fields to just ", to satisfy the strict Ruby CSV parser
   # This method returns itself, satisfying the {each_with_index, size} inteface for
   # iterating over CSV rows.
   def transform(csv_string)
-    @csv_string = csv_string.encode('UTF-8', 'binary', {
-      invalid: :replace,
-      undef: :replace,
-      replace: ''
-    }).gsub("\\\"", "")
+    @csv_string = ParseableCsvReader.new(@log).from_string(csv_string)
     self
   end
 

--- a/app/importers/file_importers/streaming_csv_transformer.rb
+++ b/app/importers/file_importers/streaming_csv_transformer.rb
@@ -17,7 +17,7 @@ class StreamingCsvTransformer
   # This method returns itself, satisfying the {each_with_index, size} inteface for
   # iterating over CSV rows.
   def transform(csv_string)
-    @csv_string = ParseableCsvReader.new(@log).from_string(csv_string)
+    @csv_string = ParseableCsvString.new(@log).from_string(csv_string)
     self
   end
 

--- a/app/importers/file_importers/student_section_assignments_importer.rb
+++ b/app/importers/file_importers/student_section_assignments_importer.rb
@@ -31,7 +31,7 @@ class StudentSectionAssignmentsImporter
   end
 
   def data_transformer
-    CsvTransformer.new
+    CsvTransformer.new(@log)
   end
 
   def filter

--- a/app/importers/file_importers/student_section_grades_importer.rb
+++ b/app/importers/file_importers/student_section_grades_importer.rb
@@ -50,7 +50,7 @@ class StudentSectionGradesImporter
   end
 
   def data_transformer
-    CsvTransformer.new(headers: CSV_HEADERS)
+    CsvTransformer.new(@log, headers: CSV_HEADERS)
   end
 
   def filter

--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -26,7 +26,7 @@ class StudentsImporter
   end
 
   def data_transformer
-    CsvTransformer.new
+    CsvTransformer.new(@log)
   end
 
   def filter

--- a/app/importers/file_importers/x2_assessment_importer.rb
+++ b/app/importers/file_importers/x2_assessment_importer.rb
@@ -28,7 +28,7 @@ class X2AssessmentImporter
   end
 
   def data_transformer
-    CsvTransformer.new
+    CsvTransformer.new(@log)
   end
 
   def filter

--- a/spec/importers/data_transformers/csv_transformer_spec.rb
+++ b/spec/importers/data_transformers/csv_transformer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CsvTransformer do
   describe '#transform' do
     context 'tracks total and processed rows' do
       let!(:csv_string) { File.read("#{Rails.root}/spec/fixtures/fake_behavior_export.txt") }
-      let(:transformer) { CsvTransformer.new }
+      let(:transformer) { CsvTransformer.new(LogHelper::FakeLog.new) }
 
       it '#size and #pre_cleanup_csv_size filter out row with bad date' do
         output = transformer.transform(csv_string)
@@ -16,7 +16,7 @@ RSpec.describe CsvTransformer do
 
     context 'headers in csv' do
       let!(:csv_string) { File.read("#{Rails.root}/spec/fixtures/fake_behavior_export.txt") }
-      let(:transformer) { CsvTransformer.new }
+      let(:transformer) { CsvTransformer.new(LogHelper::FakeLog.new) }
       let(:output) { transformer.transform(csv_string) }
 
       it '#each_with_index' do
@@ -42,7 +42,7 @@ RSpec.describe CsvTransformer do
     context 'headers not in csv' do
       let!(:csv_string) { File.read("#{Rails.root}/spec/fixtures/fake_no_headers.csv") }
       let(:headers) {["section_number","student_local_id","school_local_id","course_number","term_local_id","grade"]}
-      let(:transformer) { CsvTransformer.new(headers: headers) }
+      let(:transformer) { CsvTransformer.new(LogHelper::FakeLog.new, headers: headers) }
       let(:output) { transformer.transform(csv_string) }
 
       it '#size' do

--- a/spec/importers/data_transformers/parseable_csv_string_spec.rb
+++ b/spec/importers/data_transformers/parseable_csv_string_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe ParseableCsvString do
+  def parseable_string_from(string)
+    log = LogHelper::FakeLog.new
+    parseable_string = ParseableCsvString.new(log).from_string(string)
+    [log, parseable_string]
+  end
+
+  describe 'encoding' do
+    it 'translates encoding' do
+      test_string = '"hi",\N,"bye"'.force_encoding('ASCII-8BIT')
+      log, parseable_string = parseable_string_from(test_string)
+
+      expect(parseable_string.encoding.name).to eq 'UTF-8'
+      expect(log.output).to include('stripped 0 quotes')
+      expect(log.output).to include('stripped 0 newlines')
+      expect(log.output).not_to include ('invalid character')
+      expect(parseable_string).to eq '"hi",\N,"bye"'
+    end
+
+    it 'translates encoding with know invalid characters' do
+      test_string = "\"hi\",\N,\"eating at sam\x92s caf\xE9\"".force_encoding('ASCII-8BIT')
+      log, parseable_string = parseable_string_from(test_string)
+
+      expect(parseable_string.encoding.name).to eq 'UTF-8'
+      expect(log.output).to include ('converted 2 known invalid character encodings')
+      expect(parseable_string).to eq "\"hi\",\N,\"eating at sam’s café\""
+    end
+
+    it 'warns and strips unknown invalid characters' do
+      test_string = "\"hi\",\N,\"eating s\xF2mething\"".force_encoding('ASCII-8BIT')
+      log, parseable_string = parseable_string_from(test_string)
+
+      expect(parseable_string.encoding.name).to eq 'UTF-8'
+      expect(log.output).to include ('failed to convert 1 unexpected invalid character encodings for ["\xF2"]')
+      expect(parseable_string).to eq "\"hi\",\N,\"eating smething\""
+    end
+  end
+
+  it 'converts invalid quotes' do
+    log, parseable_string = parseable_string_from("\"hi there \\\" person\",\N,\"bye\"")
+
+    expect(log.output).to include('stripped 1 quotes')
+    expect(parseable_string).to eq "\"hi there \"\" person\",\N,\"bye\""
+  end
+
+  it 'converts inline newlines to spaces' do
+    log, parseable_string = parseable_string_from("\"hi there\\\r\n person\",\N,\"bye\"")
+
+    expect(log.output).to include('stripped 1 newline')
+    expect(parseable_string).to eq "\"hi there  person\",\N,\"bye\""
+  end
+end

--- a/spec/importers/data_transformers/streaming_csv_transformer_spec.rb
+++ b/spec/importers/data_transformers/streaming_csv_transformer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe StreamingCsvTransformer do
   describe '#transform' do
     context 'tracks total and processed rows' do
       let!(:csv_string) { File.read("#{Rails.root}/spec/fixtures/fake_behavior_export.txt") }
-      let(:transformer) { StreamingCsvTransformer.new }
+      let(:transformer) { StreamingCsvTransformer.new(LogHelper::FakeLog.new) }
       let(:output) { transformer.transform(csv_string) }
 
       it '#size and #pre_cleanup_csv_size (before iteration)' do
@@ -22,7 +22,7 @@ RSpec.describe StreamingCsvTransformer do
 
     context 'headers in csv' do
       let!(:csv_string) { File.read("#{Rails.root}/spec/fixtures/fake_behavior_export.txt") }
-      let(:transformer) { StreamingCsvTransformer.new }
+      let(:transformer) { StreamingCsvTransformer.new(LogHelper::FakeLog.new) }
       let(:output) { transformer.transform(csv_string) }
 
       it '#each_with_index' do
@@ -48,7 +48,7 @@ RSpec.describe StreamingCsvTransformer do
     context 'headers not in csv' do
       let!(:csv_string) { File.read("#{Rails.root}/spec/fixtures/fake_no_headers.csv") }
       let(:headers) {["section_number","student_local_id","school_local_id","course_number","term_local_id","grade"]}
-      let(:transformer) { StreamingCsvTransformer.new(headers: headers) }
+      let(:transformer) { StreamingCsvTransformer.new(LogHelper::FakeLog.new, headers: headers) }
       let(:output) { transformer.transform(csv_string) }
 
       it '#size' do

--- a/spec/importers/file_importers/students_importer_spec.rb
+++ b/spec/importers/file_importers/students_importer_spec.rb
@@ -1,28 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe StudentsImporter do
-  class FakeLog
-    attr_reader :msgs
-
-    def initialize
-      @msgs = []
-    end
-
-    def puts(msg)
-      @msgs << msg
-    end
-  end
-
+  let(:log) { LogHelper::FakeLog.new }
   let(:students_importer) {
     described_class.new(options: {
-      school_scope: nil, log: FakeLog.new
+      school_scope: nil, log: log
     })
   }
 
   describe '#import_row' do
     context 'good data' do
       let(:file) { File.read("#{Rails.root}/spec/fixtures/fake_students_export.txt") }
-      let(:transformer) { CsvTransformer.new }
+      let(:transformer) { CsvTransformer.new(log) }
       let(:csv) { transformer.transform(file) }
       let(:import) { csv.each { |row| students_importer.import_row(row) } }
       let!(:high_school) { School.create(local_id: 'SHS') }

--- a/spec/importers/file_importers/x2_assessment_importer_spec.rb
+++ b/spec/importers/file_importers/x2_assessment_importer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe X2AssessmentImporter do
       after { Assessment.seed_somerville_assessments }
 
       let(:file) { File.read("#{Rails.root}/spec/fixtures/fake_x2_assessments.csv") }
-      let(:transformer) { CsvTransformer.new }
+      let(:transformer) { CsvTransformer.new(LogHelper::FakeLog.new) }
       let(:csv) { transformer.transform(file) }
 
       context 'for Healey school' do

--- a/spec/support/log_redirect_helper.rb
+++ b/spec/support/log_redirect_helper.rb
@@ -17,6 +17,22 @@ module LogHelper
       @file = File.new(log_path, 'w')
     end
   end
+
+  class FakeLog
+    attr_reader :msgs
+
+    def initialize
+      @msgs = []
+    end
+
+    def puts(msg)
+      @msgs << msg
+    end
+
+    def output
+      @msgs.join("\n")
+    end
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
# Who is this PR for?
Addressing https://github.com/studentinsights/studentinsights/issues/1777.

# What problem does this PR fix?
There are a few issues with character encoding and escaping in the CSV files (for Somerville in particular).  This addresses them and adds them into `StreamingCsvTransformer` and `CsvTransformer`, along with more verbose logging to see what these files are doing.

# What does this PR do?
Adds a `ParseableCsvString` class.  This moves the code handling encoding and non-standard quote escaping into one place, and adds another pass to strip newlines within fields that the Ruby CSV parser can't handle.

# Checklists
+ [x] Author included specs for new code
