### PR TITLE
Flush import logging after each write

### DIFF
--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -174,6 +174,7 @@ class ImportTask
   def log(msg)
     full_msg = "\n\n💾  ImportTask: #{msg}"
     @log.puts full_msg
+    @log.flush # prevent buffering, this seems to be a problem in production jobs
     @record.log += full_msg
     @record.save
   end


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Importer jobs don't seem to have any log output while they're running, and then have a lot all at the same instant if the process dies.  Seems like they are buffering output too much, and makes it hard to debug what's going on.

# What does this PR do?
flush after each log
