### PR TITLE
Avoid collisions on randomly generated educator names being mapped to emails

### DIFF
--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     end
     email do
       last_name, first_name = full_name.split(', ')
-      "#{first_name[0]}#{last_name}@demo.studentinsights.org"
+      "#{first_name}.#{last_name}@demo.studentinsights.org"
     end
     local_id { FactoryBot.generate(:staff_local_id) }
     association :school


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
failures like https://travis-ci.org/studentinsights/studentinsights/builds/390783980?utm_source=email&utm_medium=notification, which I think are from individual test cases that generate a bunch of educator records with random names, and sometimes then generate collisions on email addresses (with had been written as `(first initial, last name)`).  This was introduced with https://github.com/studentinsights/studentinsights/pull/1755.

# What does this PR do?
Changes emails to be `first_name.last_name` for educators made with factories.
