### PR TITLE
Add rake task to get sample of notes for coding

### DIFF
--- a/app/lib/export_notes_sample.rb
+++ b/app/lib/export_notes_sample.rb
@@ -16,44 +16,34 @@ class ExportNotesSample
       csv << []
       csv << [
         'event_note.id',
-        'event_note.text',
-        'event_note.recorded_at',
         'event_note.is_restricted',
-        'event_note.event_note_type_id',
         'event_note.event_note_type.name',
-        'event_note.educator_id',
-        'event_note.educator.full_name',
-        'event_note.educator.email',
-        'event_note.student.id',
-        'event_note.student.first_name',
-        'event_note.student.last_name',
-        'event_note.student.grade',
-        'event_note.student.school_id',
-        'event_note.student.school.name'
+        'event_note.text',
+        'hash(event_note.educator_id)',
+        'hash(event_note.student.id)',
+        'hash(event_note.student.school_id)',
+        'event_note.student.id'
       ]
       sampled_event_notes.each do |event_note|
         csv << [
           event_note.id,
-          event_note.text,
-          event_note.recorded_at,
           event_note.is_restricted,
-          event_note.event_note_type_id,
           event_note.event_note_type.name,
-          event_note.educator_id,
-          event_note.educator.full_name,
-          event_note.educator.email,
-          event_note.student.id,
-          event_note.student.first_name,
-          event_note.student.last_name,
-          event_note.student.grade,
-          event_note.student.school_id,
-          event_note.student.school.name
+          event_note.text.gsub(/\n/, ' '),
+          hash(event_note.educator_id),
+          hash(event_note.student.id),
+          hash(event_note.student.school_id),
+          event_note.student.id
         ]
       end
     end
   end
 
   private
+  def hash(value)
+    Digest::SHA256.hexdigest(value.to_s)
+  end
+
   def query(options = {})
     start_date = options[:start_date]
     end_date = options[:end_date]

--- a/app/lib/export_notes_sample.rb
+++ b/app/lib/export_notes_sample.rb
@@ -1,0 +1,75 @@
+# This is intended for use in a one-off analysis task.
+class ExportNotesSample
+  # This doesn't do any authorization checks.
+  def unsafe_csv_without_authorization_checks(options = {})
+    sampled_event_notes, total_count = query(options)
+
+    CSV.generate do |csv|
+      csv << [
+        'options:',
+        options.inspect,
+        'sampled_event_notes.size:',
+        sampled_event_notes.size,
+        'total_count:',
+        total_count,
+      ]
+      csv << []
+      csv << [
+        'event_note.id',
+        'event_note.text',
+        'event_note.recorded_at',
+        'event_note.is_restricted',
+        'event_note.event_note_type_id',
+        'event_note.event_note_type.name',
+        'event_note.educator_id',
+        'event_note.educator.full_name',
+        'event_note.educator.email',
+        'event_note.student.id',
+        'event_note.student.first_name',
+        'event_note.student.last_name',
+        'event_note.student.grade',
+        'event_note.student.school_id',
+        'event_note.student.school.name'
+      ]
+      sampled_event_notes.each do |event_note|
+        csv << [
+          event_note.id,
+          event_note.text,
+          event_note.recorded_at,
+          event_note.is_restricted,
+          event_note.event_note_type_id,
+          event_note.event_note_type.name,
+          event_note.educator_id,
+          event_note.educator.full_name,
+          event_note.educator.email,
+          event_note.student.id,
+          event_note.student.first_name,
+          event_note.student.last_name,
+          event_note.student.grade,
+          event_note.student.school_id,
+          event_note.student.school.name
+        ]
+      end
+    end
+  end
+
+  private
+  def query(options = {})
+    start_date = options[:start_date]
+    end_date = options[:end_date]
+    n = options[:n]
+    seed = options[:seed]
+
+    # Query in time range
+    event_notes = EventNote.all
+      .where('recorded_at > ?', start_date)
+      .where('recorded_at < ?', end_date
+      .advance(days: 1)).includes(:educator)
+    total_count = event_notes.size
+
+    # Sample within that, deterministically
+    sampled_event_notes = event_notes.sample(n, random: Random.new(seed))
+
+    [sampled_event_notes, total_count]
+  end
+end


### PR DESCRIPTION
# Who is this PR for?
project team

# What problem does this PR fix?
We're curious to code notes on some different dimensions, to help prioritize some further investigation ahead of the next school year.

# What does this PR do?
Adds a rake taks 

# Screenshot (if adding a client-side feature)
```
puts ExportNotesSample.new.unsafe_csv_without_authorization_checks({
  start_date: Time.parse('2018-03-15'),
  end_date: Time.parse('2018-04-15'),
  n: 5,
  seed: 42
})
```

using `n` and `seed` lets you get deterministic samples at whatever size you like.