### PR TITLE
Patch transition note bug with looking at server response

### DIFF
--- a/app/assets/javascripts/student_profile/PageContainer.js
+++ b/app/assets/javascripts/student_profile/PageContainer.js
@@ -166,20 +166,20 @@ export default class PageContainer extends React.Component {
 
     this.setState({ requests: merge(this.state.requests, requestState) });
     this.api.saveTransitionNote(this.state.student.id, noteParams)
-      .done(this.onSaveTransitionNoteDone)
-      .fail(this.onSaveTransitionNoteFail);
+      .done(this.onSaveTransitionNoteDone.bind(this, noteParams))
+      .fail(this.onSaveTransitionNoteFail.bind(this, noteParams));
   }
 
-  onSaveTransitionNoteDone(response) {
-    const requestState = (response.is_restricted)
+  onSaveTransitionNoteDone(noteParams, response) {
+    const requestState = (noteParams.is_restricted)
       ? { saveRestrictedTransitionNote: 'saved' }
       : { saveTransitionNote: 'saved' };
 
     this.setState({ requests: merge(this.state.requests, requestState) });
   }
 
-  onSaveTransitionNoteFail(request, status, message) {
-    const requestState = (request.is_restricted)
+  onSaveTransitionNoteFail(noteParams, request, status, message) {
+    const requestState = (noteParams.is_restricted)
       ? { saveRestrictedTransitionNote: 'error' }
       : { saveTransitionNote: 'error' };
 


### PR DESCRIPTION
This is for merging into https://github.com/studentinsights/studentinsights/pull/1764

# Who is this PR for?
8th grade counselors

# What problem does this PR fix?
"Save" button appears disabled on restricted note after first save.

# What does this PR do?
Updates `PageContainer` to not look at the server response for deciding which note was updated (this data isn't in the response) and instead binds the request params to tell which kind of note this is.
