### PR TITLE
Fix non-deterministic spec

### DIFF
--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -18,7 +18,7 @@ describe HomeroomsController, :type => :controller do
       it 'returns the right shape of data' do
         make_request(educator.homeroom.slug)
         expect(assigns(:rows).length).to eq 1
-        expect(assigns(:rows).first.keys).to eq([
+        expect(assigns(:rows).first.keys).to match_array([
           "id",
           "grade",
           "hispanic_latino",


### PR DESCRIPTION
# Who is this PR for?

Developers.

# What problem does this PR fix?

Fix this spec which fails nondeterministically: 

```
rspec ./spec/controllers/homerooms_controller_spec.rb:18 # HomeroomsController#show happy path returns the right shape of data
```

Travis link: https://travis-ci.org/studentinsights/studentinsights/builds/390922023?utm_source=github_status&utm_medium=notification

# What does this PR do?

Uses the order-agnostic `match_array` matcher. 