### PR TITLE
Minimal change to add counselor to profile page

### DIFF
--- a/app/assets/javascripts/student_profile/StudentProfilePage.js
+++ b/app/assets/javascripts/student_profile/StudentProfilePage.js
@@ -247,6 +247,7 @@ export default class StudentProfilePage extends React.Component {
           }}>
           {this.renderPaddedElements(styles.summaryWrapper, [
             this.renderPlacement(student),
+            this.renderCounselor(student),
             this.renderServices(student),
             this.renderStaff(student),
             this.renderSped(student)
@@ -324,6 +325,16 @@ export default class StudentProfilePage extends React.Component {
     return <SummaryList title="Services" elements={elements} />;
   }
 
+  renderCounselor(student) {
+    const {counselor} = student;
+    if (counselor === null || counselor === undefined) return null;
+    return (
+      <SummaryList
+        title="Counselor"
+        elements={[<span>{counselor}</span>]} />
+    );
+  }
+
   renderStaff(student) {
     const activeServices = this.props.feed.services.active;
     const educatorNamesFromServices = _.map(activeServices, 'provided_by_educator_name');
@@ -343,7 +354,7 @@ export default class StudentProfilePage extends React.Component {
       elements.push(['None']);
     }
 
-    return <SummaryList title="Staff providing services" elements={educatorNames} />;
+    return <SummaryList title="Staff for services" elements={educatorNames} />;
   }
 
   renderSped(student) {

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -143,6 +143,8 @@ class StudentsController < ApplicationController
       school_name: student.try(:school).try(:name),
       school_type: student.try(:school).try(:school_type),
       homeroom_name: student.try(:homeroom).try(:name),
+      house: student.house,
+      counselor: student.counselor,
       discipline_incidents_count: student.most_recent_school_year_discipline_incidents_count,
       restricted_notes_count: student.event_notes.where(is_restricted: true).count,
     }).stringify_keys

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -447,6 +447,8 @@ describe StudentsController, :type => :controller do
         'tardies_count',
         'school_name',
         'homeroom_name',
+        'house',
+        'counselor',
         'discipline_incidents_count'
       ])
     end


### PR DESCRIPTION
# Who is this PR for?
HS classroom teachers

# What problem does this PR fix?
HS teachers can't easily see the counselor.

# What does this PR do?
Adds it minimally to the profile page; this design needs some more love before next fall.

# Screenshot (if adding a client-side feature)
<img width="999" alt="screen shot 2018-06-12 at 6 30 28 pm" src="https://user-images.githubusercontent.com/1056957/41320671-b2925666-6e6e-11e8-8ce7-a050fa58d7b0.png">

