### PR TITLE
Show transition notes only for 8th graders

### DIFF
--- a/app/assets/javascripts/student_profile/StudentProfilePage.js
+++ b/app/assets/javascripts/student_profile/StudentProfilePage.js
@@ -57,12 +57,13 @@ export default class StudentProfilePage extends React.Component {
   }
 
   renderTransitionNote() {
-    const {currentEducator, actions, transitionNotes, requests} = this.props;
+    const {student, currentEducator, actions, transitionNotes, requests} = this.props;
     const labels = currentEducator.labels;
 
     const isElemCounselor = _.includes(labels, 'k8_counselor');
     const isHouseMaster = _.includes(labels, 'high_school_house_master');
 
+    if (student.grade !== '8') return null;
     if (!isElemCounselor && !isHouseMaster) return null;
 
     return (

--- a/app/assets/javascripts/student_profile/StudentProfilePage.js
+++ b/app/assets/javascripts/student_profile/StudentProfilePage.js
@@ -611,7 +611,9 @@ StudentProfilePage.propTypes = {
 
   // context
   nowMomentFn: PropTypes.func.isRequired,
-  currentEducator: PropTypes.object.isRequired,
+  currentEducator: PropTypes.shape({
+    labels: PropTypes.arrayOf(PropTypes.string).isRequired
+  }).isRequired,
 
   // constants
   educatorsIndex: PropTypes.object.isRequired,

--- a/app/assets/javascripts/student_profile/StudentProfilePage.test.js
+++ b/app/assets/javascripts/student_profile/StudentProfilePage.test.js
@@ -7,8 +7,22 @@ import PageContainer from './PageContainer';
 
 
 const helpers = {
-  renderStudentProfilePage(el, grade, dibels, absencesCount, sectionsCount, schoolType) {
+  renderStudentProfilePage(params = {}) {
+    const {
+      el,
+      grade,
+      dibels,
+      absencesCount,
+      sectionsCount,
+      schoolType,
+      educatorLabels
+    } = params;
     const serializedData = _.cloneDeep(studentProfile);
+
+    if (educatorLabels !== undefined) {
+      serializedData["currentEducator"]["labels"] = educatorLabels;
+    }
+
     if (grade !== undefined) {
       serializedData["student"]["grade"] = grade;
     }
@@ -43,12 +57,55 @@ const helpers = {
   }
 };
 
+describe('transition notes', () => {
+  function renderedTextForParams(params) {
+    const el = document.createElement('div');
+    helpers.renderStudentProfilePage({
+      el,
+      ...params
+    });
+    return $(el).text();
+  }
+
+  it('renders for k8_counselor', () => {
+    expect(renderedTextForParams({
+      grade: '8',
+      educatorLabels: ['k8_counselor']
+    })).toContain('High School Transition Note');
+  });
+
+  it('renders for high_school_house_master', () => {
+    expect(renderedTextForParams({
+      grade: '8',
+      educatorLabels: ['high_school_house_master']
+    })).toContain('High School Transition Note');
+  });
+
+  it('does not renders for 7th grader', () => {
+    expect(renderedTextForParams({
+      grade: '7',
+      educatorLabels: ['k8_counselor', 'high_school_house_master']
+    })).not.toContain('High School Transition Note');
+  });
+
+  it('does not renders for 9th grader', () => {
+    expect(renderedTextForParams({
+      grade: '9',
+      educatorLabels: ['k8_counselor', 'high_school_house_master']
+    })).not.toContain('High School Transition Note');
+  });
+});
+
 describe('renders attendance event summaries correctly', () => {
 
   describe('student with no absences this school year', () => {
     it('displays zero absences', () => {
       const el = document.createElement('div');
-      helpers.renderStudentProfilePage(el, null, [], 0);
+      helpers.renderStudentProfilePage({el,
+        grade: null,
+        dibels: [],
+        absencesCount: 0
+      });
       expect($(el).text()).toContain('Absences this school year:0');
     });
   });
@@ -56,7 +113,7 @@ describe('renders attendance event summaries correctly', () => {
   describe('student with 15 absences this school year', () => {
     it('displays 15 absences', () => {
       const el = document.createElement('div');
-      helpers.renderStudentProfilePage(el);
+      helpers.renderStudentProfilePage({el});
       expect($(el).text()).toContain('Absences this school year:15');
     });
   });
@@ -70,7 +127,11 @@ describe('renders MCAS/DIBELS correctly according to grade level', () => {
     describe('student with DIBELS result', () => {
       it('renders the latest DIBELS', () => {
         const el = document.createElement('div');
-        helpers.renderStudentProfilePage(el, '3', [{ 'performance_level': 'INTENSIVE '}]);
+        helpers.renderStudentProfilePage({
+          el,
+          grade: '3',
+          dibels: [{ 'performance_level': 'INTENSIVE '}]
+        });
         expect($(el).text()).not.toContain('MCAS ELA SGP');
         expect($(el).text()).toContain('DIBELS');
         expect($(el).text()).toContain('INTENSIVE');
@@ -81,7 +142,11 @@ describe('renders MCAS/DIBELS correctly according to grade level', () => {
     describe('student without DIBELS result', () => {
       it('renders MCAS ELA SGP', () => {
         const el = document.createElement('div');
-        helpers.renderStudentProfilePage(el, '3', []);
+        helpers.renderStudentProfilePage({
+          el,
+          grade: '3',
+          dibels: []
+        });
         expect($(el).text()).toContain('MCAS ELA SGP');
       });
     });
@@ -93,7 +158,11 @@ describe('renders MCAS/DIBELS correctly according to grade level', () => {
     describe('student with DIBELS result', () => {
       it('renders MCAS ELA SGP', () => {
         const el = document.createElement('div');
-        helpers.renderStudentProfilePage(el, '5', [{ 'performance_level': 'INTENSIVE '}]);
+        helpers.renderStudentProfilePage({
+          el,
+          grade: '5',
+          dibels: [{ 'performance_level': 'INTENSIVE '}]
+        });
         expect($(el).text()).toContain('MCAS ELA SGP');
       });
     });
@@ -101,7 +170,11 @@ describe('renders MCAS/DIBELS correctly according to grade level', () => {
     describe('student without DIBELS result', () => {
       it('renders MCAS ELA SGP', () => {
         const el = document.createElement('div');
-        helpers.renderStudentProfilePage(el, '5', []);
+        helpers.renderStudentProfilePage({
+          el,
+          grade: '5',
+          dibels: []
+        });
         expect($(el).text()).toContain('MCAS ELA SGP');
       });
     });
@@ -109,7 +182,14 @@ describe('renders MCAS/DIBELS correctly according to grade level', () => {
     describe('student with sections', () => {
       it('does not have sections count', () => {
         const el = document.createElement('div');
-        helpers.renderStudentProfilePage(el, '5', [], 0, 3, 'ES');
+        helpers.renderStudentProfilePage({
+          el,
+          grade: '5',
+          dibels: [],
+          absencesCount: 0,
+          sectionsCount: 3,
+          schoolType: 'ES'
+        });
         expect($(el).text()).not.toContain('Sections');
       });
     });
@@ -118,13 +198,27 @@ describe('renders MCAS/DIBELS correctly according to grade level', () => {
   describe('student in high school', () => {
     it('renders student with 1 section', () => {
       const el = document.createElement('div');
-      helpers.renderStudentProfilePage(el, '10', [], 0, 1, 'HS');
+      helpers.renderStudentProfilePage({
+        el,
+        grade: '10',
+        dibels: [],
+        absencesCount: 0,
+        sectionsCount: 1,
+        schoolType: 'HS'
+      });
       expect($(el).text()).toContain('1 section');
     });
 
     it('renders student with 5 sections', () => {
       const el = document.createElement('div');
-      helpers.renderStudentProfilePage(el, '10', [], 0, 5, 'HS');
+      helpers.renderStudentProfilePage({
+        el,
+        grade: '10',
+        dibels: [],
+        absencesCount: 0,
+        sectionsCount: 5,
+        schoolType: 'HS'
+      });
       expect($(el).text()).toContain('5 sections');
     });
   });

--- a/app/assets/javascripts/student_profile/fixtures.js
+++ b/app/assets/javascripts/student_profile/fixtures.js
@@ -105,7 +105,8 @@ export const currentEducator = {
   "schoolwide_access": true,
   "grade_level_access": [],
   "restricted_to_sped_students": false,
-  "restricted_to_english_language_learners": false
+  "restricted_to_english_language_learners": false,
+  "labels": []
 };
 
 export const studentProfile = {


### PR DESCRIPTION
# Who is this PR for?
8th grade counselors and 9th grade house masters.  Noticed this working on https://github.com/studentinsights/studentinsights/pull/1799.

# What problem does this PR fix?
Transition note shows for all students, not just those in 8th grade.

# What does this PR do?
Doesn't show the note for students unless they're in 8th grade.

# Checklists
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code
