### PR TITLE
Fix student photo column types

### DIFF
--- a/db/migrate/20180613172551_fix_student_photo_data_types.rb
+++ b/db/migrate/20180613172551_fix_student_photo_data_types.rb
@@ -1,0 +1,6 @@
+class FixStudentPhotoDataTypes < ActiveRecord::Migration[5.1]
+  def change
+    change_column :student_photos, :file_digest, :string
+    change_column :student_photos, :s3_filename, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180606164642) do
+ActiveRecord::Schema.define(version: 20180613172551) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -301,9 +301,9 @@ ActiveRecord::Schema.define(version: 20180606164642) do
 
   create_table "student_photos", force: :cascade do |t|
     t.bigint "student_id"
-    t.integer "file_digest"
+    t.string "file_digest"
     t.integer "file_size"
-    t.integer "s3_filename"
+    t.string "s3_filename"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["student_id"], name: "index_student_photos_on_student_id"


### PR DESCRIPTION
# Notes 

+ `s3_filename` and `file_digest` should be strings, not integers.
+ See https://github.com/studentinsights/studentinsights/pull/1787#issuecomment-397014495.
