### PR TITLE
HS levels prototype: Performance optimizations

### DIFF
--- a/app/assets/javascripts/tiering/StudentLevelsTable.js
+++ b/app/assets/javascripts/tiering/StudentLevelsTable.js
@@ -121,7 +121,7 @@ export default class StudentLevelsTable extends React.Component {
 
   renderStudent({rowData}) {
     const student = rowData;
-    return <a style={styles.person} target="_blank" href={`https://somerville.studentinsights.org/students/${student.id}`}>{student.first_name} {student.last_name}</a>;
+    return <a style={styles.person} target="_blank" href={`/students/${student.id}`}>{student.first_name} {student.last_name}</a>;
   }
 
   renderLevel({rowData}) {

--- a/app/lib/experimental_somerville_high_tiers.rb
+++ b/app/lib/experimental_somerville_high_tiers.rb
@@ -129,7 +129,7 @@ class ExperimentalSomervilleHighTiers
       query_map.each do |key, event_note_type_ids|
         # find the most recent note for this kind, we can use find because the list is sorted
         matching_partial_note = sorted_partial_event_notes.find do |partial_event_note|
-          matches_student_id = partial_event_note.student_id != student.id
+          matches_student_id = partial_event_note.student_id == student.id
           matches_event_note_type_id = event_note_type_ids.include?(partial_event_note.event_note_type_id)
           matches_student_id && matches_event_note_type_id
         end

--- a/app/lib/perf_test.rb
+++ b/app/lib/perf_test.rb
@@ -1,17 +1,92 @@
 class PerfTest
-  # Critical path authorization code
-  def self.authorized(percentage, options = {})
-    timer = PerfTest.new.run(percentage) do |t, educator|
-      Authorizer.new(educator).authorized { Student.active }
+  def self.tiering_detailed(percentage, options = {})
+    timer = PerfTest.new.run_with_tags(percentage, options) do |t, educator|
+      time_now = Time.at(1529067553)
+      school_ids = [9]
+      tiers = ExperimentalSomervilleHighTiers.new(educator)
+      authorizer = Authorizer.new(educator)
+
+      students = t.measure('students') do
+        authorizer.authorized do
+          Student.active
+            .where(school_id: school_ids)
+            .includes(student_section_assignments: [section: :course])
+            .includes(:event_notes)
+            .to_a # because of AuthorizedDispatcher#filter_relation
+        end
+      end
+
+      students_json = t.measure('students_json') do
+        students.as_json({
+          only: [:id, :first_name, :last_name, :grade, :house, :sped_placement, :program_assigned],
+          include: {
+            student_section_assignments: {
+              :only => [:id, :grade_letter, :grade_numeric],
+              :include => {
+                :section => {
+                  :only => [:id, :section_number],
+                  :methods => [:course_description]
+                }
+              }
+            }
+          }
+        })
+      end
+
+      tiers_map = {}
+      t.measure('tiers_json') do
+        students.each do |student|
+          tiers_map[student.id] = tiers.send(:tier, student, time_now: time_now).as_json
+        end
+      end
+
+      notes_map = {}
+      t.measure('notes_json') do
+        raw_rows = EventNote
+          .where(is_restricted: false)
+          .select('student_id, event_note_type_id, max(recorded_at) as most_recent_recorded_at')
+          .group(:student_id, :event_note_type_id)
+        students.each do |student|
+          notes_map[student.id] = {
+            last_sst_note: serialize_note(raw_rows.find {|r| 300 == r.event_note_type_id}),
+            last_experience_note:  serialize_note(raw_rows.find {|r| [305, 306].include?(r.event_note_type_id)})
+          }
+        end
+      end
+
+      t.measure('merge') do
+        students_json.map do |student_json|
+          student_id = student_json['id']
+          student_json.merge({
+            tier: tiers_map[student_id],
+            notes: notes_map[student_id]
+          })
+        end
+      end
     end
     pp timer.report
-    pp PerfTest::Reporter.new.report(timer.report.group_by {|tuple| tuple[0] })
     timer
+  end
+
+  def self.tiering(percentage, options = {})
+    PerfTest.new.simple(percentage, options) do |educator|
+      time_now = Time.at(1529067553)
+      school_id = 9
+      tiers = ExperimentalSomervilleHighTiers.new(educator)
+      tiers.students_with_tiering_json([school_id], time_now)
+    end
+  end
+
+  # Critical path authorization code
+  def self.authorized(percentage, options = {})
+    PerfTest.new.simple(percentage, options) do |educator|
+      Authorizer.new(educator).authorized { Student.active }
+    end
   end
 
   # See educators_controller#my_students_json
   def self.my_students(percentage, options = {})
-    timer = PerfTest.new.run(percentage) do |t, educator|
+    PerfTest.new.simple(percentage, options) do |educator|
       students = Authorizer.new(educator).authorized { Student.active.includes(:school).to_a }
       students.as_json({
         only: [:id, :first_name, :last_name, :house, :counselor, :grade],
@@ -22,39 +97,30 @@ class PerfTest
         }
       })
     end
-    pp timer.report
-    pp PerfTest::Reporter.new.report(timer.report.group_by {|tuple| tuple[0] })
-    timer
   end
 
   # See ClassListQueries.  This was driven by the view in admin/authorization, running this
   # across all educators.
   def self.is_relevant_for_educator?(percentage, options = {})
-    timer = PerfTest.new.run(percentage) do |t, educator|
+    PerfTest.new.simple(percentage, options) do |educator|
       ClassListQueries.new(educator).is_relevant_for_educator?
     end
-    pp timer.report
-    pp PerfTest::Reporter.new.report(timer.report.group_by {|tuple| tuple[0] })
-    timer
   end
 
   # For testing the high absences insight
   def self.high_absences(percentage, options = {})
-    timer = PerfTest.new.run(percentage) do |t, educator|
+    PerfTest.new.simple(percentage, options) do |educator|
       time_now = options[:time_now] || Time.at(1522779136)
       time_threshold = time_now - 45.days
       absences_threshold = 4
       insight = InsightStudentsWithHighAbsences.new(educator)
       insight.students_with_high_absences_json(time_now, time_threshold, absences_threshold)
     end
-    pp timer.report
-    pp PerfTest::Reporter.new.report(timer.report.group_by {|tuple| tuple[0] })
-    timer
   end
 
   # Usage for testing the feed
   def self.feed(percentage, options = {})
-    timer = PerfTest.new.run(percentage) do |t, educator|
+    timer = PerfTest.new.run_with_tags(percentage, options) do |t, educator|
       time_now = options[:time_now] || Time.at(1521552855)
       limit = options[:limit] || 10
       feed = Feed.new(educator)
@@ -83,19 +149,29 @@ class PerfTest
     timer
   end
 
+  # Simplest usage.  Block yields an educator.
+  def simple(percentage, options = {}, &block)
+    timer = PerfTest.new.run_with_tags(percentage, options) do |t, educator|
+      block.yield(educator)
+    end
+    pp timer.report
+    pp PerfTest::Reporter.new.report(timer.report.group_by {|tuple| tuple[0] })
+    timer
+  end
+
   # Generic perftest usage:
-  # timer = perf_test.run(0.10) do |t, educator|
+  # timer = perf_test.run_with_tags(0.10) do |t, educator|
   #   t.measure('whatever') { do_something_for(educator) }
   #   t.measure('foo') { do_something_else_for(educator) }
   # end;nil
   # pp timer.report
-  def run(percentage, &block)
+  def run_with_tags(percentage, options = {}, &block)
     timer = Timer.new
 
     puts
     puts
     puts 'Getting test set...'
-    educator_ids = test_educator_ids(percentage)
+    educator_ids = test_educator_ids(percentage, options)
     puts "Test set includes #{educator_ids.size} educators: [#{educator_ids.sort.join(',')}]"
     puts 'Done.'
     puts

--- a/spec/lib/experimental_somerville_high_tiers_spec.rb
+++ b/spec/lib/experimental_somerville_high_tiers_spec.rb
@@ -9,41 +9,40 @@ RSpec.describe ExperimentalSomervilleHighTiers do
       time_now = Time.now
       tiers = ExperimentalSomervilleHighTiers.new(pals.uri)
       students_with_tiering_json = tiers.students_with_tiering_json([pals.shs.id], time_now)
-      expect(students_with_tiering_json).to contain_exactly(*[
-        {
-          "id"=>pals.shs_freshman_mari.id,
-          "grade"=>"9",
-          "first_name"=>"Mari",
-          "last_name"=>"Kenobi",
-          "program_assigned"=>nil,
-          "sped_placement"=>nil,
-          "house"=>"Beacon",
-          "student_section_assignments"=>[{
-            "id"=>pals.shs_freshman_mari.student_section_assignments.first.id,
-            "grade_numeric"=>67.0,
-            "grade_letter"=>"D",
-            "section"=>{
-              "id"=>pals.shs_tuesday_biology_section.id,
-              "section_number"=>"SHS-BIO-TUES",
-              "course_description"=>"BIOLOGY 1 HONORS"
-            }
-          }],
-          "tier"=>{
-            "level"=>0,
-            "triggers"=>[],
-            "data"=>{
-              "course_failures"=>0,
-              "course_ds"=>1,
-              "recent_absence_rate"=>1.0,
-              "recent_discipline_actions"=>0
-            }
-          },
-          "notes"=>{
-            "last_sst_note"=>{},
-            "last_experience_note"=>{},
-            "last_other_note"=>{}
+      expect(students_with_tiering_json).to contain_exactly(*[{
+        "id"=>pals.shs_freshman_mari.id,
+        "grade"=>"9",
+        "first_name"=>"Mari",
+        "last_name"=>"Kenobi",
+        "program_assigned"=>nil,
+        "sped_placement"=>nil,
+        "house"=>"Beacon",
+        "student_section_assignments"=>[{
+          "id"=>pals.shs_freshman_mari.student_section_assignments.first.id,
+          "grade_numeric"=>"67.0",
+          "grade_letter"=>"D",
+          "section"=>{
+            "id"=>pals.shs_tuesday_biology_section.id,
+            "section_number"=>"SHS-BIO-TUES",
+            "course_description"=>"BIOLOGY 1 HONORS"
+          }
+        }],
+        "tier"=>{
+          "level"=>0,
+          "triggers"=>[],
+          "data"=>{
+            "course_failures"=>0,
+            "course_ds"=>1,
+            "recent_absence_rate"=>1.0,
+            "recent_discipline_actions"=>0
           }
         },
+        "notes"=>{
+          "last_sst_note"=>{},
+          "last_experience_note"=>{},
+          "last_other_note"=>{}
+        }
+      },
         {
           "id"=>pals.shs_freshman_amir.id,
           "grade"=>"9",
@@ -54,7 +53,7 @@ RSpec.describe ExperimentalSomervilleHighTiers do
           "house"=>"Elm",
           "student_section_assignments"=>[{
             "id"=>pals.shs_freshman_amir.student_section_assignments.first.id,
-            "grade_numeric"=>84.0,
+            "grade_numeric"=>"84.0",
             "grade_letter"=>"B",
             "section"=>{
               "id"=>pals.shs_third_period_physics.id,


### PR DESCRIPTION
# Who is this PR for?
HS pilot users

# What problem does this PR fix?
https://github.com/studentinsights/studentinsights/pull/1801 takes a while to load, often over 30 seconds, which hits the Heroku timeout.

# What does this PR do?
Makes performance optimizations to the querying, primarily batching up the query for latest notes into an optimized single query that then gets merged back into the response.  It also adds a new `PerfTest`.  Here's production data, although note that there's a fair bit of variability here:

```
# before
[["all_for_educator", 105746],
[["all_for_educator", 71790],

# after
[["all_for_educator", 10728],
[["all_for_educator", 15650]]
```

So still not fast :) but under the 30 second timeout threshold.