### PR TITLE
Add visible "my students" link, replacing "home"

### DIFF
--- a/app/lib/paths_for_educator.rb
+++ b/app/lib/paths_for_educator.rb
@@ -7,11 +7,7 @@ class PathsForEducator
   # Links shown on the navbar, different depending on role
   def navbar_links
     links = {}
-
-    if EnvironmentVariable.is_true('HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8') && @educator.labels.include?('high_school_house_master')
-      links[:my_students] = url_helpers.educators_my_students_path
-    end
-
+    
     if PerDistrict.new.enabled_class_lists? && ClassListQueries.new(@educator).is_relevant_for_educator?
       links[:classlists] = '/classlists'
     end

--- a/app/views/shared/_navbar_signed_in.html.erb
+++ b/app/views/shared/_navbar_signed_in.html.erb
@@ -34,7 +34,6 @@
   <% # Everyone has these %>
   <%= link_to "My notes", educators_notes_feed_path %>
   <%= link_to 'My students', educators_my_students_path %>
-  <%= link_to "Home", home_path %>
   <span class="navbar-spacer"></span>
   <p class="search-label">Search for student:</p>
   <input class="student-searchbar" />

--- a/app/views/shared/_navbar_signed_in.html.erb
+++ b/app/views/shared/_navbar_signed_in.html.erb
@@ -33,9 +33,7 @@
 
   <% # Everyone has these %>
   <%= link_to "My notes", educators_notes_feed_path %>
-  <% if links.has_key?(:my_students) %>
-    <%= link_to 'My students', links[:my_students] %>
-  <% end %>
+  <%= link_to 'My students', educators_my_students_path %>
   <%= link_to "Home", home_path %>
   <span class="navbar-spacer"></span>
   <p class="search-label">Search for student:</p>

--- a/spec/lib/paths_for_educator_spec.rb
+++ b/spec/lib/paths_for_educator_spec.rb
@@ -20,28 +20,7 @@ RSpec.describe PathsForEducator do
       end
     end
 
-    context 'when HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8 disabled' do
-      before { @housemasters_authorized_for_grade_eight = ENV['HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8'] }
-      before { ENV['HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8'] = nil }
-      after { ENV['HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8'] = @housemasters_authorized_for_grade_eight }
-
-      it 'respects PerDistrict for /educators/my_students' do
-        expect(navbar_links(pals.shs_harry_housemaster)).to eq({
-          school: '/schools/shs',
-          absences: '/schools/shs/absences',
-          tardies: '/schools/shs/tardies'
-        })
-      end
-    end
-
     context 'with all feature switches enabled' do
-      before { @housemasters_authorized_for_grade_eight = ENV['HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8'] }
-      before { ENV['HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8'] = 'true' }
-      after { ENV['HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8'] = @housemasters_authorized_for_grade_eight }
-      before { @enable_class_lists = ENV['ENABLE_CLASS_LISTS'] }
-      before { ENV['ENABLE_CLASS_LISTS'] = 'true' }
-      after { ENV['ENABLE_CLASS_LISTS'] = @enable_class_lists }
-
       it 'works across educators, with classlists enabled' do
         expect(navbar_links(pals.uri)).to eq({
           classlists: '/classlists',
@@ -74,7 +53,6 @@ RSpec.describe PathsForEducator do
 
         # high school (TestPals doesn't match actual production HS roles and permisssions)
         expect(navbar_links(pals.shs_harry_housemaster)).to eq({
-          my_students: '/educators/my_students',
           school: '/schools/shs',
           absences: '/schools/shs/absences',
           tardies: '/schools/shs/tardies'

--- a/spec/views/shared/_navbar_signed_in_spec.rb
+++ b/spec/views/shared/_navbar_signed_in_spec.rb
@@ -5,7 +5,7 @@ describe '_navbar_signed_in partial' do
 
   def expect_common_links(rendered)
     expect(rendered).to include('My notes')
-    expect(rendered).to include('Home')
+    expect(rendered).to include('My students')
     expect(rendered).to include('Search for student:')
     expect(rendered).to include('Sign Out')
   end


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
There's no way for educator to see exactly which students they are authorized to access.  And at the HS, no way for classroom teachers to see the list of students they have in common with a counselor or housemaster.

For developers, we can see this in a variety of ways, but this makes it more visible and accessible for debugging issues related to access.

# What does this PR do?
Update navbar links to make the page added in https://github.com/studentinsights/studentinsights/pull/1794 visible to all educators.  It also removes the "Home" link to make space for this, since the new home page has been live for months now.  Users can get to the home page by clicking on the "Student Insights" logo in the upper left of any page.

# Screenshot (if adding a client-side feature)
In the most crowded case, a K8 principal:
<img width="1018" alt="screen shot 2018-06-15 at 12 46 52 pm" src="https://user-images.githubusercontent.com/1056957/41479891-b314618c-709a-11e8-9ad0-45c4fbd8b916.png">

# Checklists
+ [x] Author included specs for new code
