### PR TITLE
Add index to students table on enrollment_status

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -38,7 +38,7 @@ class Student < ActiveRecord::Base
   validates :first_name, presence: true
   validates :last_name, presence: true
   validate :validate_grade
-  validate :validate_registration_date_cannot_be_in_future
+  validate :registration_date_cannot_be_in_future
   validate :validate_free_reduced_lunch
 
   VALID_GRADES = [
@@ -51,6 +51,20 @@ class Student < ActiveRecord::Base
     "Reduced Lunch",
     nil
   ]
+
+  def registration_date_in_future
+    return false if registration_date.nil?
+
+    return false if DateTime.now > registration_date
+
+    return true
+  end
+
+  def registration_date_cannot_be_in_future
+    if registration_date_in_future
+      errors.add(:registration_date, "cannot be in future for student local id ##{local_id}")
+    end
+  end
 
   def self.with_school
     where.not(school: nil)
@@ -316,17 +330,5 @@ class Student < ActiveRecord::Base
 
   def validate_plan_504
     errors.add(:plan_504, "invalid plan_504: #{plan_504}") unless grade.in?(PerDistrict.new.valid_plan_504_values)
-  end
-
-  def is_registration_date_in_future?
-    return false if registration_date.nil?
-    return false if DateTime.now > registration_date
-    return true
-  end
-
-  def validate_registration_date_cannot_be_in_future
-    if is_registration_date_in_future?
-      errors.add(:registration_date, "cannot be in future for student local id ##{local_id}")
-    end
   end
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -38,7 +38,7 @@ class Student < ActiveRecord::Base
   validates :first_name, presence: true
   validates :last_name, presence: true
   validate :validate_grade
-  validate :registration_date_cannot_be_in_future
+  validate :validate_registration_date_cannot_be_in_future
   validate :validate_free_reduced_lunch
 
   VALID_GRADES = [
@@ -51,20 +51,6 @@ class Student < ActiveRecord::Base
     "Reduced Lunch",
     nil
   ]
-
-  def registration_date_in_future
-    return false if registration_date.nil?
-
-    return false if DateTime.now > registration_date
-
-    return true
-  end
-
-  def registration_date_cannot_be_in_future
-    if registration_date_in_future
-      errors.add(:registration_date, "cannot be in future for student local id ##{local_id}")
-    end
-  end
 
   def self.with_school
     where.not(school: nil)
@@ -330,5 +316,17 @@ class Student < ActiveRecord::Base
 
   def validate_plan_504
     errors.add(:plan_504, "invalid plan_504: #{plan_504}") unless grade.in?(PerDistrict.new.valid_plan_504_values)
+  end
+
+  def is_registration_date_in_future?
+    return false if registration_date.nil?
+    return false if DateTime.now > registration_date
+    return true
+  end
+
+  def validate_registration_date_cannot_be_in_future
+    if is_registration_date_in_future?
+      errors.add(:registration_date, "cannot be in future for student local id ##{local_id}")
+    end
   end
 end

--- a/db/migrate/20180618170626_add_active_student_index.rb
+++ b/db/migrate/20180618170626_add_active_student_index.rb
@@ -1,0 +1,5 @@
+class AddActiveStudentIndex < ActiveRecord::Migration[5.1]
+  def change
+    add_index :students, :enrollment_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,13 +35,6 @@ ActiveRecord::Schema.define(version: 20180618170626) do
     t.datetime "updated_at"
   end
 
-  create_table "class_list_snapshots", force: :cascade do |t|
-    t.integer "class_list_id"
-    t.json "students_json"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "class_lists", force: :cascade do |t|
     t.string "workspace_id"
     t.integer "created_by_teacher_educator_id"
@@ -415,7 +408,6 @@ ActiveRecord::Schema.define(version: 20180618170626) do
   end
 
   add_foreign_key "absences", "students"
-  add_foreign_key "class_list_snapshots", "class_lists"
   add_foreign_key "class_lists", "educators", column: "created_by_teacher_educator_id", name: "classrooms_for_created_by_educator_id_fk"
   add_foreign_key "class_lists", "educators", column: "revised_by_principal_educator_id", name: "class_lists_revised_by_principal_educator_id_fk"
   add_foreign_key "class_lists", "schools", name: "classrooms_for_grades_school_id_fk"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180614133835) do
+ActiveRecord::Schema.define(version: 20180618170626) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,13 @@ ActiveRecord::Schema.define(version: 20180614133835) do
     t.string "subject"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "class_list_snapshots", force: :cascade do |t|
+    t.integer "class_list_id"
+    t.json "students_json"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "class_lists", force: :cascade do |t|
@@ -376,6 +383,7 @@ ActiveRecord::Schema.define(version: 20180614133835) do
     t.text "house"
     t.text "counselor"
     t.text "sped_liaison"
+    t.index ["enrollment_status"], name: "index_students_on_enrollment_status"
     t.index ["homeroom_id"], name: "index_students_on_homeroom_id"
     t.index ["local_id"], name: "index_students_on_local_id"
     t.index ["school_id"], name: "index_students_on_school_id"
@@ -407,6 +415,7 @@ ActiveRecord::Schema.define(version: 20180614133835) do
   end
 
   add_foreign_key "absences", "students"
+  add_foreign_key "class_list_snapshots", "class_lists"
   add_foreign_key "class_lists", "educators", column: "created_by_teacher_educator_id", name: "classrooms_for_created_by_educator_id_fk"
   add_foreign_key "class_lists", "educators", column: "revised_by_principal_educator_id", name: "class_lists_revised_by_principal_educator_id_fk"
   add_foreign_key "class_lists", "schools", name: "classrooms_for_grades_school_id_fk"


### PR DESCRIPTION
# Who is this PR for?
K8 educators, especially HS classroom teachers

# What problem does this PR fix?
In looking at query speed for the `/educators/my_students` page, one thing that came up is the common `Student.active` query that is passed to the authorizer (and in several other places too) is filtering down to only active students, but there's no index on that field.  This would add one, which in looking at SPS production data would cut this to 68% of all student row.

I'm not certain the query planner will use this - it doesn't in development but suspect it will in production.

# What does this PR do?
Adds an index on `enrollment_status` on the `students` table.
