### PR TITLE
Clear sessionStorage on sign out

### DIFF
--- a/app/assets/javascripts/studentSearchbar.js
+++ b/app/assets/javascripts/studentSearchbar.js
@@ -26,7 +26,7 @@ function downloadStudentNames () {
   });
 }
 
-export default function studentSearchbar() {
+export function initSearchBar() {
   if (!(window.sessionStorage)) {
     downloadStudentNames();       // Query for names if we have no local storage
     throw 'no session storage';   // Let rollbar know we're not caching
@@ -38,4 +38,10 @@ export default function studentSearchbar() {
 
   return downloadStudentNames();  // Student names haven't cached yet,
                                   // so let's download and cache them
+}
+
+export function clearStorage() {
+  if (window.sessionStorage && window.sessionStorage.clear) {
+    window.sessionStorage.clear();
+  }
 }

--- a/app/views/shared/_navbar_signed_in.html.erb
+++ b/app/views/shared/_navbar_signed_in.html.erb
@@ -38,5 +38,5 @@
   <p class="search-label">Search for student:</p>
   <input class="student-searchbar" />
   <span class="navbar-spacer"></span>
-  <%= link_to "Sign Out", destroy_educator_session_path, method: :delete %>
+  <%= link_to "Sign Out", destroy_educator_session_path, method: :delete, class: 'navbar-sign-out' %>
 </div>

--- a/ui/index.js
+++ b/ui/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import {BrowserRouter} from 'react-router-dom';
 import datepickerConfig from '../app/assets/javascripts/datepickerConfig';
 import sessionTimeoutWarning from '../app/assets/javascripts/sessionTimeoutWarning';
-import studentSearchbar from '../app/assets/javascripts/studentSearchbar';
+import {initSearchBar, clearStorage} from '../app/assets/javascripts/studentSearchbar';
 import legacyRouteHandler from './legacyRouteHandler';
 import App from './App';
 
@@ -20,11 +20,14 @@ if ($('body').hasClass('students')  ||
 // Session timeout
 if ($('body').hasClass('educator-signed-in')) {
   sessionTimeoutWarning(window.shared.Env);
+} else {
+  clearStorage(); // extra guard that there's no storage if not signed in
 }
 
-// Student searchbar
+// Student searchbar, and clearing cache on sign out
 if ($('.student-searchbar').length > 0) {
-  studentSearchbar();
+  initSearchBar();
+  $('.navbar-sign-out').click(clearStorage);
 }
 
 // Routing


### PR DESCRIPTION
# Who is this PR for?
educators, students

# What problem does this PR fix?
For signed-in users, student names for the search bar are cached in `sessionStorage` to keep the searchbar navigation speedy across pages.  The browser clears this data when the tab or window is closed.  In the event that a signed-in user signs out and keeps the tab or window open afterward, these names aren't cleared and would be accessible to someone on the JS console, or by signing into the product as a different user with different permissions.

# What does this PR do?
Clears `sessionStorage` on sign out, and on loading a signed-out page as an additional guard.
