### PR TITLE
Remove some logging from class list snapshots, filter out nil diffs

### DIFF
--- a/app/models/class_list_snapshot.rb
+++ b/app/models/class_list_snapshot.rb
@@ -51,18 +51,18 @@ class ClassListSnapshot < ActiveRecord::Base
       snapshot.class_list.workspace_id
     end
 
-    snapshots_by_workspace.map do |key, snapshots|
+    snapshots_by_workspace.flat_map do |key, snapshots|
       if snapshots.size < 2
-        nil
+        []
       else
         first = snapshots.first
         last = snapshots.last
-        {
+        [{
           workspace_id: first.class_list.workspace_id,
           first: first.id,
           last: last.id,
           diff: JsonDiff.diff(first.students_json, last.students_json)
-        }
+        }]
       end
     end
   end

--- a/lib/tasks/class_lists_snaphot.rake
+++ b/lib/tasks/class_lists_snaphot.rake
@@ -1,7 +1,6 @@
 namespace :class_lists do
   desc 'Capture student values for class lists at this moment in time'
   task snapshot: :environment do
-
-    puts ClassListSnapshot.snapshot_all_workspaces
+    ClassListSnapshot.snapshot_all_workspaces
   end
 end


### PR DESCRIPTION
# Who is this PR for?
developers, follow on to https://github.com/studentinsights/studentinsights/pull/1828

# What problem does this PR fix?
The rake task logs more than it should, no need for that getting into logentries.  The diff function also includes nil values for workspaces that haven't changed at all, no need for that either.

# What does this PR do?
Removes the logging, filters out the nils.
