### PR TITLE
Relax CSP style rules

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -13,7 +13,12 @@ SecureHeaders::Configuration.default do |config|
       connect_src: %w('self' https:),
       form_action: %w('self' https:),
       script_src: %w('unsafe-inline' https: api.mixpanel.com cdn.mxpnl.com https://cdnjs.cloudflare.com/ajax/libs/rollbar.js/),
-      style_src: %w('self' https: fonts.googleapis.com),
+
+      # unsafe-inline comes primarily from react-select and react-beautiful-dnd
+      # see https://github.com/JedWatson/react-select/issues/2030
+      # and https://github.com/JedWatson/react-input-autosize#csp-and-the-ie-clear-indicator
+      # and https://github.com/atlassian/react-beautiful-dnd/blob/master/src/view/style-marshal/style-marshal.js#L46
+      style_src: %w('unsafe-inline' https: fonts.googleapis.com),
       font_src: %w('self' https: data: fonts.gstatic.com),
       img_src: %w('self' https: data:),
       report_uri: %w(https://studentinsights-csp-logger.herokuapp.com/csp),


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
I tried a few approaches to resolving the issues in https://github.com/studentinsights/studentinsights/issues/1704, but neither worked.  One source comes from `react-select`, which injects some styles for IE workarounds and also an autosize components.  Disabling these didn't help, I think because we're still using `style-loader` to inject the stylesheet for the library itself.  We could work around this by adding hashes, but `react-beautiful-dnd` also injects styles.  I tried a few times to see if those were deterministic, but ran into a few that came from what looked like autosizing code and gave different hashes.

So rather than continuing to block on not enabling any CSP protection, let's relax this a bit and get it out, then we can revisit and tighten further.

# What does this PR do?
Relaxes CSP for styles to allow inline styles.  With the env flag on, this is still in report-only mode.

I verified this looks good in the demo site, and will watch the CSP logger after flipping this on in production.