### PR TITLE
Fix JS timezone in JS tests

### DIFF
--- a/app/assets/javascripts/helpers/toMoment.js
+++ b/app/assets/javascripts/helpers/toMoment.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 
 // Allow a few strict formats of dates

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "js-cookie": "^2.1.4",
     "lodash": "3.10.1",
     "moment": "2.19.3",
+    "moment-timezone": "^0.5.20",
     "object-assign": "^4.1.1",
     "percentile": "^1.2.0",
     "promise-polyfill": "^6.0.2",

--- a/ui/config/setupTests.js
+++ b/ui/config/setupTests.js
@@ -37,3 +37,7 @@ if (process.listeners('unhandledRejection').length === 0) { // eslint-disable-li
     throw error;
   });
 }
+
+// Fix the timezone to ET for test
+import moment from 'moment';
+moment.tz.setDefault('America/New_York');

--- a/ui/config/setupTests.js
+++ b/ui/config/setupTests.js
@@ -38,6 +38,6 @@ if (process.listeners('unhandledRejection').length === 0) { // eslint-disable-li
   });
 }
 
-// Fix the timezone to ET for test
-import moment from 'moment';
+// Fix the timezone for test
+import moment from 'moment-timezone';
 moment.tz.setDefault('America/New_York');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5219,9 +5219,19 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment-timezone@^0.5.20:
+  version "0.5.20"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.20.tgz#fe66da425dd9f9bbf416f131bf17659680aabb99"
+  dependencies:
+    moment ">= 2.9.0"
+
 moment@2.19.3:
   version "2.19.3"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.3.tgz#bdb99d270d6d7fda78cc0fbace855e27fe7da69f"
+
+"moment@>= 2.9.0":
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
# Who is this PR for?
@alexsoble 

# What problem does this PR fix?
Snapshot tests produce different output when run in different timezones.

# What does this PR do?
Adds moment-timezone, fixes the timezone in test as NY, and updates the offending test.  We could simplify the way date/timezone parsing works across timezones more generally but this is just trying to unblock https://github.com/studentinsights/studentinsights/pull/1823#issuecomment-398533720
