### PR TITLE
Fix timezone to NYC in Jest tests

### DIFF
--- a/app/assets/javascripts/helpers/toMoment.test.js
+++ b/app/assets/javascripts/helpers/toMoment.test.js
@@ -10,25 +10,10 @@ it('#toMoment and then back to text', () => {
   expect(toMoment('01-5-18').format('YYYY-MM-DD')).toEqual('2018-01-05');
 });
 
-
-describe('#toMomentFromTime works as expected across timezones', () => {
-  /* eslint-disable no-undef */
-  describe('in NYC', () => {
+describe('#toMomentFromTime', () => {
+  it('works as expected because local timezone is set as expected', () => {
     const string = '2018-05-09T12:03:26.664Z';
-    const tz = process.env.TZ; 
-    process.env.TZ = 'America/New_York';
-    expect(toMomentFromTime(string).local().format('dddd M/D, h:mma')).toEqual('Wednesday 5/9, 7:03am');
+    expect(toMomentFromTime(string).local().format('dddd M/D, h:mma')).toEqual('Wednesday 5/9, 8:03am');
     expect(toMomentFromTime(string).toDate().toLocaleTimeString()).toEqual('08:03:26');
-    process.env.TZ = tz;
   });
-
-  describe('in Chicago', () => {
-    const string = '2018-05-09T12:03:26.664Z';
-    const tz = process.env.TZ;
-    process.env.TZ = 'America/Chicago';
-    expect(toMomentFromTime(string).local().format('dddd M/D, h:mma')).toEqual('Wednesday 5/9, 7:03am');
-    expect(toMomentFromTime(string).toDate().toLocaleTimeString()).toEqual('08:03:26');
-    process.env.TZ = tz;
-  });
-  /* eslint-enable no-undef */
 });

--- a/app/assets/javascripts/helpers/toMoment.test.js
+++ b/app/assets/javascripts/helpers/toMoment.test.js
@@ -1,4 +1,6 @@
+import {toMomentFromTime} from '../helpers/toMoment';
 import {toMoment} from './toMoment';
+
 
 it('#toMoment and then back to text', () => {
   expect(toMoment('12/19/2018').format('YYYY-MM-DD')).toEqual('2018-12-19');
@@ -6,4 +8,27 @@ it('#toMoment and then back to text', () => {
   expect(toMoment('1/15/18').format('YYYY-MM-DD')).toEqual('2018-01-15');
   expect(toMoment('01/5/18').format('YYYY-MM-DD')).toEqual('2018-01-05');
   expect(toMoment('01-5-18').format('YYYY-MM-DD')).toEqual('2018-01-05');
+});
+
+
+describe('#toMomentFromTime works as expected across timezones', () => {
+  /* eslint-disable no-undef */
+  describe('in NYC', () => {
+    const string = '2018-05-09T12:03:26.664Z';
+    const tz = process.env.TZ; 
+    process.env.TZ = 'America/New_York';
+    expect(toMomentFromTime(string).local().format('dddd M/D, h:mma')).toEqual('Wednesday 5/9, 7:03am');
+    expect(toMomentFromTime(string).toDate().toLocaleTimeString()).toEqual('08:03:26');
+    process.env.TZ = tz;
+  });
+
+  describe('in Chicago', () => {
+    const string = '2018-05-09T12:03:26.664Z';
+    const tz = process.env.TZ;
+    process.env.TZ = 'America/Chicago';
+    expect(toMomentFromTime(string).local().format('dddd M/D, h:mma')).toEqual('Wednesday 5/9, 7:03am');
+    expect(toMomentFromTime(string).toDate().toLocaleTimeString()).toEqual('08:03:26');
+    process.env.TZ = tz;
+  });
+  /* eslint-enable no-undef */
 });

--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
     "lint-cli": "eslint --ext jsx --ext js -c .eslintrc app/assets/javascripts spec/javascripts ui",
     "dev": "NODE_ENV=development webpack --config ui/config/webpack.dev.js --watch",
     "build": "NODE_ENV=production webpack --config ui/config/webpack.prod.js",
-    "start": "concurrently --kill-others \"bundle exec rails s\" \"yarn run dev\"",
-    "test": "jest --config jest.json --watch",
-    "test-cli": "yarn run lint-cli && jest --config jest.json",
+    "start": "concurrently --kill-others \"bundle exec rails s\" \"yarn dev\"",
+    "jest": "TZ='America/New_York' jest --config jest.json",
+    "test": "yarn jest --watch",
+    "test-cli": "yarn lint-cli && yarn jest",
     "storybook": "start-storybook -p 6006 --config-dir ui/config/.storybook"
   },
   "dependencies": {

--- a/ui/config/setupTests.js
+++ b/ui/config/setupTests.js
@@ -37,6 +37,3 @@ if (process.listeners('unhandledRejection').length === 0) { // eslint-disable-li
     throw error;
   });
 }
-
-// Fix timezone in tests
-process.env.TZ = 'America/New_York'; // eslint-disable-line no-undef

--- a/ui/config/setupTests.js
+++ b/ui/config/setupTests.js
@@ -37,3 +37,6 @@ if (process.listeners('unhandledRejection').length === 0) { // eslint-disable-li
     throw error;
   });
 }
+
+// Fix timezone in tests
+process.env.TZ = 'America/New_York'; // eslint-disable-line no-undef


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
The JS tests run in local timezone, but we use test and snapshots that expect to be running in a particular timezone.

# What does this PR do?
Sets TZ env variable when running tests.  We tried doing this with moment-timezone and I also tried just setting this env value in `setupTests` but seems that is more complicated (eg https://github.com/nodejs/node/issues/3449#issuecomment-271295444).

One wrinkle is that for developers who are working in a different timezone, there will be differences between what they see in a story/development mode and what they see in a test for the same fixture.  I'm not sure how to work around that but that's more icing while this current issue blocks development.

This is a better and more global solution than https://github.com/studentinsights/studentinsights/pull/1833, which was a short-term patch.