### PR TITLE
Remove unsafe use of _.template in older lodash

### DIFF
--- a/app/assets/javascripts/student_profile/AttendanceDetails.js
+++ b/app/assets/javascripts/student_profile/AttendanceDetails.js
@@ -112,7 +112,6 @@ class AttendanceDetails extends React.Component {
         titleText="Discipline Incidents"
         id="disciplineChart"
         monthsBack={48}
-        tooltipTemplateString="<span><a href='#history' style='font-size: 12px'><%= moment.utc(e.occurred_at).format('MMMM Do, YYYY')%></a></span>"
         phaselines={this.phaselines()} />
     );
   }

--- a/app/assets/javascripts/student_profile/ProfileBarChart.js
+++ b/app/assets/javascripts/student_profile/ProfileBarChart.js
@@ -37,18 +37,18 @@ export default class ProfileBarChart extends React.Component {
 
   // This returns a function, since HighCharts passes in the current element
   // as `this` instead of a parameter.
-  createUnsafeTooltipFormatter(monthBuckets, props){
+  createUnsafeTooltipFormatter(monthBuckets){
     return function() {
       const graphPointIndex = this.series.data.indexOf(this.point);
       const events = monthBuckets[graphPointIndex];
       if (events.length == 0) return false;
 
-      let htmlstring = "";
+      let unsafeHtmlString = '';
       _.each(events, function(e){
-        htmlstring += _.template(props.tooltipTemplateString)({e, moment});
-        htmlstring += "<br>";
+        unsafeHtmlString += `<span>${moment.utc(e.occurred_at).format('MMMM Do, YYYY')}</span>`;
+        unsafeHtmlString += '<br />';
       });
-      return htmlstring;
+      return unsafeHtmlString;
     };
   }
 
@@ -105,7 +105,7 @@ export default class ProfileBarChart extends React.Component {
             title: {text: this.props.titleText}
           }}
           tooltip={{
-            formatter: this.createUnsafeTooltipFormatter(monthBuckets, this.props),
+            formatter: this.createUnsafeTooltipFormatter(monthBuckets),
             useHTML: true
           }}
           series={[
@@ -142,7 +142,6 @@ ProfileBarChart.propTypes = {
   id: PropTypes.string.isRequired, // short string identifier for links to jump to
   events: PropTypes.array.isRequired, // array of JSON event objects.
   monthsBack: PropTypes.number.isRequired, // how many months in the past to display?
-  tooltipTemplateString: PropTypes.string.isRequired, // Underscore template string that displays each line of a tooltip.
   titleText: PropTypes.string.isRequired,
   nowMomentUTC: PropTypes.instanceOf(moment),
   monthKeyFn: PropTypes.func,
@@ -150,7 +149,6 @@ ProfileBarChart.propTypes = {
 };
 
 ProfileBarChart.defaultProps = {
-  tooltipTemplateString: "<span><%= moment.utc(e.occurred_at).format('MMMM Do, YYYY')%></span>",
   phaselines: [],
   nowMomentUTC: moment.utc(),
   monthKeyFn(event) {

--- a/app/assets/javascripts/student_profile/ProfileChart.js
+++ b/app/assets/javascripts/student_profile/ProfileChart.js
@@ -44,7 +44,7 @@ export default class ProfileChart extends React.Component {
 
     const range = [now.clone().subtract(n, 'months'), now];
     const startDates = schoolYearStartDates(range);
-    const create_label = function(current, grade){
+    const create_label = function(grade){
       // Assumes that the student progressed grades in the usual fashion;
       // wasn't held back or skipped forward.
       // John Breslin says these events are very rare.
@@ -55,17 +55,13 @@ export default class ProfileChart extends React.Component {
       // No label for "negative" grades
       if (grade < 0) return '';
 
-      return _.template("<b>Grade <%=grade%><br>started</b>")({
-        year: current.year(),
-        grade: grade
-      });
+      return `<b>Grade ${grade}<br>started</b>`;
     };
 
     return _.object(
       startDates.map(date => date.valueOf()),
       startDates.map((date, i) => {
         return create_label(
-          date,
           (current_grade - startDates.length) + (i + 1) // (current_grade - n/12) to current_grade inclusive
         );
       })


### PR DESCRIPTION
# Who is this PR for?
developers, security

# What problem does this PR fix?
CSP violations in using `_.template`, which uses `eval` in the current older version of lodash.  This in code working with Highcharts, where we have to pass it HTML strings.

# What does this PR do?
Removes the use of `_.template` and remove special-casing for clicking on the tooltip date to navigate on the discipline chart (which didn't seem to work anyway).

# Screenshot (if adding a client-side feature)
<img width="979" alt="screen shot 2018-06-20 at 7 29 13 am" src="https://user-images.githubusercontent.com/1056957/41655842-2d69905a-745c-11e8-979d-32a23af135e0.png">
