### PR TITLE
Add more secure headers, add more reporting for CSP violations

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -46,7 +46,7 @@ SecureHeaders::Configuration.default do |config|
   report_only_policy = {
     script_src: %w('self' https: api.mixpanel.com cdn.mxpnl.com https://cdnjs.cloudflare.com/ajax/libs/rollbar.js/),
     style_src: %w('self' https: fonts.googleapis.com),
-    report_uri: [report_uri + '?report_only']
+    report_uri: [report_uri]
   }
 
   # Enforce CSP or report only

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -42,6 +42,12 @@ SecureHeaders::Configuration.default do |config|
     plugin_types: nil
   }
 
+  # collect additional report-only data on these violations, but don't enforce
+  report_only_policy = {
+    script_src: %w('self' https: api.mixpanel.com cdn.mxpnl.com https://cdnjs.cloudflare.com/ajax/libs/rollbar.js/),
+    style_src: %w('self' https: fonts.googleapis.com),
+    report_uri: [report_uri + '?report_only']
+  }
 
   # Enforce CSP or report only
   # CSP and HTTPS cookies are not enforced locally or in test
@@ -51,14 +57,9 @@ SecureHeaders::Configuration.default do |config|
     config.csp_report_only = SecureHeaders::OPT_OUT
   elsif EnvironmentVariable.is_true('CSP_REPORT_ONLY_WITHOUT_ENFORCEMENT')
     config.csp = SecureHeaders::OPT_OUT
-    config.csp_report_only = policy
+    config.csp_report_only = policy.merge(report_only_policy)
   else
     config.csp = policy
-    # collect additional data on any violations here
-    config.csp_report_only = {
-      script_src: %w('self' https: api.mixpanel.com cdn.mxpnl.com https://cdnjs.cloudflare.com/ajax/libs/rollbar.js/),
-      style_src: %w('self' https: fonts.googleapis.com),
-      report_uri: [report_uri + '?report_only']
-    }
+    config.csp_report_only = report_only_policy
   end
 end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,4 +1,13 @@
 SecureHeaders::Configuration.default do |config|
+  # Set these all explicitly on top of the defaults, starting from guidance in
+  # https://github.com/twitter/secure_headers/blob/5c47914f9c481d8c69fb7af141ed5a79b213bfa1/README.md#configuration
+  config.hsts = "max-age=#{1.week.to_i}"
+  config.x_frame_options = "DENY"
+  config.x_content_type_options = "nosniff"
+  config.x_xss_protection = "1; mode=block"
+  config.x_permitted_cross_domain_policies = "none"
+  config.referrer_policy = %w(origin-when-cross-origin strict-origin-when-cross-origin)
+
   # Unblock PDF downloading for student report and for IEP-at-a-glance
   config.x_download_options = nil
 
@@ -29,7 +38,7 @@ SecureHeaders::Configuration.default do |config|
     media_src: %w('none'),
     object_src: %w('none'),
     worker_src: %w('none'),
-    plugin_types: nil,
+    plugin_types: nil
   }
 
 

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -12,6 +12,7 @@ SecureHeaders::Configuration.default do |config|
   config.x_download_options = nil
 
   # Content security policy rules
+  report_uri = ENV['CSP_REPORT_URI']
   policy = {
     # core resources
     default_src: %w('self' https:),
@@ -28,7 +29,7 @@ SecureHeaders::Configuration.default do |config|
     style_src: %w('unsafe-inline' https: fonts.googleapis.com),
     font_src: %w('self' https: data: fonts.gstatic.com),
     img_src: %w('self' https: data:),
-    report_uri: %w(https://studentinsights-csp-logger.herokuapp.com/csp),
+    report_uri: [report_uri],
 
     # disable others
     block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
@@ -45,12 +46,19 @@ SecureHeaders::Configuration.default do |config|
   # Enforce CSP or report only
   # CSP and HTTPS cookies are not enforced locally or in test
   if Rails.env.test? || Rails.env.development?
-    config.cookies = SecureHeaders::OPT_OUT
     config.csp = SecureHeaders::OPT_OUT
+    config.cookies = SecureHeaders::OPT_OUT # no https locally
+    config.csp_report_only = SecureHeaders::OPT_OUT
   elsif EnvironmentVariable.is_true('CSP_REPORT_ONLY_WITHOUT_ENFORCEMENT')
-    config.csp_report_only = policy
     config.csp = SecureHeaders::OPT_OUT
+    config.csp_report_only = policy
   else
     config.csp = policy
+    # collect additional data on any violations here
+    config.csp_report_only = {
+      script_src: %w('self' https: api.mixpanel.com cdn.mxpnl.com https://cdnjs.cloudflare.com/ajax/libs/rollbar.js/),
+      style_src: %w('self' https: fonts.googleapis.com),
+      report_uri: [report_uri + '?report_only']
+    }
   end
 end


### PR DESCRIPTION
# Who is this PR for?
developers, security, part of https://github.com/studentinsights/studentinsights/issues/1704.

# What problem does this PR fix?
Adds a few more headers from `secure_headers`, but also updates the CSP setup to allow enforcing one level while reporting other levels.

Verified on demo site.