### PR TITLE
Disable extra CSP reporting for styles

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -45,7 +45,6 @@ SecureHeaders::Configuration.default do |config|
   # collect additional report-only data on these violations, but don't enforce
   report_only_policy = {
     script_src: %w('self' https: api.mixpanel.com cdn.mxpnl.com https://cdnjs.cloudflare.com/ajax/libs/rollbar.js/),
-    style_src: %w('self' https: fonts.googleapis.com),
     report_uri: [report_uri]
   }
 


### PR DESCRIPTION
# Who is this PR for?
developers, security, part of https://github.com/studentinsights/studentinsights/issues/1704.

# What problem does this PR fix?
I looked at hashing each inline style in https://github.com/studentinsights/studentinsights/tree/patch/try-hashing-styles, but this was more involved than I expected since there are a few libraries that do this, and setting these hashes manually would be tough to maintain without tooling support.

# What does this PR do?
Remove additional CSP reporting for styles.
