### PR TITLE
Fix bug with secure_headers setup

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -59,6 +59,6 @@ SecureHeaders::Configuration.default do |config|
     config.csp_report_only = policy.merge(report_only_policy)
   else
     config.csp = policy
-    config.csp_report_only = report_only_policy
+    config.csp_report_only = policy.merge(report_only_policy)
   end
 end


### PR DESCRIPTION
# Who is this PR for?
part of https://github.com/studentinsights/studentinsights/issues/1704

# What problem does this PR fix?
`secure_headers` needs a full CSP policy for report only; a fragment will raise and prevent the app from booting.

# What does this PR do?
merges report-only additions in with enforced policy
