### PR TITLE
Remove CSP report-only noise

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -42,12 +42,6 @@ SecureHeaders::Configuration.default do |config|
     plugin_types: nil
   }
 
-  # To collect additional report-only data on particular violations before
-  # enforcing, merge them in here.
-  # For report-only, filter out some options that the browser will complain
-  # about.
-  report_only_policy = policy.except(:upgrade_insecure_requests)
-
   # Enforce CSP or report only
   # CSP and HTTPS cookies are not enforced locally or in test
   if Rails.env.test? || Rails.env.development?
@@ -56,9 +50,9 @@ SecureHeaders::Configuration.default do |config|
     config.csp_report_only = SecureHeaders::OPT_OUT
   elsif EnvironmentVariable.is_true('CSP_REPORT_ONLY_WITHOUT_ENFORCEMENT')
     config.csp = SecureHeaders::OPT_OUT
-    config.csp_report_only = report_only_policy
+    config.csp_report_only = policy.except(:upgrade_insecure_requests) # some browsers complain about this in report-only mode
   else
     config.csp = policy
-    config.csp_report_only = report_only_policy
+    config.csp_report_only = SecureHeaders::OPT_OUT
   end
 end


### PR DESCRIPTION
# Who is this PR for?
developers, part of https://github.com/studentinsights/studentinsights/issues/1704.

# What problem does this PR fix?
By sending headers for CSP and CSP-report-only, the browser logs twice and it might seem at first glance as if there's only reports.

# What does this PR do?
Removes the report-only when the policy is enforced.  Originally this was to be able to enforce at one level and report at another, but we don't need that except for when we're actively working on this.