### PR TITLE
Factor StudentPhoto into component

### DIFF
--- a/app/assets/javascripts/components/StudentPhoto.js
+++ b/app/assets/javascripts/components/StudentPhoto.js
@@ -5,7 +5,7 @@ import * as Routes from '../helpers/Routes';
 const whitePixel = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
 // Pure UI component for displaying a student photo
-class StudentPhoto extends React.Component {
+export default class StudentPhoto extends React.Component {
 
   onError(e) {
     e.target.src = whitePixel;

--- a/app/assets/javascripts/components/StudentPhoto.js
+++ b/app/assets/javascripts/components/StudentPhoto.js
@@ -24,7 +24,7 @@ export default class StudentPhoto extends React.Component {
            style={style}
            src={Routes.studentPhoto(student.id)}
            height={height}
-           alt={this.altText}
+           alt={this.altText()}
            onError={this.onError}
         />
     );

--- a/app/assets/javascripts/components/StudentPhoto.js
+++ b/app/assets/javascripts/components/StudentPhoto.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import * as Routes from '../helpers/Routes';
 
 const whitePixel = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';

--- a/app/assets/javascripts/components/StudentPhoto.js
+++ b/app/assets/javascripts/components/StudentPhoto.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import * as Routes from '../helpers/Routes';
+
+const whitePixel = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+// Pure UI component for displaying a student photo
+class StudentPhoto extends React.Component {
+
+  onError(e) {
+    e.target.src = whitePixel;
+  }
+
+  altText() {
+    const {student} = this.props;
+    return `Student photo for ${student.first_name} ${student.last_name}`;
+  }
+
+  render() {
+    const {student, height, style} = this.props;
+
+    return (
+      <img id='student-photo'
+           style={style}
+           src={Routes.studentPhoto(student.id)}
+           height={height}
+           alt={this.altText}
+           onError={this.onError}
+        />
+    );
+  }
+}
+
+StudentPhoto.propTypes = {
+  student: PropTypes.object.isRequired,
+  height: PropTypes.number.isRequired,
+  style: PropTypes.object,
+};
+

--- a/app/assets/javascripts/components/StudentPhoto.js
+++ b/app/assets/javascripts/components/StudentPhoto.js
@@ -7,13 +7,13 @@ const whitePixel = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALA
 // Pure UI component for displaying a student photo
 export default class StudentPhoto extends React.Component {
 
-  onError(e) {
-    e.target.src = whitePixel;
-  }
-
   altText() {
     const {student} = this.props;
     return `Student photo for ${student.first_name} ${student.last_name}`;
+  }
+
+  onError(e) {
+    e.target.src = whitePixel;
   }
 
   render() {

--- a/app/assets/javascripts/components/StudentPhoto.js
+++ b/app/assets/javascripts/components/StudentPhoto.js
@@ -32,7 +32,9 @@ export default class StudentPhoto extends React.Component {
 }
 
 StudentPhoto.propTypes = {
-  student: PropTypes.object.isRequired,
+  student: PropTypes.shape({
+    id: PropTypes.number.isRequired
+  }).isRequired,
   height: PropTypes.number.isRequired,
   style: PropTypes.object,
 };

--- a/app/assets/javascripts/helpers/Routes.js
+++ b/app/assets/javascripts/helpers/Routes.js
@@ -23,3 +23,7 @@ export function section(id) {
 export function newClassList() {
   return '/classlists/new';
 }
+
+export function studentPhoto(id) {
+  return `/students/${id}/photo`;
+}

--- a/app/assets/javascripts/student_profile/StudentProfileHeader.js
+++ b/app/assets/javascripts/student_profile/StudentProfileHeader.js
@@ -23,7 +23,7 @@ export default class StudentProfileHeader extends React.Component {
         <StudentPhoto
            student={student}
            style={{float: 'right', paddingRight: 44}}
-           height={80}
+           height={90}
         />
       </div>
     );

--- a/app/assets/javascripts/student_profile/StudentProfileHeader.js
+++ b/app/assets/javascripts/student_profile/StudentProfileHeader.js
@@ -5,6 +5,7 @@ import RiskBubble from '../student_profile/RiskBubble';
 import ModalSmall from '../student_profile/ModalSmall';
 import * as Routes from '../helpers/Routes';
 import {hasStudentPhotos} from '../helpers/PerDistrict';
+import StudentPhoto from '../components/StudentPhoto';
 
 /*
 This pure UI component renders top-line information like the student's name, school,
@@ -18,16 +19,11 @@ export default class StudentProfileHeader extends React.Component {
     if (!shouldShowPhoto) return null;
 
     return (
-      <div style={{ width: '15em', display: 'flex', justifyContent: 'flex-end'}}>
-        <img id='student-photo' /* Mostly for testing. */
-             style={{float: 'right', paddingRight: 44}}
-             src={`/students/${student.id}/photo`}
-             height={80}
-             alt={`Student photo for ${student.first_name} ${student.last_name}`}
-             onError={(e) => {
-              /* Renders a 1x1 white pixel. */
-               e.target.src='data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-             }}
+      <div style={{width: '15em', display: 'flex', justifyContent: 'flex-end'}}>
+        <StudentPhoto
+           student={student}
+           style={{float: 'right', paddingRight: 44}}
+           height={80}
         />
       </div>
     );

--- a/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
@@ -197,7 +197,7 @@ exports[`snapshots works for aladdin 1`] = `
     >
       <img
         alt="Student photo for Aladdin Mouse"
-        height={80}
+        height={90}
         id="student-photo"
         onError={[Function]}
         src="/students/104/photo"
@@ -2876,7 +2876,7 @@ exports[`snapshots works for olaf 1`] = `
     >
       <img
         alt="Student photo for Olaf White"
-        height={80}
+        height={90}
         id="student-photo"
         onError={[Function]}
         src="/students/16/photo"
@@ -5527,7 +5527,7 @@ exports[`snapshots works for pluto 1`] = `
     >
       <img
         alt="Student photo for Pluto Poppins"
-        height={80}
+        height={90}
         id="student-photo"
         onError={[Function]}
         src="/students/8/photo"
@@ -7932,7 +7932,7 @@ exports[`snapshots works for pluto 1`] = `
                   March 11, 2018
                 </div>
                 <div>
-                  3 months
+                  4 months
                 </div>
               </div>
               <div>


### PR DESCRIPTION
# Who is this PR for?

Developers.

# What does this PR do?

Makes it easier to reuse Student Photo across the client side by pulling it into a pure UI component, passing in image height, student, and styles as props. 

# Screenshot (if adding a client-side feature)

## Student photo present

![screen shot 2018-06-26 at 9 19 06 am](https://user-images.githubusercontent.com/3209501/41918530-2b2208d4-7922-11e8-82cb-af0210838191.png)

## Student photo record missing 

![screen shot 2018-06-26 at 9 20 08 am](https://user-images.githubusercontent.com/3209501/41918529-2b0b1d18-7922-11e8-936f-e0617a0ca32b.png)
