### PR TITLE
Fix bug with overmatching on slash quote conversions

### DIFF
--- a/spec/importers/data_transformers/parseable_csv_string_spec.rb
+++ b/spec/importers/data_transformers/parseable_csv_string_spec.rb
@@ -5,6 +5,18 @@ RSpec.describe ParseableCsvString do
     [log, parseable_string]
   end
 
+  # verify we can actually parse without raising
+  def parse(parseable_string)
+    rows = []
+    CSV.new(parseable_string, {
+      header_converters: :symbol,
+      encoding: 'binary:UTF-8'
+    }).each.with_index do |row, index|
+      rows << row
+    end
+    rows
+  end
+
   describe 'encoding' do
     it 'translates encoding' do
       test_string = '"hi",\N,"bye"'.force_encoding('ASCII-8BIT')
@@ -15,6 +27,7 @@ RSpec.describe ParseableCsvString do
       expect(log.output).to include('stripped 0 newlines')
       expect(log.output).not_to include ('invalid character')
       expect(parseable_string).to eq '"hi",\N,"bye"'
+      expect { parse(parseable_string) }.not_to raise_error
     end
 
     it 'translates encoding with know invalid characters' do
@@ -24,6 +37,7 @@ RSpec.describe ParseableCsvString do
       expect(parseable_string.encoding.name).to eq 'UTF-8'
       expect(log.output).to include ('converted 2 known invalid character encodings')
       expect(parseable_string).to eq "\"hi\",\N,\"eating at sam’s café\""
+      expect { parse(parseable_string) }.not_to raise_error
     end
 
     it 'warns and strips unknown invalid characters' do
@@ -33,20 +47,45 @@ RSpec.describe ParseableCsvString do
       expect(parseable_string.encoding.name).to eq 'UTF-8'
       expect(log.output).to include ('failed to convert 1 unexpected invalid character encodings for ["\xF2"]')
       expect(parseable_string).to eq "\"hi\",\N,\"eating smething\""
+      expect { parse(parseable_string) }.not_to raise_error
     end
   end
 
-  it 'converts invalid quotes' do
-    log, parseable_string = parseable_string_from("\"hi there \\\" person\",\N,\"bye\"")
+  it 'converts slash quote (`\"`) to double quote (`""`)' do
+    string = "\"hi there \\\"friend\\\" person\",\N,\"bye\""
+    log, parseable_string = parseable_string_from(string)
 
-    expect(log.output).to include('stripped 1 quotes')
-    expect(parseable_string).to eq "\"hi there \"\" person\",\N,\"bye\""
+    expect(log.output).to include('stripped 2 quotes')
+    expect(parseable_string).to eq "\"hi there \"\"friend\"\" person\",\N,\"bye\""
+    expect { parse(parseable_string) }.not_to raise_error
+  end
+
+  it 'does not get confused by `\\"` sequence and mistakenly convert slash quote' do
+    string = "\"hi there friend\\\\\",\N,\"bye\""
+    log, parseable_string = parseable_string_from(string)
+
+    expect(log.output).to include('stripped 0 newline')
+    expect(log.output).to include('stripped 0 quotes')
+    expect(parseable_string).to eq "\"hi there friend\\\\\",\N,\"bye\""
+    expect { parse(parseable_string) }.not_to raise_error
+  end
+
+  it 'converts `\CRLF` and does not get confused by `\\"`' do
+    string = "\"123\",\"456\",\"1\",\"0\",\"0\",\N,\"0\",\"mom sick\\\r\n\\\\\",\"2015-03-01\",\"SCHOOL\""
+    log, parseable_string = parseable_string_from(string)
+
+    expect(log.output).to include('stripped 1 newline')
+    expect(log.output).to include('stripped 0 quotes')
+    expect(parseable_string).to eq "\"123\",\"456\",\"1\",\"0\",\"0\",\N,\"0\",\"mom sick \\\\\",\"2015-03-01\",\"SCHOOL\""
+    expect { parse(parseable_string) }.not_to raise_error
   end
 
   it 'converts inline newlines to spaces' do
     log, parseable_string = parseable_string_from("\"hi there\\\r\n person\",\N,\"bye\"")
 
     expect(log.output).to include('stripped 1 newline')
+    expect(log.output).to include('stripped 0 quotes')
     expect(parseable_string).to eq "\"hi there  person\",\N,\"bye\""
+    expect { parse(parseable_string) }.not_to raise_error
   end
 end


### PR DESCRIPTION
# Who is this PR for?
developers, educators

# What problem does this PR fix?
Addresses import errors in https://github.com/studentinsights/studentinsights/issues/1777, step towards resolving problem with attendance import job aborting and not completing.  This also blocked work on https://github.com/studentinsights/studentinsights/issues/1657.

# What does this PR do?
Fixes a bug introduced in https://github.com/studentinsights/studentinsights/pull/1778 which was trying to address this problem originally.  The regex cleanup would overmatch on particular escape sequences and cause the cleaner to produce unparseable strings.

It adds test cases and also has each test case verifying that the output of `ParseableCsvString` is in fact parseable.

# Checklists
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code
