### PR TITLE
Resolve issue with deploy script

### DIFF
--- a/scripts/deploy/all.sh
+++ b/scripts/deploy/all.sh
@@ -1,13 +1,13 @@
 # Deploy to all sites in parallel
-echo "🚢  Fetching from GitHub...";
+echo "🚢  Fetching from GitHub..."
 git fetch origin
 
-echo "🚢  Deploying...";
-yarn run concurrently \
+echo "🚢  Deploying..."
+yarn concurrently \
   --names "demo,somerville,new-bedford" \
   -c "yellow.bold,blue.bold,magenta.bold" \
-  'scripts/deploy/deploy.sh demo' \
-  'scripts/deploy/deploy.sh somerville' \
-  'scripts/deploy/deploy.sh new-bedford' \
+  \"scripts/deploy/deploy.sh demo\" \
+  \"scripts/deploy/deploy.sh somerville\" \
+  \"scripts/deploy/deploy.sh new-bedford\"
 
-echo "🚢  Done.";
+echo "🚢  Done."


### PR DESCRIPTION
# Who is this PR for?
developers, me specifically

# What problem does this PR fix?
deploy script didn't work for me today, not sure why.  Example output:
```
$ scripts/deploy/all.sh
🚢  Fetching from GitHub...
🚢  Deploying...
yarn run v1.3.2
warning ../package.json: No license field
$ /Users/krobinson/Documents/github/studentinsights/node_modules/.bin/concurrently --names demo,somerville,new-bedford -c yellow.bold,blue.bold,magenta.bold scripts/deploy/deploy.sh demo scripts/deploy/deploy.sh somerville scripts/deploy/deploy.sh new-bedford
[somerville] /bin/sh: demo: command not found
[] /bin/sh: somerville: command not found
[] /bin/sh: new-bedford: command not found
[] scripts/deploy/deploy.sh exited with code 0
[new-bedford] scripts/deploy/deploy.sh exited with code 0
[demo] scripts/deploy/deploy.sh exited with code 0
[] new-bedford exited with code 127
[] somerville exited with code 127
[somerville] demo exited with code 127
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
🚢  Done.
```

# What does this PR do?
It looks like there's some kind of escaping issue.  This escapes the quotes around each command, and this resolved the problem for me.