### PR TITLE
Add Rollbar notification for LDAP connection errors

### DIFF
--- a/app/lib/ldap_authenticatable_tiny/strategy.rb
+++ b/app/lib/ldap_authenticatable_tiny/strategy.rb
@@ -22,6 +22,7 @@ module Devise
           fail!(:invalid) and return unless is_authorized_by_ldap?(ldap_class, email, password)
           success!(educator) and return
         rescue => error
+          Rollbar.error('LdapAuthenticatableTiny error', error)
           logger.error "LdapAuthenticatableTiny, error: #{error}"
           fail!(:error) and return
         end

--- a/spec/lib/ldap_authenticatable_tiny_spec.rb
+++ b/spec/lib/ldap_authenticatable_tiny_spec.rb
@@ -52,6 +52,20 @@ RSpec.describe 'LdapAuthenticatableTiny' do
       expect(strategy.user).to eq nil
     end
 
+    it 'reports error and calls fail! when is_authorized_by_ldap? times out' do
+      expect(Rollbar).to receive(:error).with(any_args)
+
+      strategy = test_strategy
+      allow(strategy).to receive(:authentication_hash) { { email: 'uri@demo.studentinsights.org' } }
+      allow(strategy).to receive(:password) { 'supersecure' }
+      allow(strategy).to receive(:is_authorized_by_ldap?).with(MockLDAP, 'uri@demo.studentinsights.org', 'supersecure').and_raise(Net::LDAP::Error)
+      strategy.authenticate!
+
+      expect(strategy.result).to eq :failure
+      expect(strategy.message).to eq :error
+      expect(strategy.user).to eq nil
+    end
+
     it 'calls success! even when cases are different' do
       strategy = test_strategy
       allow(strategy).to receive(:authentication_hash) { { email: 'URI@demo.studentinsights.org' } }


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
If there are connection issues (eg, during firewall upgrades), we log this but don't notify.

# What does this PR do?
Notifies on connection errors via Rollbar.

# Checklists
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code
