### PR TITLE
Simplify CSV cleaning regex, add more tests for different edge cases

### DIFF
--- a/app/importers/data_transformers/parseable_csv_string.rb
+++ b/app/importers/data_transformers/parseable_csv_string.rb
@@ -71,9 +71,9 @@ class ParseableCsvString
     @log.puts '#convert_slash_quote_to_double_quote...'
 
     quotes_converted_count = 0
-    string_without_slash_quotes = string.gsub(/[^\\]\\"/) do |match|
+    string_without_slash_quotes = string.gsub(/([^\\])\\\"/) do |match|
       quotes_converted_count = quotes_converted_count + 1
-      '""'
+      "#{Regexp.last_match.captures.first}\"\""
     end
 
     @log.puts "  stripped #{quotes_converted_count} quotes."
@@ -88,9 +88,9 @@ class ParseableCsvString
     @log.puts '#strip_inline_newlines...'
 
     newlines_stripped_count = 0
-    string_without_inline_newlines = string.gsub("\\r\n") do |match|
+    string_without_inline_newlines = string.gsub(/([^\\])\\\r\n/) do |match|
       newlines_stripped_count = newlines_stripped_count + 1
-      ' '
+      "#{Regexp.last_match.captures.first} "
     end
 
     @log.puts "  stripped #{newlines_stripped_count} newlines."

--- a/app/importers/data_transformers/parseable_csv_string.rb
+++ b/app/importers/data_transformers/parseable_csv_string.rb
@@ -70,10 +70,13 @@ class ParseableCsvString
   def convert_slash_quote_to_double_quote(string)
     @log.puts '#convert_slash_quote_to_double_quote...'
 
+    # This uses a "negative lookbehind" in the regex to prevent
+    # overmatching: https://www.regular-expressions.info/lookaround.html
+    # Escaping is confusing: https://stackoverflow.com/questions/1542214/weird-backslash-substitution-in-ruby
     quotes_converted_count = 0
-    string_without_slash_quotes = string.gsub(/([^\\])\\\"/) do |match|
+    string_without_slash_quotes = string.gsub(/(?<!\\)\\"/) do
       quotes_converted_count = quotes_converted_count + 1
-      "#{Regexp.last_match.captures.first}\"\""
+      '""'
     end
 
     @log.puts "  stripped #{quotes_converted_count} quotes."
@@ -88,9 +91,9 @@ class ParseableCsvString
     @log.puts '#strip_inline_newlines...'
 
     newlines_stripped_count = 0
-    string_without_inline_newlines = string.gsub(/([^\\])\\\r\n/) do |match|
+    string_without_inline_newlines = string.gsub(/(?<!\\)\\\r\n/) do
       newlines_stripped_count = newlines_stripped_count + 1
-      "#{Regexp.last_match.captures.first} "
+      ' '
     end
 
     @log.puts "  stripped #{newlines_stripped_count} newlines."

--- a/app/importers/data_transformers/parseable_csv_string.rb
+++ b/app/importers/data_transformers/parseable_csv_string.rb
@@ -71,9 +71,9 @@ class ParseableCsvString
     @log.puts '#convert_slash_quote_to_double_quote...'
 
     quotes_converted_count = 0
-    string_without_slash_quotes = string.gsub(/([^\\])\\\"/) do |match|
+    string_without_slash_quotes = string.gsub(/[^\\]\\"/) do |match|
       quotes_converted_count = quotes_converted_count + 1
-      "#{Regexp.last_match.captures.first}\"\""
+      '""'
     end
 
     @log.puts "  stripped #{quotes_converted_count} quotes."
@@ -88,9 +88,9 @@ class ParseableCsvString
     @log.puts '#strip_inline_newlines...'
 
     newlines_stripped_count = 0
-    string_without_inline_newlines = string.gsub(/([^\\])\\\r\n/) do |match|
+    string_without_inline_newlines = string.gsub("\\r\n") do |match|
       newlines_stripped_count = newlines_stripped_count + 1
-      "#{Regexp.last_match.captures.first} "
+      ' '
     end
 
     @log.puts "  stripped #{newlines_stripped_count} newlines."

--- a/spec/importers/data_transformers/parseable_csv_string_spec.rb
+++ b/spec/importers/data_transformers/parseable_csv_string_spec.rb
@@ -41,32 +41,36 @@ RSpec.describe ParseableCsvString do
     end
 
     it 'warns and strips unknown invalid characters' do
-      test_string = "\"hi\",\N,\"eating s\xF2mething\"".force_encoding('ASCII-8BIT')
+      test_string = "\"hi\",\"eating s\xF2mething\"".force_encoding('ASCII-8BIT')
       log, parseable_string = parseable_string_from(test_string)
 
       expect(parseable_string.encoding.name).to eq 'UTF-8'
       expect(log.output).to include ('failed to convert 1 unexpected invalid character encodings for ["\xF2"]')
-      expect(parseable_string).to eq "\"hi\",\N,\"eating smething\""
+      expect(parseable_string).to eq '"hi","eating smething"'
       expect { parse(parseable_string) }.not_to raise_error
     end
   end
 
   it 'converts slash quote (`\"`) to double quote (`""`)' do
-    string = "\"hi there \\\"friend\\\" person\",\N,\"bye\""
+    string = '"hi there \"friend\" person","bye"'
     log, parseable_string = parseable_string_from(string)
 
     expect(log.output).to include('stripped 2 quotes')
-    expect(parseable_string).to eq "\"hi there \"\"friend\"\" person\",\N,\"bye\""
+    expect(parseable_string).to eq '"hi there ""friend"" person","bye"'
     expect { parse(parseable_string) }.not_to raise_error
   end
 
   it 'does not get confused by `\\"` sequence and mistakenly convert slash quote' do
-    string = "\"hi there friend\\\\\",\N,\"bye\""
+    string = '"hi there friend\\","bye"'
     log, parseable_string = parseable_string_from(string)
+
+    puts string
+    puts log.output
+    puts parseable_string
 
     expect(log.output).to include('stripped 0 newline')
     expect(log.output).to include('stripped 0 quotes')
-    expect(parseable_string).to eq "\"hi there friend\\\\\",\N,\"bye\""
+    expect(parseable_string).to eq '"hi there friend\","bye"'
     expect { parse(parseable_string) }.not_to raise_error
   end
 
@@ -77,6 +81,19 @@ RSpec.describe ParseableCsvString do
     expect(log.output).to include('stripped 1 newline')
     expect(log.output).to include('stripped 0 quotes')
     expect(parseable_string).to eq "\"123\",\"456\",\"1\",\"0\",\"0\",\N,\"0\",\"mom sick \\\\\",\"2015-03-01\",\"SCHOOL\""
+    expect { parse(parseable_string) }.not_to raise_error
+  end
+
+  it 'works on New Bedford test case' do
+    string = '"312","321","something","2014-03-02","07:23:00","Classroom","saying: \"no.\"\"no way.\"\"no thanks.\"\"do not want.\"","654"'
+    log, parseable_string = parseable_string_from(string)
+
+    puts string
+    puts log.output
+    puts parseable_string
+    # expect(log.output).to include('stripped 1 newline')
+    # expect(log.output).to include('stripped 0 quotes')
+    # expect(parseable_string).to eq "\"123\",\"456\",\"1\",\"0\",\"0\",\N,\"0\",\"mom sick \\\\\",\"2015-03-01\",\"SCHOOL\""
     expect { parse(parseable_string) }.not_to raise_error
   end
 

--- a/spec/importers/data_transformers/parseable_csv_string_spec.rb
+++ b/spec/importers/data_transformers/parseable_csv_string_spec.rb
@@ -41,36 +41,32 @@ RSpec.describe ParseableCsvString do
     end
 
     it 'warns and strips unknown invalid characters' do
-      test_string = "\"hi\",\"eating s\xF2mething\"".force_encoding('ASCII-8BIT')
+      test_string = "\"hi\",\N,\"eating s\xF2mething\"".force_encoding('ASCII-8BIT')
       log, parseable_string = parseable_string_from(test_string)
 
       expect(parseable_string.encoding.name).to eq 'UTF-8'
       expect(log.output).to include ('failed to convert 1 unexpected invalid character encodings for ["\xF2"]')
-      expect(parseable_string).to eq '"hi","eating smething"'
+      expect(parseable_string).to eq "\"hi\",\N,\"eating smething\""
       expect { parse(parseable_string) }.not_to raise_error
     end
   end
 
   it 'converts slash quote (`\"`) to double quote (`""`)' do
-    string = '"hi there \"friend\" person","bye"'
+    string = "\"hi there \\\"friend\\\" person\",\N,\"bye\""
     log, parseable_string = parseable_string_from(string)
 
     expect(log.output).to include('stripped 2 quotes')
-    expect(parseable_string).to eq '"hi there ""friend"" person","bye"'
+    expect(parseable_string).to eq "\"hi there \"\"friend\"\" person\",\N,\"bye\""
     expect { parse(parseable_string) }.not_to raise_error
   end
 
   it 'does not get confused by `\\"` sequence and mistakenly convert slash quote' do
-    string = '"hi there friend\\","bye"'
+    string = "\"hi there friend\\\\\",\N,\"bye\""
     log, parseable_string = parseable_string_from(string)
-
-    puts string
-    puts log.output
-    puts parseable_string
 
     expect(log.output).to include('stripped 0 newline')
     expect(log.output).to include('stripped 0 quotes')
-    expect(parseable_string).to eq '"hi there friend\","bye"'
+    expect(parseable_string).to eq "\"hi there friend\\\\\",\N,\"bye\""
     expect { parse(parseable_string) }.not_to raise_error
   end
 
@@ -81,19 +77,6 @@ RSpec.describe ParseableCsvString do
     expect(log.output).to include('stripped 1 newline')
     expect(log.output).to include('stripped 0 quotes')
     expect(parseable_string).to eq "\"123\",\"456\",\"1\",\"0\",\"0\",\N,\"0\",\"mom sick \\\\\",\"2015-03-01\",\"SCHOOL\""
-    expect { parse(parseable_string) }.not_to raise_error
-  end
-
-  it 'works on New Bedford test case' do
-    string = '"312","321","something","2014-03-02","07:23:00","Classroom","saying: \"no.\"\"no way.\"\"no thanks.\"\"do not want.\"","654"'
-    log, parseable_string = parseable_string_from(string)
-
-    puts string
-    puts log.output
-    puts parseable_string
-    # expect(log.output).to include('stripped 1 newline')
-    # expect(log.output).to include('stripped 0 quotes')
-    # expect(parseable_string).to eq "\"123\",\"456\",\"1\",\"0\",\"0\",\N,\"0\",\"mom sick \\\\\",\"2015-03-01\",\"SCHOOL\""
     expect { parse(parseable_string) }.not_to raise_error
   end
 


### PR DESCRIPTION
# Who is this PR for?
NB educators

# What problem does this PR fix?
https://github.com/studentinsights/studentinsights/pull/1855 and https://github.com/studentinsights/studentinsights/pull/1778 have been trying to address https://github.com/studentinsights/studentinsights/issues/1777, but there are interactions between the different kinds of cleaning.  Fixing one issue for Somerville created a separate one for New Bedford.

# What does this PR do?
Improves the regex for translating `\"` to `""`, to satisfy what the strict Ruby CSV parser expects.  In particular, this prevents overmatching on the `\\"` sequence, and makes sure it matches the `\"\"` sequence, both of which were problematic.

# Checklists
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code
