### PR TITLE
Fix bug with resolving drift when trying to export class lists

### DIFF
--- a/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.js
@@ -334,6 +334,7 @@ export default class ClassListCreatorWorkflow extends React.Component {
 
     if (students === null || educators === null || studentIdsByRoom === null) return <Loading />;
 
+    const studentIds = students.map(student => student.id);
     return (
       <div key="export" style={styles.stepContent}>
         <ExportList
@@ -343,8 +344,8 @@ export default class ClassListCreatorWorkflow extends React.Component {
           gradeLevelNextYear={gradeLevelNextYear}
           students={students} 
           fetchProfile={studentId => fetchProfile(workspaceId, studentId)}
-          teacherStudentIdsByRoom={studentIdsByRoom}
-          principalStudentIdsByRoom={principalStudentIdsByRoom}
+          teacherStudentIdsByRoom={resolveDriftForStudents(studentIdsByRoom, studentIds)}
+          principalStudentIdsByRoom={principalStudentIdsByRoom ? resolveDriftForStudents(principalStudentIdsByRoom, studentIds) : null}
           educators={educators}
           principalTeacherNamesByRoom={principalTeacherNamesByRoom}
           onPrincipalTeacherNamesByRoomChanged={isRevisable ? onPrincipalTeacherNamesByRoomChanged : null}


### PR DESCRIPTION
# Who is this PR for?
K5 principals

# What problem does this PR fix?
Fixes https://rollbar.com/somerville-teacher-tool/somerville-teacher-tool/items/169/; when students are withdrawn or move schools, there's drift between the set of students in the class lists and the current set of students.  The class list UI code resolves this in a few places, but not in the export list.  So if a student is withdrawn, this page raises an error.

# What does this PR do?
Calls the resolve function for the `ExportList` component too.
