### PR TITLE
Tune how ImportJob handles failure

### DIFF
--- a/app/importers/file_importers/csv_downloader.rb
+++ b/app/importers/file_importers/csv_downloader.rb
@@ -10,10 +10,13 @@ class CsvDownloader
   end
 
   def get_data
+    log('Downloading...')
     file_contents = download_file
 
+    log('Transforming...')
     data = @transformer.transform(file_contents)
 
+    log('CleanupReport...')
     CleanupReport.new(
       @log, @remote_file_name, @transformer.pre_cleanup_csv_size, data.size
     ).print
@@ -22,7 +25,7 @@ class CsvDownloader
   end
 
   def download_file
-    log("\nDownloading #{@remote_file_name}...")
+    log("Downloading remote_filename: #{@remote_file_name}")
 
     downloaded_file = @client.download_file(@remote_file_name)
     File.read(downloaded_file)

--- a/app/importers/file_importers/csv_downloader.rb
+++ b/app/importers/file_importers/csv_downloader.rb
@@ -10,13 +10,10 @@ class CsvDownloader
   end
 
   def get_data
-    log('Downloading...')
     file_contents = download_file
 
-    log('Transforming...')
     data = @transformer.transform(file_contents)
 
-    log('CleanupReport...')
     CleanupReport.new(
       @log, @remote_file_name, @transformer.pre_cleanup_csv_size, data.size
     ).print
@@ -25,7 +22,7 @@ class CsvDownloader
   end
 
   def download_file
-    log("Downloading remote_filename: #{@remote_file_name}")
+    log("\nDownloading #{@remote_file_name}...")
 
     downloaded_file = @client.download_file(@remote_file_name)
     File.read(downloaded_file)

--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -11,6 +11,9 @@ class ImportTask
     # options["only_recent_attendance"]
     @only_recent_attendance = @options.fetch("only_recent_attendance", false)
 
+    # to skip updating any indexes after (eg, when tuning a particular job)
+    @skip_index_updates = @options.fetch('skip_index_updates', false)
+
     @log = Rails.env.test? ? LogHelper::Redirect.instance.file : STDOUT
   end
 
@@ -153,6 +156,11 @@ class ImportTask
   ## RUN TASKS THAT CACHE DATA ##
 
   def run_update_tasks
+    if @skip_index_updates
+      log('Skipping index updates...')
+      return
+    end
+
     begin
       Student.update_risk_levels!
       Student.update_recent_student_assessments

--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -34,10 +34,14 @@ class ImportTask
       @report.print_final_counts_report
       log('Done.')
     rescue SignalException => err
+      # Delayed::Job can trap and raise this (eg, if Heroku is about to restart the
+      # dyno).  This is an expected occurrence, and the worker should stop, and after it comes back
+      # up the new worker should retry the job and succeed.  So we don't need to alert on each occurrence.
       log("ImportTask caught a SignalException: #{err}")
       log('Re-raising the SignalException...')
       raise err
     rescue => err
+      # Note that there is also separate error handling for each importer class independently.
       log("ImportTask aborted because of an error: #{err}")
       Rollbar.error('ImportTask aborted because of an error', err)
     end

--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -11,9 +11,6 @@ class ImportTask
     # options["only_recent_attendance"]
     @only_recent_attendance = @options.fetch("only_recent_attendance", false)
 
-    # to skip updating any indexes after (eg, when tuning a particular job)
-    @skip_index_updates = @options.fetch('skip_index_updates', false)
-
     @log = Rails.env.test? ? LogHelper::Redirect.instance.file : STDOUT
   end
 
@@ -156,11 +153,6 @@ class ImportTask
   ## RUN TASKS THAT CACHE DATA ##
 
   def run_update_tasks
-    if @skip_index_updates
-      log('Skipping index updates...')
-      return
-    end
-
     begin
       Student.update_risk_levels!
       Student.update_recent_student_assessments

--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -9,14 +9,6 @@ class ImportJob
     ImportTask.new(options: @options).connect_transform_import
   end
 
-  def max_attempts
-    1
-  end
-
-  def max_run_time
-    6.hours
-  end
-
   def error(job, exception)
     extra_info =  { "hook" => "error", "job" => job.as_json(except: :log) }
     ErrorMailer.error_report(exception, extra_info).deliver_now if Rails.env.production?

--- a/app/jobs/test_job.rb
+++ b/app/jobs/test_job.rb
@@ -1,0 +1,44 @@
+# This is for testing different failure modes.
+class TestJob
+  def perform
+    begin
+      puts 'starting...'
+      (0..120).each do |i|
+        sleep(1.seconds)
+        puts "slept #{i} seconds..."
+      end
+      puts 'ending...'
+    rescue SignalException => e
+      puts 'rescued'
+      puts e
+      puts 're-raising...'
+      raise e
+    end
+  end
+
+  def max_attempts
+    2
+  end
+
+  def max_run_time
+    5.minutes
+  end
+
+  # unhandled Exception
+  def error(job, exception)
+    extra_info =  { "hook" => "error", "job" => job.as_json(except: :log) }
+    puts "error"
+    puts exception
+    puts extra_info
+  end
+
+  # When the job itself has ultimately failed and can no
+  # longer continue, or it encounters a DeserializationError and can't even start.
+  def failure(job)
+    extra_info =  { "hook" => "failure", "job" => job.as_json(except: :log) }
+    exception = StandardError.new('ImportJob#failure')
+    puts "failure"
+    puts exception
+    puts extra_info
+  end
+end

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,30 +1,28 @@
-# This is overridden in specific jobs, but in general we don't want anything to run this long ever.
-Delayed::Worker.max_run_time = 24.hours
+# This is overridden in specific jobs.  Note that this does not determine the maximum time a job 
+# can run before being killed - it actually describes how long to wait until taking over a job
+# that has been locked.  So in effect, this means "how long does a worker have to release until
+# the system takes that job back and retries it."
+Delayed::Worker.max_run_time = 6.hours
 
 # For the import job, we want it to run as one big job since the steps are sequential and dependent
 # on running in a particular order.  The job overall is idempotent, but dependending on where it fails,
 # the database may be in a somewhat inconsistent state (eg, only some records in a table are updated but
 # others are still stale).  We tolerate that, and on failure re-run the entire job.
-#
-# The failure cases we've seen are running out of memory or a dyno restart from a config change, when
-# Heroku sends a SIGERM and then SIGKILL.  In that case, we want want the job to be retried one more
-# time and then not retried anymore if it fails the second time.
-#
-# We found that creating this flow was difficult to do through Delayed::Job config. Instead, we're
-# handling SIGTERM in the ImportTask class with `rescue SignalException`.
-#
-# * * We may be able to remove these two lines of config since they don't appear to be having
-# * * an effect, see https://github.com/studentinsights/studentinsights/issues/1626#issue-314269511:
 Delayed::Worker.max_attempts = 2
 Delayed::Worker.destroy_failed_jobs = false
 
+# Some failure cases we've seen are running out of memory (SIGKILL) or a dyno restart from a config
+# change, when Heroku sends a SIGTERM and then SIGKILL.  In that case, we want want the job to be retried
+# one more time and then not retried anymore if it fails the second time.
+#
 # If we didn't set `raise_signal_exception`, when the task was killed the job would stay locked and
-# when the worker dyno comes back up, it wouldn't be retried.  Hours laters (depending on the max_run_time),
-# Delayed::Job would release the job and it would be retried then.  If the job kept failing (eg, if it
-# kept running out of memory), this would go on indefinitely for up to `max_attempts`, which with the
-# default settings means it would keep retrying for ~20 days.
-Delayed::Worker.raise_signal_exceptions = true
-
+# when the worker dyno comes back up, it wouldn't be retried immediately.  Hours later (depending
+# on the max_run_time), Delayed::Job would consider the job released, and it would retry then.
+# This means that on SIGTERM, we'll retry immediately.  On SIGKILL, we wait until `max_run_time` to
+# try again.
+#
 # More reading:
 # see https://github.com/collectiveidea/delayed_job#gory-details
 # https://stackoverflow.com/questions/10438100/long-running-delayed-job-jobs-stay-locked-after-a-restart-on-heroku
+Delayed::Worker.raise_signal_exceptions = true
+

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -11,9 +11,6 @@ Delayed::Worker.max_run_time = 2.hours
 Delayed::Worker.max_attempts = 2
 Delayed::Worker.destroy_failed_jobs = false
 
-# This raises the default to a minute instead of querying every 5 seconds.
-Delayed::Worker.sleep_delay = 60 # seconds
-
 # Some failure cases we've seen are running out of memory (SIGKILL) or a dyno restart from a config
 # change, when Heroku sends a SIGTERM and then SIGKILL.  In that case, we want want the job to be retried
 # one more time and then not retried anymore if it fails the second time.

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,7 +1,17 @@
-# This is overridden in specific jobs.  Note that this does not determine the maximum time a job 
-# can run before being killed - it actually describes how long to wait until taking over a job
-# that has been locked.  So in effect, this means "how long does a worker have to release until
-# the system takes that job back and retries it."
+# `max_run_time` controls two different things.
+#
+# First, it acts as a timeout and the worker process
+# will abort jobs that take longer than this (see the timeout code here https://github.com/collectiveidea/delayed_job/blob/master/lib/delayed/worker.rb#L230).
+#
+# Second, it controls how long to wait until taking over a job that has been locked but not completed or not
+# failed (eg, the worker process was forcibly killed).  So in effect, this means "how long does a worker have
+# to wait before an abandoned job is considered released and the worker can reserve that job to try again."
+# 
+# Also, there is a bug in the call to `#reserve` between the `delayed_job` and `delayed_job_active_record` gems,
+# which means that the per-job value is not respected.  We can patch that on the call side or on the receiving side,
+# but to work around for now we just set that value here.
+# call side: https://github.com/collectiveidea/delayed_job/blob/master/lib/delayed/worker.rb#L316
+# receiving side: https://github.com/collectiveidea/delayed_job_active_record/blob/master/lib/delayed/backend/active_record.rb#L74
 Delayed::Worker.max_run_time = 2.hours
 
 # For the import job, we want it to run as one big job since the steps are sequential and dependent
@@ -9,17 +19,21 @@ Delayed::Worker.max_run_time = 2.hours
 # the database may be in a somewhat inconsistent state (eg, only some records in a table are updated but
 # others are still stale).  We tolerate that, and on failure re-run the entire job.
 Delayed::Worker.max_attempts = 2
+
+# For jobs that have hit errors or failed more than `max_attempts`, this will leave the record in the database
+# so we can look at it, but the `failed_at` timestamp will be set so that it is not worked anymore.
 Delayed::Worker.destroy_failed_jobs = false
 
-# Some failure cases we've seen are running out of memory (SIGKILL) or a dyno restart from a config
-# change, when Heroku sends a SIGTERM and then SIGKILL.  In that case, we want want the job to be retried
-# one more time and then not retried anymore if it fails the second time.
+# This is for handling different failure cases.
+# 
+# Heroku regularly restarts dynos, and also restarts them on config changes (eg, an environment variable is
+# changed).  In this case it sends SIGTERM, and we can use `raise_signal_exceptions` to catch that.  Then we
+# can either cleanup the job and exit for it to be considered completed successfully, or we can re-raise
+# so that the job is considered a failure.  When re-raising, this will run the normal delayed job failure 
+# handling paths, and set `last_error` on the job and reschedule it for its next run.
 #
-# If we didn't set `raise_signal_exception`, when the task was killed the job would stay locked and
-# when the worker dyno comes back up, it wouldn't be retried immediately.  Hours later (depending
-# on the max_run_time), Delayed::Job would consider the job released, and it would retry then.
-# This means that on SIGTERM, we'll retry immediately.  On SIGKILL, we wait until `max_run_time` to
-# try again.
+# Another failure case is running out of memory, (where Heroku sends SIGKILL).  In that case, the job will be 
+# forcibly killed and abandoned, so it won't be re-run until the `max_run_time` window has passed.
 #
 # More reading:
 # see https://github.com/collectiveidea/delayed_job#gory-details

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -2,7 +2,7 @@
 # can run before being killed - it actually describes how long to wait until taking over a job
 # that has been locked.  So in effect, this means "how long does a worker have to release until
 # the system takes that job back and retries it."
-Delayed::Worker.max_run_time = 6.hours
+Delayed::Worker.max_run_time = 2.hours
 
 # For the import job, we want it to run as one big job since the steps are sequential and dependent
 # on running in a particular order.  The job overall is idempotent, but dependending on where it fails,
@@ -10,6 +10,9 @@ Delayed::Worker.max_run_time = 6.hours
 # others are still stale).  We tolerate that, and on failure re-run the entire job.
 Delayed::Worker.max_attempts = 2
 Delayed::Worker.destroy_failed_jobs = false
+
+# This raises the default to a minute instead of querying every 5 seconds.
+Delayed::Worker.sleep_delay = 60 # seconds
 
 # Some failure cases we've seen are running out of memory (SIGKILL) or a dyno restart from a config
 # change, when Heroku sends a SIGTERM and then SIGKILL.  In that case, we want want the job to be retried

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -18,16 +18,14 @@ class Import
       desc: "Only import attendance rows from the past 90 days for faster attendance import"
     class_option :background,
       type: :boolean,
-      default: true,
+      default: false,
       desc: "Import data in a background job"
 
     def import
-      job_options = options.merge({ attempt: 0 })
-
       if options.fetch(:background)
-        Delayed::Job.enqueue ImportJob.new(options: job_options)
+        Delayed::Job.enqueue ImportJob.new(options: options)
       else
-        ImportTask.new(options: job_options).connect_transform_import
+        ImportTask.new(options: options).connect_transform_import
       end
     end
   end

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -16,6 +16,10 @@ class Import
       type: :boolean,
       default: false,
       desc: "Only import attendance rows from the past 90 days for faster attendance import"
+    class_option :skip_index_updates,
+      type: :boolean,
+      default: false,
+      desc: "Skip updating indexes after the import task is completed (not recommended except for when profiling)"
     class_option :background,
       type: :boolean,
       default: true,

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -16,10 +16,6 @@ class Import
       type: :boolean,
       default: false,
       desc: "Only import attendance rows from the past 90 days for faster attendance import"
-    class_option :skip_index_updates,
-      type: :boolean,
-      default: false,
-      desc: "Skip updating indexes after the import task is completed (not recommended except for when profiling)"
     class_option :background,
       type: :boolean,
       default: true,


### PR DESCRIPTION
# Who is this PR for?
NB educators, developers

# What problem does this PR fix?
The NB importer jobs haven't been super healthy, and have been retrying in a few different ways. 
 See https://github.com/studentinsights/studentinsights/issues/1626#issue-314269511, and also https://github.com/studentinsights/studentinsights/pull/1861 which addresses the memory usage issues.

Right now, there are two separate mechanisms for replaying that don't know about each other - the `attempt` option passed to the `ImportJob`, and the `attempts` value owned by `Delayed::Job`.  And we're seeing jobs that are repeatedly retried at increasing frequency for NB, suggesting these two mechanisms may be interacting to amplify the total number of retries.

# What does this PR do?
Changes how ImportJob handles failure.

1. Moves `Delayed::Job` configuration from `ImportJob` into `delayed_job_config` so it's altogether.  This also addresses https://github.com/collectiveidea/delayed_job_active_record/issues/159.
2. Tunes down `max_run_time` to two hours.  This param tunes how long a job can run, but also tunes how long it is until `Delayed::Job` considers the worker to have died and allows reserving the job again.  So having it so high makes it so that retries get delayed 24 hours now, which isn't what we want.  I looked back at the logs to see how long jobs take, and they are consistently well under two hours.
3. Removes special behavior on `SignalException` - catch it and log, but re-raise.  The intention here is that re-raising will "causing the running job to abort and be unlocked, which makes the job available to other workers." (https://github.com/collectiveidea/delayed_job#gory-details).  I confirmed this works as expected locally, and sending worker tasks SIGTERM leads to the task being retried right away (from the teardown process setting `attempts` and `last_error` and `run_at` on the record).

There are two other related threads to this work.  One, with https://github.com/studentinsights/studentinsights/pull/1861#issuecomment-401558466, we haven't had any issues over the last week, and all jobs look healthy.  So this isn't as much of a concern anymore anyway.  Two, right now we're paying for 24 hours of worker dynos that are just polling the database, and we may be able to switch to using one-off dynos for all tasks to reduce those costs.