### PR TITLE
Optimize StudentsImporter to use StreamingCsvTransformer, and to only save changed records

### DIFF
--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -12,7 +12,7 @@ class StudentsImporter
       log: @log, remote_file_name: remote_file_name, client: client, transformer: data_transformer
     ).get_data
 
-    @data.each.each_with_index do |row, index|
+    @data.each_with_index do |row, index|
       import_row(row) if filter.include?(row)
     end
   end
@@ -26,7 +26,7 @@ class StudentsImporter
   end
 
   def data_transformer
-    CsvTransformer.new(@log)
+    StreamingCsvTransformer.new(@log)
   end
 
   def filter
@@ -39,7 +39,8 @@ class StudentsImporter
 
   def import_row(row)
     student = StudentRow.new(row, school_ids_dictionary).build
-    return if student.registration_date_in_future
+    return nil if student.registration_date_in_future
+    return student unless student.changed?
 
     did_save = student.save
     if !did_save


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
`StudentsImporters` takes ~8 minutes and is one of the slowest importers for Somerville.

# What does this PR do?
Uses `StreamingCsvTransformer` and only calls `.save!` if anything has changed, taking approach from https://github.com/studentinsights/studentinsights/pull/1861#issuecomment-401558466.
