### PR TITLE
Tune down production log level

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Upgrading Rails in https://github.com/studentinsights/studentinsights/pull/1832 changed the default log level to DEBUG, so all queries are logged now.  This is somewhat helpful for debugging performance issues (eg, in import jobs), but also adds a ton of log noise.  It's also hitting some logentries limits:
<img width="205" alt="screen shot 2018-07-09 at 10 47 31 am" src="https://user-images.githubusercontent.com/1056957/42457496-a0cbd2ac-8365-11e8-9971-8faea02b056b.png">

We can always enable this in more fine-grained way for profiling particular code if we want to.

# What does this PR do?
Sets log level back to :info.
