### PR TITLE
Try forcing STDOUT.sync true for logging timestamps

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,6 +81,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
+    STDOUT.sync = true
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Import task timestamps still aren't always flushed synchronously, making it hard to understand how long parts of the task are taking by looking at logs.

# What does this PR do?
Based on https://github.com/heroku/rails_stdout_logging#migrating-to-rails-5 and related PRs, it seems there is a config value controlling this, but that Heroku requires one other change in additional to the default Rails 5 changes.  The env variable seems magical too, as it doesn't show up in `heroku config` but does if you run a Rails console and check it.  I added those explicitly now.
