### PR TITLE
Always log StreamingCsvTransformer skipped dirty rows

### DIFF
--- a/app/importers/data_transformers/streaming_csv_transformer.rb
+++ b/app/importers/data_transformers/streaming_csv_transformer.rb
@@ -14,7 +14,7 @@ class StreamingCsvTransformer
   end
 
   # Performs whole-file transformations first
-  # This method returns itself, satisfying the {each_with_index} inteface for
+  # This method returns itself, satisfying the {each_with_index} interface for
   # iterating over CSV rows.
   def transform(csv_string)
     @csv_string = ParseableCsvString.new(@log).from_string(csv_string)

--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -39,7 +39,6 @@ class AttendanceImporter
     end
 
     log('Done loop.')
-    log("StreamingCsvTransformer#stats: #{streaming_csv.stats}")
     log("@skipped_from_school_filter: #{@skipped_from_school_filter}")
     log("@skipped_old_rows_count: #{@skipped_old_rows_count}")
     log("@skipped_other_rows_count: #{@skipped_other_rows_count}")

--- a/app/importers/file_importers/x2_assessment_importer.rb
+++ b/app/importers/file_importers/x2_assessment_importer.rb
@@ -34,7 +34,6 @@ class X2AssessmentImporter
     end
 
     log('Done loop.')
-    log("StreamingCsvTransformer#stats: #{streaming_csv.stats}")
     log("@skipped_from_school_filter: #{@skipped_from_school_filter}")
     log("@skipped_old_rows_count: #{@skipped_old_rows_count}")
     log("@skipped_because_of_test_type: #{@skipped_because_of_test_type}")

--- a/spec/importers/data_transformers/streaming_csv_transformer_spec.rb
+++ b/spec/importers/data_transformers/streaming_csv_transformer_spec.rb
@@ -9,17 +9,17 @@ RSpec.describe StreamingCsvTransformer do
       let(:output) { transformer.transform(csv_string) }
 
       it '#stats (before iteration)' do
-        expect(transformer.stats).to eq({
+        expect(transformer.send(:stats)).to eq({
           :processed_rows_count => 0,
-          :total_rows_count => 0,
+          :skipped_dirty_rows_count => 0
         })
       end
 
       it '#stats (after iteration) filter out row with bad date' do
         output.each_with_index {|row, index| nil }
-        expect(transformer.stats).to eq({
+        expect(transformer.send(:stats)).to eq({
           :processed_rows_count => 3,
-          :total_rows_count => 4
+          :skipped_dirty_rows_count => 1
         })
       end
     end
@@ -60,9 +60,9 @@ RSpec.describe StreamingCsvTransformer do
         output.each_with_index {|row, index| rows << row }
         expect(rows.size).to eq(6)
         expect(rows.first.headers).to match_array(headers.map(&:to_sym))
-        expect(transformer.stats).to eq({
+        expect(transformer.send(:stats)).to eq({
           :processed_rows_count => 6,
-          :total_rows_count => 6,
+          :skipped_dirty_rows_count => 0
         })
       end
     end


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
We really want to know the records skipped because they're dirty, but the logging in https://github.com/studentinsights/studentinsights/pull/1872 makes you do subtraction to tell.

# What does this PR do?
Logs `skipped_dirty_rows_count` directly, moves logging into `StreamingCsvTransformer` rather than out in the importer so we can see this for each one.  This also gives us the information needed to factor out `CsvRowCleaner` to the importer jobs that benefit from its filtering.
