### PR TITLE
Fix layout bug with note and note attachment overflow

### DIFF
--- a/app/assets/javascripts/components/NoteText.js
+++ b/app/assets/javascripts/components/NoteText.js
@@ -8,6 +8,7 @@ export const exportedNoteText = {
   fontFamily: "'Open Sans', sans-serif",
   fontSize: 14,
   whiteSpace: 'pre-wrap',
+  wordBreak: 'break-all',
   border: '1px solid transparent' // for sizing when we add a border on hover when editable
 };
 

--- a/app/assets/javascripts/feed/__snapshots__/EventNoteCard.test.js.snap
+++ b/app/assets/javascripts/feed/__snapshots__/EventNoteCard.test.js.snap
@@ -140,6 +140,7 @@ exports[`matches snapshot 1`] = `
             "padding": 0,
             "style": undefined,
             "whiteSpace": "pre-wrap",
+            "wordBreak": "break-all",
           }
         }
       >

--- a/app/assets/javascripts/feed/__snapshots__/FeedView.test.js.snap
+++ b/app/assets/javascripts/feed/__snapshots__/FeedView.test.js.snap
@@ -178,6 +178,7 @@ exports[`FeedView pure component matches snapshot 1`] = `
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -341,6 +342,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -516,6 +518,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -704,6 +707,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -865,6 +869,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -1040,6 +1045,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -1228,6 +1234,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -1416,6 +1423,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -1590,6 +1598,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -1751,6 +1760,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -1939,6 +1949,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -2127,6 +2138,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -2315,6 +2327,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -2476,6 +2489,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -2651,6 +2665,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -2826,6 +2841,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -3001,6 +3017,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -3189,6 +3206,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >
@@ -3350,6 +3368,7 @@ Philis is meeting with parent next week and will present an attendance contract.
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
+              "wordBreak": "break-all",
             }
           }
         >

--- a/app/assets/javascripts/student_profile/NoteCard.js
+++ b/app/assets/javascripts/student_profile/NoteCard.js
@@ -74,15 +74,22 @@ export default class NoteCard extends React.Component {
     return attachments.map(attachment => {
       return (
         <div key={attachment.id}>
-          <p>
-            {'link: '}
+          <p style={{
+            display: 'flex',
+            alignItems: 'center',
+            marginTop: 10
+          }}>
+            <span>link:</span>
             <a
               href={attachment.url}
               target="_blank"
               rel="noopener noreferrer"
               style={{
                 display: 'inline-block',
-                marginTop: 20
+                marginLeft: 10,
+                marginRight: 10,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis'
               }}>
               {attachment.url}
             </a>

--- a/app/assets/javascripts/student_profile/NotesDetails.js
+++ b/app/assets/javascripts/student_profile/NotesDetails.js
@@ -10,7 +10,7 @@ import TakeNotes from './TakeNotes';
 
 const styles = {
   notesContainer: {
-    flex: 1,
+    width: '50%',
     marginRight: 20
   },
   restrictedNotesButton: {

--- a/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
@@ -1934,6 +1934,7 @@ exports[`snapshots works for aladdin 1`] = `
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-all",
                     }
                   }
                 />
@@ -2041,6 +2042,7 @@ exports[`snapshots works for aladdin 1`] = `
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-all",
                     }
                   }
                 />
@@ -2148,6 +2150,7 @@ exports[`snapshots works for aladdin 1`] = `
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-all",
                     }
                   }
                 />
@@ -2255,6 +2258,7 @@ exports[`snapshots works for aladdin 1`] = `
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-all",
                     }
                   }
                 />
@@ -2362,6 +2366,7 @@ exports[`snapshots works for aladdin 1`] = `
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-all",
                     }
                   }
                 />
@@ -2469,6 +2474,7 @@ exports[`snapshots works for aladdin 1`] = `
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-all",
                     }
                   }
                 />
@@ -2576,6 +2582,7 @@ exports[`snapshots works for aladdin 1`] = `
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-all",
                     }
                   }
                 />
@@ -4766,6 +4773,7 @@ exports[`snapshots works for olaf 1`] = `
                     "padding": 0,
                     "style": undefined,
                     "whiteSpace": "pre-wrap",
+                    "wordBreak": "break-all",
                   }
                 }
               >
@@ -4851,6 +4859,7 @@ Reduce behavior.
                     "padding": 0,
                     "style": undefined,
                     "whiteSpace": "pre-wrap",
+                    "wordBreak": "break-all",
                   }
                 }
               >
@@ -4936,6 +4945,7 @@ Increase how often the student is engaged in positive behaviors.
                     "padding": 0,
                     "style": undefined,
                     "whiteSpace": "pre-wrap",
+                    "wordBreak": "break-all",
                   }
                 }
               >
@@ -5035,6 +5045,7 @@ Reduce behavior.
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-all",
                     }
                   }
                 />
@@ -5128,6 +5139,7 @@ Reduce behavior.
                     "padding": 0,
                     "style": undefined,
                     "whiteSpace": "pre-wrap",
+                    "wordBreak": "break-all",
                   }
                 }
               >
@@ -5227,6 +5239,7 @@ Increase how often the student is engaged in positive behaviors.
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-all",
                     }
                   }
                 />
@@ -7300,6 +7313,7 @@ exports[`snapshots works for pluto 1`] = `
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-all",
                     }
                   }
                 />
@@ -7407,6 +7421,7 @@ exports[`snapshots works for pluto 1`] = `
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-all",
                     }
                   }
                 />
@@ -7514,6 +7529,7 @@ exports[`snapshots works for pluto 1`] = `
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-all",
                     }
                   }
                 />
@@ -7621,6 +7637,7 @@ exports[`snapshots works for pluto 1`] = `
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-all",
                     }
                   }
                 />
@@ -7728,6 +7745,7 @@ exports[`snapshots works for pluto 1`] = `
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-all",
                     }
                   }
                 />

--- a/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
@@ -1777,8 +1777,8 @@ exports[`snapshots works for aladdin 1`] = `
         className="NotesDetails"
         style={
           Object {
-            "flex": 1,
             "marginRight": 20,
+            "width": "50%",
           }
         }
       >
@@ -4609,8 +4609,8 @@ exports[`snapshots works for olaf 1`] = `
         className="NotesDetails"
         style={
           Object {
-            "flex": 1,
             "marginRight": 20,
+            "width": "50%",
           }
         }
       >
@@ -7129,8 +7129,8 @@ exports[`snapshots works for pluto 1`] = `
         className="NotesDetails"
         style={
           Object {
-            "flex": 1,
             "marginRight": 20,
+            "width": "50%",
           }
         }
       >


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
When there is long text that's unbroken (like a URL), the note text overflows.  This impacts the event note attachments as well.

# What does this PR do?
Fixes this layout bug.

# Screenshot (if adding a client-side feature)
### before, home
<img width="1017" alt="screen shot 2018-07-10 at 1 48 55 pm" src="https://user-images.githubusercontent.com/1056957/42528002-3b9cc344-8448-11e8-94b2-d9a430485e93.png">

### before, profile, IE
<img width="1022" alt="screen shot 2018-07-10 at 1 49 17 pm" src="https://user-images.githubusercontent.com/1056957/42528017-47c63e02-8448-11e8-9969-fb074ee37dab.png">

### before, profile, Chrome
<img width="1026" alt="screen shot 2018-07-10 at 1 49 32 pm" src="https://user-images.githubusercontent.com/1056957/42528012-421dde74-8448-11e8-8c97-6bc56ca31437.png">

### after, home
<img width="1023" alt="screen shot 2018-07-10 at 1 48 14 pm" src="https://user-images.githubusercontent.com/1056957/42528027-4daf1190-8448-11e8-96bb-cf3633910ebd.png">

### after, profile
<img width="988" alt="screen shot 2018-07-10 at 1 47 55 pm" src="https://user-images.githubusercontent.com/1056957/42528036-52d78a8a-8448-11e8-9f83-21a9b6adc4ef.png">


# Checklists
+ [x] Author checked latest in IE - Student Profile
+ [x] Author checked latest in IE - Home page