### PR TITLE
Update IEP PDF importer with paths for new instance

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -116,6 +116,14 @@ class PerDistrict
     @district_key == SOMERVILLE
   end
 
+  def filenames_for_iep_pdf_zips
+    if @district_key == SOMERVILLE
+      LoadDistrictConfig.new.remote_filenames.fetch('FILENAMES_FOR_IEP_PDF_ZIPS', [])
+    else
+      []
+    end
+  end
+
   private
   def raise_not_handled!
     raise Exceptions::DistrictKeyNotHandledError

--- a/app/importers/iep_import/iep_file_name_parser.rb
+++ b/app/importers/iep_import/iep_file_name_parser.rb
@@ -8,8 +8,8 @@ class IepFileNameParser < Struct.new :path
     path.split("/").last
   end
 
-  def check_iep_at_a_glance
-    raise 'oh no!' if pdf_basename.split('_')[1] != 'IEPAtAGlance'
+  def validata_filename_or_raise!
+    raise 'Filename does not contain `IEPAtAGlance` as expected' if pdf_basename.split('_')[1] != 'IEPAtAGlance'
   end
 
   private

--- a/app/importers/iep_import/iep_storer.rb
+++ b/app/importers/iep_import/iep_storer.rb
@@ -13,10 +13,12 @@ class IepStorer
 
   def store
     @student = Student.find_by_local_id(@local_id)
+    if @student.nil?
+      @logger.info("student local_id: #{@local_id} not found, dropping the IEP PDF file...")
+      return nil
+    end
 
-    return @logger.info("student not in db!") unless @student
-
-    return unless store_object_in_s3
+    return nil unless store_object_in_s3
 
     store_object_in_database
   end

--- a/config/district_somerville.yml
+++ b/config/district_somerville.yml
@@ -11,6 +11,13 @@ remote_filenames:
   FILENAME_FOR_STAR_READING_IMPORT:                 SR.csv
   FILENAME_FOR_STAR_MATH_IMPORT:                    SM.csv
   FILENAME_FOR_STAR_ZIP_FILE:                       Somerville Public Schools.zip
+  FILENAMES_FOR_IEP_PDF_ZIPS:   # order is important here, these need to be oldest > newest
+    - /home/jbreslin/data/student-documents-6.zip
+    - /home/jbreslin/data/student-documents-5.zip
+    - /home/jbreslin/data/student-documents-4.zip
+    - /home/jbreslin/data/student-documents-3.zip
+    - /home/jbreslin/data/student-documents-2.zip
+    - /home/jbreslin/data/student-documents-1.zip
 schools:
   -
     local_id: BRN


### PR DESCRIPTION
# Who is this PR for?
Somerville educators

# What problem does this PR fix?
I noticed this in verifying that https://github.com/studentinsights/studentinsights/pull/1876 was correct.  It turns out that when we cut over to a new instance, we didn't update this importer and it has been broken.  This wasn't obvious, since it's normal that IEPs aren't updated every day, and would be even more normal if this happened during the summertime.  But these have been updated (at least in this past week), and the import task was not picking them up since it wasn't looking at the correct path for the new instance.

# What does this PR do?
Updates the paths and moves them into `PerDistrict` and yaml config, and adds a bit more logging.

before, not finding any files:
```
I, [2018-07-10T19:25:04.248109 #13]  INFO -- : open /home/jbreslin/data/student-documents-6.zip: no such file (2)
I, [2018-07-10T19:25:04.248189 #13]  INFO -- : No file found but no worries, just means no educators added IEPs into the EasyIEP system that particular day
...
```

after, finding files:
```
I, [2018-07-10T18:57:05.220782 #13]  INFO -- : parsing unzipped pdfs from <path>...!
```

before, not info to debug why student not found:
```
student not in db!
```

after, with info about student not found and total count of PDFs dropped:
```
student local_id: 123456 not found, dropping the IEP PDF file...
...
IepPdfImportJob: stored 8 IEP PDFs and dropped 1 PDF files...
```

Verified this manually.