### PR TITLE
Add more explicit logging for EducatorsImporter

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -124,6 +124,15 @@ class PerDistrict
     end
   end
 
+  # In the import process, NB uses 0-000 as a special code in the staff CSV to indicate "no homeroom"
+  def is_nil_homeroom_name?(homeroom_name)
+    if @district_key == NEW_BEDFORD
+      homeroom_name == '0-000'
+    else
+      false
+    end
+  end
+
   private
   def raise_not_handled!
     raise Exceptions::DistrictKeyNotHandledError

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -8,13 +8,30 @@ class EducatorsImporter
   def import
     return unless remote_file_name
 
+    log('Downloading...')
     streaming_csv = CsvDownloader.new(
       log: @log, remote_file_name: remote_file_name, client: client, transformer: data_transformer
     ).get_data
 
+    log('Starting loop...')
+    @skipped_from_school_filter = 0
+    @invalid_rows_count = 0
+    @touched_rows_count = 0
+    @ignored_special_nil_homeroom_count = 0
+    @ignored_no_homeroom_count = 0
+    @ignored_unknown_homeroom_count = 0
+    @touched_homeroom_count = 0
     streaming_csv.each_with_index do |row, index|
-      import_row(row) if filter.include?(row)
+      import_row(row)
     end
+
+    log('Done loop.')
+    log("@skipped_from_school_filter: #{@skipped_from_school_filter}")
+    log("@invalid_rows_count: #{@invalid_rows_count}")
+    log("@touched_rows_count: #{@touched_rows_count}")
+    log("@ignored_special_nil_homeroom_count: #{@ignored_special_nil_homeroom_count}")
+    log("@ignored_no_homeroom_count: #{@ignored_no_homeroom_count}")
+    log("@ignored_unknown_homeroom_count: #{@ignored_unknown_homeroom_count}")
   end
 
   def client
@@ -38,16 +55,46 @@ class EducatorsImporter
   end
 
   def import_row(row)
-    educator = EducatorRow.new(row, school_ids_dictionary).build
-
-    if educator.present?
-      educator.save!
-
-      homeroom = Homeroom.find_by_name(row[:homeroom]) if row[:homeroom]
-      homeroom.update(educator: educator) if homeroom.present?
-    else
-      @log.puts("EducatorsImporter: nil EducatorRow, skipping row")
+    if !filter.include?(row)
+      @skipped_from_school_filter = @skipped_from_school_filter + 1
+      return
     end
+
+    maybe_educator = EducatorRow.new(row, school_ids_dictionary).build
+    if maybe_educator.nil?
+      @invalid_rows_count = @invalid_rows_count + 1
+      return
+    end
+    educator = maybe_educator
+
+    educator.save!
+    @touched_rows_count = @touched_rows_count + 1
+
+    # Special case for NB magic "nil" value
+    if PerDistrict.new.is_nil_homeroom_name?(row[:homeroom])
+      @ignored_special_nil_homeroom_count = @ignored_special_nil_homeroom_count + 1
+      return
+    end
+
+    # No homeroom
+    if !row[:homeroom]
+      @ignored_no_homeroom_count = @ignored_no_homeroom_count + 1
+      return
+    end
+
+    # Update homeroom
+    homeroom = Homeroom.find_by_name(row[:homeroom])
+    if homeroom.nil?
+      @ignored_unknown_homeroom_count = @ignored_unknown_homeroom_count + 1
+      return
+    end
+    homeroom.update!(educator: educator)
+    @touched_homeroom_count = @touched_homeroom_count + 1
   end
 
+  private
+  def log(msg)
+    text = if msg.class == String then msg else JSON.pretty_generate(msg) end
+    @log.puts "EducatorsImporter: #{text}"
+  end
 end

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -32,6 +32,7 @@ class EducatorsImporter
     log("@ignored_special_nil_homeroom_count: #{@ignored_special_nil_homeroom_count}")
     log("@ignored_no_homeroom_count: #{@ignored_no_homeroom_count}")
     log("@ignored_unknown_homeroom_count: #{@ignored_unknown_homeroom_count}")
+    log("@touched_homeroom_count: #{@touched_homeroom_count}")
   end
 
   def client
@@ -62,6 +63,10 @@ class EducatorsImporter
 
     maybe_educator = EducatorRow.new(row, school_ids_dictionary).build
     if maybe_educator.nil?
+      @invalid_rows_count = @invalid_rows_count + 1
+      return
+    end
+    if !maybe_educator.valid?
       @invalid_rows_count = @invalid_rows_count + 1
       return
     end

--- a/app/importers/file_importers/unwrap_file_importer_options.rb
+++ b/app/importers/file_importers/unwrap_file_importer_options.rb
@@ -1,5 +1,7 @@
 class UnwrapFileImporterOptions
 
+  # Some of these are circular for a first-time run - eg, StudentsImporter creates Homeroom records, and
+  # EducatorsImporter matches on those.
   PRIORITY = {
     EducatorsImporter => 0,
     CoursesSectionsImporter => 1,

--- a/app/importers/rows/educator_row.rb
+++ b/app/importers/rows/educator_row.rb
@@ -10,7 +10,7 @@ class EducatorRow < Struct.new(:row, :school_ids_dictionary)
   end
 
   def build
-    return if row[:login_name].nil? || row[:login_name] == ''
+    return nil if row[:login_name].nil? || row[:login_name] == ''
 
     educator = Educator.find_or_initialize_by(email: email)
 

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -117,7 +117,7 @@ class Educator < ActiveRecord::Base
   private
   def validate_has_school_unless_districtwide
     if school.blank?
-      errors.add(:school_id, "must be assigned a school") unless districtwide_access?
+      errors.add(:school_id, 'must be assigned a school unless districtwide') unless districtwide_access?
     end
   end
 

--- a/spec/importers/file_importers/educators_importer_spec.rb
+++ b/spec/importers/file_importers/educators_importer_spec.rb
@@ -6,11 +6,20 @@ RSpec.describe EducatorsImporter do
   after { ENV['DISTRICT_KEY'] = @district_key }
 
   let(:log) { LogHelper::Redirect.instance.file }
-  let(:educators_importer) {
-    described_class.new(options: {
-      school_scope: nil, log: log
+  def make_educators_importer
+    importer = EducatorsImporter.new(options: {
+      school_scope: nil,
+      log: log
     })
-  }
+    importer.instance_variable_set(:@skipped_from_school_filter, 0)
+    importer.instance_variable_set(:@invalid_rows_count, 0)
+    importer.instance_variable_set(:@touched_rows_count, 0)
+    importer.instance_variable_set(:@ignored_special_nil_homeroom_count, 0)
+    importer.instance_variable_set(:@ignored_no_homeroom_count, 0)
+    importer.instance_variable_set(:@ignored_unknown_homeroom_count, 0)
+    importer.instance_variable_set(:@touched_homeroom_count, 0)
+    importer
+  end
 
   describe '#import_row' do
     let!(:school) { FactoryBot.create(:healey) }
@@ -28,7 +37,7 @@ RSpec.describe EducatorsImporter do
             }
 
             before do
-              educators_importer.import_row(row)
+              make_educators_importer.import_row(row)
             end
 
             it 'creates an educator' do
@@ -60,11 +69,11 @@ RSpec.describe EducatorsImporter do
                 }
               }
               it 'creates an educator' do
-                expect { educators_importer.import_row(row) }.to change(Educator, :count).by 1
+                expect { make_educators_importer.import_row(row) }.to change(Educator, :count).by 1
               end
 
               it 'sets the attributes correctly' do
-                educators_importer.import_row(row)
+                make_educators_importer.import_row(row)
                 educator = Educator.last
                 expect(educator.full_name).to eq("Young, Jenny")
                 expect(educator.state_id).to eq("500")
@@ -75,7 +84,7 @@ RSpec.describe EducatorsImporter do
 
               it 'sets the attributes correctly, PerDistrict' do
                 ENV['DISTRICT_KEY'] = PerDistrict::NEW_BEDFORD
-                educators_importer.import_row(row)
+                make_educators_importer.import_row(row)
                 educator = Educator.last
                 expect(educator.email).to eq('jyoung@newbedfordschools.org')
               end
@@ -93,9 +102,10 @@ RSpec.describe EducatorsImporter do
                   }
                 }
                 it 'creates multiple educators' do
+                  importer = make_educators_importer
                   expect {
-                    educators_importer.import_row(row)
-                    educators_importer.import_row(another_row)
+                    importer.import_row(row)
+                    importer.import_row(another_row)
                   }.to change(Educator, :count).by 2
                 end
               end
@@ -113,7 +123,7 @@ RSpec.describe EducatorsImporter do
               }
 
               it 'assigns the educator to the correct school' do
-                educators_importer.import_row(row)
+                make_educators_importer.import_row(row)
                 educator = Educator.last
                 expect(educator.school).to eq(school)
               end
@@ -134,7 +144,7 @@ RSpec.describe EducatorsImporter do
           }
 
           it 'sets the administrator attributes correctly' do
-            educators_importer.import_row(row)
+            make_educators_importer.import_row(row)
             educator = Educator.last
             expect(educator.admin).to eq(true)
             expect(educator.can_view_restricted_notes).to eq true
@@ -154,10 +164,10 @@ RSpec.describe EducatorsImporter do
         }
 
         it 'does not create an educator' do
-          expect { educators_importer.import_row(row) }.to change(Educator, :count).by 0
+          expect { make_educators_importer.import_row(row) }.to change(Educator, :count).by 0
         end
         it 'updates the educator attributes' do
-          educators_importer.import_row(row)
+          make_educators_importer.import_row(row)
           educator = Educator.last
           expect(educator.full_name).to eq("Young, Jenny")
           expect(educator.state_id).to eq("500")
@@ -182,11 +192,11 @@ RSpec.describe EducatorsImporter do
         }
 
         it 'does not create a new educator' do
-          expect { educators_importer.import_row(row) }.to change(Educator, :count).by 0
+          expect { make_educators_importer.import_row(row) }.to change(Educator, :count).by 0
         end
 
         it 'does not revoke the schoolwide access, restricted notes access' do
-          educators_importer.import_row(row)
+          make_educators_importer.import_row(row)
           educator = Educator.last
           expect(educator.schoolwide_access).to eq(true)
           expect(educator.can_view_restricted_notes).to eq(true)
@@ -202,7 +212,7 @@ RSpec.describe EducatorsImporter do
         }
 
         it 'does not create an educator' do
-          expect { educators_importer.import_row(row) }.to change(Educator, :count).by 0
+          expect { make_educators_importer.import_row(row) }.to change(Educator, :count).by 0
         end
       end
     end
@@ -221,14 +231,14 @@ RSpec.describe EducatorsImporter do
       context 'name of homeroom that exists' do
         let!(:homeroom) { FactoryBot.create(:homeroom, :named_hea_100) }
         it 'assigns the homeroom to the educator' do
-          educators_importer.import_row(row)
+          make_educators_importer.import_row(row)
           expect(Educator.last.homeroom).to eq homeroom
         end
       end
 
       context 'name of homeroom that does not exist' do
         it 'raises an error' do
-          expect { educators_importer.import_row(row) }.to_not raise_error
+          expect { make_educators_importer.import_row(row) }.to_not raise_error
         end
       end
     end


### PR DESCRIPTION
# Who is this PR for?
NB educators

# What problem does this PR fix?
NB has educators from other schools beyond the first schools.

# What does this PR do?
Adds more explicit logging to see what's happening in `EducatorsImporter`.  This came up from noticing that NB had more educators beyond the first schools, and trying to scope this back.

Example output:
```
StreamingCsvTransformer#stats: {:skipped_dirty_rows_count=>0, :processed_rows_count=>2020}
EducatorsImporter: Done loop.
EducatorsImporter: @skipped_from_school_filter: 1878
EducatorsImporter: @invalid_rows_count: 38
EducatorsImporter: @touched_rows_count: 104
EducatorsImporter: @ignored_special_nil_homeroom_count: 2
EducatorsImporter: @ignored_no_homeroom_count: 0
EducatorsImporter: @ignored_unknown_homeroom_count: 50
```

Verified on both instances in production.
