### PR TITLE
Update wrapping for long text like URLs in NoteText

### DIFF
--- a/app/assets/javascripts/components/NoteText.js
+++ b/app/assets/javascripts/components/NoteText.js
@@ -2,13 +2,20 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 
+// The sizing for long text with no space (eg, URLs) is different
+// in IE11 vs. Chrome.  Chrome forces `break-all` essentially when the
+// CSS is `break-word` and IE doesn't.  So the `overflow` is for IE so that
+// that text doesn't spill over or influence layout.  It's not ideal
+// but it's okay if the end of long URLs are hidden, this is an uncommon
+// case.
 export const exportedNoteText = {
   marginTop: 5,
   padding: 0,
   fontFamily: "'Open Sans', sans-serif",
   fontSize: 14,
   whiteSpace: 'pre-wrap',
-  wordBreak: 'break-all',
+  wordBreak: 'break-word',
+  overflowX: 'hidden',
   border: '1px solid transparent' // for sizing when we add a border on hover when editable
 };
 

--- a/app/assets/javascripts/feed/__snapshots__/EventNoteCard.test.js.snap
+++ b/app/assets/javascripts/feed/__snapshots__/EventNoteCard.test.js.snap
@@ -137,10 +137,11 @@ exports[`matches snapshot 1`] = `
             "fontFamily": "'Open Sans', sans-serif",
             "fontSize": 14,
             "marginTop": 5,
+            "overflowX": "hidden",
             "padding": 0,
             "style": undefined,
             "whiteSpace": "pre-wrap",
-            "wordBreak": "break-all",
+            "wordBreak": "break-word",
           }
         }
       >

--- a/app/assets/javascripts/feed/__snapshots__/FeedView.test.js.snap
+++ b/app/assets/javascripts/feed/__snapshots__/FeedView.test.js.snap
@@ -175,10 +175,11 @@ exports[`FeedView pure component matches snapshot 1`] = `
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -339,10 +340,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -515,10 +517,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -704,10 +707,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -866,10 +870,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -1042,10 +1047,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -1231,10 +1237,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -1420,10 +1427,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -1595,10 +1603,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -1757,10 +1766,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -1946,10 +1956,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -2135,10 +2146,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -2324,10 +2336,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -2486,10 +2499,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -2662,10 +2676,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -2838,10 +2853,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -3014,10 +3030,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -3203,10 +3220,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >
@@ -3365,10 +3383,11 @@ Philis is meeting with parent next week and will present an attendance contract.
               "fontFamily": "'Open Sans', sans-serif",
               "fontSize": 14,
               "marginTop": 5,
+              "overflowX": "hidden",
               "padding": 0,
               "style": undefined,
               "whiteSpace": "pre-wrap",
-              "wordBreak": "break-all",
+              "wordBreak": "break-word",
             }
           }
         >

--- a/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
@@ -1931,10 +1931,11 @@ exports[`snapshots works for aladdin 1`] = `
                       "fontFamily": "'Open Sans', sans-serif",
                       "fontSize": 14,
                       "marginTop": 5,
+                      "overflowX": "hidden",
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
-                      "wordBreak": "break-all",
+                      "wordBreak": "break-word",
                     }
                   }
                 />
@@ -2039,10 +2040,11 @@ exports[`snapshots works for aladdin 1`] = `
                       "fontFamily": "'Open Sans', sans-serif",
                       "fontSize": 14,
                       "marginTop": 5,
+                      "overflowX": "hidden",
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
-                      "wordBreak": "break-all",
+                      "wordBreak": "break-word",
                     }
                   }
                 />
@@ -2147,10 +2149,11 @@ exports[`snapshots works for aladdin 1`] = `
                       "fontFamily": "'Open Sans', sans-serif",
                       "fontSize": 14,
                       "marginTop": 5,
+                      "overflowX": "hidden",
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
-                      "wordBreak": "break-all",
+                      "wordBreak": "break-word",
                     }
                   }
                 />
@@ -2255,10 +2258,11 @@ exports[`snapshots works for aladdin 1`] = `
                       "fontFamily": "'Open Sans', sans-serif",
                       "fontSize": 14,
                       "marginTop": 5,
+                      "overflowX": "hidden",
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
-                      "wordBreak": "break-all",
+                      "wordBreak": "break-word",
                     }
                   }
                 />
@@ -2363,10 +2367,11 @@ exports[`snapshots works for aladdin 1`] = `
                       "fontFamily": "'Open Sans', sans-serif",
                       "fontSize": 14,
                       "marginTop": 5,
+                      "overflowX": "hidden",
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
-                      "wordBreak": "break-all",
+                      "wordBreak": "break-word",
                     }
                   }
                 />
@@ -2471,10 +2476,11 @@ exports[`snapshots works for aladdin 1`] = `
                       "fontFamily": "'Open Sans', sans-serif",
                       "fontSize": 14,
                       "marginTop": 5,
+                      "overflowX": "hidden",
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
-                      "wordBreak": "break-all",
+                      "wordBreak": "break-word",
                     }
                   }
                 />
@@ -2579,10 +2585,11 @@ exports[`snapshots works for aladdin 1`] = `
                       "fontFamily": "'Open Sans', sans-serif",
                       "fontSize": 14,
                       "marginTop": 5,
+                      "overflowX": "hidden",
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
-                      "wordBreak": "break-all",
+                      "wordBreak": "break-word",
                     }
                   }
                 />
@@ -4770,10 +4777,11 @@ exports[`snapshots works for olaf 1`] = `
                     "fontFamily": "'Open Sans', sans-serif",
                     "fontSize": 14,
                     "marginTop": 5,
+                    "overflowX": "hidden",
                     "padding": 0,
                     "style": undefined,
                     "whiteSpace": "pre-wrap",
-                    "wordBreak": "break-all",
+                    "wordBreak": "break-word",
                   }
                 }
               >
@@ -4856,10 +4864,11 @@ Reduce behavior.
                     "fontFamily": "'Open Sans', sans-serif",
                     "fontSize": 14,
                     "marginTop": 5,
+                    "overflowX": "hidden",
                     "padding": 0,
                     "style": undefined,
                     "whiteSpace": "pre-wrap",
-                    "wordBreak": "break-all",
+                    "wordBreak": "break-word",
                   }
                 }
               >
@@ -4942,10 +4951,11 @@ Increase how often the student is engaged in positive behaviors.
                     "fontFamily": "'Open Sans', sans-serif",
                     "fontSize": 14,
                     "marginTop": 5,
+                    "overflowX": "hidden",
                     "padding": 0,
                     "style": undefined,
                     "whiteSpace": "pre-wrap",
-                    "wordBreak": "break-all",
+                    "wordBreak": "break-word",
                   }
                 }
               >
@@ -5042,10 +5052,11 @@ Reduce behavior.
                       "fontFamily": "'Open Sans', sans-serif",
                       "fontSize": 14,
                       "marginTop": 5,
+                      "overflowX": "hidden",
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
-                      "wordBreak": "break-all",
+                      "wordBreak": "break-word",
                     }
                   }
                 />
@@ -5136,10 +5147,11 @@ Reduce behavior.
                     "fontFamily": "'Open Sans', sans-serif",
                     "fontSize": 14,
                     "marginTop": 5,
+                    "overflowX": "hidden",
                     "padding": 0,
                     "style": undefined,
                     "whiteSpace": "pre-wrap",
-                    "wordBreak": "break-all",
+                    "wordBreak": "break-word",
                   }
                 }
               >
@@ -5236,10 +5248,11 @@ Increase how often the student is engaged in positive behaviors.
                       "fontFamily": "'Open Sans', sans-serif",
                       "fontSize": 14,
                       "marginTop": 5,
+                      "overflowX": "hidden",
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
-                      "wordBreak": "break-all",
+                      "wordBreak": "break-word",
                     }
                   }
                 />
@@ -7310,10 +7323,11 @@ exports[`snapshots works for pluto 1`] = `
                       "fontFamily": "'Open Sans', sans-serif",
                       "fontSize": 14,
                       "marginTop": 5,
+                      "overflowX": "hidden",
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
-                      "wordBreak": "break-all",
+                      "wordBreak": "break-word",
                     }
                   }
                 />
@@ -7418,10 +7432,11 @@ exports[`snapshots works for pluto 1`] = `
                       "fontFamily": "'Open Sans', sans-serif",
                       "fontSize": 14,
                       "marginTop": 5,
+                      "overflowX": "hidden",
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
-                      "wordBreak": "break-all",
+                      "wordBreak": "break-word",
                     }
                   }
                 />
@@ -7526,10 +7541,11 @@ exports[`snapshots works for pluto 1`] = `
                       "fontFamily": "'Open Sans', sans-serif",
                       "fontSize": 14,
                       "marginTop": 5,
+                      "overflowX": "hidden",
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
-                      "wordBreak": "break-all",
+                      "wordBreak": "break-word",
                     }
                   }
                 />
@@ -7634,10 +7650,11 @@ exports[`snapshots works for pluto 1`] = `
                       "fontFamily": "'Open Sans', sans-serif",
                       "fontSize": 14,
                       "marginTop": 5,
+                      "overflowX": "hidden",
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
-                      "wordBreak": "break-all",
+                      "wordBreak": "break-word",
                     }
                   }
                 />
@@ -7742,10 +7759,11 @@ exports[`snapshots works for pluto 1`] = `
                       "fontFamily": "'Open Sans', sans-serif",
                       "fontSize": 14,
                       "marginTop": 5,
+                      "overflowX": "hidden",
                       "padding": 0,
                       "style": Object {},
                       "whiteSpace": "pre-wrap",
-                      "wordBreak": "break-all",
+                      "wordBreak": "break-word",
                     }
                   }
                 />


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
In https://github.com/studentinsights/studentinsights/pull/1877 I tried to fix layout of long URLs in notes, but this led to notes breaking mid-word.

# What does this PR do?
Changes back to `break-word` and adds `overflow-x`: hidden for IE - the behavior here is different in Chrome (which forcibly breaks the long text) and IE (which does not).  So in IE this is less than ideal, it truncates the text without visual indication and allow horizontal scrolling in the area with the keyboard if it's editable.  This only impacts a small number of pages, so shipping the improvement here of "not breaking the whole page layout" seems okay.

# Screenshot (if adding a client-side feature)
### before, showing forcibly breaks within words
<img width="664" alt="screen shot 2018-07-12 at 6 37 47 pm" src="https://user-images.githubusercontent.com/1056957/42663232-b5dddf2e-8602-11e8-9d4b-0a8da85efe45.png">

### after, showing long links are forcibly broken but not wrapped in IE11
<img width="981" alt="screen shot 2018-07-12 at 6 30 58 pm" src="https://user-images.githubusercontent.com/1056957/42663247-ca0b8a82-8602-11e8-82cc-dff530bd6ae4.png">
<img width="1014" alt="screen shot 2018-07-12 at 6 29 50 pm" src="https://user-images.githubusercontent.com/1056957/42663248-ca1bb330-8602-11e8-88d4-4f8545590010.png">
