### PR TITLE
Revise copy for URL on roster page

### DIFF
--- a/app/assets/javascripts/school_overview/SliceButtons.js
+++ b/app/assets/javascripts/school_overview/SliceButtons.js
@@ -58,7 +58,7 @@ class SliceButtons extends React.Component {
           href={this.props.filtersHash}
           target="_blank"
           style={{ fontSize: styles.fontSize }}>
-          Share this view
+          Link to save these filters
         </a>
       </div>
     );

--- a/app/assets/javascripts/school_overview/SliceButtons.test.js
+++ b/app/assets/javascripts/school_overview/SliceButtons.test.js
@@ -16,5 +16,5 @@ it('renders without crashing', () => {
   const props = testProps();
   const el = document.createElement('div');
   ReactDOM.render(<SliceButtons {...props} />, el);
-  expect(el.innerHTML).toContain('Share');
+  expect(el.innerHTML).toContain('Link to save these filters');
 });


### PR DESCRIPTION
# Who is this PR for?
educators, from feedback from LL

# What problem does this PR fix?
Make more explicit that particular filter combinations can be loaded by URL.

# What does this PR do?
Changes the copy.

# Screenshot (if adding a client-side feature)
### before
<img width="421" alt="screen shot 2018-07-12 at 6 39 51 pm" src="https://user-images.githubusercontent.com/1056957/42663380-494f513e-8603-11e8-99a8-ee0c9922c129.png">

### after
<img width="496" alt="screen shot 2018-07-12 at 6 40 15 pm" src="https://user-images.githubusercontent.com/1056957/42663369-3a7f319c-8603-11e8-87ca-8509e25679eb.png">

