### PR TITLE
Fix sort order on ProfileBarChart date tooltips

### DIFF
--- a/app/assets/javascripts/student_profile/ProfileBarChart.js
+++ b/app/assets/javascripts/student_profile/ProfileBarChart.js
@@ -44,7 +44,8 @@ export default class ProfileBarChart extends React.Component {
       if (events.length == 0) return false;
 
       let unsafeHtmlString = '';
-      _.each(events, function(e){
+      const sortedEvents = _.sortBy(events, e => moment.utc(e.occurred_at));
+      _.each(sortedEvents, function(e){
         unsafeHtmlString += `<span>${moment.utc(e.occurred_at).format('MMMM Do, YYYY')}</span>`;
         unsafeHtmlString += '<br />';
       });


### PR DESCRIPTION
# Who is this PR for?
educators, came up working on https://github.com/studentinsights/studentinsights/issues/1657

# What problem does this PR fix?
On hover, dates for absences are in reverse order, recent to oldest.  This sort of makes sense in a "what happened most recently sense" but not in what you'd expect just reading a chart.

# What does this PR do?
Sorts oldest - recent.

# Screenshot (if adding a client-side feature)
### before
<img width="210" alt="screen shot 2018-07-13 at 9 36 16 am" src="https://user-images.githubusercontent.com/1056957/42694469-81ee9eb4-8680-11e8-8c15-5f7e27b69968.png">

### after
<img width="246" alt="screen shot 2018-07-13 at 9 36 09 am" src="https://user-images.githubusercontent.com/1056957/42694471-852deed6-8680-11e8-99c9-9770b39f43ff.png">
