### PR TITLE
Update absence chart to show excused absences, with reasons and comments on hover

### DIFF
--- a/app/assets/javascripts/student_profile/AttendanceDetails.js
+++ b/app/assets/javascripts/student_profile/AttendanceDetails.js
@@ -1,42 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from 'lodash';
 import moment from 'moment';
-import ProfileBarChart from './ProfileBarChart';
+import ProfileBarChart, {tooltipEventTextFn, createUnsafeTooltipFormatter} from './ProfileBarChart';
 import IncidentCard from '../components/IncidentCard';
 import * as InsightsPropTypes from '../helpers/InsightsPropTypes';
 
-const styles = {
-  title: {
-    color: 'black',
-    paddingBottom: 20,
-    fontSize: 24
-  },
-  container: {
-    width: '100%',
-    marginTop: 50,
-    marginLeft: 'auto',
-    marginRight: 'auto',
-    border: '1px solid #ccc',
-    padding: '30px 30px 30px 30px',
-    position: 'relative'
-  },
-  secHead: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    position: 'relative',
-    bottom: 10
-  },
-  navBar: {
-    fontSize: 18
-  },
-  navTop: {
-    textAlign: 'right',
-    verticalAlign: 'text-top'
-  }
-};
 
-
-class AttendanceDetails extends React.Component {
+export default class AttendanceDetails extends React.Component {
 
   phaselines() {
     const activeServices = this.props.feed.services.active;
@@ -123,7 +94,10 @@ class AttendanceDetails extends React.Component {
         id="absences"
         titleText="Absences"
         monthsBack={48}
-        phaselines={this.phaselines()} />
+        phaselines={this.phaselines()}
+        seriesFn={absenceSeriesFn}
+        tooltipFn={absenceTooltipFn}
+        />
     );
   }
 
@@ -172,4 +146,80 @@ AttendanceDetails.propTypes = {
   serviceTypesIndex: PropTypes.object.isRequired
 };
 
-export default AttendanceDetails;
+
+function absenceSeriesFn(monthBuckets) {
+  return [{
+    name: 'Excused',
+    color: '#ccc',
+    showInLegend: true,
+    data: _.map(monthBuckets, es => es.filter(e => e.excused).length)
+  },
+  {
+    name: 'Unexcused absences',
+    color: '#7cb5ec',
+    showInLegend: true,
+    data: _.map(monthBuckets, es => es.filter(e => !e.excused).length)
+  }];
+}
+
+
+function absenceTooltipFn(monthBuckets) {
+  return {
+    formatter: createUnsafeTooltipFormatter(monthBuckets, tooltipTextFn),
+    useHTML: true
+  };
+}
+
+function tooltipTextFn(e) {
+  const date = tooltipEventTextFn(e);
+  const explanation = absenceExplanationText(e);
+  return `${date}${explanation}`;
+}
+
+function absenceExplanationText(absence) {
+  if (absence.excused && absence.reason && absence.comment) {
+    return ` (Excused, ${absence.reason}, ${absence.comment})`;
+  } else if (absence.excused && absence.reason) {
+    return ` (Excused, ${absence.reason})`;
+  } else if (absence.excused) {
+    return ` (Excused)`;
+  } else if (absence.reason) {
+    return ` (${absence.reason})`;
+  } else if (absence.comment) {
+    return ` (${absence.comment})`;
+  }
+
+  return '';
+}
+
+
+const styles = {
+  title: {
+    color: 'black',
+    paddingBottom: 20,
+    fontSize: 24
+  },
+  container: {
+    width: '100%',
+    marginTop: 50,
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    border: '1px solid #ccc',
+    padding: '30px 30px 30px 30px',
+    position: 'relative'
+  },
+  secHead: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    position: 'relative',
+    bottom: 10
+  },
+  navBar: {
+    fontSize: 18
+  },
+  navTop: {
+    textAlign: 'right',
+    verticalAlign: 'text-top'
+  }
+};
+


### PR DESCRIPTION
# Who is this PR for?
K12 SST, AP, counselors

# What problem does this PR fix?
Student data in Aspen shows more detail about whether absences are excused and reasons or comments about why the student is out; Insights doesn't reflect this.

# What does this PR do?
Updates the detailed absence chart on the student profile page to show this.  This is a minimal change, which will let us also look at this data for quality checks, and we might want to revisit the design later.  But this makes the information functionally usable.

# Screenshot (if adding a client-side feature)
### stacked, hover shows excused
<img width="1161" alt="screen shot 2018-07-16 at 1 27 43 pm" src="https://user-images.githubusercontent.com/1056957/42773708-1524dc98-88fc-11e8-96e6-c162fdd55c12.png">

### hover shows comment (not excused)
<img width="1167" alt="screen shot 2018-07-16 at 1 27 49 pm" src="https://user-images.githubusercontent.com/1056957/42773727-23689e84-88fc-11e8-8b50-ff1dddb8e9f3.png">

### no regressions to other charts
<img width="1162" alt="screen shot 2018-07-16 at 1 27 58 pm" src="https://user-images.githubusercontent.com/1056957/42773719-1ee0b3a6-88fc-11e8-9482-1039fb8ee833.png">
