### PR TITLE
Update Absences, Tardies and Discipline dashboards to use "any note" rather than SST

### DIFF
--- a/app/assets/javascripts/components/eventNoteType.js
+++ b/app/assets/javascripts/components/eventNoteType.js
@@ -10,6 +10,18 @@ export function eventNoteTypeText(eventNoteTypeId) {
   return textMap[eventNoteTypeId] || 'Other';
 }
 
+const miniTextMap = {
+  300: 'SST',
+  301: 'MTSS',
+  302: 'Parent',
+  304: 'Other',
+  305: '9GE',
+  306: '10GE'
+};
+export function eventNoteTypeTextMini(eventNoteTypeId) {
+  return miniTextMap[eventNoteTypeId] || 'Other';
+}
+
 const colorMap =  {
   300: '#31AB39',
   301: '#EB4B26',

--- a/app/assets/javascripts/school_administrator_dashboard/DashboardTestData.js
+++ b/app/assets/javascripts/school_administrator_dashboard/DashboardTestData.js
@@ -55,7 +55,10 @@ export function createStudents(nowMoment) {
     absences: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo, testEvents.threeMonthsAgo],
     tardies: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo, testEvents.threeMonthsAgo],
     events: 3,
-    last_sst_date_text: moment.utc(testEvents.threeMonthsAgo.occurred_at).format('M/D/YY')
+    latest_note: {
+      event_note_type_id: 300,
+      recorded_at: testEvents.threeMonthsAgo.occurred_at
+    }
   },
   {
     first_name: 'Pierrette',
@@ -66,7 +69,7 @@ export function createStudents(nowMoment) {
     absences: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo],
     tardies: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo],
     events: 2,
-    last_sst_date_text: null
+    latest_note: null
   },
   {
     first_name: 'Arlecchino',
@@ -77,7 +80,7 @@ export function createStudents(nowMoment) {
     absences: [],
     tardies: [],
     events: 0,
-    last_sst_date_text: null
+    latest_note: null
   },
   {
     first_name: 'Colombina',
@@ -88,7 +91,7 @@ export function createStudents(nowMoment) {
     absences: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo, testEvents.oneYearAgo],
     tardies: [testEvents.thisMonth],
     events: 3,
-    last_sst_date_text: null
+    latest_note: null
   },
   {
     first_name: 'Scaramuccia',
@@ -99,7 +102,7 @@ export function createStudents(nowMoment) {
     absences: [testEvents.twoMonthsAgo, testEvents.threeMonthsAgo],
     tardies: [testEvents.oneYearAgo],
     events: 2,
-    last_sst_date_text: null
+    latest_note: null
   },
   {
     first_name: 'Pulcinella',
@@ -110,7 +113,7 @@ export function createStudents(nowMoment) {
     absences: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo],
     tardies: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo],
     events: 2,
-    last_sst_date_text: null
+    latest_note: null
   }];
 }
 

--- a/app/assets/javascripts/school_administrator_dashboard/DashboardTestData.js
+++ b/app/assets/javascripts/school_administrator_dashboard/DashboardTestData.js
@@ -1,6 +1,3 @@
-import moment from 'moment';
-
-
 // Stubbed events for dashboard specs
 export function createTestEvents(nowMoment) {
   return {

--- a/app/assets/javascripts/school_administrator_dashboard/StudentsTable.test.js
+++ b/app/assets/javascripts/school_administrator_dashboard/StudentsTable.test.js
@@ -17,10 +17,10 @@ it('renders the students list', () => {
   expect(table.find("div").first().hasClass("StudentsTable")).toEqual(true);
 });
 
-it('renders headers for name, incident count and last SST', () => {
+it('renders headers for name, incident count and latest note', () => {
   const table = testRender();
   const headerTexts = table.find('.ReactVirtualized__Table__headerColumn').map(node => node.text());
-  expect(headerTexts).toEqual(['Name', 'Grade', 'Test Incidents', 'Last SST']);
+  expect(headerTexts).toEqual(['Name', 'Grade', 'Test Incidents', 'Last note']);
 });
 
 it('renders the first row', () => {
@@ -31,7 +31,7 @@ it('renders the first row', () => {
     "Pierrot Zanni",
     "4",
     "3",
-    nowMoment.clone().subtract(3, 'months').format('M/D/YY'),
+    `SST${nowMoment.clone().subtract(3, 'months').format('M/D/YY')}`,
   ]);
 });
 
@@ -72,8 +72,8 @@ it('orders students by events when Incidents is clicked', () => {
   expect(table.state().sortBy).toEqual("events");
 });
 
-it('orders students by events when Last SST is clicked', () => {
+it('orders students by events when Last note is clicked', () => {
   const table = testRender();
   table.find('.ReactVirtualized__Table__headerColumn').at(3).simulate('click');
-  expect(table.state().sortBy).toEqual("last_sst_date_text");
+  expect(table.state().sortBy).toEqual("latest_note");
 });

--- a/app/assets/javascripts/school_administrator_dashboard/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/absences_dashboard/SchoolAbsenceDashboard.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import moment from 'moment';
-import {latestNoteDateText} from '../../helpers/latestNoteDateText';
 import DashboardHelpers from '../DashboardHelpers';
 import StudentsTable from '../StudentsTable';
 import DashboardBarChart from '../DashboardBarChart';

--- a/app/assets/javascripts/school_administrator_dashboard/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/absences_dashboard/SchoolAbsenceDashboard.js
@@ -127,7 +127,7 @@ class SchoolAbsenceDashboard extends React.Component {
         id: student.id,
         first_name: student.first_name,
         last_name: student.last_name,
-        last_sst_date_text: latestNoteDateText(300, student.sst_notes),
+        latest_note: student.latest_note,
         events: studentAbsenceCounts[student.id] || 0,
         grade: student.grade,
       });

--- a/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/SchoolDisciplineDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/SchoolDisciplineDashboard.js
@@ -4,7 +4,6 @@ import _ from 'lodash';
 import moment from 'moment';
 import Select from 'react-select';
 import 'react-select/dist/react-select.css';
-import {latestNoteDateText} from '../../helpers/latestNoteDateText';
 import {sortByGrade} from '../../helpers/SortHelpers';
 import ExperimentalBanner from '../../components/ExperimentalBanner';
 import DashboardHelpers from '../DashboardHelpers';
@@ -170,7 +169,7 @@ class SchoolDisciplineDashboard extends React.Component {
         id: student.id,
         first_name: student.first_name,
         last_name: student.last_name,
-        last_sst_date_text: latestNoteDateText(300, student.sst_notes),
+        latest_note: student.latest_note,
         events: studentDisciplineIncidentCounts[student.id] || 0,
         grade: student.grade
       });

--- a/app/assets/javascripts/school_administrator_dashboard/tardies_dashboard/SchoolTardiesDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/tardies_dashboard/SchoolTardiesDashboard.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import moment from 'moment';
-import {latestNoteDateText} from '../../helpers/latestNoteDateText';
 import DashboardHelpers from '../DashboardHelpers';
 import StudentsTable from '../StudentsTable';
 import DashboardBarChart from '../DashboardBarChart';
@@ -162,7 +161,7 @@ class SchoolTardiesDashboard extends React.Component {
         id: student.id,
         first_name: student.first_name,
         last_name: student.last_name,
-        last_sst_date_text: latestNoteDateText(300, student.sst_notes),
+        latest_note: student.latest_note,
         events: studentTardyCounts[student.id] || 0,
         grade: student.grade
       });

--- a/app/lib/dashboard_queries.rb
+++ b/app/lib/dashboard_queries.rb
@@ -6,7 +6,7 @@ class DashboardQueries
 
   def absence_dashboard_data(school)
     student_absence_data = authorized_students_for_dashboard(school) do |students_relation|
-      students_relation.includes([homeroom: :educator], :dashboard_absences,:sst_notes)
+      students_relation.includes([homeroom: :educator], :dashboard_absences, :event_notes)
     end
     student_absence_data.map do |student|
       individual_student_absence_data(student)
@@ -15,7 +15,7 @@ class DashboardQueries
 
   def tardies_dashboard_data(school)
     student_tardies_data = authorized_students_for_dashboard(school) do |students_relation|
-      students_relation.includes([homeroom: :educator], :dashboard_tardies,:sst_notes)
+      students_relation.includes([homeroom: :educator], :dashboard_tardies, :event_notes)
     end
     student_tardies_data.map do |student|
       individual_student_tardies_data(student)
@@ -25,8 +25,9 @@ class DashboardQueries
   def discipline_dashboard_data(school)
     student_discipline_data = authorized_students_for_dashboard(school) do |students_relation|
       students_relation
-        .includes([homeroom: :educator], :discipline_incidents,:sst_notes)
-        .where('occurred_at >= ?', 1.year.ago).references(:discipline_incidents)
+        .includes([homeroom: :educator], :discipline_incidents, :event_notes)
+        .where('occurred_at >= ?', 1.year.ago)
+        .references(:discipline_incidents)
     end
     student_discipline_data.map do |student|
       individual_student_discipline_data(student)
@@ -35,6 +36,7 @@ class DashboardQueries
 
   private
   def shared_student_fields(student)
+    latest_note = student.event_notes.order(recorded_at: :desc).first(1).first
     student.as_json(only: [
       :first_name,
       :last_name,
@@ -42,7 +44,7 @@ class DashboardQueries
       :id
     ]).merge({
       homeroom_label: homeroom_label(student.homeroom),
-      sst_notes: student.sst_notes.as_json(only: [:event_note_type_id, :recorded_at])
+      latest_note: latest_note.as_json(only: [:event_note_type_id, :recorded_at])
     })
   end
 

--- a/spec/lib/dashboard_queries_spec.rb
+++ b/spec/lib/dashboard_queries_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DashboardQueries do
         :id,
         :last_name,
         :homeroom_label,
-        :sst_notes
+        :latest_note
       ])
     end
 
@@ -27,7 +27,7 @@ RSpec.describe DashboardQueries do
         :id,
         :last_name,
         :homeroom_label,
-        :sst_notes
+        :latest_note
       ])
     end
 
@@ -44,7 +44,7 @@ RSpec.describe DashboardQueries do
         :id,
         :last_name,
         :homeroom_label,
-        :sst_notes
+        :latest_note
       ])
       expect(json[:discipline_incidents].first.keys).to contain_exactly(*[
         "student_id",


### PR DESCRIPTION
# Who is this PR for?
K12 SST staff, administrators, counselors, housemasters.  part of https://github.com/studentinsights/studentinsights/issues/1655.

# What problem does this PR fix?
These dashboards show data on the last SST note, but often there are other notes going on, and we want to stay at "discuss what's going on with this student" rather than the more narrow technical SST focus per se (and avoid folks adding notes as SST to impact this view).

# What does this PR do?
Changes server query to look for just latest note, and then updates UI to show it along with the type inline.

# Screenshot (if adding a client-side feature)
### before, absences (others are similar)
<img width="433" alt="screen shot 2018-07-16 at 3 56 25 pm" src="https://user-images.githubusercontent.com/1056957/42780300-d03999ba-8910-11e8-8f48-13c6f36da102.png">

### after, absences (others are similar)
<img width="438" alt="screen shot 2018-07-16 at 3 39 44 pm" src="https://user-images.githubusercontent.com/1056957/42780275-bfe0d10a-8910-11e8-84f5-e83e0ad15bd8.png">

# Checklists
+ [x] Author included specs for new code
