### PR TITLE
Add hacky fix for risk level bug

### DIFF
--- a/app/helpers/students_query_helper.rb
+++ b/app/helpers/students_query_helper.rb
@@ -4,7 +4,9 @@ module StudentsQueryHelper
   INCLUDE_FOR_STUDENTS = Student.column_names.map(&:to_sym) - [
     :primary_phone,
     :primary_email,
-    :student_address
+    :student_address,
+    :risk_level  # Hacky fix for risk level not clearing from column names
+                 # cache after deploying https://github.com/studentinsights/studentinsights/pull/1892.
   ]
 
   INCLUDE_FOR_EVENT_NOTES = [


### PR DESCRIPTION
# What problem does this PR fix?

Bugfix; https://rollbar.com/somerville-teacher-tool/somerville-teacher-tool/items/178/.

# What does this PR do?

Explicitly remove risk_level from students query, even though risk level was removed from the students table in #1892. (Seems there's some kind of bug with the column_names ActiveRecord cache.)

# Note

```
2.5.1 :001 > ['a'] - ['c']
 => ["a"]
```

So we're safe removing an item (column name) that shouldn't be there long-term.