### PR TITLE
Add alternative `all.sh` deploy script

### DIFF
--- a/scripts/deploy/all_alt.sh
+++ b/scripts/deploy/all_alt.sh
@@ -1,0 +1,14 @@
+# Deploy to all sites in parallel
+# See https://github.com/studentinsights/studentinsights/pull/1856.
+echo "🚢  Fetching from GitHub..."
+git fetch origin
+
+echo "🚢  Deploying..."
+yarn concurrently \
+  --names "demo,somerville,new-bedford" \
+  -c "yellow.bold,blue.bold,magenta.bold" \
+  'scripts/deploy/deploy.sh demo' \
+  'scripts/deploy/deploy.sh somerville' \
+  'scripts/deploy/deploy.sh new-bedford'
+
+echo "🚢  Done."


### PR DESCRIPTION
# Who is this PR for?

Devs.

# What problem does this PR fix?

Slightly different dev environments mean that our `all.sh` deploy script doesn't work consistently across computers.

# What does this PR do?

Adds an alt script that works on my machine. Kicking this particular problem down the road. 👋 