### PR TITLE
Add empty ApplicationJob as part of Rails 5 migration

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,2 @@
+class ApplicationJob < ActiveJob::Base
+end


### PR DESCRIPTION
# What problem does this PR fix?

The Rails docs mention that to upgrade to Rails 5, we need to add an `ApplicationJob` class that inherits from `ActiveJob::Base`:

http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#activejob-now-inherits-from-applicationjob-by-default

This wasn't a big issue in our app. We only used Delayed::Job in one instance (and we're not using it there anymore). And we hadn't added any libraries that called `ApplicationJob`... until recently! 

#1897 caused the site to go down because authtrail expects `ApplicationJob` to be present. My understanding is that once this PR is merged, we could un-revert authtrail safely. 

# Question to consider!

Rails recommends that after you add `ApplicationJob`, "make sure that all your job classes inherit from it." 

Is this something we should go ahead and do?

Looking at the jobs in our app/jobs folder: two are for testing purposes, three are for import jobs that run nightly. None of them are "background jobs" in the sense that they contain large volumes of work coming in continually to be processed in the background by a background processor like Sidekiq or Delayed::Job. This makes me wonder if we should move them out of app/jobs and into another top-level folder (/tasks?). This way we aren't at odds with Rails expectations about what a "job" is and what classes it should inherit from.