### PR TITLE
Migrate Absence and Tardy models for stricter validations and field types

### DIFF
--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -1,4 +1,6 @@
 class Absence < ActiveRecord::Base
   belongs_to :student
-  validates_presence_of :student, :occurred_at
+
+  validates :student, presence: true
+  validates :occurred_at, presence: true, uniqueness: { scope: [:student_id] }
 end

--- a/app/models/tardy.rb
+++ b/app/models/tardy.rb
@@ -1,4 +1,6 @@
 class Tardy < ActiveRecord::Base
   belongs_to :student
-  validates_presence_of :student, :occurred_at
+
+  validates :student, presence: true
+  validates :occurred_at, presence: true, uniqueness: { scope: [:student_id] }
 end

--- a/db/migrate/20180717184037_absence_not_null.rb
+++ b/db/migrate/20180717184037_absence_not_null.rb
@@ -8,5 +8,9 @@ class AbsenceNotNull < ActiveRecord::Migration[5.2]
     # by date.
     change_column :absences, :occurred_at, :date, null: false
     change_column  :tardies, :occurred_at, :date, null: false
+
+    # Enforce only one event per day per student
+    add_index :absences, [:student_id, :occurred_at], unique: true
+    add_index  :tardies, [:student_id, :occurred_at], unique: true
   end
 end

--- a/db/migrate/20180717184037_absence_not_null.rb
+++ b/db/migrate/20180717184037_absence_not_null.rb
@@ -1,0 +1,12 @@
+class AbsenceNotNull < ActiveRecord::Migration[5.2]
+  def change
+    # This was nullable before and it shouldn't be.
+    change_column :absences, :student_id, :integer, null: false
+    change_column  :tardies, :student_id, :integer, null: false
+
+    # This was a datetime, but logically it's a date and we want to enforce uniqueness
+    # by date.
+    change_column :absences, :occurred_at, :date, null: false
+    change_column  :tardies, :occurred_at, :date, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_16_183457) do
+ActiveRecord::Schema.define(version: 2018_07_17_184037) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "absences", id: :serial, force: :cascade do |t|
-    t.datetime "occurred_at", null: false
+    t.date "occurred_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "student_id"
+    t.integer "student_id", null: false
     t.boolean "dismissed"
     t.boolean "excused"
     t.string "reason"
@@ -398,10 +398,10 @@ ActiveRecord::Schema.define(version: 2018_07_16_183457) do
   end
 
   create_table "tardies", id: :serial, force: :cascade do |t|
-    t.datetime "occurred_at", null: false
+    t.date "occurred_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "student_id"
+    t.integer "student_id", null: false
     t.boolean "dismissed"
     t.boolean "excused"
     t.string "reason"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2018_07_17_184037) do
     t.boolean "excused"
     t.string "reason"
     t.string "comment"
+    t.index ["student_id", "occurred_at"], name: "index_absences_on_student_id_and_occurred_at", unique: true
     t.index ["student_id"], name: "index_absences_on_student_id"
   end
 
@@ -406,6 +407,7 @@ ActiveRecord::Schema.define(version: 2018_07_17_184037) do
     t.boolean "excused"
     t.string "reason"
     t.string "comment"
+    t.index ["student_id", "occurred_at"], name: "index_tardies_on_student_id_and_occurred_at", unique: true
     t.index ["student_id"], name: "index_tardies_on_student_id"
   end
 


### PR DESCRIPTION
# Who is this PR for?
K12 admin, counselors, housemasters, redirect, came out of working on https://github.com/studentinsights/studentinsights/issues/1657.

# What problem does this PR fix?
Validations aren't being enforced on absences and tardy models right now.

# What does this PR do?
Enforces the result of some investigations.  Here's what I did:

Any missing student_id?
```
> Absence.where(student_id: nil).size
=> 24984 (somerville)
=> 0 (new bedford)

> Tardy.where(student_id: nil).size
=> 17818 (somerville)
=> 0 (new bedford)

```

When?
```
  # somerville
  updated_at_nils = nils.map(&:updated_at).sort;nil
  [updated_at_nils.first, updated_at_nils.last]
  => [Tue, 15 Dec 2015 20:34:13 UTC +00:00, Fri, 09 Jun 2017 05:43:56 UTC +00:00]

  [created_at_nils.first, created_at_nils.last]
  => [Wed, 19 Aug 2015 19:41:43 UTC +00:00, Fri, 09 Jun 2017 05:43:56 UTC +00:00]

  > [occurred_at_nils.first, occurred_at_nils.last]
  => [Fri, 23 Sep 2005 00:00:00 UTC +00:00, Thu, 08 Jun 2017 00:00:00 UTC +00:00]
```
The first `ParseableCsvString` PR was 6/10: https://github.com/studentinsights/studentinsights/commit/8fe6b13127fc7636808b0d6c5601b6070d737106#diff-eec5a5ee0453bf81b48de921c755e36b but not sure how that's related.

Why didn't RecordSyncer destroy these?
 > because it queries within a whitelist of schools, which is done by joining through the student table, so these are considered out of scope for syncing

Why didn't the integrity task catch this?
> It doesn't look at the Absence model.  we could add it, but that task already takes an hour to run and this would potentially double the time.  We can enforce this in the database instead.

Why didn't the database enforce this?
> The `student_id` field is set as nullable.  This PR fixes that.

Why didn't rails enforce this?
> I'm not sure, if these records are loaded, they correctly fail the presence validation if you call `.valid?`  We'd have to look back at old importer code to see how this could have been happening.  Looking quickly at the git history, nothing jumped out so I'm not sure how this could have happened.

Anyway, let's remove them manually...
```
  nils = Absence.where(student_id: nil);nil
  nils.each_with_index do |absence, index|
    absence.destroy!
    puts "index: #{index}" if index % 1000 == 0
  end;nil

  tardy_nils.each_with_index do |tardy, index|
    tardy.destroy!
    puts "index: #{index}" if index % 1000 == 0
  end;nil

  # no more duplicates
  pairs = Absence.pluck(:occurred_at, :student_id);nil
  uniques = pairs.uniq;nil
  pairs.size == pairs.uniq.size
  => true
```

To enforce the uniqueness validation, we want these to be unique by date, but the Postgres field is a datetime.  So can we migrate this?

Are any datetimes stored instead of plain dates?
```
  times = Absence.pluck(:occurred_at);nil
  times.map(&:class).uniq
  => [ActiveSupport::TimeWithZone]

  nondates = times.select {|time| time.to_date != time };nil
  nondates.size
  => 0
  
  # nope, same for Tardy across both sites
```

So we're safe to migrate and add the validation.