### PR TITLE
Remove model validations on Absence and Tardy, since they regress Importer performance

### DIFF
--- a/app/demo_data/demo_data_util.rb
+++ b/app/demo_data/demo_data_util.rb
@@ -1,6 +1,15 @@
 class DemoDataUtil
   FIVE_YEARS_OF_SECONDS = 157766400
 
+  def self.generate_unique(n, &block)
+    values = []
+    while values.size < n
+      values << block.call
+      values = values.uniq
+    end
+    values
+  end
+
   def self.random_time(options = {})
     time_now = options[:time_now] || DateTime.now
     seconds_back = options[:seconds_back] || FIVE_YEARS_OF_SECONDS

--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -241,9 +241,11 @@ class FakeStudent
 
     events_for_year = DemoDataUtil.sample_from_distribution(d)
 
-    events_for_year.times do
-      # Randomly determine when it occurred.
-      occurred_at = DemoDataUtil.random_time.to_date
+    occurred_ats = DemoDataUtil.generate_unique(events_for_year) do
+      DemoDataUtil.random_time.to_date
+    end
+    events_for_year.times do |index|
+      occurred_at = occurred_ats[index]
 
       attendance_event = [Absence.new, Tardy.new].sample
       attendance_event.occurred_at = occurred_at

--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -1,6 +1,12 @@
 class Absence < ActiveRecord::Base
   belongs_to :student
 
-  validates :student, presence: true
-  validates :occurred_at, presence: true, uniqueness: { scope: [:student_id] }
+  # The database enforces more constraints, since adding them
+  # as validations here impacts the performance of the import task.
+  # With validations on associations, each call to check whether a record
+  # is valid triggers additional queries to other tables to validate the foreign keys
+  # In most cases, this in unnecessary, and when there is a violation the database
+  # will enforce it.
+  validates :student_id, presence: true
+  validates :occurred_at, presence: true
 end

--- a/app/models/tardy.rb
+++ b/app/models/tardy.rb
@@ -1,6 +1,12 @@
 class Tardy < ActiveRecord::Base
   belongs_to :student
 
-  validates :student, presence: true
-  validates :occurred_at, presence: true, uniqueness: { scope: [:student_id] }
+  # The database enforces more constraints, since adding them
+  # as validations here impacts the performance of the import task.
+  # With validations on associations, each call to check whether a record
+  # is valid triggers additional queries to other tables to validate the foreign keys
+  # In most cases, this in unnecessary, and when there is a violation the database
+  # will enforce it.
+  validates :student_id, presence: true
+  validates :occurred_at, presence: true
 end

--- a/spec/models/absence_spec.rb
+++ b/spec/models/absence_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Absence, type: :model do
   subject(:absence) {
     Absence.create!(
       occurred_at: Time.now,
-      student: student
+      student_id: student.id
     )
   }
 
   it { is_expected.to belong_to :student }
-  it { is_expected.to validate_presence_of :student }
+  it { is_expected.to validate_presence_of :student_id }
   it { is_expected.to validate_presence_of :occurred_at }
 end

--- a/spec/models/tardy_spec.rb
+++ b/spec/models/tardy_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Tardy do
   subject(:tardy) {
     Tardy.create!(
       occurred_at: Time.now,
-      student: student
+      student_id: student.id
     )
   }
 
   it { is_expected.to belong_to :student }
-  it { is_expected.to validate_presence_of :student }
+  it { is_expected.to validate_presence_of :student_id }
   it { is_expected.to validate_presence_of :occurred_at }
 end


### PR DESCRIPTION
# Who is this PR for?
developers, follow on to https://github.com/studentinsights/studentinsights/pull/1908

# What problem does this PR fix?
https://github.com/studentinsights/studentinsights/pull/1908 migrated the database but also added two Rails validations.  These validations mean that each call to `valid?` or `save!` also leads to database queries on associated models to enforce the validations.  This slows down the Somerville `AttendanceImporter` significantly since it has to do this for every row it processes - after 74 minutes on a 1x box it's only about halfway done.  We don't really care about how long this task takes in general, but it really slows down iterating on the last steps for https://github.com/studentinsights/studentinsights/issues/1657.

# What does this PR do?
Removes the model validations.  These are enforced by the database already:
```
ActiveRecord::InvalidForeignKey (PG::ForeignKeyViolation: ERROR:  insert or update on table "absences" violates foreign key constraint "fk_rails_dc2c1be879")
DETAIL:  Key (student_id)=(99999999) is not present in table "students".
: INSERT INTO "absences" ("occurred_at", "created_at", "updated_at", "student_id") VALUES ($1, $2, $3, $4) RETURNING "id"
...
ActiveRecord::RecordNotUnique (PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_absences_on_student_id_and_occurred_at")
DETAIL:  Key (student_id, occurred_at)=(7068, 2018-07-16) already exists.
: INSERT INTO "absences" ("occurred_at", "created_at", "updated_at", "student_id") VALUES ($1, $2, $3, $4) RETURNING "id"
```
