### PR TITLE
Update seed task to raise on errors and respect validations for duplicates

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -74,11 +74,11 @@ end
 puts 'Creating more students for each homeroom...'
 Homeroom.order(:name).each do |homeroom|
   puts "  Creating for homeroom: #{homeroom.name}..."
-  homeroom_class_size.times { FakeStudent.new(homeroom.school, homeroom) }
+  homeroom_class_size.times { FakeStudent.create!(homeroom.school, homeroom) }
 end
 
 puts 'Creating additional students for the Healey with no homeroom...'
-9.times { FakeStudent.new(pals.healey, nil) }
+9.times { FakeStudent.create!(pals.healey, nil) }
 
 puts 'Creating more sophomore students...'
 Section.all.each do |section|
@@ -87,9 +87,9 @@ Section.all.each do |section|
   9.times do
     grade_letter = ['A','B','C','D','F'].sample
     grade_numeric = sample_numeric_grade_from_letter(grade_letter)
-    fake_student = FakeStudent.new(school, pals.shs_sophomore_homeroom)
+    student = FakeStudent.create!(school, pals.shs_sophomore_homeroom)
     StudentSectionAssignment.create!({
-      student: fake_student.student,
+      student: student,
       section: section,
       grade_numeric: grade_numeric,
       grade_letter: grade_letter

--- a/spec/demo_data/fake_student_spec.rb
+++ b/spec/demo_data/fake_student_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FakeStudent do
   let!(:homeroom) { FactoryBot.create(:homeroom, grade: '5') }
   before { FactoryBot.create(:educator, :admin) }
 
-  let(:student) { described_class.new(school, homeroom).student }
+  let(:student) { FakeStudent.create!(school, homeroom) }
 
   it 'sets student name' do
     expect(student.first_name).not_to be_nil

--- a/spec/reports/students_spreadsheet_spec.rb
+++ b/spec/reports/students_spreadsheet_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe StudentsSpreadsheet do
     before do
       # the test data is not deterministic (setting a seed in srand only worked on
       # a single-file test run), so we only test for the output shape
-      3.times { FakeStudent.new(school, homeroom) }
+      3.times { FakeStudent.create!(school, homeroom) }
       Student.update_recent_student_assessments
     end
 


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
https://github.com/studentinsights/studentinsights/pull/1908 added stricter validations for absences and tardies, which the seed task can violate, depending on how the randomization comes out.  Separately, `FakeStudent` used `.save` in several places instead of `.save!` which meant that it silently ignored Rails validation errors (although `.save` does respect database-enforced constraint violations like in https://github.com/studentinsights/studentinsights/pull/1911).  Changing this to `.save!` revealed that the code was trying to create two separate sets of Access assessments and was violating the `StudentAssessment` Rails validations.

# What does this PR do?
Updates `FakeStudent` to use `save!` and refactors the call to be `FakeStudent.create!` reflecting this instead of `FakeStudent.new`.  Renames the methods for assessments to be about individual assessments types so it's clear what's in their scope.