### PR TITLE
Don't show unexcused absences on Absences dashboard if feature is unsupported

### DIFF
--- a/app/assets/javascripts/components/PerDistrictContainer.js
+++ b/app/assets/javascripts/components/PerDistrictContainer.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+
+// A container that provides `districtKey`, assumed to be static across
+// the lifetime of all JS execution.  For React components, use this instead of
+// `readEnv`, which is intended for bootstrap code.
+export default class PerDistrictContainer extends React.Component {
+  getChildContext() {
+    const {districtKey} = this.props;
+    return {districtKey};
+  }
+
+  render() {
+    const {children} = this.props;
+    return children;
+  }
+}
+PerDistrictContainer.childContextTypes = {
+  districtKey: PropTypes.string
+};
+PerDistrictContainer.propTypes = {
+  districtKey: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired
+};

--- a/app/assets/javascripts/envForJs.js
+++ b/app/assets/javascripts/envForJs.js
@@ -1,4 +1,7 @@
-// Read the stub written by the Rails HTML in the layout
+// Read the stub written by the Rails HTML in the layout.  Intended for the JS
+// boot process only.
+//
+// Use `PerDistrict` if you're trying to get `districtKey` from inside a React component.
 export function readEnv() {
   if (window.ENV_FOR_JS === undefined) {
     const el = document.getElementById('env-for-js');

--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -1,5 +1,9 @@
 import * as Filters from './Filters';
 
+export const SOMERVILLE = 'somerville';
+export const NEW_BEDFORD = 'new_bedford';
+export const DEMO = 'demo';
+
 export function hasStudentPhotos(districtKey) {
   if (districtKey === 'somerville') return true;
   if (districtKey === 'new_bedford') return false;
@@ -99,6 +103,11 @@ export function shouldDisplayHouse(school) {
 // This only applies to high schools.
 export function shouldDisplayCounselor(school) {
   return (school && school.school_type === 'HS');
+}
+
+export function supportsExcusedAbsences(districtKey) {
+  if (districtKey === 'somerville') return true;
+  return false;
 }
 
 // This returns user-facing text to describe their program and placement

--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -5,20 +5,20 @@ export const NEW_BEDFORD = 'new_bedford';
 export const DEMO = 'demo';
 
 export function hasStudentPhotos(districtKey) {
-  if (districtKey === 'somerville') return true;
-  if (districtKey === 'new_bedford') return false;
+  if (districtKey === SOMERVILLE) return true;
+  if (districtKey === NEW_BEDFORD) return false;
   return false;
 }
 
 const ORDERED_DISABILITY_VALUES_MAP = {
-  'new_bedford': [
+  [NEW_BEDFORD]: [
     "Does Not Apply",
     "Low-Less Than 2hrs/week",
     "Low-2+ hrs/week",
     "Moderate",
     "High"
   ],
-  'somerville': [
+  [SOMERVILLE]: [
     // also include null
     'Low < 2',
     'Low >= 2',
@@ -57,7 +57,7 @@ export function renderSlicePanelsDisabilityTable(districtKey, options = {}) {
 
   // Somerville uses a null value for no disability, while New Bedford
   // uses a separate value to describe that explicitly.
-  const items = (districtKey === 'somerville')
+  const items = (districtKey === SOMERVILLE)
     ? [createItemFn('None', Filters.Null(key))].concat(itemsFromValues)
     : itemsFromValues;
   return renderTableFn({items, title: 'Disability'});
@@ -88,7 +88,7 @@ const ORDERED_SOMERVILLE_SCHOOL_SLUGS_BY_GRADE = {
 };
 
 export function sortSchoolSlugsByGrade(districtKey, slugA, slugB) {
-  if (districtKey === 'somerville') {
+  if (districtKey === SOMERVILLE) {
     return ORDERED_SOMERVILLE_SCHOOL_SLUGS_BY_GRADE[slugA] - ORDERED_SOMERVILLE_SCHOOL_SLUGS_BY_GRADE[slugB];
   }
 
@@ -106,7 +106,8 @@ export function shouldDisplayCounselor(school) {
 }
 
 export function supportsExcusedAbsences(districtKey) {
-  if (districtKey === 'somerville') return true;
+  if (districtKey === SOMERVILLE) return true;
+  if (districtKey === DEMO) return true;
   return false;
 }
 

--- a/app/assets/javascripts/school_administrator_dashboard/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/absences_dashboard/SchoolAbsenceDashboard.js
@@ -2,21 +2,26 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import moment from 'moment';
+import {supportsExcusedAbsences} from '../../helpers/PerDistrict';
+import SectionHeading from '../../components/SectionHeading';
 import DashboardHelpers from '../DashboardHelpers';
 import StudentsTable from '../StudentsTable';
 import DashboardBarChart from '../DashboardBarChart';
 import DashRangeButtons from '../DashRangeButtons';
 import DashButton from '../DashButton';
-import SectionHeading from '../../components/SectionHeading';
 
 
 export default class SchoolAbsenceDashboard extends React.Component {
 
-  constructor(props) {
+  constructor(props, context) {
     super(props);
+
+    const {dateRange} = props;
+    const {districtKey} = context;
+    const showExcused = supportsExcusedAbsences(districtKey) ? false : true;
     this.state = {
-      displayDates: this.props.dateRange,
-      showExcused: false,
+      showExcused,
+      displayDates: dateRange,
       selectedHomeroom: null,
       selectedRange: 'This School Year'
     };
@@ -147,8 +152,11 @@ export default class SchoolAbsenceDashboard extends React.Component {
   }
 
   renderExcusedAbsencesSelect() {
+    const {districtKey} = this.context;
+    if (!supportsExcusedAbsences(districtKey)) return null;
+
     return(
-      <div style={styles.excusedFilter}>
+      <div style={styles.excusedFilter} className="SchoolAbsenceDashboard-excused-absences-select">
         <DashButton
             buttonText={"Unexcused Absences Only"}
             onClick={() => this.setState({showExcused: false})}
@@ -203,23 +211,25 @@ export default class SchoolAbsenceDashboard extends React.Component {
     });
 
     return (
-        <DashboardBarChart
-          id = {'string'}
-          categories = {{categories: homerooms}}
-          seriesData = {homeroomSeries}
-          yAxisMin = {80}
-          yAxisMax = {100}
-          titleText = {`Average Attendance By Homeroom (${this.state.selectedRange})`}
-          measureText = {'Attendance (Percent)'}
-          tooltip = {{
-            pointFormat: 'Average Daily Attendance: <b>{point.y}</b>',
-            valueSuffix: '%'}}
-          onColumnClick = {this.setStudentList}
-          onBackgroundClick = {this.resetStudentList}/>
+      <DashboardBarChart
+        id = {'string'}
+        categories = {{categories: homerooms}}
+        seriesData = {homeroomSeries}
+        yAxisMin = {80}
+        yAxisMax = {100}
+        titleText = {`Average Attendance By Homeroom (${this.state.selectedRange})`}
+        measureText = {'Attendance (Percent)'}
+        tooltip = {{
+          pointFormat: 'Average Daily Attendance: <b>{point.y}</b>',
+          valueSuffix: '%'}}
+        onColumnClick = {this.setStudentList}
+        onBackgroundClick = {this.resetStudentList}/>
     );
   }
 }
-
+SchoolAbsenceDashboard.contextTypes = {
+  districtKey: PropTypes.string.isRequired
+};
 SchoolAbsenceDashboard.propTypes = {
   schoolAverageDailyAttendance: PropTypes.object.isRequired,
   schoolAverageDailyAttendanceUnexcused: PropTypes.object.isRequired,

--- a/app/lib/env.rb
+++ b/app/lib/env.rb
@@ -5,21 +5,28 @@ class Env
   # development.rb and test.rb like normal.
   def self.set_for_development_and_test!
     return unless Rails.env.development? || Rails.env.test?
+    default_env = {}
 
     # instance config
-    ENV['DISTRICT_KEY'] = 'somerville'
-    ENV['DISTRICT_NAME'] = 'Localhost Public Schools'
+    default_env['DISTRICT_KEY'] = 'somerville'
+    default_env['DISTRICT_NAME'] = 'Localhost Public Schools'
 
     # service config
-    ENV['USE_MOCK_LDAP'] = 'true'
-    ENV['MOCK_LDAP_PASSWORD'] = 'demo-password'
-    ENV['AWS_REGION'] = 'us-west-2'
-    ENV['MIXPANEL_TOKEN'] = 'foo';
-    ENV['ROLLBAR_JS_ACCESS_TOKEN'] = 'foo';
+    default_env['USE_MOCK_LDAP'] = 'true'
+    default_env['MOCK_LDAP_PASSWORD'] = 'demo-password'
+    default_env['AWS_REGION'] = 'us-west-2'
+    default_env['MIXPANEL_TOKEN'] = 'foo';
+    default_env['ROLLBAR_JS_ACCESS_TOKEN'] = 'foo';
 
     # feature switches
-    ENV['ENABLE_CLASS_LISTS'] = 'true'
-    ENV['ENABLE_COUNSELOR_BASED_FEED'] = 'true'
-    ENV['HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8'] = 'true'
+    default_env['ENABLE_CLASS_LISTS'] = 'true'
+    default_env['ENABLE_COUNSELOR_BASED_FEED'] = 'true'
+    default_env['HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8'] = 'true'
+
+    # only set values if ENV hasn't already set them (ie, allow command line overrides)
+    default_env.each do |key, value|
+      next if ENV.has_key?(key)
+      ENV[key] = value
+    end
   end
 end

--- a/ui/App.js
+++ b/ui/App.js
@@ -7,6 +7,7 @@ import {
 import moment from 'moment';
 import MixpanelUtils from '../app/assets/javascripts/helpers/MixpanelUtils';
 import NowContainer from '../app/assets/javascripts/testing/NowContainer';
+import PerDistrictContainer from '../app/assets/javascripts/components/PerDistrictContainer';
 import HomePage from '../app/assets/javascripts/home/HomePage';
 import EducatorPage from '../app/assets/javascripts/educator/EducatorPage';
 import TieringPage from '../app/assets/javascripts/tiering/TieringPage';
@@ -41,11 +42,15 @@ class App extends React.Component {
   }
 
   // `NowContainer` provides a fn to read the time
-  // in any deeply nested component.
+  // in any deeply nested component,
+  // `PerDistrictContainer` provides `districtKey`.
   render() {
+    const {districtKey} = this.props;
     return (
       <NowContainer nowFn={() => moment.utc()}>
-        {this.renderRoutes()}
+        <PerDistrictContainer districtKey={districtKey}>
+          {this.renderRoutes()}
+        </PerDistrictContainer>
       </NowContainer>
     );
   }
@@ -172,6 +177,7 @@ class App extends React.Component {
   }
 }
 App.propTypes = {
+  districtKey: PropTypes.string.isRequired,
   currentEducator: PropTypes.shape({
     id: PropTypes.number.isRequired,
     admin: PropTypes.bool.isRequired,

--- a/ui/App.test.js
+++ b/ui/App.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {mount} from 'enzyme';
+import {NEW_BEDFORD} from '../app/assets/javascripts/helpers/PerDistrict';
 import App from './App';
 import HomePage from '../app/assets/javascripts/home/HomePage';
 import EducatorPage from '../app/assets/javascripts/educator/EducatorPage';
@@ -23,9 +24,10 @@ jest.mock('../app/assets/javascripts/class_lists/ClassListsViewPage');
 
 function renderPath(path, options = {}) {
   const educator = options.educator || createSerializedDataEducator();
+  const districtKey = options.districtKey || NEW_BEDFORD;
   return (
     <MemoryRouter initialEntries={[path]}>
-      <App currentEducator={educator} />
+      <App currentEducator={educator} districtKey={districtKey} />
     </MemoryRouter>
   );
 }

--- a/ui/index.js
+++ b/ui/index.js
@@ -41,9 +41,13 @@ const mainEl = document.getElementById('main');
 if (mainEl) {
   const didRoute = legacyRouteHandler(mainEl);
   if (!didRoute) {
+    const {districtKey} = readEnv();
     const serializedData = $('#serialized-data').data() || {};
     const {currentEducator} = serializedData;
     ReactDOM.render(
-      <BrowserRouter><App currentEducator={currentEducator} /></BrowserRouter>, mainEl);
+      <BrowserRouter>
+        <App currentEducator={currentEducator} districtKey={districtKey} />
+      </BrowserRouter>
+    , mainEl);
   }
 }


### PR DESCRIPTION
# Who is this PR for?
K12 New Bedford educators

# What problem does this PR fix?
Part of https://github.com/studentinsights/studentinsights/issues/1657#issuecomment-396062667, related to https://github.com/studentinsights/studentinsights/pull/1811.  We don't have this data for New Bedford, but the UI currently makes it seem like we do and that these buttons will filter by them.

# What does this PR do?
Removes these options for New Bedford.  There are a few related bits necessary to enable this - providing the `districtKey` as context within `<App />` and updating the Rails config to allow passing env values on the command line (which previously, prevented us from starting the app in a different instance with `DISTRICT_KEY=new_bedford rails s`).

# Screenshot (if adding a client-side feature)
### for new bedford
<img width="768" alt="screen shot 2018-07-20 at 11 10 20 am" src="https://user-images.githubusercontent.com/1056957/43010210-d6f24c84-8c0d-11e8-820c-aa513cd91220.png">
