### PR TITLE
Update styling for StudentsTable dates

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/StudentsTable.js
+++ b/app/assets/javascripts/school_administrator_dashboard/StudentsTable.js
@@ -176,15 +176,26 @@ export default class StudentsTable extends React.Component {
     if (!latestNote || !latestNote.recorded_at) return null;
 
     const {nowFn} = this.context;
-    const now = nowFn();
-    const daysAgoText = now.diff(moment.utc(latestNote.recorded_at), 'days');
     const noteTypeText = eventNoteTypeTextMini(latestNote.event_note_type_id);
+    const lastNoteMoment = moment.utc(latestNote.recorded_at);
     return (
       <div style={{paddingRight: 10, display: 'flex', justifyContent: 'space-between'}}>
         <span style={{color: '#999'}}>{noteTypeText}</span>
-        <span>{daysAgoText} days ago</span>
+        {this.renderDaysAgo(lastNoteMoment, nowFn())}
       </div>
     );
+  }
+
+  renderDaysAgo(lastNoteMoment, now) {
+    const daysAgo = now.diff(lastNoteMoment, 'days');
+    const isOld = (daysAgo > 45);
+    const text = (isOld)
+      ? `${now.diff(lastNoteMoment, 'weeks')} weeks`
+      : `${daysAgo} days`;
+    const color = (isOld)
+      ? '#ccc'
+      : 'black';
+    return <span style={{color}}>{text}</span>;
   }
 
   renderCaption() {

--- a/app/assets/javascripts/school_administrator_dashboard/StudentsTable.test.js
+++ b/app/assets/javascripts/school_administrator_dashboard/StudentsTable.test.js
@@ -38,7 +38,7 @@ it('renders the first row', () => {
     "Pierrot Zanni",
     "4",
     "3",
-    'SST30 days ago',
+    'SST30 days',
   ]);
 });
 


### PR DESCRIPTION
# Who is this PR for?
K12 AP, redirect, counselors, housemasters

# What problem does this PR fix?
The dates are a wall of text, doesn't triage for you.

# What does this PR do?
Adds color to encode the length of time, fading out over time, using the same 45 days guidance.  And switches from "days" to "weeks" after the threshold.

# Screenshot (if adding a client-side feature)
<img width="116" alt="screen shot 2018-07-20 at 1 25 50 pm" src="https://user-images.githubusercontent.com/1056957/43016306-71142082-8c20-11e8-93e1-2efb972e277b.png">
