### PR TITLE
Update insight box for absences to exclude excused absences by default

### DIFF
--- a/app/lib/insight_students_with_high_absences.rb
+++ b/app/lib/insight_students_with_high_absences.rb
@@ -1,7 +1,8 @@
 class InsightStudentsWithHighAbsences
-  def initialize(educator)
+  def initialize(educator, options = {})
     @educator = educator
     @authorizer = Authorizer.new(@educator)
+    @include_excused_absences = options.fetch(:include_excused_absences, false)
   end
 
   # Returns a list of all students that the educator has access
@@ -46,9 +47,11 @@ class InsightStudentsWithHighAbsences
   private
   # An array of hashes with [{:student, :count}]
   def absence_counts_for_students(student_ids, time_threshold, absences_threshold)
+    excused_values = if @include_excused_absences then [true, false, nil] else [false, nil] end
     absence_count_map = Absence
       .includes(:student)
       .where(student_id: student_ids)
+      .where(excused: excused_values)
       .where('occurred_at > ?', time_threshold)
       .group(:student)
       .count


### PR DESCRIPTION
# Who is this PR for?
K12 APs, redirect, counselors, housemasters, classroom teachers

# What problem does this PR fix?
Part of https://github.com/studentinsights/studentinsights/issues/1657.  These suggestions include students who already have been documented separately as being absence for excused reasons, so this results in them being false positives here (ie, an educator is already aware and has note that).

# What does this PR do?
This PR ignores those excused absences by default, if that data is present.  For districts without that data, nothing changes.

# Checklists
+ [x] Author included specs for new code
