### PR TITLE
Update yarn test command to work with yarn 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "concurrently --kill-others \"bundle exec rails s\" \"yarn dev\"",
     "jest": "TZ='America/New_York' jest --config jest.json",
     "t": "yarn test",
-    "test": "yarn jest --watch",
+    "test": "yarn jest -- --watch",
     "test-cli": "yarn lint-cli && yarn jest",
     "storybook": "start-storybook -p 6006 --config-dir ui/config/.storybook"
   },


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
yarn command line handling changed from 1.3.0 to 1.7.0, the `--watch` was getting dropped when I upgraded.

# What does this PR do?
adds `--` to separate
