### PR TITLE
Remove Filter by text for absence dashboard if excused absences not enabled

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/absences_dashboard/SchoolAbsenceDashboard.js
@@ -135,13 +135,13 @@ export default class SchoolAbsenceDashboard extends React.Component {
     const {timeRangeKey, excusedAbsencesKey} = this.state;
     return (
       <EscapeListener style={styles.filterBarContainer} onEscape={this.onResetFilters}>
-        <FilterBar>
-          {supportsExcusedAbsences(districtKey) &&
+        {supportsExcusedAbsences(districtKey) &&
+          <FilterBar>
             <SelectExcusedAbsences
               excusedAbsencesKey={excusedAbsencesKey}
               onChange={this.onExcusedAbsencesChanged} />
-          }
-        </FilterBar>
+          </FilterBar>
+        }
         <FilterBar labelText="Time range">
           <SelectTimeRange
             timeRangeKey={timeRangeKey}


### PR DESCRIPTION
This was branching on the select; should be branching on the whole bar:

<img width="1021" alt="screen shot 2018-07-21 at 11 20 16 am" src="https://user-images.githubusercontent.com/1056957/43037151-18751162-8cd8-11e8-86ad-64c6dfd62227.png">
