### PR TITLE
Update My students to remove filters for New Bedford

### DIFF
--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -95,6 +95,12 @@ export function sortSchoolSlugsByGrade(districtKey, slugA, slugB) {
   return slugA.localeCompare(slugB);
 }
 
+export function supportsHouse(districtKey) {
+  if (districtKey === SOMERVILLE) return true;
+  if (districtKey === DEMO) return true;
+  return false;
+}
+
 // This only applies to Somerville HS.
 export function shouldDisplayHouse(school) {
   return (school && school.local_id === 'SHS');
@@ -109,9 +115,21 @@ export function somervilleHouses() {
   ];
 }
 
+export function supportsCounselor(districtKey) {
+  if (districtKey === SOMERVILLE) return true;
+  if (districtKey === DEMO) return true;
+  return false;
+}
+
 // This only applies to high schools.
 export function shouldDisplayCounselor(school) {
   return (school && school.school_type === 'HS');
+}
+
+export function supportsSpedLiaison(districtKey) {
+  if (districtKey === SOMERVILLE) return true;
+  if (districtKey === DEMO) return true;
+  return false;
 }
 
 export function supportsExcusedAbsences(districtKey) {

--- a/app/assets/javascripts/my_students/FilterStudentsBar.js
+++ b/app/assets/javascripts/my_students/FilterStudentsBar.js
@@ -99,10 +99,11 @@ export default class FilterStudentsBar extends React.Component {
   }
 
   renderHouseSelect() {
-    const {students} = this.props;
+    const {students, includeHouse} = this.props;
+    if (!includeHouse) return null;
+
     const {house} = this.state;
     const sortedHouses = _.sortBy(_.uniq(_.compact(students.map(student => student.house))));
-    if (sortedHouses.length === 0) return;
     return (
       <SelectHouse
         house={house}
@@ -112,19 +113,21 @@ export default class FilterStudentsBar extends React.Component {
   }
 
   renderCounselorSelect() {
-    const {students} = this.props;
+    const {students, includeCounselor} = this.props;
+    if (!includeCounselor) return null;
     const {counselor} = this.state;
     const sortedCounselors = _.sortBy(_.uniq(_.compact(students.map(student => student.counselor))));
-    if (sortedCounselors.length === 0) return;
     return (
       <SelectCounselor
         counselor={counselor}
         counselors={sortedCounselors}
-        onChange={this.onHouseChanged} />
+        onChange={this.onCounselorChanged} />
     );
   }
 }
 FilterStudentsBar.propTypes = {
+  includeCounselor: PropTypes.bool.isRequired,
+  includeHouse: PropTypes.bool.isRequired,
   students: PropTypes.arrayOf(PropTypes.shape({
     first_name: PropTypes.string.isRequired,
     last_name: PropTypes.string.isRequired,

--- a/app/assets/javascripts/my_students/FilterStudentsBar.test.js
+++ b/app/assets/javascripts/my_students/FilterStudentsBar.test.js
@@ -9,6 +9,8 @@ function testProps(props = {}) {
   return {
     students: myStudentsJson.students,
     children: jest.fn(),
+    includeCounselor: true,
+    includeHouse: true,
     ...props
   };
 }
@@ -63,8 +65,19 @@ it('filters students by counselor', () => {
   expect(_.uniq(studentsAfterClick.map(student => student.counselor))).toEqual(['WOODY']);
 });
 
-it('snapshots', () => {
+it('snapshots with all options', () => {
   const props = testProps();
+  const tree = renderer
+    .create(<FilterStudentsBar {...props} />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('snapshots without options', () => {
+  const props = testProps({
+    includeHouse: false,
+    includeCounselor: false
+  });
   const tree = renderer
     .create(<FilterStudentsBar {...props} />)
     .toJSON();

--- a/app/assets/javascripts/my_students/MyStudentsPage.test.js
+++ b/app/assets/javascripts/my_students/MyStudentsPage.test.js
@@ -2,11 +2,20 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {mount} from 'enzyme';
 import fetchMock from 'fetch-mock/es5/client';
+import PerDistrictContainer from '../components/PerDistrictContainer';
 import MyStudentsPage from './MyStudentsPage';
 import myStudentsJson from './myStudentsJson.fixture';
 
 function testProps() {
   return {};
+}
+
+function testEl(props = {}) {
+  return (
+    <PerDistrictContainer districtKey="somerville">
+      <MyStudentsPage {...props} />
+    </PerDistrictContainer>
+  );
 }
 
 beforeEach(() => {
@@ -17,13 +26,13 @@ beforeEach(() => {
 it('renders without crashing', () => {
   const props = testProps();
   const el = document.createElement('div');
-  ReactDOM.render(<MyStudentsPage {...props} />, el);
+  ReactDOM.render(testEl(props), el);
 });
 
 describe('integration tests', () => {
   it('renders after fetch', done => {
     const props = testProps();
-    const wrapper = mount(<MyStudentsPage {...props} />);
+    const wrapper = mount(testEl(props));
     expect(wrapper.text()).toContain('Loading...');
 
     setTimeout(() => {

--- a/app/assets/javascripts/my_students/__snapshots__/FilterStudentsBar.test.js.snap
+++ b/app/assets/javascripts/my_students/__snapshots__/FilterStudentsBar.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`snapshots 1`] = `
+exports[`snapshots with all options 1`] = `
 <div
   className="FilterStudentsBar EscapeListener"
   onKeyUp={[Function]}
@@ -256,6 +256,143 @@ exports[`snapshots 1`] = `
             >
               <input
                 aria-activedescendant="react-select-16--value"
+                aria-describedby={undefined}
+                aria-expanded="false"
+                aria-haspopup="false"
+                aria-label={undefined}
+                aria-labelledby={undefined}
+                aria-owns=""
+                className={undefined}
+                id={undefined}
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                required={false}
+                role="combobox"
+                style={
+                  Object {
+                    "boxSizing": "content-box",
+                    "width": "5px",
+                  }
+                }
+                tabIndex={undefined}
+                value=""
+              />
+              <div
+                style={
+                  Object {
+                    "height": 0,
+                    "left": 0,
+                    "overflow": "scroll",
+                    "position": "absolute",
+                    "top": 0,
+                    "visibility": "hidden",
+                    "whiteSpace": "pre",
+                  }
+                }
+              >
+                
+              </div>
+            </div>
+          </span>
+          <span
+            className="Select-arrow-zone"
+            onMouseDown={[Function]}
+          >
+            <span
+              className="Select-arrow"
+              onMouseDown={[Function]}
+            />
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`snapshots without options 1`] = `
+<div
+  className="FilterStudentsBar EscapeListener"
+  onKeyUp={[Function]}
+  style={undefined}
+>
+  <div
+    className="FilterBar"
+    style={undefined}
+  >
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+        }
+      }
+    >
+      <span
+        style={
+          Object {
+            "display": "inline-block",
+            "marginRight": 10,
+          }
+        }
+      >
+        Filter by
+      </span>
+      <input
+        onChange={[Function]}
+        placeholder="Search 74 students..."
+        style={
+          Object {
+            "border": "1px solid #ccc",
+            "borderRadius": 4,
+            "display": "inline-block",
+            "fontSize": 14,
+            "marginLeft": 20,
+            "marginRight": 10,
+            "padding": "7px 7px 7px 12px",
+            "width": 220,
+          }
+        }
+        value=""
+      />
+      <div
+        className="Select is-searchable Select--single"
+        style={undefined}
+      >
+        <div
+          className="Select-control"
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          style={
+            Object {
+              "marginLeft": 10,
+              "width": "10em",
+            }
+          }
+        >
+          <span
+            className="Select-multi-value-wrapper"
+            id="react-select-17--value"
+          >
+            <div
+              className="Select-placeholder"
+            >
+              Grade...
+            </div>
+            <div
+              className="Select-input"
+              style={
+                Object {
+                  "display": "inline-block",
+                }
+              }
+            >
+              <input
+                aria-activedescendant="react-select-17--value"
                 aria-describedby={undefined}
                 aria-expanded="false"
                 aria-haspopup="false"


### PR DESCRIPTION
# Who is this PR for?
NB educators

# What problem does this PR fix?
The "My students" page lists fields and filters that don't apply for NB since we don't have this data.

# What does this PR do?
Branches to remove those when not supported; adds functions to `PerDistrict.js` to track this.

# Screenshot (if adding a client-side feature)
### somerville
<img width="1019" alt="screen shot 2018-07-21 at 11 43 55 am" src="https://user-images.githubusercontent.com/1056957/43037513-e3a90b88-8cdb-11e8-8c1a-3e187cd58dc2.png">

### new bedford
<img width="1022" alt="screen shot 2018-07-21 at 11 43 25 am" src="https://user-images.githubusercontent.com/1056957/43037516-e6fca042-8cdb-11e8-89e9-b88d193a0cc8.png">

# Checklists
+ [x] Author included specs for new code
