### PR TITLE
Add placeholder element for flex layout to work when no absences filter on dashboard

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/absences_dashboard/SchoolAbsenceDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/absences_dashboard/SchoolAbsenceDashboard.js
@@ -135,12 +135,13 @@ export default class SchoolAbsenceDashboard extends React.Component {
     const {timeRangeKey, excusedAbsencesKey} = this.state;
     return (
       <EscapeListener style={styles.filterBarContainer} onEscape={this.onResetFilters}>
-        {supportsExcusedAbsences(districtKey) &&
-          <FilterBar>
-            <SelectExcusedAbsences
-              excusedAbsencesKey={excusedAbsencesKey}
-              onChange={this.onExcusedAbsencesChanged} />
-          </FilterBar>
+        {supportsExcusedAbsences(districtKey)
+          ? <FilterBar>
+              <SelectExcusedAbsences
+                excusedAbsencesKey={excusedAbsencesKey}
+                onChange={this.onExcusedAbsencesChanged} />
+            </FilterBar>
+          : <div /> /* empty element for justify-content: space-between */
         }
         <FilterBar labelText="Time range">
           <SelectTimeRange


### PR DESCRIPTION
# Who is this PR for?
NB educators

# What problem does this PR fix?
https://github.com/studentinsights/studentinsights/pull/1924 removed this filter; this means `justify-content: space-around` doesn't push this to the right.

# What does this PR do?
Adds a placeholder element so the layout works for both configurations.

# Screenshot (if adding a client-side feature)
### before
<img width="1021" alt="screen shot 2018-07-21 at 11 50 55 am" src="https://user-images.githubusercontent.com/1056957/43037572-893827a0-8cdc-11e8-909f-0a750eb718e3.png">

### after
<img width="1113" alt="screen shot 2018-07-21 at 11 50 21 am" src="https://user-images.githubusercontent.com/1056957/43037575-8c7d10c4-8cdc-11e8-82f0-4bd967182adf.png">
