### PR TITLE
Tune down Devise timeoutable

### DIFF
--- a/app/assets/javascripts/sessionTimeoutWarning.js
+++ b/app/assets/javascripts/sessionTimeoutWarning.js
@@ -6,15 +6,20 @@ function show() {
   $('#renew-session').slideDown();
 }
 
+// Show a warning that the user's session is likely to timeout shortly.
+// This will be reset by Ajax calls or single-page navigation, so isn't entirely
+// accurate and will warn a bit too aggressively.  But it will work well for full-page
+// loads without other interactions.
 export default function sessionTimeoutWarning(sessionTimeoutInSeconds) {
-  count(sessionTimeoutInSeconds);
+  const showWarningTimeoutInSeconds = sessionTimeoutInSeconds * 0.85;
+  count(showWarningTimeoutInSeconds);
 
   $("#renew-sesion-link").click(() => {
     $.ajax({
       url: '/educators/reset',
       success() {
         $('#renew-session').slideUp();
-        count(sessionTimeoutInSeconds);   // Resent timeout count
+        count(showWarningTimeoutInSeconds);   // Resent timeout count
       }
     });
   });

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -99,7 +99,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 6.hours
+  config.timeout_in = 30.minutes
 
   # ==> Navigation configuration
   # Lists the formats that should be treated as navigational. Formats like


### PR DESCRIPTION
# Who is this PR for?
K12 educators, security

# What problem does this PR fix?
I mistakenly increased this in https://github.com/studentinsights/studentinsights/pull/32, thinking it was an absolute measure from sign-in, and not the total time since the last request.

# What does this PR do?
Cuts it down to 30 minutes, and comments about the heuristic in the UI warning about this.
