### PR TITLE
Increase LDAP connection timeout

### DIFF
--- a/app/lib/ldap_authenticatable_tiny/strategy.rb
+++ b/app/lib/ldap_authenticatable_tiny/strategy.rb
@@ -56,6 +56,7 @@ module Devise
         {
           host: host,
           port: port,
+          connect_timeout: 10, # seconds
           auth: {
             :method => :simple,
             :username => email,

--- a/spec/lib/ldap_authenticatable_tiny_spec.rb
+++ b/spec/lib/ldap_authenticatable_tiny_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe 'LdapAuthenticatableTiny' do
           :username=>"foo",
           :password=>"bar"
         },
+        :connect_timeout => 10,
         :encryption => {
           :method=>:simple_tls,
           :tls_options=>{


### PR DESCRIPTION
# Who is this PR for?
K12 educators

# What problem does this PR fix?
We've seen a few transient false-positive timeouts (eg, https://rollbar.com/somerville-teacher-tool/somerville-teacher-tool/items/177/), no need to block users from signing in because of this, we can tolerate the LDAP server taking a bit longer to respond.

# What does this PR do?
Increases the connection timeout from the default 5 seconds to 10 seconds.
