### PR TITLE
Tune down log level in test, since it is taking up GBs :)

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.log_level = :info
 end


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Seeding the database with more students and running the tests a few times can lead to log sizes of a few GB.

# What does this PR do?
Tune down log level in test; I don't think we ever use this anyway.
