### PR TITLE
Fix layout bug with restricted notes page columns

### DIFF
--- a/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
+++ b/app/assets/javascripts/restricted_notes/RestrictedNotesPageContainer.js
@@ -118,7 +118,7 @@ class RestrictedNotesPageContainer extends React.Component {
   render() {
     return (
       <div className="RestrictedNotesPageContainer">
-        <div className="RestrictedNotesDetails" style={{display: 'flex', width: '50%', padding: 10}}>
+        <div className="RestrictedNotesDetails" style={{display: 'flex', padding: 10}}>
           <NotesDetails
             {...merge(_.pick(this.state,
               'currentEducator',


### PR DESCRIPTION
# Who is this PR for?
K12 principals, APs, redirect, counselors

# What problem does this PR fix?
Layout on restricted notes page is too narrow.

# What does this PR do?
Fixes it.

# Screenshot (if adding a client-side feature)
### before
<img width="1019" alt="screen shot 2018-07-24 at 9 20 10 am" src="https://user-images.githubusercontent.com/1056957/43141016-e7c54c42-8f22-11e8-9127-31452ceef284.png">
### after
<img width="1018" alt="screen shot 2018-07-24 at 9 19 36 am" src="https://user-images.githubusercontent.com/1056957/43141017-e7d721ec-8f22-11e8-94bb-1f3ef58e858a.png">
