### PR TITLE
Patch bug in HomeroomTable showing dates of notes

### DIFF
--- a/app/assets/javascripts/homeroom/HomeroomTable.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.js
@@ -422,7 +422,7 @@ class HomeroomTable extends React.Component {
           style={style}>
         <td className="name">{fullName}</td>
         {this.eventNoteTypeIds().map(eventNoteTypeId => {
-          const key = eventNoteTypeTextMini(eventNoteTypeId);
+          const key = `latest_note_${eventNoteTypeId}_date_text`;
           return this.renderDataCell('supports', row[key], {key});
         })}
         {this.renderDataCell('program', row['program_assigned'])}

--- a/app/assets/javascripts/homeroom/HomeroomTable.test.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.test.js
@@ -32,6 +32,12 @@ function headerTexts(el) {
   return $(el).find('table thead tr th').toArray().map(el => $(el).text());
 }
 
+function sstAndMtssDateTexts(el) {
+  return $(el).find('table tbody tr').toArray().map(el => {
+    return $(el).find('td').toArray().slice(0, 3).map(el => $(el).text());
+  });
+}
+
 describe('high-level integration test', () => {
   // Prevent test pollution
   beforeEach(() => Cookies.remove('columnsDisplayed'));
@@ -61,6 +67,18 @@ describe('high-level integration test', () => {
     expect($(el).find('span.table-header').length).toEqual(9);
     ReactTestUtils.Simulate.click($(el).find('input[type=checkbox]').get(0));
     expect($(el).find('span.table-header').length).toEqual(7);
+  });
+
+  it('renders SST and MTSS dates correctly for Somerville grade 2 as a happy path test case', () => {
+    const {el} = testRender(testProps());
+    expect(sstAndMtssDateTexts(el)).toEqual([
+      ["Aladdin Kenobi", "—", '—'],
+      ["Chip Pan", "2/16/11", '—'],
+      ["Pluto Poppins", "9/2/11", '6/5/11'],
+      ["Rapunzel Duck", "1/2/11", '8/6/11'],
+      ["Snow Skywalker", "10/31/10", '—'],
+      ["Snow Kenobi", "8/29/11", '7/27/11']
+    ]);
   });
 
   it('renders correct headers for Somerville grade 2', () => {


### PR DESCRIPTION
# Who is this PR for?
K8 teachers

# What problem does this PR fix?
Note dates don't work on HomeroomTable, a bug in https://github.com/studentinsights/studentinsights/pull/1931.

# What does this PR do?
Fixes the bug.

# Screenshot (if adding a client-side feature)
### before
<img width="432" alt="screen shot 2018-07-24 at 9 55 36 am" src="https://user-images.githubusercontent.com/1056957/43143495-dd6ebf52-8f28-11e8-810e-3ab04d820ed6.png">

### after
<img width="454" alt="screen shot 2018-07-24 at 9 55 01 am" src="https://user-images.githubusercontent.com/1056957/43143500-df96dce2-8f28-11e8-9eae-b29834e66017.png">

# Checklists
+ [x] Author improved specs for code in need of better test coverage
