### PR TITLE
Allow school_type to be null in HomeroomTable

### DIFF
--- a/app/assets/javascripts/homeroom/HomeroomTable.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.js
@@ -15,7 +15,7 @@ import Cookies from 'js-cookie';
 
 
 // Shows a homeroom roster, for K8 and HS homerooms.
-class HomeroomTable extends React.Component {
+export default class HomeroomTable extends React.Component {
 
   constructor(props) {
     super(props);
@@ -535,8 +535,7 @@ HomeroomTable.propTypes = {
   })).isRequired,
   grade: PropTypes.string,
   school: PropTypes.shape({
-    school_type: PropTypes.string.isRequired
+    school_type: PropTypes.string
   }).isRequired
 };
 
-export default HomeroomTable;


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
propType warning that can happen, since `school_type: nil` is valid, and not set for any schools in NB.

# What does this PR do?
Relaxes propType, other code treats this as a whitelist so this is fine.