### PR TITLE
Add foreign key constraints and presence validations for event_note_type_id references

### DIFF
--- a/app/models/event_note.rb
+++ b/app/models/event_note.rb
@@ -7,6 +7,6 @@ class EventNote < ActiveRecord::Base
   has_many :event_note_attachments, dependent: :destroy
   accepts_nested_attributes_for :event_note_attachments
 
-  validates :educator_id, :student_id, :event_note_type_id, :recorded_at, presence: true
+  validates :educator, :student, :event_note_type, :recorded_at, presence: true
   validates :is_restricted, inclusion: { in: [true, false] }
 end

--- a/app/models/event_note_revision.rb
+++ b/app/models/event_note_revision.rb
@@ -1,4 +1,8 @@
 class EventNoteRevision < ActiveRecord::Base
   belongs_to :event_note
   belongs_to :educator
+  belongs_to :student
+  belongs_to :event_note_type
+
+  validates :educator, :student, :event_note_type, :event_note, presence: true
 end

--- a/db/migrate/20180724143823_event_note_type_constraints.rb
+++ b/db/migrate/20180724143823_event_note_type_constraints.rb
@@ -1,0 +1,7 @@
+class EventNoteTypeConstraints < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key :event_notes, :event_note_types
+    add_foreign_key :event_note_revisions, :event_note_types
+    add_foreign_key :event_note_revisions, :event_notes
+  end
+end

--- a/db/migrate/20180724151520_event_note_revisions_key.rb
+++ b/db/migrate/20180724151520_event_note_revisions_key.rb
@@ -1,0 +1,5 @@
+class EventNoteRevisionsKey < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key "event_note_revisions", "students", name: "event_note_revisions_student_id_fk"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_24_143823) do
+ActiveRecord::Schema.define(version: 2018_07_24_151520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -448,6 +448,7 @@ ActiveRecord::Schema.define(version: 2018_07_24_143823) do
   add_foreign_key "event_note_revisions", "event_note_types"
   add_foreign_key "event_note_revisions", "event_notes"
   add_foreign_key "event_note_revisions", "event_notes", name: "event_note_revisions_event_note_id_fk"
+  add_foreign_key "event_note_revisions", "students", name: "event_note_revisions_student_id_fk"
   add_foreign_key "event_notes", "educators", name: "event_notes_educator_id_fk"
   add_foreign_key "event_notes", "event_note_types"
   add_foreign_key "event_notes", "event_note_types", name: "event_notes_event_note_type_id_fk"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_17_184037) do
+ActiveRecord::Schema.define(version: 2018_07_24_143823) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -445,8 +445,11 @@ ActiveRecord::Schema.define(version: 2018_07_17_184037) do
   add_foreign_key "educators", "schools", name: "educators_school_id_fk"
   add_foreign_key "event_note_attachments", "event_notes", name: "event_note_attachments_event_note_id_fk"
   add_foreign_key "event_note_revisions", "educators", name: "event_note_revisions_educator_id_fk"
+  add_foreign_key "event_note_revisions", "event_note_types"
+  add_foreign_key "event_note_revisions", "event_notes"
   add_foreign_key "event_note_revisions", "event_notes", name: "event_note_revisions_event_note_id_fk"
   add_foreign_key "event_notes", "educators", name: "event_notes_educator_id_fk"
+  add_foreign_key "event_notes", "event_note_types"
   add_foreign_key "event_notes", "event_note_types", name: "event_notes_event_note_type_id_fk"
   add_foreign_key "event_notes", "students", name: "event_notes_student_id_fk"
   add_foreign_key "homerooms", "educators", name: "homerooms_educator_id_fk"

--- a/spec/controllers/event_notes_controller_spec.rb
+++ b/spec/controllers/event_notes_controller_spec.rb
@@ -213,8 +213,8 @@ describe EventNotesController, :type => :controller do
 
       context 'valid second edit request' do
         let!(:event_note_revision) { FactoryBot.create(:event_note_revision) }
-        let(:event_note) { event_note_revision.event_note }
-        let(:post_params) {
+        let!(:event_note) { event_note_revision.event_note }
+        let!(:post_params) {
           {
             id: event_note.id,
             student_id: student.id,

--- a/spec/factories/event_note_revisions.rb
+++ b/spec/factories/event_note_revisions.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :event_note_revision do
     association :event_note
     association :educator
-    student_id 1
-    event_note_type_id 1
+    association :student
+    event_note_type { EventNoteType.all.sample }
     text "MyText"
     created_at "2016-04-11 01:41:48"
     updated_at "2016-04-11 01:41:48"


### PR DESCRIPTION
# Who is this PR for?
developers, educators

# What problem does this PR fix?
Potential for data quality drift.

# What does this PR do?
Enforce data integrity for `event_note_type_id` values through both foreign key constraints and validations.
