### PR TITLE
Add more New Bedford Schools to admin page (+ update thor import task)

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -52,7 +52,22 @@ class PerDistrict
   # with pilot schools in New Bedford shown first.
   def ordered_schools_for_admin_page
     if @district_key == NEW_BEDFORD
-      School.where(local_id: ['115', '123']) # parker and pulaski, the first pilot schools
+      School.where(local_id: [
+        # Pilot schools
+        '115',  # Parker
+        '123',  # Pulaski
+
+        # New 2018-19 school year schools
+        '078',  # Hayden McFadden
+        '063',  # Gomes
+        '050',  # DeValles
+        '040',  # Congdon
+        '045',  # Carney
+        '095',  # Lincoln
+        '405',  # Keith Middle
+        '415',  # Roosevelt Middle
+        '410',  # Normandin Middle
+      ])
     else
       School.all
     end

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -58,15 +58,14 @@ class PerDistrict
         '123',  # Pulaski
 
         # New 2018-19 school year schools
-        '078',  # Hayden McFadden
-        '063',  # Gomes
-        '050',  # DeValles
         '040',  # Congdon
-        '045',  # Carney
-        '095',  # Lincoln
+        '050',  # DeValles
         '405',  # Keith Middle
         '415',  # Roosevelt Middle
         '410',  # Normandin Middle
+        '063',  # Gomes
+        '045',  # Carney
+        '078',  # Hayden McFadden
       ])
     else
       School.all


### PR DESCRIPTION
# Who is this PR for?

Group of New Bedford principals who are going to be trained on Student Insights the week of 8/20. Depending on how the import process goes, we may be able to show them data from their own schools (beyond the two pilot schools) at that meeting.

# What does this PR do?

Adds additional schools to the admin page, using the schools whose leaders/staff will be attending the demo meeting this week. 

This way the admin page will include all the schools whose data we've imported from New Bedford, since we're going to try to import data for those pilot schools before the meeting. 

# Heroku deploy notes

+ [ ] Update task to: `thor import:start --background=false --skip-old-records --school '115' '123' '078' '063' '050' '040' '045' '405' '415' '410'`