### PR TITLE
Validate STAR assessment data; add more data quality code comments

### DIFF
--- a/app/importers/file_importers/star_math_importer.rb
+++ b/app/importers/file_importers/star_math_importer.rb
@@ -63,16 +63,16 @@ class StarMathImporter
       return
     end
 
-    star_assessment = StudentAssessment.where({
+    star_assessment = StudentAssessment.find_or_initialize_by(
       student_id: student.id,
       date_taken: date_taken,
       assessment: star_mathematics_assessment
-    }).first_or_initialize
+    )
 
-    star_assessment.update_attributes({
+    star_assessment.assign_attributes(
       percentile_rank: row['PercentileRank'],
       grade_equivalent: row['GradeEquivalent']
-    })
+    )
 
     star_assessment.save!
   end

--- a/app/importers/file_importers/star_math_importer.rb
+++ b/app/importers/file_importers/star_math_importer.rb
@@ -67,12 +67,14 @@ class StarMathImporter
       student_id: student.id,
       date_taken: date_taken,
       assessment: star_mathematics_assessment
-    }).first_or_create!
+    }).first_or_initialize
 
-    star_assessment.update!({
+    star_assessment.update_attributes({
       percentile_rank: row['PercentileRank'],
       grade_equivalent: row['GradeEquivalent']
     })
+
+    star_assessment.save!
   end
 
   def log(msg)

--- a/app/importers/file_importers/star_reading_importer.rb
+++ b/app/importers/file_importers/star_reading_importer.rb
@@ -63,13 +63,13 @@ class StarReadingImporter
       return
     end
 
-    star_assessment = StudentAssessment.where({
+    star_assessment = StudentAssessment.find_or_initialize_by(
       student_id: student.id,
       date_taken: date_taken,
       assessment: star_reading_assessment
-    }).first_or_initialize
+    )
 
-    star_assessment.update_attributes({
+    star_assessment.assign_attributes({
       percentile_rank: row['PercentileRank'],
       instructional_reading_level: row['IRL'],
       grade_equivalent: row['GradeEquivalent']

--- a/app/importers/file_importers/star_reading_importer.rb
+++ b/app/importers/file_importers/star_reading_importer.rb
@@ -67,13 +67,15 @@ class StarReadingImporter
       student_id: student.id,
       date_taken: date_taken,
       assessment: star_reading_assessment
-    }).first_or_create!
+    }).first_or_initialize
 
-    star_assessment.update!({
+    star_assessment.update_attributes({
       percentile_rank: row['PercentileRank'],
       instructional_reading_level: row['IRL'],
       grade_equivalent: row['GradeEquivalent']
     })
+
+    star_assessment.save!
   end
 
   def log(msg)

--- a/app/models/student_assessment.rb
+++ b/app/models/student_assessment.rb
@@ -21,10 +21,25 @@ class StudentAssessment < ActiveRecord::Base
       # backfilled to older records, ~40% of STAR records in the Somerville
       # production database have grade_equivalent of nil.
 
+      # TODO: For STAR, is zero a valid percentile?
+
+      # TODO: For STAR, can students take the assessment multiple times on the
+      # same day? How is that recorded in the data?
+
       if assessment.subject == 'Reading' && !valid_star_reading_attributes?
         errors.add(:instructional_reading_level, "invalid")
       end
     end
+
+    # For MCAS:
+      # Looking at Somerville raw data July 2018:
+      #   * ~40% of rows have no growth percentile.
+      #   * ~5% of rows have no scale score.
+      #   * Almost all rows have performance level (only 1 exception).
+      # Looking at New Bedford raw data July 2018:
+      #   * Zero rows have growth percentile.
+      #   * 33% of rows have no scale score.
+      #   * 16% of rows have no performance level.
 
     # TODO: Add validation for MCAS, DIBELS, and ACCESS assessments.
   end

--- a/app/models/student_assessment.rb
+++ b/app/models/student_assessment.rb
@@ -1,3 +1,7 @@
+# NOTE: Right now, this single model holds data for different assessments, including
+# MCAS, STAR, DIBELS, and ACCESS. Over time, we want to create a separate model
+# and table for each assessment. Each assessment has its own unique fields.
+# Breaking them into separate tables will let us add database-level validations.
 class StudentAssessment < ActiveRecord::Base
   belongs_to :assessment
   belongs_to :student

--- a/app/models/student_assessment.rb
+++ b/app/models/student_assessment.rb
@@ -14,8 +14,8 @@ class StudentAssessment < ActiveRecord::Base
 
       # TODO: Add validation for STAR grade_equivalent field.
       # This should be present for all STAR records, but because this wasn't
-      # backfilled to older records, ~40% of STAR records in production
-      # have grade_equivalent of nil.
+      # backfilled to older records, ~40% of STAR records in the Somerville
+      # production database have grade_equivalent of nil.
 
       if assessment.subject == 'Reading' && !valid_star_reading_attributes?
         errors.add(:instructional_reading_level, "invalid")

--- a/app/models/student_assessment.rb
+++ b/app/models/student_assessment.rb
@@ -9,34 +9,31 @@ class StudentAssessment < ActiveRecord::Base
 
   def valid_assessment_attributes
     case assessment.family
-    when 'MCAS'
-      # errors.add(:scale_score, "invalid attributes") unless valid_mcas_attributes
     when 'STAR'
-      # errors.add(:scale_score, "invalid attributes") unless valid_star_attributes
-    when 'DIBELS'
-      # errors.add(:scale_score, "invalid attributes") unless valid_dibels_attributes
+      errors.add(:percentile_rank, "invalid") unless valid_star_attributes?
+
+      # TODO: Add validation for STAR grade_equivalent field.
+      # This should be present for all STAR records, but because this wasn't
+      # backfilled to older records, ~40% of STAR records in production
+      # have grade_equivalent of nil.
+
+      if assessment.subject == 'Reading' && !valid_star_reading_attributes?
+        errors.add(:instructional_reading_level, "invalid")
+      end
     end
+
+    # TODO: Add validation for MCAS, DIBELS, and ACCESS assessments.
   end
 
-  def valid_mcas_attributes
-    scale_score.present? &&
-    growth_percentile.present? &&
-    performance_level.present? &&
-    percentile_rank.nil?
-  end
-
-  def valid_star_attributes
+  def valid_star_attributes?
     percentile_rank.present? &&
-    scale_score.nil? &&
-    growth_percentile.nil? &&
-    performance_level.nil?
+      scale_score.nil? &&
+      growth_percentile.nil? &&
+      performance_level.nil?
   end
 
-  def valid_dibels_attributes
-    performance_level.present? &&
-    percentile_rank.nil? &&
-    scale_score.nil? &&
-    growth_percentile.nil?
+  def valid_star_reading_attributes?
+    instructional_reading_level.present?
   end
 
   def self.order_by_date_taken_desc

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -710,7 +710,7 @@ describe StudentsController, :type => :controller do
           assessment = FactoryBot.create(:assessment, :access)
           student_assessment = FactoryBot.create(:access, student: student, assessment: assessment, date_taken: '2016-08-16')
           assessment = FactoryBot.create(:assessment, :math, :star)
-          student_assessment = FactoryBot.create(:star_math_assessment, student: student, assessment: assessment, date_taken: '2017-02-16', percentile_rank: 50)
+          student_assessment = FactoryBot.create(:star_math_assessment, student: student, assessment: assessment, date_taken: '2017-02-16', percentile_rank: 57)
           get_student_report_pdf(student.id)
 
           expect(assigns(:student_assessments)).to include("ACCESS Composite")
@@ -718,7 +718,7 @@ describe StudentsController, :type => :controller do
           expect(assigns(:student_assessments)["ACCESS Composite"]).to eq([["2016-08-16 00:00:00 UTC", nil]])
           expect(assigns(:student_assessments)).to include("STAR Mathematics Percentile")
           expect(assigns(:student_assessments)["STAR Mathematics Percentile"]).to be_kind_of(Array)
-          expect(assigns(:student_assessments)["STAR Mathematics Percentile"]).to eq([["2017-02-16 00:00:00 UTC", nil]])
+          expect(assigns(:student_assessments)["STAR Mathematics Percentile"]).to eq([["2017-02-16 00:00:00 UTC", 57]])
         end
       end
     end

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -710,7 +710,7 @@ describe StudentsController, :type => :controller do
           assessment = FactoryBot.create(:assessment, :access)
           student_assessment = FactoryBot.create(:access, student: student, assessment: assessment, date_taken: '2016-08-16')
           assessment = FactoryBot.create(:assessment, :math, :star)
-          student_assessment = FactoryBot.create(:star_math_assessment, student: student, assessment: assessment, date_taken: '2017-02-16')
+          student_assessment = FactoryBot.create(:star_math_assessment, student: student, assessment: assessment, date_taken: '2017-02-16', percentile_rank: 50)
           get_student_report_pdf(student.id)
 
           expect(assigns(:student_assessments)).to include("ACCESS Composite")

--- a/spec/models/student_assessment_spec.rb
+++ b/spec/models/student_assessment_spec.rb
@@ -64,10 +64,10 @@ RSpec.describe StudentAssessment, type: :model do
   end
 
   describe '.by_family' do
-    let!(:student_assessment) { FactoryBot.create(:student_assessment, assessment: assessment) }
     context 'ACCESS' do
       context 'there are only ACCESS student assessments' do
         let(:assessment) { FactoryBot.create(:assessment, :access) }
+        let(:student_assessment) { FactoryBot.create(:student_assessment, assessment: assessment) }
         it 'returns the ACCESS student assessments' do
           expect(StudentAssessment.by_family("ACCESS")).to eq([student_assessment])
         end

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -123,12 +123,6 @@ RSpec.describe Student do
             date_taken: Date.today - 1.year,
           )
         }
-        context 'when the student has a Math result but not MCAS' do
-          let(:assessment_family) { "STAR" }
-          it 'returns nil' do
-            expect(result).to be_nil
-          end
-        end
         context 'when the student has an MCAS Math result' do
           context 'when the student has one MCAS Math result' do
             it 'returns the MCAS result' do


### PR DESCRIPTION
# What problem does this PR fix?

+ Unclear and unenforced validations around STAR assessment data attributes.

# What does this PR do?

+ Enforces validations for STAR records, records based on analysis of what the raw data coming in from STAR looks like. (Data quality is high from STAR with no missing fields found in their CSV exports).
+ Add notes about STAR `:grade_equivalent` data in Somerville's production instance. 
+ Delete validation code that has been commented out.