### PR TITLE
Fix up STAR import by passing only School Local ID to school filter

### DIFF
--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -111,7 +111,7 @@ class AttendanceImporter
 
   def import_row(row)
     # Skip based on school filter
-    if !school_filter.include?(row)
+    if !school_filter.include?(row[:school_local_id])
       @skipped_from_school_filter += 1
       return
     end

--- a/app/importers/file_importers/behavior_importer.rb
+++ b/app/importers/file_importers/behavior_importer.rb
@@ -45,7 +45,7 @@ class BehaviorImporter
   end
 
   def import_row(row)
-    if !school_filter.include?(row)
+    if !school_filter.include?(row[:school_local_id])
       @skipped_from_school_filter += 1
       return
     end

--- a/app/importers/file_importers/courses_sections_importer.rb
+++ b/app/importers/file_importers/courses_sections_importer.rb
@@ -13,7 +13,7 @@ class CoursesSectionsImporter
     ).get_data
 
     streaming_csv.each_with_index do |row, index|
-      import_row(row) if filter.include?(row)
+      import_row(row) if filter.include?(row[:school_local_id])
     end
   end
 

--- a/app/importers/file_importers/educator_section_assignments_importer.rb
+++ b/app/importers/file_importers/educator_section_assignments_importer.rb
@@ -14,7 +14,7 @@ class EducatorSectionAssignmentsImporter
     ).get_data
 
     streaming_csv.each_with_index do |row, index|
-      import_row(row) if filter.include?(row)
+      import_row(row) if filter.include?(row[:school_local_id])
     end
 
     delete_rows

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -56,7 +56,7 @@ class EducatorsImporter
   end
 
   def import_row(row)
-    if !filter.include?(row)
+    if !filter.include?(row[:school_local_id])
       @skipped_from_school_filter = @skipped_from_school_filter + 1
       return
     end

--- a/app/importers/file_importers/star_math_importer.rb
+++ b/app/importers/file_importers/star_math_importer.rb
@@ -22,7 +22,7 @@ class StarMathImporter
       data = data_transformer.transform(data_string)
 
       data.each_with_index do |row, index|
-        import_row(row) if filter.include?(row)
+        import_row(row) if filter.include?(row['SchoolLocalID'])
         @log.puts("processed #{index} rows.") if index % 1000 == 0
       end
     end

--- a/app/importers/file_importers/star_reading_importer.rb
+++ b/app/importers/file_importers/star_reading_importer.rb
@@ -22,7 +22,7 @@ class StarReadingImporter
       data = data_transformer.transform(data_string)
 
       data.each_with_index do |row, index|
-        import_row(row) if filter.include?(row)
+        import_row(row) if filter.include?(row['SchoolLocalID'])
         log("processed #{index} rows.") if index % 1000 == 0
       end
     end

--- a/app/importers/file_importers/student_section_assignments_importer.rb
+++ b/app/importers/file_importers/student_section_assignments_importer.rb
@@ -14,7 +14,7 @@ class StudentSectionAssignmentsImporter
     ).get_data
 
     streaming_csv.each_with_index do |row, index|
-      import_row(row) if filter.include?(row)
+      import_row(row) if filter.include?(row[:school_local_id])
     end
 
     delete_rows

--- a/app/importers/file_importers/student_section_grades_importer.rb
+++ b/app/importers/file_importers/student_section_grades_importer.rb
@@ -37,7 +37,7 @@ class StudentSectionGradesImporter
     ).get_data
 
     streaming_csv.each_with_index do |row, index|
-      import_row(row) if filter.include?(row)
+      import_row(row) if filter.include?(row[:school_local_id])
     end
   end
 

--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -13,7 +13,7 @@ class StudentsImporter
     ).get_data
 
     @data.each_with_index do |row, index|
-      import_row(row) if filter.include?(row)
+      import_row(row) if filter.include?(row[:school_local_id])
     end
   end
 

--- a/app/importers/file_importers/x2_assessment_importer.rb
+++ b/app/importers/file_importers/x2_assessment_importer.rb
@@ -79,7 +79,7 @@ class X2AssessmentImporter
     #   :assessment_name, :assessment_subject, :assessment_test
 
     # Skip based on school filter
-    if !school_filter.include?(row)
+    if !school_filter.include?(row[:school_local_id])
       @skipped_from_school_filter = @skipped_from_school_filter + 1
       return
     end

--- a/app/importers/helpers/school_filter.rb
+++ b/app/importers/helpers/school_filter.rb
@@ -1,5 +1,5 @@
 class SchoolFilter < Struct.new(:school_local_ids)
-  def include?(row)
-    school_local_ids.nil? || school_local_ids.include?(row[:school_local_id])
+  def include?(school_local_id)
+    school_local_ids.nil? || school_local_ids.include?(school_local_id)
   end
 end


### PR DESCRIPTION
# Who is this PR for?

Data import process. 

# What problem does this PR fix?

Bug in STAR data import; the bug blocks new STAR data from importing.

The SchoolFilter class assumes each row has the same shape and checks for `row[:school_local_id]`; STAR rows have a different shape and store this data as `row['SchoolLocalID']`. 

# What does this PR do?

The implementation details of the key name shouldn't matter to the SchoolFilter class, and it doesn't need to know anything about a `row` other than it's school local ID. This changes the code so that only school local ID gets passed in. 