### PR TITLE
Profile v3: Prototype for design iterations (not completely functional)

### DIFF
--- a/app/assets/javascripts/components/HelpBubble.js
+++ b/app/assets/javascripts/components/HelpBubble.js
@@ -31,9 +31,10 @@ class HelpBubble extends React.Component {
   }
 
   render(){
+    const {style, linkStyle} = this.props;
     return (
-      <div style={{display: 'inline', marginLeft: 10}}>
-        <a href="#" onClick={this.openModal} style={{fontSize: 12, outline: 'none'}}>
+      <div style={{display: 'inline', marginLeft: 10, ...style}}>
+        <a href="#" onClick={this.openModal} style={{fontSize: 12, outline: 'none', ...linkStyle}}>
           {this.props.teaser}
         </a>
         {// The modal is not logically here, but even while not displayed it needs a location in the DOM.
@@ -82,7 +83,9 @@ class HelpBubble extends React.Component {
 HelpBubble.propTypes = {
   title: PropTypes.string.isRequired, // e.g. 'What is a Note?'
   content: PropTypes.node.isRequired, // React DOM objects which will be displayed in the modal text box.
-  teaser: PropTypes.node.isRequired // text displayed before the user clicks, e.g. 'Find out more.'
+  teaser: PropTypes.node.isRequired, // text displayed before the user clicks, e.g. 'Find out more.'
+  style: PropTypes.object,
+  linkStyle: PropTypes.object
 };
 
 export default HelpBubble;

--- a/app/assets/javascripts/components/SectionHeading.js
+++ b/app/assets/javascripts/components/SectionHeading.js
@@ -3,17 +3,19 @@ import React from 'react';
 
 
 // Visual UI component, the heading for a primary section on a page
-function SectionHeading({children}) {
+function SectionHeading({children,  style = {}, titleStyle = {}}) {
   return (
-    <div className="SectionHeading" style={styles.root}>
-      <h4 style={styles.title}>
+    <div className="SectionHeading" style={{...styles.root, ...style}}>
+      <h4 style={{...styles.title, ...titleStyle}}>
         {children}
       </h4>
     </div>
   );
 }
 SectionHeading.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  style: PropTypes.object,
+  titleStyle: PropTypes.object
 };
 
 const styles = {

--- a/app/assets/javascripts/components/StudentPhoto.js
+++ b/app/assets/javascripts/components/StudentPhoto.js
@@ -17,15 +17,16 @@ export default class StudentPhoto extends React.Component {
   }
 
   render() {
-    const {student, height, style} = this.props;
+    const {student, height, width, style} = this.props;
 
     return (
       <img id='student-photo'
-           style={style}
-           src={Routes.studentPhoto(student.id)}
-           height={height}
-           alt={this.altText()}
-           onError={this.onError}
+        style={style}
+        src={Routes.studentPhoto(student.id)}
+        width={width}
+        height={height}
+        alt={this.altText()}
+        onError={this.onError}
         />
     );
   }
@@ -35,7 +36,8 @@ StudentPhoto.propTypes = {
   student: PropTypes.shape({
     id: PropTypes.number.isRequired
   }).isRequired,
-  height: PropTypes.number.isRequired,
+  width: PropTypes.number,
+  height: PropTypes.number,
   style: PropTypes.object,
 };
 

--- a/app/assets/javascripts/helpers/language.js
+++ b/app/assets/javascripts/helpers/language.js
@@ -1,0 +1,3 @@
+export function isLimitedOrFlep(student) {
+  return ['Limited', 'FLEP'].indexOf(student.limited_english_proficiency) !== -1;
+}

--- a/app/assets/javascripts/student_profile/AttendanceDetails.js
+++ b/app/assets/javascripts/student_profile/AttendanceDetails.js
@@ -40,6 +40,9 @@ export default class AttendanceDetails extends React.Component {
   }
 
   renderNavBar() {
+    const {hideNavbar} = this.props;
+    if (hideNavbar) return null;
+    
     return (
       <div style={styles.navBar}>
         <a style={styles.navBar} href="#disciplineChart">
@@ -143,7 +146,8 @@ AttendanceDetails.propTypes = {
   disciplineIncidents: PropTypes.array.isRequired,
   student: PropTypes.object.isRequired,
   feed: InsightsPropTypes.feed.isRequired,
-  serviceTypesIndex: PropTypes.object.isRequired
+  serviceTypesIndex: PropTypes.object.isRequired,
+  hideNavbar: PropTypes.bool
 };
 
 

--- a/app/assets/javascripts/student_profile/ElaDetails.js
+++ b/app/assets/javascripts/student_profile/ElaDetails.js
@@ -78,6 +78,9 @@ export default class ElaDetails extends React.Component {
   }
 
   renderNavBar() {
+    const {hideNavbar} = this.props;
+    if (hideNavbar) return null;
+    
     return (
       <div style={styles.navBar}>
         <a style={styles.navBar} href="#Star">
@@ -203,7 +206,8 @@ ElaDetails.propTypes = {
     next_gen_mcas_ela_scaled: PropTypes.array,
     mcas_series_ela_growth: PropTypes.array.isRequired
   }).isRequired,
-  student: PropTypes.object.isRequired
+  student: PropTypes.object.isRequired,
+  hideNavbar: PropTypes.bool
 };
 
 const styles = {

--- a/app/assets/javascripts/student_profile/LightCarousel.js
+++ b/app/assets/javascripts/student_profile/LightCarousel.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+
+// A visual UI element for a badge indicating a particular 
+// event note type.
+export default class LightCarousel extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      index: 0
+    };
+    this.onIntervalTicked = this.onIntervalTicked.bind(this);
+    this.onNext = this.onNext.bind(this);
+    this.resetInterval = this.resetInterval.bind(this);
+  }
+
+  componentDidMount() {
+    this.resetInterval();
+  }
+
+  resetInterval() {
+    if (this.interval) window.clearInterval(this.interval);
+    this.interval = window.setInterval(this.onIntervalTicked, 10000);
+  }
+
+  onIntervalTicked() {
+    const {index} = this.state;
+    const {quotes} = this.props;
+    const nextIndex = (index + 1 >= quotes.length) ? 0 : index + 1;
+    this.setState({ index: nextIndex });
+  }
+
+  onNext() {
+    this.onIntervalTicked();
+    this.resetInterval();
+  }
+
+  render() {
+    const {style, quotes} = this.props;
+    const {index} = this.state;
+    const item = quotes[index];
+    const {quote, tagline, source, withoutQuotes} = item;
+    const quoted = (withoutQuotes) ? quote : `“${quote}”`;
+    return (
+      <div style={{display: 'flex', height: '100%', flexDirection: 'column', justifyContent: 'space-between', ...style}}>
+        <div style={{margin: 20, marginBottom: 0, marginTop: 15}}>
+          <div style={{fontSize: 20}}>{quoted}</div>
+        </div>
+        <div style={{fontSize: 12, display: 'flex', flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', margin: 20, marginBottom: 10}}>
+          <div>
+            <div style={{fontSize: 12, color: '#333'}}>
+              <div>{tagline}</div>
+              <div>{source}</div>
+            </div>
+          </div>
+          <div>
+            <div style={{color: '#ccc', cursor: 'pointer'}} onClick={this.onNext}>edit</div>
+            <div style={{color: '#ccc', cursor: 'pointer'}} onClick={this.onNext}>next</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+LightCarousel.propTypes = {
+  quotes: PropTypes.array.isRequired,
+  style: PropTypes.object
+};

--- a/app/assets/javascripts/student_profile/LightCarousel.js
+++ b/app/assets/javascripts/student_profile/LightCarousel.js
@@ -18,8 +18,16 @@ export default class LightCarousel extends React.Component {
     this.resetInterval();
   }
 
-  resetInterval() {
+  componentWillUnmount() {
+    this.clearInterval();
+  }
+
+  clearInterval() {
     if (this.interval) window.clearInterval(this.interval);
+  }
+
+  resetInterval() {
+    this.clearInterval();
     this.interval = window.setInterval(this.onIntervalTicked, 10000);
   }
 

--- a/app/assets/javascripts/student_profile/LightCarousel.js
+++ b/app/assets/javascripts/student_profile/LightCarousel.js
@@ -2,8 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 
-// A visual UI element for a badge indicating a particular 
-// event note type.
+// A component that rotates through the `quotes` passed.
 export default class LightCarousel extends React.Component {
   constructor(props) {
     super(props);

--- a/app/assets/javascripts/student_profile/LightHelpBubble.js
+++ b/app/assets/javascripts/student_profile/LightHelpBubble.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import HelpBubble from '../components/HelpBubble';
+
+
+// UI for a question mark that pops up a `HelpBubble` dialog when clicked.
+export default function LightHelpBubble(props) {
+  const {style, pixelSize} = props;
+  return (
+    <HelpBubble
+      teaser={questionMarkEl(pixelSize, style)}
+      style={{display: 'inline-block'}}
+      linkStyle={{display: 'flex'}}
+      {...props} />
+  );
+}
+LightHelpBubble.propTypes = {
+  ..._.omit(HelpBubble.propTypes, 'teaser'),
+  pixelSize: PropTypes.number,
+  style: PropTypes.object
+};
+LightHelpBubble.defaultProps = {
+  style: {},
+  pixelSize: 20
+};
+
+
+// Render an SVG question mark
+function questionMarkEl(pixelSize, style) {
+  const mergedStyle = {
+    fill: '#ddd',
+    ...style
+  };
+  return (
+    <svg style={mergedStyle} xmlns="http://www.w3.org/2000/svg" width={pixelSize} height={pixelSize} viewBox="0 0 24 24">
+      <path d="M0 0h24v24H0z" fill="none"/>
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"/>
+    </svg>
+  );
+}

--- a/app/assets/javascripts/student_profile/LightHelpBubble.test.js
+++ b/app/assets/javascripts/student_profile/LightHelpBubble.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactTestUtils from 'react-addons-test-utils';
+import renderer from 'react-test-renderer';
+import LightHelpBubble from './LightHelpBubble';
+
+function testProps(props) {
+  return {
+    title: "Hello",
+    content: <div>message</div>,
+    ...props
+  };
+}
+
+it('opens dialog on click', () => {
+  const el = document.createElement('div');
+  ReactDOM.render(<LightHelpBubble {...testProps()} />, el);
+  expect(el.innerHTML).not.toContain('Hello');
+  expect(el.innerHTML).not.toContain('message');
+
+  ReactTestUtils.Simulate.click($(el).find('a').get(0));
+  // the modal isn't in the same part of the DOM
+  expect(window.document.body.innerHTML).toContain('Hello');
+  expect(window.document.body.innerHTML).toContain('message');
+});
+
+it('snapshots view', () => {
+  const tree = renderer
+    .create(<LightHelpBubble {...testProps()} />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/assets/javascripts/student_profile/LightNotesDetails.js
+++ b/app/assets/javascripts/student_profile/LightNotesDetails.js
@@ -1,0 +1,156 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import * as InsightsPropTypes from '../helpers/InsightsPropTypes';
+import SectionHeading from '../components/SectionHeading';
+import LightHelpBubble from './LightHelpBubble';
+import NotesList from './NotesList';
+import TakeNotes from './TakeNotes';
+
+
+const styles = {
+  notesContainer: {
+    width: '50%',
+    marginRight: 20
+  },
+  restrictedNotesButton: {
+    color: 'white',
+    fontSize: 12,
+    padding: 8,
+    float: 'right'
+  }
+};
+
+/*
+The bottom region of the page, showing notes about the student, services
+they are receiving, and allowing users to enter new information about
+these as well.
+*/
+export default class LightNotesDetails extends React.Component {
+
+  constructor(props){
+    super(props);
+    this.state = {
+      isTakingNotes: false
+    };
+
+    this.onClickTakeNotes = this.onClickTakeNotes.bind(this);
+    this.onClickSaveNotes = this.onClickSaveNotes.bind(this);
+    this.onCancelNotes = this.onCancelNotes.bind(this);
+  }
+
+  onClickTakeNotes(event) {
+    this.setState({ isTakingNotes: true });
+  }
+
+  onCancelNotes(event) {
+    this.setState({ isTakingNotes: false });
+  }
+
+  onClickSaveNotes(eventNoteParams, event) {
+    this.props.actions.onClickSaveNotes(eventNoteParams);
+    this.setState({ isTakingNotes: false });
+  }
+
+  render() {
+    const { student, title } = this.props;
+
+    return (
+      <div className="LightNotesDetails" style={styles.notesContainer}>
+        {<SectionHeading titleStyle={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
+          <div style={{display: 'flex', alignItems: 'center'}}>
+            <span>{title} for {student.first_name}</span>
+            <LightHelpBubble
+              title={this.props.helpTitle}
+              content={this.props.helpContent} />
+          </div>
+          {/*this.renderRestrictedNotesButtonIfAppropriate()*/}
+          {this.renderTakeNotesSection()}
+        </SectionHeading>}
+        <NotesList
+          feed={this.props.feed}
+          educatorsIndex={this.props.educatorsIndex}
+          onSaveNote={this.onClickSaveNotes}
+          onEventNoteAttachmentDeleted={this.props.actions.onDeleteEventNoteAttachment} />
+      </div>
+    );
+  }
+
+  renderTakeNotesSection() {
+    const showTakeNotes = this.state.isTakingNotes ||
+                          this.props.requests.saveNote !== null ||
+                          this.props.noteInProgressText.length > 0 ||
+                          this.props.noteInProgressAttachmentUrls.length > 0;
+
+    if (showTakeNotes) {
+      return (
+        <TakeNotes
+          // TODO(kr) thread through
+          nowMoment={moment.utc()}
+          currentEducator={this.props.currentEducator}
+          onSave={this.onClickSaveNotes}
+          onCancel={this.onCancelNotes}
+          requestState={this.props.requests.saveNote}
+          noteInProgressText={this.props.noteInProgressText}
+          noteInProgressType={this.props.noteInProgressType}
+          noteInProgressAttachmentUrls={this.props.noteInProgressAttachmentUrls}
+          onClickNoteType={this.props.actions.onClickNoteType}
+          onChangeNoteInProgressText={this.props.actions.onChangeNoteInProgressText}
+          onChangeAttachmentUrl={this.props.actions.onChangeAttachmentUrl} />
+      );
+    }
+
+    return (
+      <button
+        className="btn take-notes"
+        style={{display: 'inline-block', margin: 0}}
+        onClick={this.onClickTakeNotes}>
+        <span><span style={{fontWeight: 'bold', paddingRight: 5}}>+</span><span>note</span></span>
+      </button>
+    );
+  }
+
+  renderRestrictedNotesButtonIfAppropriate() {
+    return false;
+
+  //   if (this.props.currentEducator.can_view_restricted_notes && !this.props.showingRestrictedNotes){
+  //     return (
+  //       <a
+  //         className="btn btn-warning"
+  //         style={styles.restrictedNotesButton}
+  //         href={'/students/' + this.props.student.id + '/restricted_notes'}>
+  //         {'Restricted (' + this.props.student.restricted_notes_count + ')'}
+  //       </a>
+  //     );
+  //   } else {
+  //     return null;
+  //   }
+  }
+}
+
+LightNotesDetails.propTypes = {
+  student: PropTypes.object.isRequired,
+  educatorsIndex: PropTypes.object.isRequired,
+  currentEducator: PropTypes.object.isRequired,
+  actions: PropTypes.shape({
+    onClickSaveNotes: PropTypes.func.isRequired,
+    onEventNoteAttachmentDeleted: PropTypes.func,
+    onDeleteEventNoteAttachment: PropTypes.func,
+    onChangeNoteInProgressText: PropTypes.func.isRequired,
+    onClickNoteType: PropTypes.func.isRequired,
+    onChangeAttachmentUrl: PropTypes.func.isRequired,
+  }),
+  feed: InsightsPropTypes.feed.isRequired,
+  requests: PropTypes.object.isRequired,
+
+  noteInProgressText: PropTypes.string.isRequired,
+  noteInProgressType: PropTypes.number,
+  noteInProgressAttachmentUrls: PropTypes.arrayOf(
+    PropTypes.string
+  ).isRequired,
+
+  showingRestrictedNotes: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
+  helpContent: PropTypes.node.isRequired,
+  helpTitle: PropTypes.string.isRequired,
+};

--- a/app/assets/javascripts/student_profile/LightNotesHelpContext.js
+++ b/app/assets/javascripts/student_profile/LightNotesHelpContext.js
@@ -1,0 +1,58 @@
+import React from 'react';
+
+export default function LightNotesHelpContext() {
+  return (
+    <div>
+      <p>
+        The Notes tab is the place to keep notes about a student, whether it’s SST, MTSS,         a parent conversation, or some informal strategies that a teacher/team is using to help a student.         More formal strategies (e.g. the student meets with a tutor or counselor every week) should be recorded in Services.
+      </p>
+      <br />
+      <p>
+        <b>
+          {'Who can enter a note? '}
+        </b>
+        Anyone who works with or involved with the student,         including classroom/ELL/SPED teachers, principals/assistant principals, counselors, and attendance officers.
+      </p>
+      <br/>
+      <p>
+        <b>
+          {'What can/should I put in a note? '}
+        </b>
+        The true test is to think about whether the information will help your         team down the road in supporting this student, either in the coming weeks, or a few years from now. Examples include:
+      </p>
+      <br/>
+      <ul>
+        <li>
+          "Oscar just showed a 20 point increase in ORF. It seems like the take home readings are working (parents are very supportive) and we will continue it."
+        </li>
+        <li>
+          "This is a follow-up MTSS meeting for Julie. Over the last 4 weeks, she is not showing many gains despite the volunteer tutor and the change in seating…."
+        </li>
+        <li>
+          "Alex just got an M on the latest F&P. Will try having him go next door to join the other 4th grade group during guided reading."
+        </li>
+        <li>
+          "Medicine change for Uri on 4/10. So far slight increase in focus."
+        </li>
+        <li>
+          "51a filed on 3/21. Waiting determination and follow-up from DCF."
+        </li>
+        <li>
+          "Just found that Cora really likes to go help out in grade 1. Best incentive yet for when she stays on task and completes work."
+        </li>
+        <li>
+          "Arranged for Kevin to go to community schools 2x/week and to get extra homework help."
+        </li>
+        <li>
+          "Julia will do an FBA and report back at the next SST meeting to determine sources of the behavior."
+        </li>
+        <li>
+          "Mediation occurred between Oscar and Uri and went well. Both have agreed to keep distance for 2 weeks."
+        </li>
+        <li>
+          "Parent called to report that Jill won art award and will be going to nationals. She suggested this might be an outlet if she shows frustration in schoolwork."
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/app/assets/javascripts/student_profile/LightProfileHeader.js
+++ b/app/assets/javascripts/student_profile/LightProfileHeader.js
@@ -1,0 +1,416 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import moment from 'moment';
+import {AutoSizer} from 'react-virtualized';
+import {isLimitedOrFlep} from '../helpers/language';
+import * as Routes from '../helpers/Routes';
+import {hasStudentPhotos} from '../helpers/PerDistrict';
+import {hasInfoAbout504Plan} from '../helpers/PerDistrict';
+import HelpBubble from '../components/HelpBubble';
+import Educator from '../components/Educator';
+import StudentPhoto from '../components/StudentPhoto';
+import LightCarousel from './LightCarousel';
+import {parseTransitionNoteText} from './lightTransitionNotes';
+
+/*
+UI component for top-line information like the student's name, school,
+photo and classroom.  Also includes a carousel of humanizing quotes about
+the student, and some buttons for exporting, etc.
+*/
+export default class LightProfileHeader extends React.Component {
+  render() {
+    const {style} = this.props;
+    return (
+      <div className="LightProfileHeader" style={{...styles.root, style}}>
+        <div style={{flex: 3, display: 'flex', flexDirection: 'row'}}>
+          {this.renderStudentPhotoOrNull()}
+          {this.renderOverview()}
+        </div>
+        <div style={{flex: 2, display: 'flex', flexDirection: 'row', marginTop: 10}}>
+          {this.renderGlance()}
+          {this.renderButtons()}
+        </div>
+      </div>
+    );
+  }
+
+  renderStudentPhotoOrNull() {
+    const {student, districtKey} = this.props;
+    const shouldShowPhoto = hasStudentPhotos(districtKey);
+    if (!shouldShowPhoto) return null;
+
+    return (
+      <div style={{flex: 1, marginLeft: 10}}>
+        <AutoSizer>
+          {({width, height}) => (
+            <StudentPhoto
+              style={{...styles.photoEl, maxWidth: width, maxHeight: height}}
+              student={student} />
+          )}
+        </AutoSizer>
+      </div>
+    );
+  }
+
+  renderOverview() {
+    const {student} = this.props;
+    return (
+      <div style={styles.overview}>
+        <div style={styles.overviewColumn}>
+          <a href={Routes.studentProfile(student.id)} style={styles.nameTitle}>
+            {student.first_name + ' ' + student.last_name}
+          </a>
+          {this.renderHomeroomOrEnrollmentStatus()}
+          <div style={styles.subtitleItem}>{'Grade ' + student.grade}</div>
+          <a href={Routes.school(student.school_id)} style={styles.subtitleItem}>
+            {student.school_name}
+          </a>
+        </div>
+        <div style={styles.headerBitsRow}>
+          <div style={styles.headerBitsColumn}>
+            <div style={{marginTop: 20}}>{this.renderAge()}</div>
+            {this.renderDateOfBirth()}
+            <div style={styles.subtitleItem}>{student.home_language} at home</div>
+            {this.renderContactIcon()}
+          </div>
+          <div style={styles.headerBitsColumn}>
+            <div style={{marginTop: 20}}>{this.renderIEPLink()}</div>
+            {this.render504()}
+            {this.renderLanguage()}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  renderIEPLink() {
+    const {student} = this.props;
+    const {iepDocument} = student;
+    const hasDisability = student.disability !== 'None' && student.disability !== null;
+    const hasLiaison = student.sped_liaison !== null && student.sped_liaison !== undefined;
+    const spedPlacement = student.sped_placement || null;
+    const hasIep = (iepDocument || hasDisability || hasLiaison || spedPlacement);
+
+    if (hasIep && iepDocument) return <a target="_blank" href={`/iep_documents/${iepDocument.id}`}>IEP</a>;
+    if (hasIep && hasDisability) return <span>IEP for {student.disability}</span>;
+    if (hasIep) return <span>IEP</span>;
+    return null;
+  }
+
+  render504() {
+    const {student} = this.props;
+    const plan504 = student.plan_504;
+    return (hasInfoAbout504Plan(plan504))
+      ? <div style={styles.subtitleItem}>504 plan</div>
+      : null;
+  }
+
+  renderLanguage() {
+    const {student, access} = this.props;
+    if (!isLimitedOrFlep(student)) return null;
+
+    const el = <div style={styles.subtitleItem}>{student.limited_english_proficiency}</div>;
+    if (!access) return el;
+
+    return (
+      <HelpBubble
+        style={{marginLeft: 0, display: 'block'}}
+        linkStyle={{fontSize: 14}}
+        teaser={el}
+        title="Language learning"
+        content={this.renderLanguageDialog()} />
+    );
+  }
+
+  renderLanguageDialog() {
+    const {access} = this.props;
+    const access_result_rows = Object.keys(access).map(subject => {
+      return (
+        <tr key={subject}>
+          <td style={styles.accessLeftTableCell}>
+            {subject}
+          </td>
+          <td>
+            {access[subject] || '—'}
+          </td>
+        </tr>
+      );
+    });
+
+    return (
+      <div style={_.merge(styles.column, {display: 'flex', flex: 1})}>
+        <h4 style={styles.title}>
+          ACCESS
+        </h4>
+        <table>
+          <thead>
+            <tr>
+              <th style={styles.tableHeader}>
+                Subject
+              </th>
+              <th style={styles.tableHeader}>
+                Score
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {access_result_rows}
+          </tbody>
+        </table>
+        <div />
+        <div style={styles.accessTableFootnote}>
+          Most recent ACCESS scores shown.
+        </div>
+      </div>
+    );
+  }
+
+  renderButtons() {
+    return (
+      <div style={{marginLeft: 10, display: 'flex', flexDirection: 'column', justifyContent: 'space-between'}}>
+        <div>
+          <a title="Next student" href="#" style={{display: 'block'}}>
+            <svg style={styles.svgIcon} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+              <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/>
+              <path d="M0 0h24v24H0z" fill="none"/>
+            </svg>
+          </a>
+        </div>
+        <div>
+          <a title="Print PDF" href="#" style={{display: 'block'}}>
+            <svg style={styles.svgIcon} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+              <path d="M19 8H5c-1.66 0-3 1.34-3 3v6h4v4h12v-4h4v-6c0-1.66-1.34-3-3-3zm-3 11H8v-5h8v5zm3-7c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-1-9H6v4h12V3z"/>
+              <path d="M0 0h24v24H0z" fill="none"/>
+            </svg>
+          </a>
+          <a title="List all data points" href="#" style={{display: 'block'}}>
+            <svg style={styles.svgIcon} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+              <path d="M14 17H4v2h10v-2zm6-8H4v2h16V9zM4 15h16v-2H4v2zM4 5v2h16V5H4z"/>
+              <path d="M0 0h24v24H0z" fill="none"/>
+            </svg>
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  renderGlance() {
+    const {transitionNotes, educatorsIndex, student} = this.props;
+    const style = {fontSize: 12};
+    const useRealTransitionNotes = window.location.search.indexOf('transition') !== -1;
+    const quotes = (useRealTransitionNotes)
+      ? quotesFrom(transitionNotes, educatorsIndex, style)
+      : sampleQuotes(style);
+    const upsellQuotes = [{
+      quote: `Add an insight about ${student.first_name}!`,
+      withoutQuotes: true,
+      source: <span>See <a href="#" style={style}>Ileana</a> or <a href="#" style={style}>Manuel</a> for examples from other educators.</span>,
+      tagline: ''
+    }];
+    const quotesOrUpsell = (quotes.length === 0) ? upsellQuotes : quotes;
+    return (
+      <div style={{
+        width: 350,
+        background: '#eee'
+      }}>
+        <LightCarousel quotes={quotesOrUpsell} />
+      </div>
+    );
+  }
+
+  renderHomeroomOrEnrollmentStatus() {
+    const student =  this.props.student;
+    if (student.enrollment_status === 'Active') {
+      if (student.homeroom_name) return (
+        <a
+          className="homeroom-link"
+          href={Routes.homeroom(student.homeroom_id)}
+          style={styles.subtitleItem}>
+          {'Homeroom ' + student.homeroom_name}
+        </a>
+      );
+
+      return (<span style={styles.subtitleItem}>No homeroom</span>);
+    } else {
+      return (
+        <span style={styles.subtitleItem}>
+          {student.enrollment_status}
+        </span>
+      );
+    }
+  }
+
+  renderDateOfBirth () {
+    const student =  this.props.student;
+    const dateOfBirth = student.date_of_birth;
+    if (!dateOfBirth) return null;
+
+    const momentDOB = moment.utc(dateOfBirth);
+    return <div style={styles.subtitleItem}>{momentDOB.format('M/D/YYYY')}</div>;
+  }
+
+  renderAge() {
+    const student =  this.props.student;
+    const dateOfBirth = student.date_of_birth;
+    if (!dateOfBirth) return null;
+
+    const momentDOB = moment.utc(dateOfBirth);
+    return <div style={styles.subtitleItem}>{moment().diff(momentDOB, 'years')} years old</div>;
+  }
+
+  renderContactIcon () {
+    return (
+      <HelpBubble
+        style={{marginLeft: 0, display: 'inline-block'}}
+        linkStyle={{fontSize: 14}}
+        teaser={<div style={styles.subtitleItem}>Family contacts</div>}
+        title="Family contact information"
+        content={this.renderContactInformationDialog()} />
+    );
+  }
+
+  renderContactInformationDialog(){
+    const student = this.props.student;
+    return (
+      <span>
+        <span style={styles.contactItem}>
+          {student.student_address}
+        </span>
+        <span style={styles.contactItem}>
+          {student.primary_phone}
+        </span>
+        <span style={styles.contactItem}>
+          <a href={'mailto:'+ student.primary_email}>{student.primary_email}</a>
+        </span>
+      </span>
+    );
+  }
+}
+
+LightProfileHeader.propTypes = {
+  student: PropTypes.object.isRequired,
+  access: PropTypes.object,
+  educatorsIndex: PropTypes.object,
+  transitionNotes: PropTypes.array,
+  districtKey: PropTypes.string.isRequired,
+  style: PropTypes.object
+};
+
+const styles = {
+  root: {
+    display: 'flex',
+    minHeight: 200,
+    fontSize: 14,
+    padding: 20,
+    marginBottom: 20
+  },
+
+  overview: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    flex: 2
+  },
+  photo: {
+    paddingLeft: 10,
+    paddingRight: 20
+  },
+  photoEl: {
+    borderRadius: 2,
+    border: '1px solid #ccc',
+    marginRight: 20
+  },
+  nameTitle: {
+    fontWeight: 'bold',
+    marginRight: 5,
+    fontSize: 20
+  },
+
+  headerBitsRow: {
+    display: 'flex',
+    flexDirection: 'row'
+  },
+  headerBitsColumn: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'flex-end'
+  },
+  overviewColumn: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1
+  },
+  subtitleItem: {
+    display: 'block'
+  },
+  contactItem: {
+    padding: 6,
+    display: 'flex'
+  },
+  svgIcon: {
+    fill: "#3177c9",
+    opacity: 0.5
+  }
+};
+
+
+function sampleQuotes(style) {  
+  const quotes = [
+    'Smart, very athletic, baseball, works w/uncle (carpenter)',
+    'Truly bilingual in English & French',
+    'Very social; gets along well w/adults and most kids'
+  ];
+  return quotes.map(quote => {
+    const dateText = moment.utc().subtract(Math.random() * 30, 'days').format('M/D/YY');
+    const tagline = <span><a href="#" style={style}>Samwise Gamgee</a>, Counselor</span>;
+    const source = <span><a href="#" style={{fontSize: 12}}>Transition note</a> on {dateText}</span>;
+    return {quote, tagline, source};
+  });
+}
+
+function quotesFrom(transitionNotes, educatorsIndex, style) {
+  const safeNotes = transitionNotes.filter(transitionNote => !transitionNote.is_restricted);
+
+  return _.flatten(safeNotes.map(note => {
+    const dateText = moment.utc(note.recorded_at).format('M/D/YY');
+    const educator = educatorsIndex[note.educator_id] || educatorsIndex[_.keys(educatorsIndex)[0]];
+    const tagline = <span>from <Educator style={style} educator={educator} /></span>;
+    const source = (
+      <span>
+        <span>in</span>
+        <HelpBubble
+          style={{marginLeft: 5, marginRight: 5}}
+          linkStyle={style}
+          teaser="Transition note"
+          title="Transition note"
+          content={renderTransitionNote(note.text, dateText, <Educator educator={educator} />)} />
+        <span>on {dateText}</span>
+      </span>
+    );
+
+    // only strengths for now
+    const noteParts = parseTransitionNoteText(note.text);
+    const quote = noteParts.strengths;
+    if (!quote || quote.length === 0) return [];
+    return [{quote, source, tagline}];
+  }));
+   
+}
+
+function renderTransitionNote(text, dateText, educatorEl) {
+  return (
+    <div>
+      <div style={{
+        whiteSpace: 'pre',
+        marginBottom: 10,
+        padding: 20,
+        border: '1px solid #ccc',
+        background: '#eee'
+      }}>{text}</div>
+      <div>by {educatorEl}</div>
+      <div>on {dateText}</div>
+    </div>
+  );
+}

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -1,0 +1,416 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import _ from 'lodash';
+import * as InsightsPropTypes from '../helpers/InsightsPropTypes';
+import {toMomentFromTime} from '../helpers/toMoment';
+import LightProfileHeader from './LightProfileHeader';
+import LightProfileTab, {LightShoutNumber} from './LightProfileTab';
+import AttendanceDetails from './AttendanceDetails';
+import ElaDetails from './ElaDetails';
+import MathDetails from './MathDetails';
+import LightNotesDetails from './LightNotesDetails';
+import LightServiceDetails from './LightServiceDetails';
+import LightNotesHelpContext from './LightNotesHelpContext';
+import StudentSectionsRoster from './StudentSectionsRoster';
+import {tags} from './lightTagger';
+import {toMoment, toValue} from './QuadConverter';
+
+
+// Prototype of profile v3
+export default class LightProfilePage extends React.Component {
+  countEventsBetween(events, daysBack) {
+    const {nowMomentFn} = this.props;
+    const startMoment = nowMomentFn().startOf('day');
+    const endMoment = startMoment.clone().subtract(daysBack, 'days');
+    return countEventsBetween(events, startMoment, endMoment);
+  }
+
+  onColumnClicked(columnKey) {
+    this.props.actions.onColumnClicked(columnKey);
+  }
+
+  render() {
+    const {student, districtKey, access, transitionNotes, educatorsIndex} = this.props;
+    const isHighSchool = (student.school_type === 'HS');
+    return (
+      <div className="LightProfilePage">
+        <LightProfileHeader
+          student={student}
+          access={access}
+          transitionNotes={transitionNotes}
+          educatorsIndex={educatorsIndex}
+          districtKey={districtKey}
+        />
+        <div style={styles.tabsContainer}>
+          <div style={styles.tabLayout}>{this.renderNotesColumn()}</div>
+          {isHighSchool && <div style={styles.tabLayout}>{this.renderGradesColumn()}</div>}
+          {!isHighSchool && <div style={styles.tabLayout}>{this.renderReadingColumn()}</div>}
+          {!isHighSchool && <div style={styles.tabLayout}>{this.renderMathColumn()}</div>}
+          <div style={styles.tabLayout}>{this.renderAttendanceColumn()}</div>
+          <div style={styles.tabLayout}>{this.renderBehaviorColumn()}</div>
+        </div>
+        <div style={styles.detailsContainer}>
+          {this.renderSectionDetails()}
+        </div>
+      </div>
+    );
+  }
+
+  renderSectionDetails() {
+    const {selectedColumnKey} = this.props;
+    if (selectedColumnKey === 'notes') return this.renderNotes();
+    if (selectedColumnKey === 'grades') return this.renderGrades();
+    if (selectedColumnKey === 'reading') return this.renderReading();
+    if (selectedColumnKey === 'math') return this.renderMath();
+    if (selectedColumnKey === 'attendance') return this.renderAttendance();
+    if (selectedColumnKey === 'behavior') return this.renderBehavior();
+    return null;
+  }
+
+  renderNotesColumn() {
+    const {feed, nowMomentFn, selectedColumnKey} = this.props;
+    const columnKey = 'notes';
+    const topRecentTags = findTopRecentTags(feed.event_notes, nowMomentFn());
+
+    return (
+      <LightProfileTab
+        style={styles.tab}
+        isSelected={selectedColumnKey === columnKey}
+        onClick={this.onColumnClicked.bind(this, columnKey)}
+        intenseColor="#4A90E2"
+        fadedColor="#ededed"
+        text="Notes">
+          {(topRecentTags.length === 0)
+            ? <div>No recent keywords</div>
+            : topRecentTags.map(tag => <div key={tag}>“{tag}”</div>)}
+        </LightProfileTab>
+    );
+  }
+
+  renderGradesColumn() {
+    const {sections, selectedColumnKey} = this.props;
+    const columnKey = 'grades';
+    const strugglingSectionsCount = sections.filter(section => section.grade_numeric < 69).length;
+
+    return (
+      <LightProfileTab
+        style={styles.tab}
+        isSelected={selectedColumnKey === columnKey}
+        onClick={this.onColumnClicked.bind(this, columnKey)}
+        intenseColor="#ff7f00"
+        fadedColor="hsl(24, 100%, 92%)"
+        text="Grades">
+          <LightShoutNumber number={strugglingSectionsCount}>
+            <div>courses with a D or F</div>
+            <div>right now</div>
+          </LightShoutNumber>
+        </LightProfileTab>
+    );
+  }
+
+  renderReadingColumn() {
+    const {chartData, nowMomentFn, selectedColumnKey} = this.props;
+    const columnKey = 'reading';
+    const {nDaysText, percentileText} = latestStar(chartData.star_series_reading_percentile, nowMomentFn());
+    return (
+      <LightProfileTab
+        style={styles.tab}
+        isSelected={selectedColumnKey === columnKey}
+        onClick={this.onColumnClicked.bind(this, columnKey)}
+        intenseColor="#ff7f00"
+        fadedColor="hsl(24, 100%, 92%)"
+        text="Reading">
+          <LightShoutNumber number={percentileText}>
+            <div>STAR percentile</div>
+            <div>{nDaysText}</div>
+          </LightShoutNumber>
+        </LightProfileTab>
+    );
+  }
+
+  renderMathColumn() {
+    const {selectedColumnKey, chartData, nowMomentFn} = this.props;
+    const columnKey = 'math';
+    const {nDaysText, percentileText} = latestStar(chartData.star_series_math_percentile, nowMomentFn());
+    return (
+      <LightProfileTab
+        style={styles.tab}
+        isSelected={selectedColumnKey === columnKey}
+        onClick={this.onColumnClicked.bind(this, columnKey)}
+        intenseColor="#6A2987"
+        fadedColor="hsl(237,80%,95%)"
+        text="Math">
+          <LightShoutNumber number={percentileText}>
+            <div>STAR percentile</div>
+            <div>{nDaysText}</div>
+          </LightShoutNumber>
+        </LightProfileTab>
+    );
+  }
+
+  renderAttendanceColumn() {
+    const {selectedColumnKey} = this.props;
+    const columnKey = 'attendance';
+    const count = this.countEventsBetween(this.props.attendanceData.absences, DAYS_AGO);
+    return (
+      <LightProfileTab
+        style={styles.tab}
+        isSelected={selectedColumnKey === columnKey}
+        onClick={this.onColumnClicked.bind(this, columnKey)}
+        intenseColor="#c8326b"
+        fadedColor="#f5e1e8"
+        text="Attendance">
+          <LightShoutNumber number={count}>
+            <div>{count === 1 ? 'absence' : 'absences'}</div>
+            <div>last {DAYS_AGO} days</div>
+          </LightShoutNumber>
+        </LightProfileTab>
+    );
+  }
+
+  renderBehaviorColumn() {
+    const {selectedColumnKey} = this.props;
+    const columnKey = 'behavior';
+    const count = this.countEventsBetween(this.props.attendanceData.discipline_incidents, DAYS_AGO);
+
+    return (
+      <LightProfileTab
+        style={styles.tab}
+        isSelected={selectedColumnKey === columnKey}
+        onClick={this.onColumnClicked.bind(this, columnKey)}
+        intenseColor="#31AB39"
+        fadedColor="hsl(120,80%,95%)"
+        text="Behavior">
+          <LightShoutNumber number={count}>
+            <div>{count === 1 ? 'discipline incident' : 'discipline incidents'}</div>
+            <div>last {DAYS_AGO} days</div>
+          </LightShoutNumber>
+        </LightProfileTab>
+    );
+  }
+
+  renderNotes() {
+    return (
+      <div className="LightProfilePage-notes" style={{display: 'flex', flexDirection: 'row'}}>
+        <LightNotesDetails
+          student={this.props.student}
+          educatorsIndex={this.props.educatorsIndex}
+          currentEducator={this.props.currentEducator}
+          feed={this.props.feed}
+          actions={this.props.actions}
+          requests={this.props.requests}
+          showingRestrictedNotes={false}
+          helpContent={<LightNotesHelpContext />}
+          helpTitle="What is a Note?"
+          title="Notes"
+          noteInProgressText={this.props.noteInProgressText}
+          noteInProgressType={this.props.noteInProgressType}
+          noteInProgressAttachmentUrls={this.props.noteInProgressAttachmentUrls }/>
+        <LightServiceDetails
+          student={this.props.student}
+          serviceTypesIndex={this.props.serviceTypesIndex}
+          educatorsIndex={this.props.educatorsIndex}
+          currentEducator={this.props.currentEducator}
+          feed={this.props.feed}
+          actions={this.props.actions}
+          requests={this.props.requests} />
+      </div>
+    );
+  }
+
+  renderGrades() {
+    const sections = this.props.sections;
+
+    // If there are no sections, don't generate the student sections roster
+    if (!sections || sections.length == 0) return null;
+
+    // If this student is not a high school student, don't generate the student sections roster
+    if (this.props.student.school_type != 'HS') return null;
+
+    return (
+      <div id="sections-roster" className="roster" style={styles.roundedBox}>
+        <h4 style={styles.sectionsRosterTitle}>
+          Sections
+        </h4>
+        <StudentSectionsRoster
+          sections={this.props.sections}
+          linkableSections={this.props.currentEducatorAllowedSections}
+          />
+      </div>
+
+    );
+  }
+
+  renderReading() {
+    return (
+      <ElaDetails
+        className="LightProfilePage-ela"
+        hideNavbar={true}
+        chartData={this.props.chartData}
+        student={this.props.student} />
+    );
+  }
+
+  renderMath() {
+    return (
+      <MathDetails
+        className="LightProfilePage-math"
+        hideNavbar={true}
+        chartData={this.props.chartData}
+        student={this.props.student} />
+    );
+  }
+
+  renderAttendance() {
+    return (
+      <AttendanceDetails
+        className="LightProfilePage-attendance"
+        hideNavbar={true}
+        disciplineIncidents={this.props.attendanceData.discipline_incidents}
+        absences={this.props.attendanceData.absences}
+        tardies={this.props.attendanceData.tardies}
+        student={this.props.student}
+        feed={this.props.feed}
+        serviceTypesIndex={this.props.serviceTypesIndex} />
+    );
+  }
+
+  renderBehavior() {
+    return (
+      <AttendanceDetails
+        className="LightProfilePage-attendance"
+        hideNavbar={true}
+        disciplineIncidents={this.props.attendanceData.discipline_incidents}
+        absences={this.props.attendanceData.absences}
+        tardies={this.props.attendanceData.tardies}
+        student={this.props.student}
+        feed={this.props.feed}
+        serviceTypesIndex={this.props.serviceTypesIndex} />
+    );
+  }
+}
+LightProfilePage.propTypes = {
+  // UI
+  selectedColumnKey: PropTypes.string.isRequired,
+
+  // context
+  nowMomentFn: PropTypes.func.isRequired,
+  currentEducator: PropTypes.shape({
+    labels: PropTypes.arrayOf(PropTypes.string).isRequired
+  }).isRequired,
+  districtKey: PropTypes.string.isRequired,
+
+  // constants
+  educatorsIndex: PropTypes.object.isRequired,
+  serviceTypesIndex: PropTypes.object.isRequired,
+
+  // data
+  student: PropTypes.object.isRequired,
+  feed: PropTypes.object.isRequired,
+  transitionNotes: PropTypes.array.isRequired,
+  dibels: PropTypes.array.isRequired,
+  chartData: PropTypes.shape({
+    // ela
+    most_recent_star_reading_percentile: PropTypes.number,
+    most_recent_mcas_ela_scaled: PropTypes.number,
+    most_recent_mcas_ela_growth: PropTypes.number,
+    star_series_reading_percentile: PropTypes.array,
+    mcas_series_ela_scaled: PropTypes.array,
+    mcas_series_ela_growth: PropTypes.array,
+    // math
+    most_recent_star_math_percentile: PropTypes.number,
+    most_recent_mcas_math_scaled: PropTypes.number,
+    most_recent_mcas_math_growth: PropTypes.number,
+    star_series_math_percentile: PropTypes.array,
+    mcas_series_math_scaled: PropTypes.array,
+    mcas_series_math_growth: PropTypes.array
+  }),
+  attendanceData: PropTypes.shape({
+    discipline_incidents: PropTypes.array,
+    tardies: PropTypes.array,
+    absences: PropTypes.array
+  }),
+  noteInProgressText: PropTypes.string.isRequired,
+  noteInProgressType: PropTypes.number,
+  noteInProgressAttachmentUrls: PropTypes.arrayOf(
+    PropTypes.string
+  ).isRequired,
+  access: PropTypes.object,
+  iepDocument: PropTypes.object,
+  sections: PropTypes.array,
+  currentEducatorAllowedSections: PropTypes.array,
+
+  // flux-y bits
+  requests: InsightsPropTypes.requests,
+  actions: InsightsPropTypes.actions
+};
+
+
+const styles = {
+  tabsContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    margin: 20,
+    flex: 1
+  },
+  tabLayout: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  tab: {
+    flex: 1,
+    textAlign: 'center'
+  },
+  detailsContainer: {
+    margin: 20
+  }
+};
+
+
+
+function findTopRecentTags(eventNotes, nowMoment) {
+  const thresholdInDays = 100000; // should be 45, this is for testing locally, where dates are busted
+  const recentNotes = eventNotes.filter(e => nowMoment.clone().diff(toMomentFromTime(e.recorded_at), 'days') < thresholdInDays);
+  const recentNotesText = recentNotes.map(e => e.text).join(' ');
+  const recentTags = tags(recentNotesText);
+  return recentTags.slice(0, 4);
+}
+
+
+function countEventsBetween(events, startMoment, endMoment) {
+  return events.filter(event => {
+    return moment.utc(event.occurred_at).isBetween(startMoment, endMoment);
+  }).length;
+}
+
+const DAYS_AGO = 45;
+
+
+function latestStar(sortedQuads, nowMoment) {
+  const quad = _.last(sortedQuads);
+  if (!quad) return {
+    nDaysText: 'not yet taken',
+    percentileText: '-'
+  };
+
+  const testMoment = toMoment(quad);
+  const nDaysText = testMoment.from(nowMoment);
+  const percentile = toValue(quad);
+  const percentileText = (percentile)
+    ? percentileWithSuffix(percentile)
+    : '-';
+  return {nDaysText, percentileText};
+}
+
+function percentileWithSuffix(percentile) {
+  const lastDigit = _.last(percentile.toString());
+  const suffix = {
+    1: 'st',
+    2: 'nd',
+    3: 'rd'
+  }[lastDigit] || 'th';
+  return `${percentile}${suffix}`;
+}

--- a/app/assets/javascripts/student_profile/LightProfileTab.js
+++ b/app/assets/javascripts/student_profile/LightProfileTab.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import chroma from 'chroma-js';
+
+
+// A clickable tab showing a key bit of information
+export default function LightProfileTab(props) {
+  const {
+    isSelected,
+    children,
+    intenseColor,
+    fadedColor,
+    text,
+    style,
+    onClick
+  } = props;
+
+
+  return (
+    <div
+      className="LightProfileTab"
+      style={{
+        ...styles.root,
+        background: fadedColor,
+        opacity: (isSelected ? 1 : 0.6),
+        ...style
+      }}
+      onClick={onClick}>
+        <div style={{
+          ...styles.title,
+          opacity: isSelected ? 1 : 0.6,
+          background: isSelected
+            ? intenseColor
+            : chroma(intenseColor).desaturate().hex()
+        }}>{text}</div>
+        <div
+          style={{
+            ...styles.space,
+            background: fadedColor,
+          }}>{children}</div>
+    </div>
+  );
+}
+
+LightProfileTab.propTypes = {
+  children: PropTypes.node.isRequired,
+  intenseColor: PropTypes.string.isRequired,
+  fadedColor: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+  isSelected: PropTypes.bool,
+  style: PropTypes.object
+};
+
+const styles = {
+  root: {
+    cursor: 'pointer',
+    fontSize: 14
+  },
+  title:{
+    width: '100%',
+    textAlign: 'center',
+    padding: 10,
+    margin: 0,
+    fontWeight: 'bold',
+    color: 'white'
+  },
+  space: {
+    flex: 1,
+    padding: 10
+  }
+};
+
+
+// A big number with subtext underneath, rendered inside a tab
+export function LightShoutNumber(props) {
+  const {number, children} = props;
+  return (
+    <div>
+      <div style={{marginBottom: 10, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 32}}>{number}</div>
+      <div style={{color: '#333', display: 'flex', alignItems: 'center', flexDirection: 'column'}}>
+        <div style={{textAlign: 'center'}}>{children}</div>
+      </div>
+    </div>
+  );
+}
+LightShoutNumber.propTypes = {
+  number: PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired
+};

--- a/app/assets/javascripts/student_profile/LightServiceDetails.js
+++ b/app/assets/javascripts/student_profile/LightServiceDetails.js
@@ -1,0 +1,165 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import * as InsightsPropTypes from '../helpers/InsightsPropTypes';
+import SectionHeading from '../components/SectionHeading';
+import LightHelpBubble from './LightHelpBubble';
+import ServicesList from './ServicesList';
+import RecordService from './RecordService';
+
+/*
+The bottom region of the page, showing notes about the student, services
+they are receiving, and allowing users to enter new information about
+these as well.
+*/
+export default class ServiceDetails extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isAddingService: false
+    };
+
+    this.onClickRecordService = this.onClickRecordService.bind(this);
+    this.onCancelRecordService = this.onCancelRecordService.bind(this);
+    this.onClickSaveService = this.onClickSaveService.bind(this);
+    this.onClickDiscontinueService = this.onClickDiscontinueService.bind(this);
+  }
+
+  onClickRecordService(event) {
+    this.setState({ isAddingService: true });
+  }
+
+  onCancelRecordService(event) {
+    this.setState({ isAddingService: false });
+  }
+
+  onClickSaveService(serviceParams, event) {
+    this.props.actions.onClickSaveService(serviceParams);
+    this.setState({ isAddingService: false });
+  }
+
+  onClickDiscontinueService(serviceId, event) {
+    this.props.actions.onClickDiscontinueService(serviceId);
+  }
+
+  render() {
+    return (
+      <div className="ServicesDetails" style={styles.servicesContainer}>
+        <SectionHeading titleStyle={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
+          <div style={{display: 'flex', alignItems: 'center'}}>
+            <span>Services</span>
+            <LightHelpBubble
+              title="What is a Service?"
+              content={this.renderServicesHelpContent()} />
+          </div>
+          {this.renderRecordServiceSection()}
+        </SectionHeading>
+        <ServicesList
+          servicesFeed={this.props.feed.services}
+          educatorsIndex={this.props.educatorsIndex}
+          serviceTypesIndex={this.props.serviceTypesIndex}
+          onClickDiscontinueService={this.onClickDiscontinueService}
+          discontinueServiceRequests={this.props.requests.discontinueService} />
+      </div>
+    );
+  }
+
+  renderServicesHelpContent(){
+    return (
+      <div>
+        <p>
+          While Notes are a catch-all for student information, Services are a place to keep track of more formal         extensive interventions for a student. It includes a specific person responsible and dates.
+        </p>
+        <br />
+        <p>
+          The types of Services are:
+        </p>
+        <ul>
+          <li>
+            <b>
+              {'Attendance Officer: '}
+            </b>
+            This usually includes home visit(s), regular follow-up,           and could later on lead to a formal attendance contract.
+          </li>
+          <li>
+            <b>
+              {'Attendance Contract: '}
+            </b>
+            This is usually done in cooperation with the attendance officer,           school adjustment counselor, and/or principal. This is a more formal document that requires a parent and           student signature, along with regular checkpoints.
+          </li>
+          <li>
+            <b>
+              {'Behavior Contract: '}
+            </b>
+            This is usually done in cooperation with the attendance officer,           school adjustment counselor, and/or principal. This is a more formal document that requires a parent and           student signature, along with regular checkpoints.
+          </li>
+          <li>
+            <b>
+              {'Counseling, in-house: '}
+            </b>
+            Student receives regular weekly or bi-weekly counseling from an SPS counselor.           One time or infrequent check-ins by a counselor should just be recorded in Notes.
+          </li>
+          <li>
+            <b>
+              {'Counseling, outside: '}
+            </b>
+            Student receives regular weekly or bi-weekly counseling from an outside           counselor, ex. Riverside, Home for Little Wanderers. One time or infrequent check-ins by a counselor should           just be recorded in Notes.
+          </li>
+          <li>
+            <b>
+              {'Reading Intervention: '}
+            </b>
+            Student works with a reading specialist at least 4x/week for 30-40 minutes.
+          </li>
+        </ul>
+        <br />
+        <p>
+          If your data fits into one of these categories, it's a Service. Otherwise, it's a Note.
+        </p>
+      </div>
+    );
+  }
+
+  renderRecordServiceSection() {
+    if (this.state.isAddingService || this.props.requests.saveService !== null) {
+      return (
+        <RecordService
+          studentFirstName={this.props.student.first_name}
+          studentId={this.props.student.id}
+          onSave={this.onClickSaveService}
+          onCancel={this.onCancelRecordService}
+          requestState={this.props.requests.saveService}
+          // TODO(kr) thread through
+          nowMoment={moment.utc()}
+          currentEducator={this.props.currentEducator}
+          serviceTypesIndex={this.props.serviceTypesIndex}
+          educatorsIndex={this.props.educatorsIndex} />
+      );
+    }
+
+    return (
+      <button className="btn record-service" style={{margin: 0}} onClick={this.onClickRecordService}>
+        <span><span style={{fontWeight: 'bold', paddingRight: 5}}>+</span><span>service</span></span>
+      </button>
+    );
+  }
+}
+ServiceDetails.propTypes = {
+  student: PropTypes.object.isRequired,
+  serviceTypesIndex: PropTypes.object.isRequired,
+  educatorsIndex: PropTypes.object.isRequired,
+  currentEducator: PropTypes.object.isRequired,
+  actions: InsightsPropTypes.actions.isRequired,
+  feed: InsightsPropTypes.feed.isRequired,
+  requests: InsightsPropTypes.requests.isRequired
+};
+
+const styles = {
+  servicesContainer: {
+    flex: 1
+  },
+  addServiceContainer: {
+    marginTop: 10
+  }
+};

--- a/app/assets/javascripts/student_profile/MathDetails.js
+++ b/app/assets/javascripts/student_profile/MathDetails.js
@@ -79,6 +79,9 @@ export default class MathDetails extends React.Component {
   }
 
   renderNavBar() {
+    const {hideNavbar} = this.props;
+    if (hideNavbar) return null;
+
     return (
       <div style={styles.navBar}>
         <a style={styles.navBar} href="#starMath">
@@ -203,7 +206,8 @@ MathDetails.propTypes = {
     next_gen_mcas_mathematics_scaled: PropTypes.array,
     mcas_series_math_growth: PropTypes.array.isRequired
   }).isRequired,
-  student: PropTypes.object.isRequired
+  student: PropTypes.object.isRequired,
+  hideNavbar: PropTypes.bool
 };
 
 const styles = {

--- a/app/assets/javascripts/student_profile/StudentProfilePage.test.js
+++ b/app/assets/javascripts/student_profile/StudentProfilePage.test.js
@@ -73,9 +73,9 @@ function testPropsFromPatches(patches = {}) {
   return testPropsFromSerializedData(testSerializedData(patches));
 }
 
-function testPropsFromSerializedData(serializedData) {
+function testPropsFromSerializedData(serializedData, queryParams = {}) {
   return {
-    ...initialState(serializedData, {}),
+    ...initialState({serializedData, queryParams}),
     nowMomentFn() { return nowMoment; },
     actions: {
       onColumnClicked: jest.fn(),

--- a/app/assets/javascripts/student_profile/TakeNotes.js
+++ b/app/assets/javascripts/student_profile/TakeNotes.js
@@ -68,6 +68,7 @@ export default class TakeNotes extends React.Component {
 
   render() {
     const {
+      style,
       noteInProgressText,
       nowMoment,
       requestState,
@@ -76,7 +77,7 @@ export default class TakeNotes extends React.Component {
     } = this.props;
 
     return (
-      <div className="TakeNotes" style={styles.dialog}>
+      <div className="TakeNotes" style={{...styles.dialog, ...style}}>
         {this.renderNoteHeader({
           noteMoment: nowMoment,
           educatorEmail: currentEducator.email
@@ -221,6 +222,7 @@ TakeNotes.contextTypes = {
   districtKey: PropTypes.string.isRequired
 };
 TakeNotes.propTypes = {
+  style: PropTypes.object,
   nowMoment: PropTypes.object.isRequired,
   onSave: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,

--- a/app/assets/javascripts/student_profile/__snapshots__/LightHelpBubble.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/LightHelpBubble.test.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshots view 1`] = `
+<div
+  style={
+    Object {
+      "display": "inline",
+      "marginLeft": 10,
+    }
+  }
+>
+  <a
+    href="#"
+    onClick={[Function]}
+    style={
+      Object {
+        "display": "flex",
+        "fontSize": 12,
+        "outline": "none",
+      }
+    }
+  >
+    <svg
+      height={20}
+      style={
+        Object {
+          "fill": "#ddd",
+        }
+      }
+      viewBox="0 0 24 24"
+      width={20}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M0 0h24v24H0z"
+        fill="none"
+      />
+      <path
+        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+      />
+    </svg>
+  </a>
+</div>
+`;

--- a/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
@@ -174,6 +174,7 @@ exports[`snapshots works for aladdin 1`] = `
             "paddingRight": 44,
           }
         }
+        width={undefined}
       />
     </div>
   </div>
@@ -2834,6 +2835,7 @@ exports[`snapshots works for olaf 1`] = `
             "paddingRight": 44,
           }
         }
+        width={undefined}
       />
     </div>
   </div>
@@ -5464,6 +5466,7 @@ exports[`snapshots works for pluto 1`] = `
             "paddingRight": 44,
           }
         }
+        width={undefined}
       />
     </div>
   </div>

--- a/app/assets/javascripts/student_profile/lightTagger.js
+++ b/app/assets/javascripts/student_profile/lightTagger.js
@@ -1,0 +1,71 @@
+const ORDERED_TAGS = [
+  'placement',
+  'referral',
+
+  '51a',
+  'DCF',
+  'judge',
+  'court',
+  'police',
+
+  'kill',
+  'dying',
+  'dead',
+  'death',
+
+  'behavior',
+  'conduct',
+  'security',
+  'restraint',
+  'erratic',
+  'manic',
+  'defiant',
+  'vandal',
+  'pregnant',
+  'trauma',
+  'emergency',
+  'aggression',
+  'yelling',
+  'disruptive',
+  'defiant',
+
+  'depressed',
+  'depression',
+  'anxiety',
+  'suicide',
+  'bullying',
+  'safety plan',
+
+  'ambulance',
+  'hospital',
+  'nurse',
+  'medical',
+  'medication',
+  'health',
+
+  'counseling',
+  'counselor',
+  'redirect',
+  'sst',
+  'riverside',
+
+  'absence',
+  'attendance',
+  'tardy',
+  'tardies',
+  'attendance letter',
+  'attendance officer',
+  'attendance contract',
+
+  'mtts',
+  'comprehension',
+  'decoding',
+  'fluency',
+  'wilson'
+];
+
+export function tags(text) {
+  return ORDERED_TAGS.filter(tag => {
+    return (text.match(new RegExp('\\b' + tag + '\\b', 'g')) !== null);
+  });
+}

--- a/app/assets/javascripts/student_profile/lightTransitionNotes.js
+++ b/app/assets/javascripts/student_profile/lightTransitionNotes.js
@@ -1,0 +1,35 @@
+const STRENGTHS_PROMPT = `What are this student's strengths?`;
+const COMMUNITY_PROMPT = `What is this student's involvement in the school community like?`;
+const PEERS_PROMPT = `How does this student relate to their peers?`;
+const GUARDIAN_PROMPT = `Who is the student's primary guardian?`;
+const OTHER_PROMPT = `Any additional comments or good things to know about this student?`;
+
+
+function escapeToUseAsRegexLiteral(x) {
+  return x.replace('?', '\\?');
+}
+
+function clean(text) {
+  return text.trim().replace(/[\—\-\_]/g, '');
+}
+
+function extractOne(text, beforeText, afterText = undefined) {
+  const beforeRegexLiteral = escapeToUseAsRegexLiteral(beforeText);
+  const afterRegexLiteral = (afterText)
+    ? escapeToUseAsRegexLiteral(afterText)
+    : '';
+  const regex = new RegExp(beforeRegexLiteral + '([\\s\\S]*)' + afterRegexLiteral);
+  const matches = text.match(regex);
+  if (!matches) return null;
+  return clean(matches[1]);
+}
+
+export function parseTransitionNoteText(transitionNoteText) {
+  return {
+    strengths: extractOne(transitionNoteText, STRENGTHS_PROMPT, COMMUNITY_PROMPT),
+    community: extractOne(transitionNoteText, COMMUNITY_PROMPT, PEERS_PROMPT),
+    peers: extractOne(transitionNoteText, PEERS_PROMPT, GUARDIAN_PROMPT),
+    guardian: extractOne(transitionNoteText, GUARDIAN_PROMPT, OTHER_PROMPT),
+    other: extractOne(transitionNoteText, OTHER_PROMPT)
+  };
+}

--- a/app/assets/javascripts/student_profile/main.js
+++ b/app/assets/javascripts/student_profile/main.js
@@ -8,7 +8,6 @@ import parseQueryString from './parseQueryString';
 import PageContainer from './PageContainer';
 
 
-
 export default function renderStudentMain(el) {
   // entry point, reading static bootstrapped data from the page
   const serializedData = $('#serialized-data').data();
@@ -16,9 +15,11 @@ export default function renderStudentMain(el) {
   MixpanelUtils.track('PAGE_VISIT', { page_key: 'STUDENT_PROFILE' });
   const {districtKey} = readEnv();
 
+  const shouldUseLightProfilePage = (window.location.pathname.slice(-3) === '/v3');
   ReactDOM.render(
     <PerDistrictContainer districtKey={districtKey}>
       <PageContainer
+        shouldUseLightProfilePage={shouldUseLightProfilePage}
         districtKey={districtKey}
         nowMomentFn={() => moment.utc()}
         serializedData={serializedData}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,7 @@ Rails.application.routes.draw do
     resources :event_notes, only: [:create, :update]
 
     member do
+      get '/v3' => 'students#show'
       get :student_report
       get :restricted_notes
       get :photo


### PR DESCRIPTION
# Who is this PR for?
project team, designers 

# What problem does this PR fix?
This is a prototype of a design iteration related to the student profile page.  I'll skip describing the design intentions and features here, since we've talked about those separately over email and in person, and they're likely to change.

To enable iterating on the design, it'll be helpful to look at some real student data and see what comes out.  This PR ships that capability, aiming for minimal changes to existing product code, since this design iteration is likely to change and isn't even fully functional.  The intention is to use this for further design iterations and feedback, and a bunch of other work would be necessary to ship this for real.

I didn't include the `<ExperimentalBanner />` here like we normally would because we want feedback on the feel of the page and the layout changes, which the banner would interfere with.  But this code is all experimental and should be written so that we can delete it all with no impact to the existing profile page or other pages.

# What does this PR do?
Makes a new profile page accessible at `/students/:id/v3`.  It isn't fully functional or complete.

The overall approach for iterating on this is to create a parallel `<LightProfilePage />` that has the same API as the existing `<StudentProfilePage >/` so changes are completely isolated.  This new page uses many existing components, but in places where it would require significant changes, this PR copies those files (eg, `<LightProfileHeader />`) so these changes are isolated from the existing profile page.  This also means that all files here have this "Light" prefix (which doesn't mean anything in particular, I think maybe because it was more visually "lightweight" initially :)).

In a few places, existing components are changed minimally, such as allowing styles to be passed in, or adding an additional boolean prop.  The changes are listed below:

New work:
- `LightProfilePage`
- `LightProfileHeader`
- `LightNotesDetails`
- `LightServicesDetails`

UI elements:
- `LightProfileTab`
- `LightHelpBubble`
- `LightCarousel`

Changes to existing code:
- `<AttendanceDetails />`, `<ElaDetails />` and `<MathDetails />` take prop to hide navbar links
- Updates `<TakeNotes />`, `<HelpBubble />`, `<SectionHeading />` and `<StudentPhoto />` to take standard `style` prop for optional styles
- add `helpers/language` copied out from class lists

# Screenshot (if adding a client-side feature)
leaving these out, this is still in design phase and we'll iterate on this over email or in-person instead

# Checklists
+ [x] Author checked latest in IE - Student Profile

I added a few smoke tests, but didn't really do this yet.  That's probably for the next iteration, when we get to a decision point to go forward in this direction or not.
