### PR TITLE
Validate SchoolFilter inputs and make "all schools" option more explicit 

### DIFF
--- a/app/importers/helpers/school_filter.rb
+++ b/app/importers/helpers/school_filter.rb
@@ -1,5 +1,18 @@
-class SchoolFilter < Struct.new(:school_local_ids)
+class SchoolFilter
+  def initialize(school_local_ids)
+    raise "Invalid school_local_ids: #{school_local_ids}" unless valid?(school_local_ids)
+    @school_local_ids = school_local_ids
+  end
+
+  def valid?(school_local_ids)
+    return true if school_local_ids == :all
+    return true if school_local_ids.class == Array
+    return false
+  end
+
   def include?(school_local_id)
-    school_local_ids.nil? || school_local_ids.include?(school_local_id)
+    return true if @school_local_ids == :all
+    return true if @school_local_ids.include?(school_local_id)
+    return false
   end
 end

--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -3,7 +3,7 @@ class ImportTask
     @options = options
 
     # options["school"] is an optional filter; imports all schools if nil
-    @school = @options.fetch("school", nil)
+    @school = @options.fetch("school", :all)
 
     # options["source"] describes which external data sources to import from
     @source = @options.fetch("source", ["x2", "star"])
@@ -70,9 +70,6 @@ class ImportTask
   def validate_school_options
     # If the developer is passing in a list of school IDs to filter by,
     # we check that the IDs are valid and the schools exist in the database.
-
-    # If there's no filtering by school, we take all the school IDs listed in
-    # the district config file and make sure those schools are in the database.
 
     if @school.present?
       @school.each { |id| School.find_by!(local_id: id) }

--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -71,9 +71,9 @@ class ImportTask
     # If the developer is passing in a list of school IDs to filter by,
     # we check that the IDs are valid and the schools exist in the database.
 
-    if @school.present?
-      @school.each { |id| School.find_by!(local_id: id) }
-    end
+    return if @school == :all
+
+    @school.each { |id| School.find_by!(local_id: id) }
   end
 
   ## SET UP COMMAND LINE REPORT AND DATABASE RECORD ##

--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -74,13 +74,9 @@ class ImportTask
     # If there's no filtering by school, we take all the school IDs listed in
     # the district config file and make sure those schools are in the database.
 
-    school_ids.each { |id| School.find_by!(local_id: id) }
-  end
-
-  def school_ids
-    return @school if @school.present?
-
-    LoadDistrictConfig.new.schools.map { |school| school["local_id"] }
+    if @school.present?
+      @school.each { |id| School.find_by!(local_id: id) }
+    end
   end
 
   ## SET UP COMMAND LINE REPORT AND DATABASE RECORD ##
@@ -117,7 +113,7 @@ class ImportTask
 
   def options_for_file_importers
     {
-      school_scope: school_ids,
+      school_scope: @school,
       log: @log,
       skip_old_records: @skip_old_records
     }

--- a/spec/importers/file_importers/attendance_importer_spec.rb
+++ b/spec/importers/file_importers/attendance_importer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe AttendanceImporter do
 
   def make_attendance_importer(options = {})
     importer = AttendanceImporter.new(options: {
-      school_scope: nil,
+      school_scope: :all,
       log: nil,
       skip_old_records: false
     }.merge(options))

--- a/spec/importers/file_importers/behavior_importer_spec.rb
+++ b/spec/importers/file_importers/behavior_importer_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe BehaviorImporter do
 
   let(:base_behavior_importer) {
     described_class.new(options: {
-      school_scope: nil, log: nil, skip_old_records: false
+      school_scope: :all,
+      log: nil,
+      skip_old_records: false
     })
   }
 

--- a/spec/importers/file_importers/educators_importer_spec.rb
+++ b/spec/importers/file_importers/educators_importer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe EducatorsImporter do
   let(:log) { LogHelper::Redirect.instance.file }
   def make_educators_importer
     importer = EducatorsImporter.new(options: {
-      school_scope: nil,
+      school_scope: :all,
       log: log
     })
     importer.instance_variable_set(:@skipped_from_school_filter, 0)

--- a/spec/importers/file_importers/x2_assessment_importer_spec.rb
+++ b/spec/importers/file_importers/x2_assessment_importer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe X2AssessmentImporter do
 
   def make_x2_assessment_importer(options = {})
     X2AssessmentImporter.new(options: {
-      school_scope: nil,
+      school_scope: :all,
       log: LogHelper::FakeLog.new
     }.merge(options))
   end
@@ -31,7 +31,7 @@ RSpec.describe X2AssessmentImporter do
       it 'skips older records' do
         log = LogHelper::FakeLog.new
         importer = X2AssessmentImporter.new(options: {
-          school_scope: nil,
+          school_scope: :all,
           log: log,
           skip_old_records: true,
           time_now: Time.parse('2014-06-12')


### PR DESCRIPTION
# Who is this PR for?

Developers working with the import process.

# What problem does this PR fix?

Classes that interact with `SchoolFilter` are unclear about what inputs get sent down; makes it confusing to work with as a developer. 

The code in `SchoolFilter` says that if's passed a school local IDs list of `nil`, then it won't filter at all and will include all schools. But the code in `ImportTask` is set up differently and never sends in `nil`, it sends down an array of all school local IDs if none are supplied by the user. 

# What does this PR do?

+ Use special `:all` keyword for `SchoolFilter` to accept rows from all schools.
+ Validate argument inputs to `SchoolFilter`.
