### PR TITLE
Fix layout on share an Insight

### DIFF
--- a/app/assets/javascripts/student_profile/LightCarousel.js
+++ b/app/assets/javascripts/student_profile/LightCarousel.js
@@ -52,7 +52,7 @@ export default class LightCarousel extends React.Component {
     return (
       <div style={{display: 'flex', flex: 1, flexDirection: 'column', justifyContent: 'space-between', ...style}}>
         <div style={{flex: 1, margin: 20, marginBottom: 0, marginTop: 15, display: 'flex'}}>
-          <div style={{fontSize: 20, overflowY: 'scroll'}}>{quoted}</div>
+          <div style={{flex: 1, fontSize: 20, overflowY: 'scroll'}}>{quoted}</div>
         </div>
         <div style={{
           fontSize: 12,


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
Layout bug in https://github.com/studentinsights/studentinsights/pull/1953.

# What does this PR do?
Fixes it.

# Screenshot (if adding a client-side feature)
After:
<img width="402" alt="screen shot 2018-07-27 at 6 20 22 pm" src="https://user-images.githubusercontent.com/1056957/43348787-d6fc1b44-91c9-11e8-8782-5154aa82d9af.png">

# Checklists
This feature is isolated from production code.