### PR TITLE
Grades can be null, so skip them in profile

### DIFF
--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -107,7 +107,10 @@ export default class LightProfilePage extends React.Component {
   renderGradesColumn() {
     const {sections, selectedColumnKey} = this.props;
     const columnKey = 'grades';
-    const strugglingSectionsCount = sections.filter(section => section.grade_numeric < 69).length;
+    const strugglingSectionsCount = sections.filter(section => {
+      if (_.isNaN(section.grade_numeric)) return false;
+      return (section.grade_numeric < 69);
+    }).length;
 
     return (
       <LightProfileTab


### PR DESCRIPTION
# Who is this PR for?
HS educators

# What problem does this PR fix?
`grade_numeric` can be null and often is, so profile v3 mistakenly considers that a course with a lot grade when it should skip it.

# What does this PR do?
Fixes the bug.

# Checklists
This code doesn't touch production paths.