### PR TITLE
Fix nondeterministic JS test

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/DashboardTestData.js
+++ b/app/assets/javascripts/school_administrator_dashboard/DashboardTestData.js
@@ -9,25 +9,25 @@ export function testSchool() {
 export function createTestEvents(nowMoment) {
   return {
     oneMonthAgo: {
-      occurred_at: nowMoment.clone().subtract(1, 'months').format(),
+      occurred_at: nowMoment.clone().subtract(30, 'days').format(),
       excused: true,
       dismissed: false,
       student_id: 1,
     },
     twoMonthsAgo: {
-      occurred_at: nowMoment.clone().subtract(2, 'months').format(),
+      occurred_at: nowMoment.clone().subtract(60, 'days').format(),
       excused: false,
       dismissed: true,
       student_id: 1,
     },
     threeMonthsAgo: {
-      occurred_at: nowMoment.clone().subtract(3, 'months').format(),
+      occurred_at: nowMoment.clone().subtract(90, 'days').format(),
       excused: false,
       dismissed: false,
       student_id: 1,
     },
     fourMonthsAgo: {
-      occurred_at: nowMoment.clone().subtract(4, 'months').format(),
+      occurred_at: nowMoment.clone().subtract(120, 'days').format(),
       excused: false,
       dismissed: false,
       student_id: 1,
@@ -124,9 +124,9 @@ export function createStudents(nowMoment) {
 export function createSchoolTardyEvents(nowMoment) {
   const testEvents = createTestEvents(nowMoment);
 
-  const oneMonthAgo = nowMoment.clone().subtract(1, 'months').format('YYYY-MM-DD');
-  const threeMonthsAgo = nowMoment.clone().subtract(3, 'months').format('YYYY-MM-DD');
-  const fourMonthsAgo = nowMoment.clone().subtract(4, 'months').format('YYYY-MM-DD');
+  const oneMonthAgo = nowMoment.clone().subtract(30, 'days').format('YYYY-MM-DD');
+  const threeMonthsAgo = nowMoment.clone().subtract(90, 'days').format('YYYY-MM-DD');
+  const fourMonthsAgo = nowMoment.clone().subtract(120, 'days').format('YYYY-MM-DD');
   const oneYearAgo = nowMoment.clone().subtract(1, 'year').format('YYYY-MM-DD');
   let schoolTardyEvents = {};
 


### PR DESCRIPTION
# Note 

+ Months don't always have exactly 30 days; tests were expecting text in `StudentsTable.js` to always say "SST 30 Days Ago." Switch to using deterministic "30 days" instead of "1 month." I think this particular test might pass or fail depending on what month it's being run in.
+ Travis failure example:  https://travis-ci.org/studentinsights/studentinsights/builds/410483760.