### PR TITLE
Enforce student_id on discipline incidents at database level

### DIFF
--- a/app/importers/file_importers/behavior_importer.rb
+++ b/app/importers/file_importers/behavior_importer.rb
@@ -59,7 +59,7 @@ class BehaviorImporter
       return
     end
 
-    behavior_event = BehaviorRow.build(row, student.id)
+    behavior_event = BehaviorRow.new(row, student.id).build
     if !behavior_event.valid?
       @invalid_rows_count += 1
       return

--- a/app/importers/file_importers/behavior_importer.rb
+++ b/app/importers/file_importers/behavior_importer.rb
@@ -14,6 +14,7 @@ class BehaviorImporter
 
     log('Starting loop...')
     @skipped_from_school_filter = 0
+    @skipped_from_invalid_student_id = 0
     @touched_rows_count = 0
     @invalid_rows_count = 0
     streaming_csv.each_with_index do |row, index|
@@ -23,6 +24,7 @@ class BehaviorImporter
     log('Done loop.')
 
     log("@skipped_from_school_filter: #{@skipped_from_school_filter}")
+    log("@skipped_from_invalid_student_id: #{@skipped_from_invalid_student_id}")
     log("@touched_rows_count: #{@touched_rows_count}")
     log("@invalid_rows_count: #{@invalid_rows_count}")
   end
@@ -50,7 +52,14 @@ class BehaviorImporter
       return
     end
 
-    behavior_event = BehaviorRow.build(row)
+    student = Student.find_by_local_id(row[:local_id])
+    if student.nil?
+      @skipped_from_invalid_student_id += 1
+      log("skipping, StudentLocalID not found: #{row[:local_id]}")
+      return
+    end
+
+    behavior_event = BehaviorRow.build(row, student.id)
     if !behavior_event.valid?
       @invalid_rows_count += 1
       return

--- a/app/importers/rows/behavior_row.rb
+++ b/app/importers/rows/behavior_row.rb
@@ -6,10 +6,6 @@ class BehaviorRow < Struct.new(:row, :student_id)
   #  :state_id, :local_id, :incident_code, :event_date, :incident_time,
   #  :incident_location, :incident_description, :school_local_id
 
-  def self.build(row)
-    new(row).build
-  end
-
   def build
     discipline_incident = DisciplineIncident.find_or_initialize_by(
       occurred_at: occurred_at,

--- a/app/importers/rows/behavior_row.rb
+++ b/app/importers/rows/behavior_row.rb
@@ -1,4 +1,4 @@
-class BehaviorRow < Struct.new(:row)
+class BehaviorRow < Struct.new(:row, :student_id)
   # Represents a row in a CSV export from Somerville's Aspen X2 student information system.
   #
   # Expects the following headers:
@@ -13,7 +13,7 @@ class BehaviorRow < Struct.new(:row)
   def build
     discipline_incident = DisciplineIncident.find_or_initialize_by(
       occurred_at: occurred_at,
-      student_id: student.try(:id),
+      student_id: student_id,
       incident_code: row[:incident_code]
     )
 
@@ -42,7 +42,4 @@ class BehaviorRow < Struct.new(:row)
     row[:event_date].to_datetime + incident_time
   end
 
-  def student
-    Student.find_by_local_id(row[:local_id])
-  end
 end

--- a/db/migrate/20180731200155_discipline_incidents_constraints.rb
+++ b/db/migrate/20180731200155_discipline_incidents_constraints.rb
@@ -1,0 +1,6 @@
+class DisciplineIncidentsConstraints < ActiveRecord::Migration[5.2]
+  def change
+    # This was nullable before and it shouldn't be.
+    change_column :discipline_incidents, :student_id, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_24_151520) do
+ActiveRecord::Schema.define(version: 2018_07_31_200155) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,7 +95,7 @@ ActiveRecord::Schema.define(version: 2018_07_24_151520) do
     t.text "incident_description"
     t.datetime "occurred_at", null: false
     t.boolean "has_exact_time"
-    t.integer "student_id"
+    t.integer "student_id", null: false
     t.index ["student_id"], name: "index_discipline_incidents_on_student_id"
   end
 

--- a/spec/importers/rows/behavior_row_spec.rb
+++ b/spec/importers/rows/behavior_row_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe BehaviorRow do
     }
   end
 
-  subject(:row) { BehaviorRow.new(data) }
+  subject(:row) { BehaviorRow.new(data, student.id) }
 
   describe '#build' do
     it 'records a discipline incident' do


### PR DESCRIPTION
# Who is this PR for?

Data quality. 

# What problem does this PR fix?

Rails validations aren't sufficient to ensure data quality; database-level guards needed. We need to know the `:student_id` of a discipline incident, otherwise the record isn't useful.

# What does this PR do?

Adds a migration to enforce `null: false`. 

# Existing data quality / Deployment

## Somerville 

Digging into the Somerville database showed that there are 1,047 discipline records missing a student ID, compared with 17,650 valid records that have a student ID. This means that 5.9%. are missing a student ID.

How was this introduced? The current Rails validation on the discipline incident model (`validates_presence_of :student`) was introduced Jun 2, 2017, when we moved from associated discipline incidents with student school years to associating them with students: #929. All of the records without a student ID were introduced on or before May 25 2017. So these are older records that were added to the database before the validation was added. 

Some looking at exampled showed that these are duplicates of other discipline incident records. Because they have no student IDs, they would be excluded from scoped queries like `authorized_students_for_dashboard` and should not have ever been surfaced in the product. Of course there's no way for them to appear on any student profile since they have no student ID.

Before this PR is merged and the database migration run, I'll need to clear out the invalid data with something like:

```
DisciplineIncident.where(student_id: nil).destroy_all
```

Otherwise the migration won't run, because it would create data that violates the database constraint. 

## New Bedford

```
irb(main):005:0> DisciplineIncident.where(student_id: nil).count
=> 0
```