### PR TITLE
Sync and delete Discipline records missing from Aspen/X2 export CSV 

### DIFF
--- a/app/importers/file_importers/behavior_importer.rb
+++ b/app/importers/file_importers/behavior_importer.rb
@@ -34,6 +34,8 @@ class BehaviorImporter
     log("@invalid_rows_count: #{@invalid_rows_count}")
     log("@touched_rows_count: #{@touched_rows_count}")
 
+    log('Calling #delete_unmarked_records...')
+    @record_syncer.delete_unmarked_records!(records_within_scope)
     log("Sync stats: #{@record_syncer.stats}")
   end
 
@@ -94,7 +96,6 @@ class BehaviorImporter
     maybe_matching_record = BehaviorRow.new(row, student.id).build
 
     @record_syncer.validate_mark_and_sync!(maybe_matching_record)
-    @record_syncer.delete_unmarked_records!(records_within_scope)
   end
 
   def within_date_range?(row)

--- a/app/importers/file_importers/behavior_importer.rb
+++ b/app/importers/file_importers/behavior_importer.rb
@@ -3,6 +3,8 @@ class BehaviorImporter
   def initialize(options:)
     @school_scope = options.fetch(:school_scope)
     @log = options.fetch(:log)
+    @inclusive_date_range = create_inclusive_date_range(options)
+    @record_syncer = ::RecordSyncer.new(log: @log)
   end
 
   def import
@@ -15,21 +17,38 @@ class BehaviorImporter
     log('Starting loop...')
     @skipped_from_school_filter = 0
     @skipped_from_invalid_student_id = 0
-    @touched_rows_count = 0
+    @skipped_old_rows_count = 0
     @invalid_rows_count = 0
+    @touched_rows_count = 0
+
     streaming_csv.each_with_index do |row, index|
       import_row(row)
       log("processed #{index} rows.") if index % 10000 == 0
     end
+
     log('Done loop.')
 
     log("@skipped_from_school_filter: #{@skipped_from_school_filter}")
     log("@skipped_from_invalid_student_id: #{@skipped_from_invalid_student_id}")
-    log("@touched_rows_count: #{@touched_rows_count}")
+    log("@skipped_old_rows_count: #{@skipped_old_rows_count}")
     log("@invalid_rows_count: #{@invalid_rows_count}")
+    log("@touched_rows_count: #{@touched_rows_count}")
+
+    log("Sync stats: #{@record_syncer.stats}")
   end
 
   private
+  def create_inclusive_date_range(options)
+    time_window = options.fetch(:time_window, 90.days)
+    time_now = options.fetch(:time_now, Time.now)
+    skip_old_records = options.fetch(:skip_old_records, false)
+
+    time_window = if skip_old_records then time_window else 20.years end # or max retention policy
+    end_date = time_now.beginning_of_day.to_date
+    start_date = (end_date - time_window).beginning_of_day.to_date
+    InclusiveDateRange.new(start_date, end_date)
+  end
+
   def client
     SftpClient.for_x2
   end
@@ -46,9 +65,22 @@ class BehaviorImporter
     SchoolFilter.new(@school_scope)
   end
 
+  def records_within_scope
+    DisciplineIncident
+      .joins(:student => :school)
+      .where(:schools => {:local_id => @school_scope})
+      .where('occurred_at >= ?', @inclusive_date_range.begin)
+      .where('occurred_at <= ?', @inclusive_date_range.end)
+  end
+
   def import_row(row)
     if !school_filter.include?(row[:school_local_id])
       @skipped_from_school_filter += 1
+      return
+    end
+
+    if !within_date_range?(row)
+      @skipped_old_rows_count += 1
       return
     end
 
@@ -59,14 +91,24 @@ class BehaviorImporter
       return
     end
 
-    behavior_event = BehaviorRow.new(row, student.id).build
-    if !behavior_event.valid?
-      @invalid_rows_count += 1
-      return
-    end
+    maybe_matching_record = matching_insights_record_for_row(row)
 
-    behavior_event.save!
-    @touched_rows_count += 1
+    @record_syncer.validate_mark_and_sync!(maybe_matching_record)
+    @record_syncer.delete_unmarked_records!(records_within_scope)
+  end
+
+  def matching_insights_record_for_row(row)
+    behavior_event = BehaviorRow.new(row, student.id).build
+
+    if !behavior_event.invalid?
+      @invalid_rows_count += 1
+      return nil
+    end
+  end
+
+  def within_date_range?(row)
+    date = row[:event_date]
+    date >= @inclusive_date_range.begin && date <= @inclusive_date_range.end
   end
 
   def log(msg)

--- a/app/importers/file_importers/behavior_importer.rb
+++ b/app/importers/file_importers/behavior_importer.rb
@@ -91,19 +91,10 @@ class BehaviorImporter
       return
     end
 
-    maybe_matching_record = matching_insights_record_for_row(row)
+    maybe_matching_record = BehaviorRow.new(row, student.id).build
 
     @record_syncer.validate_mark_and_sync!(maybe_matching_record)
     @record_syncer.delete_unmarked_records!(records_within_scope)
-  end
-
-  def matching_insights_record_for_row(row)
-    behavior_event = BehaviorRow.new(row, student.id).build
-
-    if !behavior_event.invalid?
-      @invalid_rows_count += 1
-      return nil
-    end
   end
 
   def within_date_range?(row)

--- a/app/importers/helpers/record_syncer.rb
+++ b/app/importers/helpers/record_syncer.rb
@@ -80,7 +80,8 @@ class RecordSyncer
       record.destroy!
       log("  destroyed #{index} rows.") if index > 0 && index % 100 == 0
     end
-    records_to_destroy.size
+
+    @destroyed_records_count = records_to_destroy.size
   end
 
   # For debugging and testing
@@ -91,7 +92,8 @@ class RecordSyncer
       unchanged_rows_count: @unchanged_rows_count,
       updated_rows_count: @updated_rows_count,
       created_rows_count: @created_rows_count,
-      marked_ids_count: @marked_ids.size
+      marked_ids_count: @marked_ids.size,
+      destroyed_records_count: @destroyed_records_count,
     }
   end
 

--- a/app/importers/rows/behavior_row.rb
+++ b/app/importers/rows/behavior_row.rb
@@ -10,9 +10,8 @@ class BehaviorRow < Struct.new(:row, :student_id)
     # This method is picky. A record must exactly match every field in a row
     # in order to `find`; otherwise a new record is `initialized`.
 
-    # If any attributes about a discipline incident change upstream in Aspen/X2,
-    # the existing record in the Insights database won't be marked by the
-    # RecordSyncer and will be deleted at the end of the import task.
+    # If any attributes change upstream in Aspen/X2, the record in the Insights
+    # database won't be marked by and will be deleted at the end of the import task.
     DisciplineIncident.find_or_initialize_by(
       occurred_at: occurred_at,
       student_id: student_id,

--- a/app/importers/rows/behavior_row.rb
+++ b/app/importers/rows/behavior_row.rb
@@ -7,19 +7,14 @@ class BehaviorRow < Struct.new(:row, :student_id)
   #  :incident_location, :incident_description, :school_local_id
 
   def build
-    discipline_incident = DisciplineIncident.find_or_initialize_by(
+    DisciplineIncident.find_or_initialize_by(
       occurred_at: occurred_at,
       student_id: student_id,
       incident_code: row[:incident_code]
-    )
-
-    discipline_incident.assign_attributes(
       has_exact_time: has_exact_time?,
       incident_location: row[:incident_location],
       incident_description: row[:incident_description],
     )
-
-    discipline_incident
   end
 
   private

--- a/app/importers/rows/behavior_row.rb
+++ b/app/importers/rows/behavior_row.rb
@@ -15,7 +15,7 @@ class BehaviorRow < Struct.new(:row, :student_id)
     DisciplineIncident.find_or_initialize_by(
       occurred_at: occurred_at,
       student_id: student_id,
-      incident_code: row[:incident_code]
+      incident_code: row[:incident_code],
       has_exact_time: has_exact_time?,
       incident_location: row[:incident_location],
       incident_description: row[:incident_description],

--- a/app/importers/rows/behavior_row.rb
+++ b/app/importers/rows/behavior_row.rb
@@ -7,6 +7,11 @@ class BehaviorRow < Struct.new(:row, :student_id)
   #  :incident_location, :incident_description, :school_local_id
 
   def build
+    # This method is picky. A record must exactly match every field in a row
+    # in order to `find`; otherwise a new record is `initialized`.
+
+    # The existing record in the Insights database won't be marked in by
+    # RecordSyncer and will be deleted at the end of import if anything has changed.
     DisciplineIncident.find_or_initialize_by(
       occurred_at: occurred_at,
       student_id: student_id,

--- a/app/importers/rows/behavior_row.rb
+++ b/app/importers/rows/behavior_row.rb
@@ -10,8 +10,9 @@ class BehaviorRow < Struct.new(:row, :student_id)
     # This method is picky. A record must exactly match every field in a row
     # in order to `find`; otherwise a new record is `initialized`.
 
-    # The existing record in the Insights database won't be marked in by
-    # RecordSyncer and will be deleted at the end of import if anything has changed.
+    # If any attributes about a discipline incident change upstream in Aspen/X2,
+    # the existing record in the Insights database won't be marked by the
+    # RecordSyncer and will be deleted at the end of the import task.
     DisciplineIncident.find_or_initialize_by(
       occurred_at: occurred_at,
       student_id: student_id,

--- a/spec/importers/file_importers/behavior_importer_spec.rb
+++ b/spec/importers/file_importers/behavior_importer_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe BehaviorImporter do
 
   let(:base_behavior_importer) {
     described_class.new(options: {
-      school_scope: nil, log: nil, skip_old_records: false
+      school_scope: nil,
+      log: LogHelper::FakeLog.new,
+      skip_old_records: false
     })
   }
 
@@ -29,7 +31,7 @@ RSpec.describe BehaviorImporter do
         {
           local_id: student.local_id,
           incident_code: "Bullying",
-          event_date: Date.new(Time.now.year, 10, 1),
+          event_date: Date.new(Time.now.year - 1, 10, 1),
           incident_time: "13:00:00",
           incident_location: "Classroom",
           incident_description: "Hit another student.",
@@ -47,7 +49,7 @@ RSpec.describe BehaviorImporter do
         expect(incident.has_exact_time).to eq true
       end
       it 'assigns the date and time correctly' do
-        expect(incident.occurred_at).to eq Time.utc(Time.now.year, 10, 1, 13, 00)
+        expect(incident.occurred_at).to eq Time.utc(Time.now.year - 1, 10, 1, 13, 00)
       end
     end
 
@@ -59,7 +61,7 @@ RSpec.describe BehaviorImporter do
         {
           local_id: student.local_id,
           incident_code: "Bullying",
-          event_date: Date.new(Time.now.year, 10, 1),
+          event_date: Date.new(Time.now.year - 1, 10, 1),
           incident_time: "13:00:00",
           incident_location: "Classroom",
           incident_description: "Hit another student.",
@@ -70,7 +72,7 @@ RSpec.describe BehaviorImporter do
         {
           local_id: student.local_id,
           incident_code: "Bullying",
-          event_date: Date.new(Time.now.year, 10, 2),
+          event_date: Date.new(Time.now.year - 1, 10, 2),
           incident_location: "Classroom",
           incident_description: "Hit another student again.",
           school_local_id: "SHS"
@@ -95,7 +97,7 @@ RSpec.describe BehaviorImporter do
         {
           local_id: student.local_id,
           incident_code: "Bullying",
-          event_date: Date.new(Time.now.year, 10, 1),
+          event_date: Date.new(Time.now.year - 1, 10, 1),
           incident_time: "13:00:00",
           incident_location: "Classroom",
           incident_description: big_block_of_text,
@@ -115,7 +117,7 @@ RSpec.describe BehaviorImporter do
         {
           local_id: student.local_id,
           incident_code: "Bullying",
-          event_date: Date.new(Time.now.year, 10, 3),
+          event_date: Date.new(Time.now.year - 1, 10, 3),
           incident_time: nil,
           incident_location: "Classroom",
           incident_description: "Bullied another student.",
@@ -127,7 +129,7 @@ RSpec.describe BehaviorImporter do
         expect(incident.has_exact_time).to eq false
       end
       it 'assigns the date without a time' do
-        expect(incident.occurred_at).to eq Time.utc(Time.now.year, 10, 3)
+        expect(incident.occurred_at).to eq Time.utc(Time.now.year - 1, 10, 3)
       end
     end
 
@@ -137,7 +139,7 @@ RSpec.describe BehaviorImporter do
         {
           local_id: student.local_id,
           incident_code: "Bullying",
-          event_date: Date.new(Time.now.year, 10, 2),
+          event_date: Date.new(Time.now.year - 1, 10, 2),
           incident_time: "13:00:00",
           incident_location: "Classroom",
           incident_description: "pencil that didn’t need to be",

--- a/spec/importers/file_importers/behavior_importer_spec.rb
+++ b/spec/importers/file_importers/behavior_importer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe BehaviorImporter do
 
   let(:behavior_importer) {
     base_behavior_importer.instance_variable_set(:@skipped_from_school_filter, 0)
+    base_behavior_importer.instance_variable_set(:@skipped_old_rows_count, 0)
     base_behavior_importer.instance_variable_set(:@touched_rows_count, 0)
     base_behavior_importer.instance_variable_set(:@invalid_rows_count, 0)
     base_behavior_importer

--- a/spec/importers/helpers/record_syncer_spec.rb
+++ b/spec/importers/helpers/record_syncer_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe RecordSyncer do
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
-        marked_ids_count: 0
+        marked_ids_count: 0,
+        destroyed_records_count: nil,  # updated on `delete_unmarked_records!`
       })
     end
 
@@ -46,7 +47,8 @@ RSpec.describe RecordSyncer do
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
-        marked_ids_count: 0
+        marked_ids_count: 0,
+        destroyed_records_count: nil,  # updated on `delete_unmarked_records!`
       })
     end
 
@@ -61,7 +63,8 @@ RSpec.describe RecordSyncer do
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
-        marked_ids_count: 0
+        marked_ids_count: 0,
+        destroyed_records_count: nil,  # updated on `delete_unmarked_records!`
       })
     end
 
@@ -75,7 +78,8 @@ RSpec.describe RecordSyncer do
         unchanged_rows_count: 1,
         updated_rows_count: 0,
         created_rows_count: 0,
-        marked_ids_count: 1
+        marked_ids_count: 1,
+        destroyed_records_count: nil,  # updated on `delete_unmarked_records!`
       })
     end
 
@@ -90,7 +94,8 @@ RSpec.describe RecordSyncer do
         unchanged_rows_count: 0,
         updated_rows_count: 1,
         created_rows_count: 0,
-        marked_ids_count: 1
+        marked_ids_count: 1,
+        destroyed_records_count: nil,  # updated on `delete_unmarked_records!`
       })
     end
 
@@ -104,7 +109,8 @@ RSpec.describe RecordSyncer do
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 1,
-        marked_ids_count: 1
+        marked_ids_count: 1,
+        destroyed_records_count: nil,  # updated on `delete_unmarked_records!`
       })
       expect(syncer.instance_variable_get(:@marked_ids)).to eq [absence.id]
     end
@@ -120,6 +126,16 @@ RSpec.describe RecordSyncer do
 
       expect(syncer.delete_unmarked_records!(records_within_scope)).to eq(0)
       expect(Absence.count).to eq(1)
+
+      expect(syncer.stats).to eq({
+        passed_nil_record_count: 0,
+        invalid_rows_count: 0,
+        unchanged_rows_count: 0,
+        updated_rows_count: 0,
+        created_rows_count: 0,
+        marked_ids_count: 0,
+        destroyed_records_count: 0,
+      })
     end
 
     it 'keeps two marked records, destroys one unmarked record' do
@@ -144,6 +160,16 @@ RSpec.describe RecordSyncer do
         RecordSyncer:   records_to_destroy.size: 1 within scope
       HEREDOC
       expect(log.output).to eq expected_log_output.strip
+
+      expect(syncer.stats).to eq({
+        passed_nil_record_count: 0,
+        invalid_rows_count: 0,
+        unchanged_rows_count: 2,
+        updated_rows_count: 0,
+        created_rows_count: 0,
+        marked_ids_count: 2,
+        destroyed_records_count: 1,
+      })
     end
 
     it 'deletes all records in scope if nothing was marked' do
@@ -154,6 +180,16 @@ RSpec.describe RecordSyncer do
 
       expect(syncer.delete_unmarked_records!(Absence.all)).to eq(5)
       expect(Absence.count).to eq(0)
+
+      expect(syncer.stats).to eq({
+        passed_nil_record_count: 0,
+        invalid_rows_count: 0,
+        unchanged_rows_count: 0,
+        updated_rows_count: 0,
+        created_rows_count: 0,
+        marked_ids_count: 0,
+        destroyed_records_count: 5,
+      })
     end
 
     it 'does not delete newly created records' do
@@ -163,6 +199,16 @@ RSpec.describe RecordSyncer do
       expect(Absence.count).to eq(1)
 
       expect(syncer.delete_unmarked_records!(Absence.all)).to eq(0)
+
+      expect(syncer.stats).to eq({
+        passed_nil_record_count: 0,
+        invalid_rows_count: 0,
+        unchanged_rows_count: 0,
+        updated_rows_count: 0,
+        created_rows_count: 1,
+        marked_ids_count: 1,
+        destroyed_records_count: 0,
+      })
     end
 
     it 'handles edge case with a persisted record that would become invalid, deleting the Insights record rather than keeping stale values' do
@@ -174,6 +220,16 @@ RSpec.describe RecordSyncer do
 
       expect(syncer.delete_unmarked_records!(Absence.all)).to eq(1)
       expect(Absence.count).to eq(0)
+
+      expect(syncer.stats).to eq({
+        passed_nil_record_count: 0,
+        invalid_rows_count: 1,
+        unchanged_rows_count: 0,
+        updated_rows_count: 0,
+        created_rows_count: 0,
+        marked_ids_count: 0,
+        destroyed_records_count: 1,
+      })
     end
   end
 end


### PR DESCRIPTION
# Notes 

Digging into the discipline data set revealed records that don't exist anymore in the upstream CSVs from New Bedford and Somerville. Queries suggested that about 2.7% of Somerville student records and 1.7% of New Bedford student records contained one of these records. 

Often the records would look highly similar to another discipline incident in the student's event feed. This suggested a problem of educators editing or deleting discipline incident records in Aspen/X2. These changes failed to sync to the Insights database because the discipline import code has been create-only, with no delete path. Uri confirmed that this might be the case, adding that he thought editing/deleting is rare. 

This PR uses the `RecordSyncer` class that @kevinrobinson introduced in order to remove those events that are missing from the upstream CSVs. It also changes the `BehaviorRow` model to be extremely "picky": if any data about a behavior event changes upstream, the old record is destroyed and entirely new one is created. This create/destroy should be a more reliable method than trying to detect which events are the same and updating. 

# Issue

+ Fix #1709.

# Testing and QA

+ [x] Added specs for `BehaviorImporter#import` to test deleting behavior. 
+ [x] Manually imported a small amount of behavior data locally; used the Rails console to manually edit one of the events' `description` attribute; and re-imported to test create/delete behavior: 

```
Sync stats: {
:passed_nil_record_count=>0, 
:invalid_rows_count=>0, 
:unchanged_rows_count=>1225,
:updated_rows_count=>0, 
:created_rows_count=>1,
:marked_ids_count=>1226, 
:destroyed_records_count=>1
}
```


# Checklist 

+ [x] Merge and deploy
+ [ ] Run `thor import:start --source behavior` for New Bedford and Somerville; note how many discipline incident records are deleted 