### PR TITLE
Import recent STAR events to new database tables

### DIFF
--- a/config/district_somerville.yml
+++ b/config/district_somerville.yml
@@ -8,9 +8,9 @@ remote_filenames:
   FILENAME_FOR_COURSE_SECTION_IMPORT:               /home/jbreslin/data/courses_sections_export.txt
   FILENAME_FOR_STUDENTS_SECTION_ASSIGNMENT_IMPORT:  /home/jbreslin/data/student_section_assignment_export.txt
   FILENAME_FOR_EDUCATOR_SECTION_ASSIGNMENT_IMPORT:  /home/jbreslin/data/educator_section_assignment_export.txt
-  FILENAME_FOR_STAR_READING_IMPORT:                 SR_Historical.csv   # Change this back to SR.csv after historical data is imported.
-  FILENAME_FOR_STAR_MATH_IMPORT:                    SM_Historical.csv   # Change this back to SM.csv after historical data is imported.
-  FILENAME_FOR_STAR_ZIP_FILE:                       Historical_Added_Somerville Public Schools.zip
+  FILENAME_FOR_STAR_READING_IMPORT:                 SR.csv
+  FILENAME_FOR_STAR_MATH_IMPORT:                    SM.csv
+  FILENAME_FOR_STAR_ZIP_FILE:                       Somerville Public Schools.zip
   FILENAMES_FOR_IEP_PDF_ZIPS:   # order is important here, these need to be oldest > newest
     - /home/jbreslin/data/student-documents-6.zip
     - /home/jbreslin/data/student-documents-5.zip


### PR DESCRIPTION
# What does this PR do?

Follow-on to #1957: now let's import more recent STAR data from `SM.csv` and `SR.csv` to the new STAR database tables with extra rows and database-level validation. 