### PR TITLE
Fix Capuano school roster bug

### DIFF
--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -151,7 +151,7 @@ export function prettyProgramText(programAssigned, spedPlacement) {
 export function eventNoteTypeIdForAbsenceSupportMeeting(districtKey) {
   if (districtKey === NEW_BEDFORD) return 400; // bbst
   if (districtKey === SOMERVILLE) return 300; // sst
-  
+
   return 300;
 }
 
@@ -177,10 +177,11 @@ export function takeNotesChoices(districtKey) {
 // In tables of students, what eventNoteTypeIds should be shown as columns with notes
 // about those students?
 export function studentTableEventNoteTypeIds(districtKey, schoolType) {
-  const isSomervilleOrDemo = (districtKey === SOMERVILLE || districtKey === DEMO);
-  if (isSomervilleOrDemo && schoolType === 'ESMS') return [300, 301];
-  if (isSomervilleOrDemo && schoolType === 'HS') return [300, 305, 306];
   if (districtKey === NEW_BEDFORD) return [400];
-  
-  throw new Error(`unsupported districtKey: ${districtKey}`);
+  const isSomervilleOrDemo = (districtKey === SOMERVILLE || districtKey === DEMO);
+  if (!isSomervilleOrDemo) throw new Error(`unsupported districtKey: ${districtKey}`);
+
+  if (isSomervilleOrDemo && schoolType === 'HS') return [300, 305, 306];
+  if (isSomervilleOrDemo) return [300, 301];  // Includes elementary/middle, Capuano early childhood,
+                                              // and SPED.
 }

--- a/app/assets/javascripts/helpers/PerDistrict.test.js
+++ b/app/assets/javascripts/helpers/PerDistrict.test.js
@@ -1,6 +1,7 @@
 import {
   inExperienceTeam,
-  sortSchoolSlugsByGrade
+  sortSchoolSlugsByGrade,
+  studentTableEventNoteTypeIds
 } from './PerDistrict';
 
 it('#inExperienceTeam', () => {
@@ -12,4 +13,22 @@ it('#inExperienceTeam', () => {
 it('#sortSchoolSlugsByGrade', () => {
   expect(['shs', 'whcs'].sort(sortSchoolSlugsByGrade.bind(null, 'somerville'))).toEqual(['whcs', 'shs']);
   expect(['shs', 'whcs'].sort(sortSchoolSlugsByGrade.bind(null, 'other'))).toEqual(['shs', 'whcs']);
+});
+
+describe('#studentTableEventNoteTypeIds', () => {
+  it('handles somerville HS correctly', () => {
+    const eventNoteTypeIds = studentTableEventNoteTypeIds('somerville', 'HS');
+
+    expect(eventNoteTypeIds).toEqual([300, 305, 306]);
+  });
+  it('handles somerville elementary school correctly', () => {
+    const eventNoteTypeIds = studentTableEventNoteTypeIds('somerville', 'ESMS');
+
+    expect(eventNoteTypeIds).toEqual([300, 301]);
+  });
+  it('handles somerville Capuano early childhood center correctly', () => {
+    const eventNoteTypeIds = studentTableEventNoteTypeIds('somerville', null);
+
+    expect(eventNoteTypeIds).toEqual([300, 301]);
+  });
 });


### PR DESCRIPTION
# What problem does this PR fix?

Fix broken roster page for Capuano school (CAP), Parent Information Center (PIC), SPED.

# What does this PR do?

These schools don't have a school type, i.e. they're not High Schools or Elementary/Middle School. Capuano is an Early Childhood Center.

 This case wasn't handled in `PerDistrict#studentTableEventNoteTypeIds` and led to a bug with no School roster rendering. 

# What's the fix?

Handle "unsupported district key" at the top, then handle different Somerville school type cases below and and provide default for no school type. 