### PR TITLE
Add total time to STAR chart tooltips

### DIFF
--- a/app/assets/javascripts/student_profile/ProfileChartSettings.js
+++ b/app/assets/javascripts/student_profile/ProfileChartSettings.js
@@ -3,6 +3,15 @@ import moment from 'moment';
 const ProfileChartSettings = {};
 export default ProfileChartSettings;
 
+function humanizeStarTotalTime (seconds) {
+  if (seconds < 60) return `${seconds} seconds`;
+
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+
+  return `${minutes} minutes and ${remainingSeconds} seconds`;
+}
+
 ProfileChartSettings.base_options = {
   chart: {
     renderTo: 'chart',
@@ -88,13 +97,15 @@ ProfileChartSettings.star_chart_base_options = {
       const formattedGradeEquivalent = `<br>Grade Level Equivalent: <b>${gradeLevelEquivalent}</b>`;
 
       const totalTime = this.points[0].point.totalTime;
-      const duration = moment.duration(totalTime, 'seconds').humanize();
+      const duration = humanizeStarTotalTime(totalTime, 'seconds');
       const formattedTotalTime = `<br>Time Taking Test: <b>${duration}</b>`;
 
-      return `${formattedDate}
-              ${formattedPercentileRank}
-              ${formattedTotalTime}
-              ${formattedGradeEquivalent}`;
+      return [
+        formattedDate,
+        formattedPercentileRank,
+        formattedTotalTime,
+        formattedGradeEquivalent,
+      ].join('');
     },
     shared: true
   },

--- a/app/assets/javascripts/student_profile/ProfileChartSettings.js
+++ b/app/assets/javascripts/student_profile/ProfileChartSettings.js
@@ -88,7 +88,8 @@ ProfileChartSettings.star_chart_base_options = {
       const formattedGradeEquivalent = `<br>Grade Level Equivalent: <b>${gradeLevelEquivalent}</b>`;
 
       const totalTime = this.points[0].point.totalTime;
-      const formattedTotalTime = `<br>Total Time: <b>${totalTime}</b>`;
+      const duration = moment.duration(totalTime, 'seconds').humanize();
+      const formattedTotalTime = `<br>Total Time: <b>${duration}</b>`;
 
       return `${formattedDate}
               ${formattedPercentileRank}

--- a/app/assets/javascripts/student_profile/ProfileChartSettings.js
+++ b/app/assets/javascripts/student_profile/ProfileChartSettings.js
@@ -89,7 +89,7 @@ ProfileChartSettings.star_chart_base_options = {
 
       const totalTime = this.points[0].point.totalTime;
       const duration = moment.duration(totalTime, 'seconds').humanize();
-      const formattedTotalTime = `<br>Total Time: <b>${duration}</b>`;
+      const formattedTotalTime = `<br>Time Taking Test: <b>${duration}</b>`;
 
       return `${formattedDate}
               ${formattedPercentileRank}

--- a/app/assets/javascripts/student_profile/ProfileChartSettings.js
+++ b/app/assets/javascripts/student_profile/ProfileChartSettings.js
@@ -87,9 +87,13 @@ ProfileChartSettings.star_chart_base_options = {
       const gradeLevelEquivalent = this.points[0].point.gradeLevelEquivalent;
       const formattedGradeEquivalent = `<br>Grade Level Equivalent: <b>${gradeLevelEquivalent}</b>`;
 
+      const totalTime = this.points[0].point.totalTime;
+      const formattedTotalTime = `<br>Total Time: <b>${totalTime}</b>`;
+
       return `${formattedDate}
               ${formattedPercentileRank}
-              ${gradeLevelEquivalent ? formattedGradeEquivalent : ''}`;
+              ${formattedTotalTime}
+              ${formattedGradeEquivalent}`;
     },
     shared: true
   },

--- a/app/assets/javascripts/student_profile/ProfileChartSettings.js
+++ b/app/assets/javascripts/student_profile/ProfileChartSettings.js
@@ -3,6 +3,11 @@ import moment from 'moment';
 const ProfileChartSettings = {};
 export default ProfileChartSettings;
 
+// This is meant as a more precise alternative to moment.humanize(). It's geared
+// to STAR total time values, which are mostly in minutes. (The average STAR
+// total_time for Somerville is 23 minutes and 20 seconds.)
+// See https://github.com/moment/moment/issues/348 for more on problems with
+// lack of precision in moment.humanize().
 function humanizeStarTotalTime (seconds) {
   if (seconds < 60) return `${seconds} seconds`;
 

--- a/app/assets/javascripts/student_profile/ProfileChartSettings.test.js
+++ b/app/assets/javascripts/student_profile/ProfileChartSettings.test.js
@@ -1,0 +1,50 @@
+import ProfileChartSettings from './ProfileChartSettings';
+
+describe('#star_chart_base_options tooltip formatter', () => {
+  it('works when time is in minutes', () => {
+    const formatter = ProfileChartSettings.star_chart_base_options.tooltip.formatter;
+    const data = {
+      y: 90,             // Percentile rank
+      x: 1463961600000,  // Time
+      points: [
+        {
+          point: {
+            gradeLevelEquivalent: '8.00',
+            totalTime: 1420,
+          }
+        }
+      ]
+    };
+
+    expect(formatter.bind(data)()).toEqual(
+      'May 22nd 2016, 8:00:00 pm<br/>'
+       + 'Percentile Rank: <b>90</b><br>'
+       + 'Time Taking Test: <b>23 minutes and 40 seconds</b><br>'
+       + 'Grade Level Equivalent: <b>8.00</b>'
+    );
+  });
+
+  it('works when time is less than a minute', () => {
+    const formatter = ProfileChartSettings.star_chart_base_options.tooltip.formatter;
+    const data = {
+      y: 90,             // Percentile rank
+      x: 1463961600000,  // Time
+      points: [
+        {
+          point: {
+            gradeLevelEquivalent: '8.00',
+            totalTime: 24,
+          }
+        }
+      ]
+    };
+
+    expect(formatter.bind(data)()).toEqual(
+      'May 22nd 2016, 8:00:00 pm<br/>'
+       + 'Percentile Rank: <b>90</b><br>'
+       + 'Time Taking Test: <b>24 seconds</b><br>'
+       + 'Grade Level Equivalent: <b>8.00</b>'
+    );
+  });
+});
+

--- a/app/assets/javascripts/student_profile/QuadConverter.js
+++ b/app/assets/javascripts/student_profile/QuadConverter.js
@@ -56,7 +56,8 @@ export function toStarObject(starObject) {
   return {
     x: toMomentFromRailsDateTime(date_taken).valueOf(),
     y: starObject.percentile_rank,
-    gradeLevelEquivalent: starObject.grade_level_equivalent
+    gradeLevelEquivalent: starObject.grade_equivalent,
+    totalTime: starObject.total_time,
   };
 }
 

--- a/app/assets/javascripts/student_profile/StudentProfilePage.js
+++ b/app/assets/javascripts/student_profile/StudentProfilePage.js
@@ -646,18 +646,35 @@ StudentProfilePage.propTypes = {
   transitionNotes: PropTypes.array.isRequired,
   dibels: PropTypes.array.isRequired,
   chartData: PropTypes.shape({
-    // ela
+    star_series_math_percentile: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        date_taken: PropTypes.string,
+        percentile_rank: PropTypes.number,
+        grade_equivalent: PropTypes.string,
+        total_time: PropTypes.number,
+      })
+    ),
+    star_series_reading_percentile: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        date_taken: PropTypes.string,
+        percentile_rank: PropTypes.number,
+        grade_equivalent: PropTypes.string,
+        total_time: PropTypes.number,
+      })
+    ),
+
     most_recent_star_reading_percentile: PropTypes.number,
+    most_recent_star_math_percentile: PropTypes.number,
+
     most_recent_mcas_ela_scaled: PropTypes.number,
     most_recent_mcas_ela_growth: PropTypes.number,
-    star_series_reading_percentile: PropTypes.array,
     mcas_series_ela_scaled: PropTypes.array,
     mcas_series_ela_growth: PropTypes.array,
-    // math
-    most_recent_star_math_percentile: PropTypes.number,
+
     most_recent_mcas_math_scaled: PropTypes.number,
     most_recent_mcas_math_growth: PropTypes.number,
-    star_series_math_percentile: PropTypes.array,
     mcas_series_math_scaled: PropTypes.array,
     mcas_series_math_growth: PropTypes.array
   }),

--- a/app/charts/student_profile_chart.rb
+++ b/app/charts/student_profile_chart.rb
@@ -3,7 +3,7 @@ class StudentProfileChart < Struct.new :student
   def percentile_ranks_to_highcharts(star_results)
     return nil unless star_results
 
-    star_results.select(:id, :date_taken, :percentile_rank, :grade_equivalent)
+    star_results.select(:id, :date_taken, :percentile_rank, :grade_equivalent, :total_time)
   end
 
   def interventions_to_highcharts

--- a/app/demo_data/fake_star_math_result_generator.rb
+++ b/app/demo_data/fake_star_math_result_generator.rb
@@ -12,7 +12,7 @@ class FakeStarMathResultGenerator
       percentile_rank: rand(10..99),
       grade_equivalent: ["0.00", "4.00", "5.70", "2.60"].sample,
       student_id: @student.id,
-      total_time: rand(0..120)
+      total_time: rand(1000..1800)
     }
   end
 end

--- a/app/demo_data/fake_star_reading_result_generator.rb
+++ b/app/demo_data/fake_star_reading_result_generator.rb
@@ -13,7 +13,7 @@ class FakeStarReadingResultGenerator
       grade_equivalent: ["0.00", "4.00", "5.70", "2.60"].sample,
       instructional_reading_level: @student.grade.to_f + rand(-1..1),
       student_id: @student.id,
-      total_time: rand(0..120)
+      total_time: rand(1000..1800)
     }
   end
 end


### PR DESCRIPTION
# Notes

One critical piece of context for understanding STAR data results is the time the student spent taking the test. If the student spent less than a minute, that means they quit early and the data point is essentially junk data. This is a first pass at visualizing total time along with STAR results, by adding it to the additional information displayed in the tooltip.

# Screenshot (Internet Explorer, fake data)

![virtualbox_ie11 - win7_08_08_2018_10_42_48](https://user-images.githubusercontent.com/3209501/43848157-fd36c5e8-9af7-11e8-9e33-436c5e4f56eb.png)

# Checklist 

+ [x] Checked latest commit in Internet Explorer
+ [x] Added specs for additional JS