### PR TITLE
Update profile v3 to parse new STAR data points

### DIFF
--- a/app/assets/javascripts/helpers/toMoment.test.js
+++ b/app/assets/javascripts/helpers/toMoment.test.js
@@ -19,6 +19,10 @@ describe('#toMomentFromTimestamp', () => {
     expect(toMomentFromTimestamp(string).local().format('dddd M/D, h:mma')).toEqual('Wednesday 5/9, 8:03am');
     expect(toMomentFromTimestamp(string).toDate().toLocaleTimeString()).toEqual('08:03:26');
   });
+
+  it('works on example string', () => {
+    expect(toMomentFromTimestamp('2017-01-07T02:00:00.000Z').format('dddd M/D, h:mma')).toEqual('Saturday 1/7, 2:00am');
+  });
 });
 
 

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -14,7 +14,6 @@ import LightServiceDetails from './LightServiceDetails';
 import LightNotesHelpContext from './LightNotesHelpContext';
 import StudentSectionsRoster from './StudentSectionsRoster';
 import {tags} from './lightTagger';
-import {toMoment, toValue} from './QuadConverter';
 
 
 // Prototype of profile v3
@@ -408,16 +407,16 @@ function countEventsBetween(events, startMoment, endMoment) {
 const DAYS_AGO = 45;
 
 
-function latestStar(sortedQuads, nowMoment) {
-  const quad = _.last(sortedQuads);
-  if (!quad) return {
+export function latestStar(sortedStarDataPoints, nowMoment) {
+  const starDataPoint = _.last(sortedStarDataPoints);
+  if (!starDataPoint) return {
     nDaysText: 'not yet taken',
     percentileText: '-'
   };
 
-  const testMoment = toMoment(quad);
+  const testMoment = toMomentFromTimestamp(starDataPoint.date_taken);
   const nDaysText = testMoment.from(nowMoment);
-  const percentile = toValue(quad);
+  const percentile = starDataPoint.percentile_rank;
   const percentileText = (percentile)
     ? percentileWithSuffix(percentile)
     : '-';

--- a/app/assets/javascripts/student_profile/LightProfilePage.test.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.test.js
@@ -1,0 +1,15 @@
+import {toMomentFromTimestamp} from '../helpers/toMoment';
+import {latestStar} from './LightProfilePage';
+
+
+it('#latestStar', () => {
+  const nowMoment = toMomentFromTimestamp('2018-08-13T11:03:06.123Z');
+  const starSeriesReadingPercentile = [
+    {"percentile_rank":98,"total_time":1134,"grade_equivalent":"6.90","date_taken":"2017-04-23T06:00:00.000Z"},
+    {"percentile_rank":94,"total_time":1022,"grade_equivalent":"4.80","date_taken":"2017-01-07T02:00:00.000Z"}
+  ];
+  expect(latestStar(starSeriesReadingPercentile, nowMoment)).toEqual({
+    nDaysText: '2 years ago',
+    percentileText: '94th'
+  });
+});


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
https://github.com/studentinsights/studentinsights/pull/1963 made awesome improvements to STAR data, this updates the v3 profile page to read them, since now it can't show STAR data in the header section.

# What does this PR do?
Updates to remove `QuadConverter` for new format.
