### PR TITLE
Update jest to 23.x.x

### DIFF
--- a/app/assets/javascripts/class_lists/__snapshots__/ClassListCreatorWorkflow.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ClassListCreatorWorkflow.test.js.snap
@@ -348,7 +348,6 @@ When Student Insights was being developed, some teachers started asking whether 
             </div>
             <div
               className="Select has-value is-clearable is-searchable Select--single"
-              style={undefined}
             >
               <input
                 disabled={false}
@@ -363,7 +362,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 onTouchEnd={[Function]}
                 onTouchMove={[Function]}
                 onTouchStart={[Function]}
-                style={undefined}
               >
                 <span
                   className="Select-multi-value-wrapper"
@@ -371,8 +369,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 >
                   <div
                     className="Select-value"
-                    style={undefined}
-                    title={undefined}
                   >
                     <span
                       aria-selected="true"
@@ -393,14 +389,9 @@ When Student Insights was being developed, some teachers started asking whether 
                   >
                     <input
                       aria-activedescendant="react-select-2--value"
-                      aria-describedby={undefined}
                       aria-expanded="false"
                       aria-haspopup="false"
-                      aria-label={undefined}
-                      aria-labelledby={undefined}
                       aria-owns=""
-                      className={undefined}
-                      id={undefined}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -412,7 +403,6 @@ When Student Insights was being developed, some teachers started asking whether 
                           "width": "5px",
                         }
                       }
-                      tabIndex={undefined}
                       value=""
                     />
                     <div
@@ -474,7 +464,6 @@ When Student Insights was being developed, some teachers started asking whether 
             </div>
             <div
               className="Select has-value is-clearable is-searchable Select--single"
-              style={undefined}
             >
               <input
                 disabled={false}
@@ -489,7 +478,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 onTouchEnd={[Function]}
                 onTouchMove={[Function]}
                 onTouchStart={[Function]}
-                style={undefined}
               >
                 <span
                   className="Select-multi-value-wrapper"
@@ -497,8 +485,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 >
                   <div
                     className="Select-value"
-                    style={undefined}
-                    title={undefined}
                   >
                     <span
                       aria-selected="true"
@@ -519,14 +505,9 @@ When Student Insights was being developed, some teachers started asking whether 
                   >
                     <input
                       aria-activedescendant="react-select-3--value"
-                      aria-describedby={undefined}
                       aria-expanded="false"
                       aria-haspopup="false"
-                      aria-label={undefined}
-                      aria-labelledby={undefined}
                       aria-owns=""
-                      className={undefined}
-                      id={undefined}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -538,7 +519,6 @@ When Student Insights was being developed, some teachers started asking whether 
                           "width": "5px",
                         }
                       }
-                      tabIndex={undefined}
                       value=""
                     />
                     <div
@@ -995,7 +975,6 @@ When Student Insights was being developed, some teachers started asking whether 
             </div>
             <div
               className="Select has-value is-clearable is-disabled is-searchable Select--single"
-              style={undefined}
             >
               <input
                 disabled={true}
@@ -1010,7 +989,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 onTouchEnd={[Function]}
                 onTouchMove={[Function]}
                 onTouchStart={[Function]}
-                style={undefined}
               >
                 <span
                   className="Select-multi-value-wrapper"
@@ -1018,8 +996,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 >
                   <div
                     className="Select-value"
-                    style={undefined}
-                    title={undefined}
                   >
                     <span
                       aria-selected="true"
@@ -1034,8 +1010,6 @@ When Student Insights was being developed, some teachers started asking whether 
                     aria-activedescendant="react-select-4--value"
                     aria-disabled="true"
                     aria-expanded={false}
-                    aria-label={undefined}
-                    aria-labelledby={undefined}
                     aria-owns=""
                     className="Select-input"
                     onBlur={[Function]}
@@ -1075,7 +1049,6 @@ When Student Insights was being developed, some teachers started asking whether 
             </div>
             <div
               className="Select has-value is-clearable is-disabled is-searchable Select--single"
-              style={undefined}
             >
               <input
                 disabled={true}
@@ -1090,7 +1063,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 onTouchEnd={[Function]}
                 onTouchMove={[Function]}
                 onTouchStart={[Function]}
-                style={undefined}
               >
                 <span
                   className="Select-multi-value-wrapper"
@@ -1098,8 +1070,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 >
                   <div
                     className="Select-value"
-                    style={undefined}
-                    title={undefined}
                   >
                     <span
                       aria-selected="true"
@@ -1114,8 +1084,6 @@ When Student Insights was being developed, some teachers started asking whether 
                     aria-activedescendant="react-select-5--value"
                     aria-disabled="true"
                     aria-expanded={false}
-                    aria-label={undefined}
-                    aria-labelledby={undefined}
                     aria-owns=""
                     className="Select-input"
                     onBlur={[Function]}
@@ -1534,7 +1502,6 @@ When Student Insights was being developed, some teachers started asking whether 
             </div>
             <div
               className="Select has-value is-clearable is-disabled is-searchable Select--single"
-              style={undefined}
             >
               <input
                 disabled={true}
@@ -1549,7 +1516,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 onTouchEnd={[Function]}
                 onTouchMove={[Function]}
                 onTouchStart={[Function]}
-                style={undefined}
               >
                 <span
                   className="Select-multi-value-wrapper"
@@ -1557,8 +1523,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 >
                   <div
                     className="Select-value"
-                    style={undefined}
-                    title={undefined}
                   >
                     <span
                       aria-selected="true"
@@ -1573,8 +1537,6 @@ When Student Insights was being developed, some teachers started asking whether 
                     aria-activedescendant="react-select-6--value"
                     aria-disabled="true"
                     aria-expanded={false}
-                    aria-label={undefined}
-                    aria-labelledby={undefined}
                     aria-owns=""
                     className="Select-input"
                     onBlur={[Function]}
@@ -1614,7 +1576,6 @@ When Student Insights was being developed, some teachers started asking whether 
             </div>
             <div
               className="Select has-value is-clearable is-disabled is-searchable Select--single"
-              style={undefined}
             >
               <input
                 disabled={true}
@@ -1629,7 +1590,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 onTouchEnd={[Function]}
                 onTouchMove={[Function]}
                 onTouchStart={[Function]}
-                style={undefined}
               >
                 <span
                   className="Select-multi-value-wrapper"
@@ -1637,8 +1597,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 >
                   <div
                     className="Select-value"
-                    style={undefined}
-                    title={undefined}
                   >
                     <span
                       aria-selected="true"
@@ -1653,8 +1611,6 @@ When Student Insights was being developed, some teachers started asking whether 
                     aria-activedescendant="react-select-7--value"
                     aria-disabled="true"
                     aria-expanded={false}
-                    aria-label={undefined}
-                    aria-labelledby={undefined}
                     aria-owns=""
                     className="Select-input"
                     onBlur={[Function]}
@@ -2131,7 +2087,6 @@ exports[`exportProps snapshots all placed 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -2159,8 +2114,6 @@ exports[`exportProps snapshots all placed 1`] = `
                             aria-activedescendant="react-select-12--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -2208,7 +2161,6 @@ exports[`exportProps snapshots all placed 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -2236,8 +2188,6 @@ exports[`exportProps snapshots all placed 1`] = `
                             aria-activedescendant="react-select-13--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -2285,7 +2235,6 @@ exports[`exportProps snapshots all placed 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -2313,8 +2262,6 @@ exports[`exportProps snapshots all placed 1`] = `
                             aria-activedescendant="react-select-14--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -2844,7 +2791,6 @@ exports[`exportProps snapshots moves 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -2872,8 +2818,6 @@ exports[`exportProps snapshots moves 1`] = `
                             aria-activedescendant="react-select-15--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -2921,7 +2865,6 @@ exports[`exportProps snapshots moves 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -2949,8 +2892,6 @@ exports[`exportProps snapshots moves 1`] = `
                             aria-activedescendant="react-select-16--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -2998,7 +2939,6 @@ exports[`exportProps snapshots moves 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -3026,8 +2966,6 @@ exports[`exportProps snapshots moves 1`] = `
                             aria-activedescendant="react-select-17--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -3541,7 +3479,6 @@ exports[`exportProps snapshots unplaced 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -3569,8 +3506,6 @@ exports[`exportProps snapshots unplaced 1`] = `
                             aria-activedescendant="react-select-10--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -3618,7 +3553,6 @@ exports[`exportProps snapshots unplaced 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -3646,8 +3580,6 @@ exports[`exportProps snapshots unplaced 1`] = `
                             aria-activedescendant="react-select-11--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -4175,7 +4107,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                   >
                     <div
                       className="Select has-value is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -4196,8 +4127,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                         >
                           <div
                             className="Select-value"
-                            style={undefined}
-                            title={undefined}
                           >
                             <span
                               aria-selected="true"
@@ -4212,8 +4141,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                             aria-activedescendant="react-select-18--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -4261,7 +4188,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                   >
                     <div
                       className="Select has-value is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -4282,8 +4208,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                         >
                           <div
                             className="Select-value"
-                            style={undefined}
-                            title={undefined}
                           >
                             <span
                               aria-selected="true"
@@ -4298,8 +4222,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                             aria-activedescendant="react-select-19--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -4347,7 +4269,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                   >
                     <div
                       className="Select has-value is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -4368,8 +4289,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                         >
                           <div
                             className="Select-value"
-                            style={undefined}
-                            title={undefined}
                           >
                             <span
                               aria-selected="true"
@@ -4384,8 +4303,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                             aria-activedescendant="react-select-20--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -4777,7 +4694,6 @@ exports[`makeAPlanProps 1`] = `
           </div>
           <div
             className="Select has-value is-clearable is-searchable Select--multi"
-            style={undefined}
           >
             <input
               disabled={false}
@@ -4792,7 +4708,6 @@ exports[`makeAPlanProps 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
-              style={undefined}
             >
               <span
                 className="Select-multi-value-wrapper"
@@ -4800,8 +4715,6 @@ exports[`makeAPlanProps 1`] = `
               >
                 <div
                   className="Select-value"
-                  style={undefined}
-                  title={undefined}
                 >
                   <span
                     aria-hidden="true"
@@ -4837,14 +4750,9 @@ exports[`makeAPlanProps 1`] = `
                 >
                   <input
                     aria-activedescendant="react-select-8--value"
-                    aria-describedby={undefined}
                     aria-expanded="false"
                     aria-haspopup="false"
-                    aria-label={undefined}
-                    aria-labelledby={undefined}
                     aria-owns=""
-                    className={undefined}
-                    id={undefined}
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -4856,7 +4764,6 @@ exports[`makeAPlanProps 1`] = `
                         "width": "5px",
                       }
                     }
-                    tabIndex={undefined}
                     value=""
                   />
                   <div
@@ -5403,7 +5310,6 @@ exports[`makeAPlanProps 2`] = `
           </div>
           <div
             className="Select has-value is-clearable is-disabled is-searchable Select--multi"
-            style={undefined}
           >
             <input
               disabled={true}
@@ -5418,7 +5324,6 @@ exports[`makeAPlanProps 2`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
-              style={undefined}
             >
               <span
                 className="Select-multi-value-wrapper"
@@ -5426,8 +5331,6 @@ exports[`makeAPlanProps 2`] = `
               >
                 <div
                   className="Select-value"
-                  style={undefined}
-                  title={undefined}
                 >
                   <span
                     aria-selected="true"
@@ -5447,8 +5350,6 @@ exports[`makeAPlanProps 2`] = `
                   aria-activedescendant="react-select-9--value"
                   aria-disabled="true"
                   aria-expanded={false}
-                  aria-label={undefined}
-                  aria-labelledby={undefined}
                   aria-owns=""
                   className="Select-input"
                   onBlur={[Function]}
@@ -6046,7 +5947,7 @@ exports[`shareWithPrincipalProps 1`] = `
               style={Object {}}
             >
               <button
-                onClick={[Function]}
+                onClick={[MockFunction]}
                 style={
                   Object {
                     "background": "#E5370E",

--- a/app/assets/javascripts/class_lists/__snapshots__/ClassroomStats.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ClassroomStats.test.js.snap
@@ -65,7 +65,6 @@ exports[`snapshots 1`] = `
               className="Hover"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              style={undefined}
             >
               <div
                 style={
@@ -103,7 +102,6 @@ exports[`snapshots 1`] = `
               className="Hover"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              style={undefined}
             >
               <div
                 style={
@@ -141,7 +139,6 @@ exports[`snapshots 1`] = `
               className="Hover"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              style={undefined}
             >
               <div
                 style={
@@ -179,7 +176,6 @@ exports[`snapshots 1`] = `
               className="Hover"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              style={undefined}
             >
               <div
                 style={
@@ -217,7 +213,6 @@ exports[`snapshots 1`] = `
               className="Hover"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              style={undefined}
             >
               <div
                 style={
@@ -255,7 +250,6 @@ exports[`snapshots 1`] = `
               className="Hover"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              style={undefined}
             >
               <div
                 style={
@@ -293,7 +287,6 @@ exports[`snapshots 1`] = `
               className="Hover"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              style={undefined}
             >
               <div
                 style={

--- a/app/assets/javascripts/class_lists/__snapshots__/ExportList.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ExportList.test.js.snap
@@ -348,7 +348,6 @@ When Student Insights was being developed, some teachers started asking whether 
             </div>
             <div
               className="Select has-value is-clearable is-searchable Select--single"
-              style={undefined}
             >
               <input
                 disabled={false}
@@ -363,7 +362,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 onTouchEnd={[Function]}
                 onTouchMove={[Function]}
                 onTouchStart={[Function]}
-                style={undefined}
               >
                 <span
                   className="Select-multi-value-wrapper"
@@ -371,8 +369,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 >
                   <div
                     className="Select-value"
-                    style={undefined}
-                    title={undefined}
                   >
                     <span
                       aria-selected="true"
@@ -393,14 +389,9 @@ When Student Insights was being developed, some teachers started asking whether 
                   >
                     <input
                       aria-activedescendant="react-select-2--value"
-                      aria-describedby={undefined}
                       aria-expanded="false"
                       aria-haspopup="false"
-                      aria-label={undefined}
-                      aria-labelledby={undefined}
                       aria-owns=""
-                      className={undefined}
-                      id={undefined}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -412,7 +403,6 @@ When Student Insights was being developed, some teachers started asking whether 
                           "width": "5px",
                         }
                       }
-                      tabIndex={undefined}
                       value=""
                     />
                     <div
@@ -474,7 +464,6 @@ When Student Insights was being developed, some teachers started asking whether 
             </div>
             <div
               className="Select has-value is-clearable is-searchable Select--single"
-              style={undefined}
             >
               <input
                 disabled={false}
@@ -489,7 +478,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 onTouchEnd={[Function]}
                 onTouchMove={[Function]}
                 onTouchStart={[Function]}
-                style={undefined}
               >
                 <span
                   className="Select-multi-value-wrapper"
@@ -497,8 +485,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 >
                   <div
                     className="Select-value"
-                    style={undefined}
-                    title={undefined}
                   >
                     <span
                       aria-selected="true"
@@ -519,14 +505,9 @@ When Student Insights was being developed, some teachers started asking whether 
                   >
                     <input
                       aria-activedescendant="react-select-3--value"
-                      aria-describedby={undefined}
                       aria-expanded="false"
                       aria-haspopup="false"
-                      aria-label={undefined}
-                      aria-labelledby={undefined}
                       aria-owns=""
-                      className={undefined}
-                      id={undefined}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -538,7 +519,6 @@ When Student Insights was being developed, some teachers started asking whether 
                           "width": "5px",
                         }
                       }
-                      tabIndex={undefined}
                       value=""
                     />
                     <div
@@ -995,7 +975,6 @@ When Student Insights was being developed, some teachers started asking whether 
             </div>
             <div
               className="Select has-value is-clearable is-disabled is-searchable Select--single"
-              style={undefined}
             >
               <input
                 disabled={true}
@@ -1010,7 +989,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 onTouchEnd={[Function]}
                 onTouchMove={[Function]}
                 onTouchStart={[Function]}
-                style={undefined}
               >
                 <span
                   className="Select-multi-value-wrapper"
@@ -1018,8 +996,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 >
                   <div
                     className="Select-value"
-                    style={undefined}
-                    title={undefined}
                   >
                     <span
                       aria-selected="true"
@@ -1034,8 +1010,6 @@ When Student Insights was being developed, some teachers started asking whether 
                     aria-activedescendant="react-select-4--value"
                     aria-disabled="true"
                     aria-expanded={false}
-                    aria-label={undefined}
-                    aria-labelledby={undefined}
                     aria-owns=""
                     className="Select-input"
                     onBlur={[Function]}
@@ -1075,7 +1049,6 @@ When Student Insights was being developed, some teachers started asking whether 
             </div>
             <div
               className="Select has-value is-clearable is-disabled is-searchable Select--single"
-              style={undefined}
             >
               <input
                 disabled={true}
@@ -1090,7 +1063,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 onTouchEnd={[Function]}
                 onTouchMove={[Function]}
                 onTouchStart={[Function]}
-                style={undefined}
               >
                 <span
                   className="Select-multi-value-wrapper"
@@ -1098,8 +1070,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 >
                   <div
                     className="Select-value"
-                    style={undefined}
-                    title={undefined}
                   >
                     <span
                       aria-selected="true"
@@ -1114,8 +1084,6 @@ When Student Insights was being developed, some teachers started asking whether 
                     aria-activedescendant="react-select-5--value"
                     aria-disabled="true"
                     aria-expanded={false}
-                    aria-label={undefined}
-                    aria-labelledby={undefined}
                     aria-owns=""
                     className="Select-input"
                     onBlur={[Function]}
@@ -1534,7 +1502,6 @@ When Student Insights was being developed, some teachers started asking whether 
             </div>
             <div
               className="Select has-value is-clearable is-disabled is-searchable Select--single"
-              style={undefined}
             >
               <input
                 disabled={true}
@@ -1549,7 +1516,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 onTouchEnd={[Function]}
                 onTouchMove={[Function]}
                 onTouchStart={[Function]}
-                style={undefined}
               >
                 <span
                   className="Select-multi-value-wrapper"
@@ -1557,8 +1523,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 >
                   <div
                     className="Select-value"
-                    style={undefined}
-                    title={undefined}
                   >
                     <span
                       aria-selected="true"
@@ -1573,8 +1537,6 @@ When Student Insights was being developed, some teachers started asking whether 
                     aria-activedescendant="react-select-6--value"
                     aria-disabled="true"
                     aria-expanded={false}
-                    aria-label={undefined}
-                    aria-labelledby={undefined}
                     aria-owns=""
                     className="Select-input"
                     onBlur={[Function]}
@@ -1614,7 +1576,6 @@ When Student Insights was being developed, some teachers started asking whether 
             </div>
             <div
               className="Select has-value is-clearable is-disabled is-searchable Select--single"
-              style={undefined}
             >
               <input
                 disabled={true}
@@ -1629,7 +1590,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 onTouchEnd={[Function]}
                 onTouchMove={[Function]}
                 onTouchStart={[Function]}
-                style={undefined}
               >
                 <span
                   className="Select-multi-value-wrapper"
@@ -1637,8 +1597,6 @@ When Student Insights was being developed, some teachers started asking whether 
                 >
                   <div
                     className="Select-value"
-                    style={undefined}
-                    title={undefined}
                   >
                     <span
                       aria-selected="true"
@@ -1653,8 +1611,6 @@ When Student Insights was being developed, some teachers started asking whether 
                     aria-activedescendant="react-select-7--value"
                     aria-disabled="true"
                     aria-expanded={false}
-                    aria-label={undefined}
-                    aria-labelledby={undefined}
                     aria-owns=""
                     className="Select-input"
                     onBlur={[Function]}
@@ -2131,7 +2087,6 @@ exports[`exportProps snapshots all placed 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -2159,8 +2114,6 @@ exports[`exportProps snapshots all placed 1`] = `
                             aria-activedescendant="react-select-12--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -2208,7 +2161,6 @@ exports[`exportProps snapshots all placed 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -2236,8 +2188,6 @@ exports[`exportProps snapshots all placed 1`] = `
                             aria-activedescendant="react-select-13--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -2285,7 +2235,6 @@ exports[`exportProps snapshots all placed 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -2313,8 +2262,6 @@ exports[`exportProps snapshots all placed 1`] = `
                             aria-activedescendant="react-select-14--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -2844,7 +2791,6 @@ exports[`exportProps snapshots moves 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -2872,8 +2818,6 @@ exports[`exportProps snapshots moves 1`] = `
                             aria-activedescendant="react-select-15--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -2921,7 +2865,6 @@ exports[`exportProps snapshots moves 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -2949,8 +2892,6 @@ exports[`exportProps snapshots moves 1`] = `
                             aria-activedescendant="react-select-16--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -2998,7 +2939,6 @@ exports[`exportProps snapshots moves 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -3026,8 +2966,6 @@ exports[`exportProps snapshots moves 1`] = `
                             aria-activedescendant="react-select-17--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -3541,7 +3479,6 @@ exports[`exportProps snapshots unplaced 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -3569,8 +3506,6 @@ exports[`exportProps snapshots unplaced 1`] = `
                             aria-activedescendant="react-select-10--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -3618,7 +3553,6 @@ exports[`exportProps snapshots unplaced 1`] = `
                   >
                     <div
                       className="Select is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -3646,8 +3580,6 @@ exports[`exportProps snapshots unplaced 1`] = `
                             aria-activedescendant="react-select-11--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -4175,7 +4107,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                   >
                     <div
                       className="Select has-value is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -4196,8 +4127,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                         >
                           <div
                             className="Select-value"
-                            style={undefined}
-                            title={undefined}
                           >
                             <span
                               aria-selected="true"
@@ -4212,8 +4141,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                             aria-activedescendant="react-select-18--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -4261,7 +4188,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                   >
                     <div
                       className="Select has-value is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -4282,8 +4208,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                         >
                           <div
                             className="Select-value"
-                            style={undefined}
-                            title={undefined}
                           >
                             <span
                               aria-selected="true"
@@ -4298,8 +4222,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                             aria-activedescendant="react-select-19--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -4347,7 +4269,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                   >
                     <div
                       className="Select has-value is-disabled is-searchable Select--single"
-                      style={undefined}
                     >
                       <div
                         className="Select-control"
@@ -4368,8 +4289,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                         >
                           <div
                             className="Select-value"
-                            style={undefined}
-                            title={undefined}
                           >
                             <span
                               aria-selected="true"
@@ -4384,8 +4303,6 @@ exports[`exportProps snapshots with teachers 1`] = `
                             aria-activedescendant="react-select-20--value"
                             aria-disabled="true"
                             aria-expanded={false}
-                            aria-label={undefined}
-                            aria-labelledby={undefined}
                             aria-owns=""
                             className="Select-input"
                             onBlur={[Function]}
@@ -4777,7 +4694,6 @@ exports[`makeAPlanProps 1`] = `
           </div>
           <div
             className="Select has-value is-clearable is-searchable Select--multi"
-            style={undefined}
           >
             <input
               disabled={false}
@@ -4792,7 +4708,6 @@ exports[`makeAPlanProps 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
-              style={undefined}
             >
               <span
                 className="Select-multi-value-wrapper"
@@ -4800,8 +4715,6 @@ exports[`makeAPlanProps 1`] = `
               >
                 <div
                   className="Select-value"
-                  style={undefined}
-                  title={undefined}
                 >
                   <span
                     aria-hidden="true"
@@ -4837,14 +4750,9 @@ exports[`makeAPlanProps 1`] = `
                 >
                   <input
                     aria-activedescendant="react-select-8--value"
-                    aria-describedby={undefined}
                     aria-expanded="false"
                     aria-haspopup="false"
-                    aria-label={undefined}
-                    aria-labelledby={undefined}
                     aria-owns=""
-                    className={undefined}
-                    id={undefined}
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -4856,7 +4764,6 @@ exports[`makeAPlanProps 1`] = `
                         "width": "5px",
                       }
                     }
-                    tabIndex={undefined}
                     value=""
                   />
                   <div
@@ -5403,7 +5310,6 @@ exports[`makeAPlanProps 2`] = `
           </div>
           <div
             className="Select has-value is-clearable is-disabled is-searchable Select--multi"
-            style={undefined}
           >
             <input
               disabled={true}
@@ -5418,7 +5324,6 @@ exports[`makeAPlanProps 2`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
-              style={undefined}
             >
               <span
                 className="Select-multi-value-wrapper"
@@ -5426,8 +5331,6 @@ exports[`makeAPlanProps 2`] = `
               >
                 <div
                   className="Select-value"
-                  style={undefined}
-                  title={undefined}
                 >
                   <span
                     aria-selected="true"
@@ -5447,8 +5350,6 @@ exports[`makeAPlanProps 2`] = `
                   aria-activedescendant="react-select-9--value"
                   aria-disabled="true"
                   aria-expanded={false}
-                  aria-label={undefined}
-                  aria-labelledby={undefined}
                   aria-owns=""
                   className="Select-input"
                   onBlur={[Function]}
@@ -6046,7 +5947,7 @@ exports[`shareWithPrincipalProps 1`] = `
               style={Object {}}
             >
               <button
-                onClick={[Function]}
+                onClick={[MockFunction]}
                 style={
                   Object {
                     "background": "#E5370E",
@@ -6612,9 +6513,7 @@ exports[`snapshots 1`] = `
 <div
   className="ExportList"
 >
-  <div
-    style={undefined}
-  >
+  <div>
     Have all students been placed for next year's 
     1st grade
     ?
@@ -6641,9 +6540,7 @@ exports[`snapshots 1`] = `
       All students have been placed.
     </span>
   </div>
-  <div
-    style={undefined}
-  >
+  <div>
     Have you reviewed the team's plan and notes before making changes?
   </div>
   <div
@@ -6668,9 +6565,7 @@ exports[`snapshots 1`] = `
       No students were moved.
     </span>
   </div>
-  <div
-    style={undefined}
-  >
+  <div>
     Who will teach next year's 
     1st grade
     ?
@@ -6704,7 +6599,6 @@ exports[`snapshots 1`] = `
           >
             <div
               className="Select has-value is-disabled is-searchable Select--single"
-              style={undefined}
             >
               <div
                 className="Select-control"
@@ -6725,8 +6619,6 @@ exports[`snapshots 1`] = `
                 >
                   <div
                     className="Select-value"
-                    style={undefined}
-                    title={undefined}
                   >
                     <span
                       aria-selected="true"
@@ -6741,8 +6633,6 @@ exports[`snapshots 1`] = `
                     aria-activedescendant="react-select-24--value"
                     aria-disabled="true"
                     aria-expanded={false}
-                    aria-label={undefined}
-                    aria-labelledby={undefined}
                     aria-owns=""
                     className="Select-input"
                     onBlur={[Function]}
@@ -6790,7 +6680,6 @@ exports[`snapshots 1`] = `
           >
             <div
               className="Select has-value is-disabled is-searchable Select--single"
-              style={undefined}
             >
               <div
                 className="Select-control"
@@ -6811,8 +6700,6 @@ exports[`snapshots 1`] = `
                 >
                   <div
                     className="Select-value"
-                    style={undefined}
-                    title={undefined}
                   >
                     <span
                       aria-selected="true"
@@ -6827,8 +6714,6 @@ exports[`snapshots 1`] = `
                     aria-activedescendant="react-select-25--value"
                     aria-disabled="true"
                     aria-expanded={false}
-                    aria-label={undefined}
-                    aria-labelledby={undefined}
                     aria-owns=""
                     className="Select-input"
                     onBlur={[Function]}
@@ -6876,7 +6761,6 @@ exports[`snapshots 1`] = `
           >
             <div
               className="Select has-value is-disabled is-searchable Select--single"
-              style={undefined}
             >
               <div
                 className="Select-control"
@@ -6897,8 +6781,6 @@ exports[`snapshots 1`] = `
                 >
                   <div
                     className="Select-value"
-                    style={undefined}
-                    title={undefined}
                   >
                     <span
                       aria-selected="true"
@@ -6913,8 +6795,6 @@ exports[`snapshots 1`] = `
                     aria-activedescendant="react-select-26--value"
                     aria-disabled="true"
                     aria-expanded={false}
-                    aria-label={undefined}
-                    aria-labelledby={undefined}
                     aria-owns=""
                     className="Select-input"
                     onBlur={[Function]}

--- a/app/assets/javascripts/my_students/__snapshots__/FilterStudentsBar.test.js.snap
+++ b/app/assets/javascripts/my_students/__snapshots__/FilterStudentsBar.test.js.snap
@@ -4,11 +4,9 @@ exports[`snapshots with all options 1`] = `
 <div
   className="FilterStudentsBar EscapeListener"
   onKeyUp={[Function]}
-  style={undefined}
 >
   <div
     className="FilterBar"
-    style={undefined}
   >
     <div
       style={
@@ -47,7 +45,6 @@ exports[`snapshots with all options 1`] = `
       />
       <div
         className="Select is-searchable Select--single"
-        style={undefined}
       >
         <div
           className="Select-control"
@@ -82,14 +79,9 @@ exports[`snapshots with all options 1`] = `
             >
               <input
                 aria-activedescendant="react-select-14--value"
-                aria-describedby={undefined}
                 aria-expanded="false"
                 aria-haspopup="false"
-                aria-label={undefined}
-                aria-labelledby={undefined}
                 aria-owns=""
-                className={undefined}
-                id={undefined}
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -101,7 +93,6 @@ exports[`snapshots with all options 1`] = `
                     "width": "5px",
                   }
                 }
-                tabIndex={undefined}
                 value=""
               />
               <div
@@ -134,7 +125,6 @@ exports[`snapshots with all options 1`] = `
       </div>
       <div
         className="Select is-searchable Select--single"
-        style={undefined}
       >
         <div
           className="Select-control"
@@ -169,14 +159,9 @@ exports[`snapshots with all options 1`] = `
             >
               <input
                 aria-activedescendant="react-select-15--value"
-                aria-describedby={undefined}
                 aria-expanded="false"
                 aria-haspopup="false"
-                aria-label={undefined}
-                aria-labelledby={undefined}
                 aria-owns=""
-                className={undefined}
-                id={undefined}
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -188,7 +173,6 @@ exports[`snapshots with all options 1`] = `
                     "width": "5px",
                   }
                 }
-                tabIndex={undefined}
                 value=""
               />
               <div
@@ -221,7 +205,6 @@ exports[`snapshots with all options 1`] = `
       </div>
       <div
         className="Select is-searchable Select--single"
-        style={undefined}
       >
         <div
           className="Select-control"
@@ -256,14 +239,9 @@ exports[`snapshots with all options 1`] = `
             >
               <input
                 aria-activedescendant="react-select-16--value"
-                aria-describedby={undefined}
                 aria-expanded="false"
                 aria-haspopup="false"
-                aria-label={undefined}
-                aria-labelledby={undefined}
                 aria-owns=""
-                className={undefined}
-                id={undefined}
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -275,7 +253,6 @@ exports[`snapshots with all options 1`] = `
                     "width": "5px",
                   }
                 }
-                tabIndex={undefined}
                 value=""
               />
               <div
@@ -315,11 +292,9 @@ exports[`snapshots without options 1`] = `
 <div
   className="FilterStudentsBar EscapeListener"
   onKeyUp={[Function]}
-  style={undefined}
 >
   <div
     className="FilterBar"
-    style={undefined}
   >
     <div
       style={
@@ -358,7 +333,6 @@ exports[`snapshots without options 1`] = `
       />
       <div
         className="Select is-searchable Select--single"
-        style={undefined}
       >
         <div
           className="Select-control"
@@ -393,14 +367,9 @@ exports[`snapshots without options 1`] = `
             >
               <input
                 aria-activedescendant="react-select-17--value"
-                aria-describedby={undefined}
                 aria-expanded="false"
                 aria-haspopup="false"
-                aria-label={undefined}
-                aria-labelledby={undefined}
                 aria-owns=""
-                className={undefined}
-                id={undefined}
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -412,7 +381,6 @@ exports[`snapshots without options 1`] = `
                     "width": "5px",
                   }
                 }
-                tabIndex={undefined}
                 value=""
               />
               <div

--- a/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
@@ -174,7 +174,6 @@ exports[`snapshots works for aladdin 1`] = `
             "paddingRight": 44,
           }
         }
-        width={undefined}
       />
     </div>
   </div>
@@ -2835,7 +2834,6 @@ exports[`snapshots works for olaf 1`] = `
             "paddingRight": 44,
           }
         }
-        width={undefined}
       />
     </div>
   </div>
@@ -5298,7 +5296,6 @@ exports[`snapshots works for pluto 1`] = `
             "paddingRight": 44,
           }
         }
-        width={undefined}
       />
     </div>
   </div>

--- a/app/assets/javascripts/student_profile/__snapshots__/TransitionNotes.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/TransitionNotes.test.js.snap
@@ -38,7 +38,6 @@ exports[`snapshots view 1`] = `
     </div>
     <textarea
       onChange={[Function]}
-      readOnly={undefined}
       rows={10}
       style={
         Object {
@@ -96,7 +95,6 @@ Any additional comments or good things to know about this student?"
     </div>
     <textarea
       onChange={[Function]}
-      readOnly={undefined}
       rows={10}
       style={
         Object {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "enzyme-adapter-react-15.4": "^1.0.5",
     "eslint": "^3.3.1",
     "eslint-plugin-react": "^6.1.2",
-    "jest": "^21.2.1",
+    "jest": "^23.0.0",
     "react-addons-test-utils": "15.4.2",
     "script-loader": "^0.7.2",
     "style-loader": "^0.20.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,20 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0-beta.35":
+  version "7.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-rc.1.tgz#5c2154415d6c09959a71845ef519d11157e95d10"
+  dependencies:
+    "@babel/highlight" "7.0.0-rc.1"
+
+"@babel/highlight@7.0.0-rc.1":
+  version "7.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-rc.1.tgz#e0ca4731fa4786f7b9500421d6ff5e5a7753e81e"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
 "@storybook/addon-actions@3.4.6", "@storybook/addon-actions@^3.4.3":
   version "3.4.6"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.4.6.tgz#70ca84a4754ea2969640428890d9a3c9369261f6"
@@ -206,9 +220,13 @@
   version "10.1.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.1.4.tgz#606651d3f8a8bec08b8cb262161aab9209f4a29d"
 
-abab@^1.0.3:
+abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
+
+abab@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
 
 abbrev@1:
   version "1.1.1"
@@ -227,11 +245,11 @@ acorn-dynamic-import@^2.0.0:
   dependencies:
     acorn "^4.0.3"
 
-acorn-globals@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
+acorn-globals@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.1.0.tgz#ab716025dbe17c54d3ef81d32ece2b2d99fe2538"
   dependencies:
-    acorn "^4.0.4"
+    acorn "^5.0.0"
 
 acorn-jsx@^3.0.0:
   version "3.0.1"
@@ -243,13 +261,17 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^4.0.3, acorn@^4.0.4:
+acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
 acorn@^5.0.0, acorn@^5.5.0:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
+
+acorn@^5.5.3:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
 add-dom-event-listener@1.x:
   version "1.0.2"
@@ -295,7 +317,7 @@ ajv@^4.7.0:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.0.0, ajv@^5.1.0:
+ajv@^5.0.0, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -548,6 +570,10 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
+
 async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -592,9 +618,9 @@ aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
 
-aws4@^1.6.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
+aws4@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
 babel-code-frame@6.26.0, babel-code-frame@^6.16.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -802,6 +828,13 @@ babel-jest@^21.2.0:
     babel-plugin-istanbul "^4.0.0"
     babel-preset-jest "^21.2.0"
 
+babel-jest@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.4.2.tgz#f276de67798a5d68f2d6e87ff518c2f6e1609877"
+  dependencies:
+    babel-plugin-istanbul "^4.1.6"
+    babel-preset-jest "^23.2.0"
+
 babel-loader@^7.1.2, babel-loader@^7.1.4:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.4.tgz#e3463938bd4e6d55d1c174c5485d406a188ed015"
@@ -830,7 +863,7 @@ babel-plugin-dynamic-import-node@1.1.0:
     babel-template "^6.26.0"
     babel-types "^6.26.0"
 
-babel-plugin-istanbul@^4.0.0:
+babel-plugin-istanbul@^4.0.0, babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
   dependencies:
@@ -842,6 +875,10 @@ babel-plugin-istanbul@^4.0.0:
 babel-plugin-jest-hoist@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz#2cef637259bd4b628a6cace039de5fcd14dbb006"
+
+babel-plugin-jest-hoist@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
 
 babel-plugin-macros@^2.2.0:
   version "2.2.1"
@@ -1424,6 +1461,13 @@ babel-preset-jest@^21.2.0:
     babel-plugin-jest-hoist "^21.2.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
+babel-preset-jest@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
+  dependencies:
+    babel-plugin-jest-hoist "^23.2.0"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+
 babel-preset-minify@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/babel-preset-minify/-/babel-preset-minify-0.3.0.tgz#7db64afa75f16f6e06c0aa5f25195f6f36784d77"
@@ -1545,7 +1589,7 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -1559,7 +1603,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -1683,9 +1727,13 @@ brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
 
-browser-resolve@^1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
+browser-process-hrtime@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
+
+browser-resolve@^1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
   dependencies:
     resolve "1.1.7"
 
@@ -2050,6 +2098,14 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+cliui@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+    wrap-ansi "^2.0.0"
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -2115,7 +2171,7 @@ colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
-combined-stream@1.0.6, combined-stream@~1.0.5:
+combined-stream@1.0.6, combined-stream@~1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
@@ -2216,10 +2272,6 @@ constants-browserify@^1.0.0:
 content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
-
-content-type-parser@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.2.tgz#caabe80623e63638b2502fd4c7f12ff4ce2352e7"
 
 content-type@~1.0.4:
   version "1.0.4"
@@ -2455,9 +2507,9 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
 
-"cssstyle@>= 0.2.37 < 0.3.0":
-  version "0.2.37"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
+cssstyle@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.0.0.tgz#79b16d51ec5591faec60e688891f15d2a5705129"
   dependencies:
     cssom "0.3.x"
 
@@ -2484,6 +2536,14 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+data-urls@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.0.0.tgz#24802de4e81c298ea8a9388bb0d8e461c774684f"
+  dependencies:
+    abab "^1.0.4"
+    whatwg-mimetype "^2.0.0"
+    whatwg-url "^6.4.0"
 
 date-fns@^1.23.0:
   version "1.29.0"
@@ -2610,6 +2670,10 @@ detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
+detect-newline@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+
 detect-port-alt@1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/detect-port-alt/-/detect-port-alt-1.1.6.tgz#24707deabe932d4a3cf621302027c2b266568275"
@@ -2682,6 +2746,12 @@ domelementtype@1, domelementtype@^1.3.0:
 domelementtype@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
+
+domexception@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+  dependencies:
+    webidl-conversions "^4.0.2"
 
 domhandler@2.1:
   version "2.1.0"
@@ -2948,9 +3018,9 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-escodegen@^1.6.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.1.tgz#dbae17ef96c8e4bedb1356f4504fa4cc2f7cb7e2"
+escodegen@^1.9.1:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.0.tgz#b27a9389481d5bfd5bec76f7bb1eb3f8f4556589"
   dependencies:
     esprima "^3.1.3"
     estraverse "^4.2.0"
@@ -3115,6 +3185,10 @@ exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
+exit@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -3145,16 +3219,16 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-expect@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-21.2.1.tgz#003ac2ac7005c3c29e73b38a272d4afadd6d1d7b"
+expect@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-23.5.0.tgz#18999a0eef8f8acf99023fde766d9c323c2562ed"
   dependencies:
     ansi-styles "^3.2.0"
-    jest-diff "^21.2.1"
-    jest-get-type "^21.2.0"
-    jest-matcher-utils "^21.2.1"
-    jest-message-util "^21.2.1"
-    jest-regex-util "^21.2.0"
+    jest-diff "^23.5.0"
+    jest-get-type "^22.1.0"
+    jest-matcher-utils "^23.5.0"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
 
 express@^4.16.3:
   version "4.16.3"
@@ -3208,9 +3282,9 @@ extend@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
 
-extend@~3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
 external-editor@^2.0.4:
   version "2.2.0"
@@ -3431,7 +3505,7 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@~2.3.1:
+form-data@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   dependencies:
@@ -3679,11 +3753,11 @@ har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
 
-har-validator@~5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
+har-validator@~5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.0.tgz#44657f5688a22cfd4b72486e81b3a3fb11742c29"
   dependencies:
-    ajv "^5.1.0"
+    ajv "^5.3.0"
     har-schema "^2.0.0"
 
 has-ansi@^0.1.0:
@@ -3824,7 +3898,7 @@ html-element-attributes@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/html-element-attributes/-/html-element-attributes-1.3.1.tgz#9fa6a2e37e6b61790a303e87ddbbb9746e8c035f"
 
-html-encoding-sniffer@^1.0.1:
+html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
@@ -3933,7 +4007,7 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.23, iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   dependencies:
@@ -3970,6 +4044,13 @@ ignore@^3.2.0:
 immutable@^3.8.1:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+
+import-local@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
+  dependencies:
+    pkg-dir "^2.0.0"
+    resolve-cwd "^2.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -4057,7 +4138,7 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.0.0, invariant@^2.2.1, invariant@^2.2.2:
+invariant@^2.0.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -4208,6 +4289,10 @@ is-fullwidth-code-point@^2.0.0:
 is-function@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
+
+is-generator-fn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-1.0.0.tgz#969d49e1bb3329f6bb7f09089be26578b2ddd46a"
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -4394,9 +4479,9 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-istanbul-api@^1.1.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.3.2.tgz#b2cfe6d15ae6a28ee282e7a823b8e9faa235e6cf"
+istanbul-api@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.3.1.tgz#4c3b05d18c0016d1022e079b98dc82c40f488954"
   dependencies:
     async "^2.1.4"
     compare-versions "^3.1.0"
@@ -4406,12 +4491,12 @@ istanbul-api@^1.1.1:
     istanbul-lib-instrument "^1.10.1"
     istanbul-lib-report "^1.1.4"
     istanbul-lib-source-maps "^1.2.4"
-    istanbul-reports "^1.4.0"
+    istanbul-reports "^1.3.0"
     js-yaml "^3.7.0"
     mkdirp "^0.5.1"
     once "^1.4.0"
 
-istanbul-lib-coverage@^1.0.1, istanbul-lib-coverage@^1.2.0:
+istanbul-lib-coverage@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
 
@@ -4421,7 +4506,7 @@ istanbul-lib-hook@^1.2.0:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.4.2:
+istanbul-lib-instrument@^1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
   dependencies:
@@ -4442,7 +4527,7 @@ istanbul-lib-report@^1.1.4:
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
-istanbul-lib-source-maps@^1.1.0, istanbul-lib-source-maps@^1.2.4:
+istanbul-lib-source-maps@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz#cc7ccad61629f4efff8e2f78adb8c522c9976ec7"
   dependencies:
@@ -4452,95 +4537,114 @@ istanbul-lib-source-maps@^1.1.0, istanbul-lib-source-maps@^1.2.4:
     rimraf "^2.6.1"
     source-map "^0.5.3"
 
-istanbul-reports@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.4.0.tgz#3d7b44b912ecbe7652a603662b962120739646a1"
+istanbul-reports@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.3.0.tgz#2f322e81e1d9520767597dca3c20a0cce89a3554"
   dependencies:
     handlebars "^4.0.3"
 
-jest-changed-files@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-21.2.0.tgz#5dbeecad42f5d88b482334902ce1cba6d9798d29"
+jest-changed-files@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.4.2.tgz#1eed688370cd5eebafe4ae93d34bb3b64968fe83"
   dependencies:
     throat "^4.0.0"
 
-jest-cli@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-21.2.1.tgz#9c528b6629d651911138d228bdb033c157ec8c00"
+jest-cli@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.5.0.tgz#d316b8e34a38a610a1efc4f0403d8ef8a55e4492"
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
+    exit "^0.1.2"
     glob "^7.1.2"
     graceful-fs "^4.1.11"
+    import-local "^1.0.0"
     is-ci "^1.0.10"
-    istanbul-api "^1.1.1"
-    istanbul-lib-coverage "^1.0.1"
-    istanbul-lib-instrument "^1.4.2"
-    istanbul-lib-source-maps "^1.1.0"
-    jest-changed-files "^21.2.0"
-    jest-config "^21.2.1"
-    jest-environment-jsdom "^21.2.1"
-    jest-haste-map "^21.2.0"
-    jest-message-util "^21.2.1"
-    jest-regex-util "^21.2.0"
-    jest-resolve-dependencies "^21.2.0"
-    jest-runner "^21.2.1"
-    jest-runtime "^21.2.1"
-    jest-snapshot "^21.2.1"
-    jest-util "^21.2.1"
+    istanbul-api "^1.3.1"
+    istanbul-lib-coverage "^1.2.0"
+    istanbul-lib-instrument "^1.10.1"
+    istanbul-lib-source-maps "^1.2.4"
+    jest-changed-files "^23.4.2"
+    jest-config "^23.5.0"
+    jest-environment-jsdom "^23.4.0"
+    jest-get-type "^22.1.0"
+    jest-haste-map "^23.5.0"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve-dependencies "^23.5.0"
+    jest-runner "^23.5.0"
+    jest-runtime "^23.5.0"
+    jest-snapshot "^23.5.0"
+    jest-util "^23.4.0"
+    jest-validate "^23.5.0"
+    jest-watcher "^23.4.0"
+    jest-worker "^23.2.0"
     micromatch "^2.3.11"
-    node-notifier "^5.0.2"
-    pify "^3.0.0"
+    node-notifier "^5.2.1"
+    prompts "^0.1.9"
+    realpath-native "^1.0.0"
+    rimraf "^2.5.4"
     slash "^1.0.0"
     string-length "^2.0.0"
     strip-ansi "^4.0.0"
     which "^1.2.12"
-    worker-farm "^1.3.1"
-    yargs "^9.0.0"
+    yargs "^11.0.0"
 
-jest-config@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-21.2.1.tgz#c7586c79ead0bcc1f38c401e55f964f13bf2a480"
+jest-config@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.5.0.tgz#3770fba03f7507ee15f3b8867c742e48f31a9773"
   dependencies:
+    babel-core "^6.0.0"
+    babel-jest "^23.4.2"
     chalk "^2.0.1"
     glob "^7.1.1"
-    jest-environment-jsdom "^21.2.1"
-    jest-environment-node "^21.2.1"
-    jest-get-type "^21.2.0"
-    jest-jasmine2 "^21.2.1"
-    jest-regex-util "^21.2.0"
-    jest-resolve "^21.2.0"
-    jest-util "^21.2.1"
-    jest-validate "^21.2.1"
-    pretty-format "^21.2.1"
+    jest-environment-jsdom "^23.4.0"
+    jest-environment-node "^23.4.0"
+    jest-get-type "^22.1.0"
+    jest-jasmine2 "^23.5.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve "^23.5.0"
+    jest-util "^23.4.0"
+    jest-validate "^23.5.0"
+    micromatch "^2.3.11"
+    pretty-format "^23.5.0"
 
-jest-diff@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-21.2.1.tgz#46cccb6cab2d02ce98bc314011764bb95b065b4f"
+jest-diff@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.5.0.tgz#250651a433dd0050290a07642946cc9baaf06fba"
   dependencies:
     chalk "^2.0.1"
     diff "^3.2.0"
-    jest-get-type "^21.2.0"
-    pretty-format "^21.2.1"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.5.0"
 
-jest-docblock@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
-
-jest-environment-jsdom@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz#38d9980c8259b2a608ec232deee6289a60d9d5b4"
+jest-docblock@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.2.0.tgz#f085e1f18548d99fdd69b20207e6fd55d91383a7"
   dependencies:
-    jest-mock "^21.2.0"
-    jest-util "^21.2.1"
-    jsdom "^9.12.0"
+    detect-newline "^2.1.0"
 
-jest-environment-node@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-21.2.1.tgz#98c67df5663c7fbe20f6e792ac2272c740d3b8c8"
+jest-each@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.5.0.tgz#77f7e2afe6132a80954b920006e78239862b10ba"
   dependencies:
-    jest-mock "^21.2.0"
-    jest-util "^21.2.1"
+    chalk "^2.0.1"
+    pretty-format "^23.5.0"
+
+jest-environment-jsdom@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz#056a7952b3fea513ac62a140a2c368c79d9e6023"
+  dependencies:
+    jest-mock "^23.2.0"
+    jest-util "^23.4.0"
+    jsdom "^11.5.1"
+
+jest-environment-node@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.4.0.tgz#57e80ed0841dea303167cce8cd79521debafde10"
+  dependencies:
+    jest-mock "^23.2.0"
+    jest-util "^23.4.0"
 
 jest-fetch-mock@^1.4.2:
   version "1.6.2"
@@ -4549,146 +4653,192 @@ jest-fetch-mock@^1.4.2:
     isomorphic-fetch "^2.2.1"
     promise-polyfill "^7.1.1"
 
-jest-get-type@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
+jest-get-type@^22.1.0:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
 
-jest-haste-map@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-21.2.0.tgz#1363f0a8bb4338f24f001806571eff7a4b2ff3d8"
+jest-haste-map@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.5.0.tgz#d4ca618188bd38caa6cb20349ce6610e194a8065"
   dependencies:
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.11"
-    jest-docblock "^21.2.0"
+    invariant "^2.2.4"
+    jest-docblock "^23.2.0"
+    jest-serializer "^23.0.1"
+    jest-worker "^23.2.0"
     micromatch "^2.3.11"
     sane "^2.0.0"
-    worker-farm "^1.3.1"
 
-jest-jasmine2@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz#9cc6fc108accfa97efebce10c4308548a4ea7592"
+jest-jasmine2@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.5.0.tgz#05fe7f1788e650eeb5a03929e6461ea2e9f3db53"
+  dependencies:
+    babel-traverse "^6.0.0"
+    chalk "^2.0.1"
+    co "^4.6.0"
+    expect "^23.5.0"
+    is-generator-fn "^1.0.0"
+    jest-diff "^23.5.0"
+    jest-each "^23.5.0"
+    jest-matcher-utils "^23.5.0"
+    jest-message-util "^23.4.0"
+    jest-snapshot "^23.5.0"
+    jest-util "^23.4.0"
+    pretty-format "^23.5.0"
+
+jest-leak-detector@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.5.0.tgz#14ac2a785bd625160a2ea968fd5d98b7dcea3e64"
+  dependencies:
+    pretty-format "^23.5.0"
+
+jest-matcher-utils@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.5.0.tgz#0e2ea67744cab78c9ab15011c4d888bdd3e49e2a"
   dependencies:
     chalk "^2.0.1"
-    expect "^21.2.1"
-    graceful-fs "^4.1.11"
-    jest-diff "^21.2.1"
-    jest-matcher-utils "^21.2.1"
-    jest-message-util "^21.2.1"
-    jest-snapshot "^21.2.1"
-    p-cancelable "^0.3.0"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.5.0"
 
-jest-matcher-utils@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz#72c826eaba41a093ac2b4565f865eb8475de0f64"
+jest-message-util@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-23.4.0.tgz#17610c50942349508d01a3d1e0bda2c079086a9f"
   dependencies:
-    chalk "^2.0.1"
-    jest-get-type "^21.2.0"
-    pretty-format "^21.2.1"
-
-jest-message-util@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-21.2.1.tgz#bfe5d4692c84c827d1dcf41823795558f0a1acbe"
-  dependencies:
+    "@babel/code-frame" "^7.0.0-beta.35"
     chalk "^2.0.1"
     micromatch "^2.3.11"
     slash "^1.0.0"
+    stack-utils "^1.0.1"
 
-jest-mock@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-21.2.0.tgz#7eb0770e7317968165f61ea2a7281131534b3c0f"
+jest-mock@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
 
-jest-regex-util@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-21.2.0.tgz#1b1e33e63143babc3e0f2e6c9b5ba1eb34b2d530"
+jest-regex-util@^23.3.0:
+  version "23.3.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.3.0.tgz#5f86729547c2785c4002ceaa8f849fe8ca471bc5"
 
-jest-resolve-dependencies@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz#9e231e371e1a736a1ad4e4b9a843bc72bfe03d09"
+jest-resolve-dependencies@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.5.0.tgz#10c4d135beb9d2256de1fedc7094916c3ad74af7"
   dependencies:
-    jest-regex-util "^21.2.0"
+    jest-regex-util "^23.3.0"
+    jest-snapshot "^23.5.0"
 
-jest-resolve@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-21.2.0.tgz#068913ad2ba6a20218e5fd32471f3874005de3a6"
+jest-resolve@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.5.0.tgz#3b8e7f67e84598f0caf63d1530bd8534a189d0e6"
   dependencies:
-    browser-resolve "^1.11.2"
+    browser-resolve "^1.11.3"
     chalk "^2.0.1"
-    is-builtin-module "^1.0.0"
+    realpath-native "^1.0.0"
 
-jest-runner@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-21.2.1.tgz#194732e3e518bfb3d7cbfc0fd5871246c7e1a467"
+jest-runner@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.5.0.tgz#570f7a044da91648b5bb9b6baacdd511076c71d7"
   dependencies:
-    jest-config "^21.2.1"
-    jest-docblock "^21.2.0"
-    jest-haste-map "^21.2.0"
-    jest-jasmine2 "^21.2.1"
-    jest-message-util "^21.2.1"
-    jest-runtime "^21.2.1"
-    jest-util "^21.2.1"
-    pify "^3.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.1.11"
+    jest-config "^23.5.0"
+    jest-docblock "^23.2.0"
+    jest-haste-map "^23.5.0"
+    jest-jasmine2 "^23.5.0"
+    jest-leak-detector "^23.5.0"
+    jest-message-util "^23.4.0"
+    jest-runtime "^23.5.0"
+    jest-util "^23.4.0"
+    jest-worker "^23.2.0"
+    source-map-support "^0.5.6"
     throat "^4.0.0"
-    worker-farm "^1.3.1"
 
-jest-runtime@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-21.2.1.tgz#99dce15309c670442eee2ebe1ff53a3cbdbbb73e"
+jest-runtime@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.5.0.tgz#eb503525a196dc32f2f9974e3482d26bdf7b63ce"
   dependencies:
     babel-core "^6.0.0"
-    babel-jest "^21.2.0"
-    babel-plugin-istanbul "^4.0.0"
+    babel-plugin-istanbul "^4.1.6"
     chalk "^2.0.1"
     convert-source-map "^1.4.0"
+    exit "^0.1.2"
+    fast-json-stable-stringify "^2.0.0"
     graceful-fs "^4.1.11"
-    jest-config "^21.2.1"
-    jest-haste-map "^21.2.0"
-    jest-regex-util "^21.2.0"
-    jest-resolve "^21.2.0"
-    jest-util "^21.2.1"
-    json-stable-stringify "^1.0.1"
+    jest-config "^23.5.0"
+    jest-haste-map "^23.5.0"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve "^23.5.0"
+    jest-snapshot "^23.5.0"
+    jest-util "^23.4.0"
+    jest-validate "^23.5.0"
     micromatch "^2.3.11"
+    realpath-native "^1.0.0"
     slash "^1.0.0"
     strip-bom "3.0.0"
     write-file-atomic "^2.1.0"
-    yargs "^9.0.0"
+    yargs "^11.0.0"
 
-jest-snapshot@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-21.2.1.tgz#29e49f16202416e47343e757e5eff948c07fd7b0"
+jest-serializer@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.1.tgz#a3776aeb311e90fe83fab9e533e85102bd164165"
+
+jest-snapshot@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-23.5.0.tgz#cc368ebd8513e1175e2a7277f37a801b7358ae79"
   dependencies:
+    babel-types "^6.0.0"
     chalk "^2.0.1"
-    jest-diff "^21.2.1"
-    jest-matcher-utils "^21.2.1"
+    jest-diff "^23.5.0"
+    jest-matcher-utils "^23.5.0"
+    jest-message-util "^23.4.0"
+    jest-resolve "^23.5.0"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    pretty-format "^21.2.1"
+    pretty-format "^23.5.0"
+    semver "^5.5.0"
 
-jest-util@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-21.2.1.tgz#a274b2f726b0897494d694a6c3d6a61ab819bb78"
+jest-util@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.4.0.tgz#4d063cb927baf0a23831ff61bec2cbbf49793561"
   dependencies:
     callsites "^2.0.0"
     chalk "^2.0.1"
     graceful-fs "^4.1.11"
-    jest-message-util "^21.2.1"
-    jest-mock "^21.2.0"
-    jest-validate "^21.2.1"
+    is-ci "^1.0.10"
+    jest-message-util "^23.4.0"
     mkdirp "^0.5.1"
+    slash "^1.0.0"
+    source-map "^0.6.0"
 
-jest-validate@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.2.1.tgz#cc0cbca653cd54937ba4f2a111796774530dd3c7"
+jest-validate@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.5.0.tgz#f5df8f761cf43155e1b2e21d6e9de8a2852d0231"
   dependencies:
     chalk "^2.0.1"
-    jest-get-type "^21.2.0"
+    jest-get-type "^22.1.0"
     leven "^2.1.0"
-    pretty-format "^21.2.1"
+    pretty-format "^23.5.0"
 
-jest@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-21.2.1.tgz#c964e0b47383768a1438e3ccf3c3d470327604e1"
+jest-watcher@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-23.4.0.tgz#d2e28ce74f8dad6c6afc922b92cabef6ed05c91c"
   dependencies:
-    jest-cli "^21.2.1"
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    string-length "^2.0.0"
+
+jest-worker@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.2.0.tgz#faf706a8da36fae60eb26957257fa7b5d8ea02b9"
+  dependencies:
+    merge-stream "^1.0.1"
+
+jest@^23.0.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-23.5.0.tgz#80de353d156ea5ea4a7332f7962ac79135fbc62e"
+  dependencies:
+    import-local "^1.0.0"
+    jest-cli "^23.5.0"
 
 jquery@^3.2.1:
   version "3.3.1"
@@ -4724,29 +4874,36 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsdom@^9.12.0:
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.12.0.tgz#e8c546fffcb06c00d4833ca84410fed7f8a097d4"
+jsdom@^11.5.1:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
   dependencies:
-    abab "^1.0.3"
-    acorn "^4.0.4"
-    acorn-globals "^3.1.0"
+    abab "^2.0.0"
+    acorn "^5.5.3"
+    acorn-globals "^4.1.0"
     array-equal "^1.0.0"
-    content-type-parser "^1.0.1"
     cssom ">= 0.3.2 < 0.4.0"
-    cssstyle ">= 0.2.37 < 0.3.0"
-    escodegen "^1.6.1"
-    html-encoding-sniffer "^1.0.1"
-    nwmatcher ">= 1.3.9 < 2.0.0"
-    parse5 "^1.5.1"
-    request "^2.79.0"
-    sax "^1.2.1"
-    symbol-tree "^3.2.1"
-    tough-cookie "^2.3.2"
-    webidl-conversions "^4.0.0"
-    whatwg-encoding "^1.0.1"
-    whatwg-url "^4.3.0"
-    xml-name-validator "^2.0.1"
+    cssstyle "^1.0.0"
+    data-urls "^1.0.0"
+    domexception "^1.0.1"
+    escodegen "^1.9.1"
+    html-encoding-sniffer "^1.0.2"
+    left-pad "^1.3.0"
+    nwsapi "^2.0.7"
+    parse5 "4.0.0"
+    pn "^1.1.0"
+    request "^2.87.0"
+    request-promise-native "^1.0.5"
+    sax "^1.2.4"
+    symbol-tree "^3.2.2"
+    tough-cookie "^2.3.4"
+    w3c-hr-time "^1.0.1"
+    webidl-conversions "^4.0.2"
+    whatwg-encoding "^1.0.3"
+    whatwg-mimetype "^2.1.0"
+    whatwg-url "^6.4.1"
+    ws "^5.2.0"
+    xml-name-validator "^3.0.0"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -4847,6 +5004,10 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
+kleur@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-2.0.1.tgz#7cc64b0d188d0dcbc98bdcdfdda2cc10619ddce8"
+
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
@@ -4856,6 +5017,10 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
+
+left-pad@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
 
 leven@^2.1.0:
   version "2.1.0"
@@ -4979,7 +5144,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.17.10, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1:
+lodash@4.17.10, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -5081,6 +5246,12 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
+merge-stream@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
+  dependencies:
+    readable-stream "^2.0.1"
+
 merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
@@ -5136,11 +5307,21 @@ mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18:
+mime-db@~1.35.0:
+  version "1.35.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
+
+mime-types@^2.1.12, mime-types@~2.1.18:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
     mime-db "~1.33.0"
+
+mime-types@~2.1.19:
+  version "2.1.19"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
+  dependencies:
+    mime-db "~1.35.0"
 
 mime@1.4.1:
   version "1.4.1"
@@ -5373,7 +5554,7 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-node-notifier@^5.0.2:
+node-notifier@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"
   dependencies:
@@ -5479,13 +5660,13 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-"nwmatcher@>= 1.3.9 < 2.0.0":
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.4.tgz#2285631f34a95f0d0395cd900c96ed39b58f346e"
+nwsapi@^2.0.7:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.8.tgz#e3603579b7e162b3dbedae4fb24e46f771d8fa24"
 
-oauth-sign@~0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
 
 object-assign@4.x, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
@@ -5643,10 +5824,6 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-p-cancelable@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.3.0.tgz#b9e123800bcebb7ac13a479be195b507b98d30fa"
-
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
@@ -5721,9 +5898,9 @@ parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
 
-parse5@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+parse5@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
 
 parse5@^3.0.1:
   version "3.0.3"
@@ -5850,6 +6027,10 @@ pkg-dir@^2.0.0:
 pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+
+pn@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -6157,9 +6338,9 @@ pretty-error@^2.0.2:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
+pretty-format@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.5.0.tgz#0f9601ad9da70fe690a269cd3efca732c210687c"
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -6210,6 +6391,13 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prompts@^0.1.9:
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.14.tgz#a8e15c612c5c9ec8f8111847df3337c9cbd443b2"
+  dependencies:
+    kleur "^2.0.1"
+    sisteransi "^0.1.1"
+
 prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
@@ -6232,6 +6420,10 @@ prr@~1.0.1:
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
+psl@^1.1.24:
+  version "1.1.29"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
 
 public-encrypt@^4.0.0:
   version "4.0.2"
@@ -6266,6 +6458,10 @@ punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+
 q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
@@ -6274,7 +6470,7 @@ qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-qs@^6.5.1, qs@~6.5.1:
+qs@^6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
@@ -6736,6 +6932,12 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
+realpath-native@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.1.tgz#07f40a0cce8f8261e2e8b7ebebf5c95965d7b633"
+  dependencies:
+    util.promisify "^1.0.0"
+
 recast@^0.12.6:
   version "0.12.9"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.12.9.tgz#e8e52bdb9691af462ccbd7c15d5a5113647a15f1"
@@ -6885,30 +7087,44 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.79.0:
-  version "2.87.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise-native@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
+  dependencies:
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.3"
+
+request@^2.87.0:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   dependencies:
     aws-sign2 "~0.7.0"
-    aws4 "^1.6.0"
+    aws4 "^1.8.0"
     caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.1"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
     forever-agent "~0.6.1"
-    form-data "~2.3.1"
-    har-validator "~5.0.3"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
     http-signature "~1.2.0"
     is-typedarray "~1.0.0"
     isstream "~0.1.2"
     json-stringify-safe "~5.0.1"
-    mime-types "~2.1.17"
-    oauth-sign "~0.8.2"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
     performance-now "^2.1.0"
-    qs "~6.5.1"
-    safe-buffer "^5.1.1"
-    tough-cookie "~2.3.3"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
     tunnel-agent "^0.6.0"
-    uuid "^3.1.0"
+    uuid "^3.3.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -6941,6 +7157,12 @@ reselect@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
 
+resolve-cwd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
+  dependencies:
+    resolve-from "^3.0.0"
+
 resolve-dir@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
@@ -6951,6 +7173,10 @@ resolve-dir@^1.0.0:
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
+resolve-from@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
 resolve-pathname@^2.2.0:
   version "2.2.0"
@@ -7095,7 +7321,7 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.2.3"
 
-sax@^1.2.1, sax@^1.2.4, sax@~1.2.1:
+sax@^1.2.4, sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -7118,7 +7344,7 @@ script-loader@^0.7.2:
   dependencies:
     raw-loader "~0.5.1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -7261,6 +7487,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+sisteransi@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-0.1.1.tgz#5431447d5f7d1675aac667ccd0b865a4994cb3ce"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -7333,6 +7563,13 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
+source-map-support@^0.5.6:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.8.tgz#04f5581713a8a65612d0175fbf3a01f80a162613"
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
@@ -7347,7 +7584,7 @@ source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -7407,6 +7644,10 @@ ssri@^5.2.4:
   dependencies:
     safe-buffer "^5.1.1"
 
+stack-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
+
 stackframe@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
@@ -7425,6 +7666,10 @@ static-extend@^0.1.1:
 statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
+
+stealthy-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
 stream-browserify@^2.0.1:
   version "2.0.1"
@@ -7473,7 +7718,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0:
+"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -7595,7 +7840,7 @@ symbol-observable@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
-symbol-tree@^3.2.1:
+symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
@@ -7715,15 +7960,18 @@ toposort@^1.0.0:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
 
-tough-cookie@^2.3.2, tough-cookie@~2.3.3:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
+tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
   dependencies:
+    psl "^1.1.24"
     punycode "^1.4.1"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+tr46@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  dependencies:
+    punycode "^2.1.0"
 
 tree-kill@^1.1.0:
   version "1.2.0"
@@ -7910,6 +8158,13 @@ util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
+util.promisify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
+  dependencies:
+    define-properties "^1.1.2"
+    object.getownpropertydescriptors "^2.0.3"
+
 util@0.10.3, util@^0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
@@ -7928,9 +8183,13 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
-uuid@^3.1.0, uuid@^3.2.1:
+uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.3"
@@ -7978,6 +8237,12 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
+w3c-hr-time@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
+  dependencies:
+    browser-process-hrtime "^0.1.2"
+
 walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
@@ -8005,11 +8270,7 @@ watchpack@^1.4.0:
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-
-webidl-conversions@^4.0.0:
+webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
@@ -8096,16 +8357,27 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.19"
 
+whatwg-encoding@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.4.tgz#63fb016b7435b795d9025632c086a5209dbd2621"
+  dependencies:
+    iconv-lite "0.4.23"
+
 whatwg-fetch@>=0.10.0, whatwg-fetch@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 
-whatwg-url@^4.3.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.8.0.tgz#d2981aa9148c1e00a41c5a6131166ab4683bbcc0"
+whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
+
+whatwg-url@^6.4.0, whatwg-url@^6.4.1:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
   dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 whet.extend@~0.9.9:
   version "0.9.9"
@@ -8143,7 +8415,7 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
-worker-farm@^1.3.1, worker-farm@^1.5.2:
+worker-farm@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.6.0.tgz#aecc405976fab5a95526180846f0dba288f3a4a0"
   dependencies:
@@ -8174,9 +8446,15 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-xml-name-validator@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+ws@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  dependencies:
+    async-limiter "~1.0.0"
+
+xml-name-validator@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
@@ -8204,27 +8482,32 @@ yargs-parser@^7.0.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs@^8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
   dependencies:
     camelcase "^4.1.0"
-    cliui "^3.2.0"
+
+yargs@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  dependencies:
+    cliui "^4.0.0"
     decamelize "^1.1.1"
+    find-up "^2.1.0"
     get-caller-file "^1.0.1"
     os-locale "^2.0.0"
-    read-pkg-up "^2.0.0"
     require-directory "^2.1.1"
     require-main-filename "^1.0.1"
     set-blocking "^2.0.0"
     string-width "^2.0.0"
     which-module "^2.0.0"
     y18n "^3.2.1"
-    yargs-parser "^7.0.0"
+    yargs-parser "^9.0.2"
 
-yargs@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-9.0.1.tgz#52acc23feecac34042078ee78c0c007f5085db4c"
+yargs@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
   dependencies:
     camelcase "^4.1.0"
     cliui "^3.2.0"


### PR DESCRIPTION
# Who is this PR for?

Developers.

# What problem does this PR fix?

Our `jest` version is old and we were capped from being auto-upgraded above 21.x.x.

The newer version comes with better error handling in async contexts. I got stuck for a bit on #1973 because `jest` was giving me an "Timeout - Async callback was not invoked within timeout" error, when the real issue was much simpler than that. I tried again with a higher `jest` version and the error was much simpler to resolve.

See https://github.com/facebook/jest/pull/4669 for details.

# What does this PR do?

Bumps `jest` major version and commits changes to snapshots. 

These new snapshots look better because crufty `width={undefined}` type styling gets removed in favor of no width attribute at all. 