### PR TITLE
Delete deprecated student assessment records in a speedier fashion

### DIFF
--- a/lib/tasks/data_migrations/remove_deprecated_dibels_records.rake
+++ b/lib/tasks/data_migrations/remove_deprecated_dibels_records.rake
@@ -1,12 +1,17 @@
 namespace :data_migration do
   desc "Remove deprecated DIBELS records"
   task remove_deprecated_dibels: :environment do
-    puts "Records in student_assessment table: #{StudentAssessment.count}"
+    puts "Records in StudentAssessment table: #{StudentAssessment.count}"
 
-    puts "Destorying DIBELS assessments..."
-    Assessment.where(family: 'DIBELS').delete_all
+    puts "Deleting DIBELS StudentAssessments..."
+
+    dibels_assessment_id = Assessment.where(family: 'DIBELS')
+    StudentAssessment.where(assessment_id: dibels_assessment_id).delete_all
+    puts "Records in StudentAssessment table: #{StudentAssessment.count}"
+
+    puts "Destorying deprecated DIBELS Assessment record:"
+    Assessment.where(id: dibels_assessment_id).destroy_all
+
     puts "Done."
-
-    puts "Records in student_assessment table: #{StudentAssessment.count}"
   end
 end

--- a/lib/tasks/data_migrations/remove_deprecated_dibels_records.rake
+++ b/lib/tasks/data_migrations/remove_deprecated_dibels_records.rake
@@ -4,7 +4,7 @@ namespace :data_migration do
     puts "Records in student_assessment table: #{StudentAssessment.count}"
 
     puts "Destorying DIBELS assessments..."
-    Assessment.where(family: 'DIBELS').destroy_all
+    Assessment.where(family: 'DIBELS').delete_all
     puts "Done."
 
     puts "Records in student_assessment table: #{StudentAssessment.count}"

--- a/lib/tasks/data_migrations/remove_deprecated_star_records.rake
+++ b/lib/tasks/data_migrations/remove_deprecated_star_records.rake
@@ -3,10 +3,15 @@ namespace :data_migration do
   task remove_deprecated_star: :environment do
     puts "Records in student_assessment table: #{StudentAssessment.count}"
 
-    puts "Destorying STAR assessments..."
-    Assessment.where(family: 'STAR').delete_all
-    puts "Done."
+    puts "Deleting STAR StudentAssessments..."
 
+    star_assessment_ids = Assessment.where(family: 'STAR')
+    StudentAssessment.where(assessment_id: star_assessment_ids).delete_all
     puts "Records in student_assessment table: #{StudentAssessment.count}"
+
+    puts "Destorying deprecated STAR Assessment records:"
+    Assessment.where(id: star_assessment_ids).destroy_all
+
+    puts "Done."
   end
 end

--- a/lib/tasks/data_migrations/remove_deprecated_star_records.rake
+++ b/lib/tasks/data_migrations/remove_deprecated_star_records.rake
@@ -4,7 +4,7 @@ namespace :data_migration do
     puts "Records in student_assessment table: #{StudentAssessment.count}"
 
     puts "Destorying STAR assessments..."
-    Assessment.where(family: 'STAR').destroy_all
+    Assessment.where(family: 'STAR').delete_all
     puts "Done."
 
     puts "Records in student_assessment table: #{StudentAssessment.count}"


### PR DESCRIPTION
# Who is this PR for?

Developers. 

# What problem does this PR fix?

Trying to clear out deprecated records using `destroy_all` is way, way too slow. 

# What's the solution?

Use `delete_all` to clear out large numbers of deprecated student assessment records quickly. 

Then use `destroy` on the assessment record once all of its dependent records are cleared out.

# Note

STAR student assessments and assessments are already cleared out; only DIBELS needs to be cleared. But updating both migrations since they're sisters, wouldn't make sense to have them out of sync.