### PR TITLE
Minimally add Bedford to PerDistrict; deploy script

### DIFF
--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -2,6 +2,7 @@ import * as Filters from './Filters';
 
 export const SOMERVILLE = 'somerville';
 export const NEW_BEDFORD = 'new_bedford';
+export const BEDFORD = 'bedford';
 export const DEMO = 'demo';
 
 export function hasStudentPhotos(districtKey) {

--- a/app/config_objects/load_district_config.rb
+++ b/app/config_objects/load_district_config.rb
@@ -30,6 +30,7 @@ class LoadDistrictConfig
     {
       'somerville' => 'config/district_somerville.yml',
       'new_bedford' => 'config/district_new_bedford.yml',
+      'bedford' => 'config/district_bedford.yml',
     }
   end
 

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -4,13 +4,15 @@
 #
 # If this gets too big we can refactor :)
 class PerDistrict
-  NEW_BEDFORD = 'new_bedford'
   SOMERVILLE = 'somerville'
+  NEW_BEDFORD = 'new_bedford'
+  BEDFORD = 'bedford'
   DEMO = 'demo'
 
   VALID_DISTRICT_KEYS = [
     NEW_BEDFORD,
     SOMERVILLE,
+    BEDFORD,
     DEMO
   ]
 
@@ -87,6 +89,8 @@ class PerDistrict
       login_name + '@k12.somerville.ma.us'
     elsif @district_key == NEW_BEDFORD
       login_name + '@newbedfordschools.org'
+    elsif @district_key == BEDFORD
+      login_name + '@bedfordps.org'
     elsif @district_key == DEMO
       raise "PerDistrict#from_import_login_name_to_email not supported for district_key: {DEMO}"
     else
@@ -97,11 +101,11 @@ class PerDistrict
   def import_detailed_attendance_fields?
     return true if @district_key == SOMERVILLE
 
-    return false if  @district_key == NEW_BEDFORD
+    return false if @district_key == NEW_BEDFORD
 
     raise 'import_detailed_attendance_fields? not supported for DEMO' if @district_key == DEMO
 
-    raise_not_handled!
+    raise_not_handled!  # Importing attendance not handled yet for BEDFORD
   end
 
   def import_student_house?

--- a/config/district_bedford.yml
+++ b/config/district_bedford.yml
@@ -1,0 +1,19 @@
+schools:
+  -
+    name: Lane Elementary
+    local_id: Lane
+  -
+    name: Davis Elementary
+    local_id: Davis
+  -
+    name: John Glenn Middle School
+    local_id: JGMS
+  -
+    name: Bedford High School
+    local_id: BHS
+  -
+    name: Pre-K
+    local_id: BHS Pre-K
+  -
+    name: System
+    local_id: System

--- a/scripts/deploy/all.sh
+++ b/scripts/deploy/all.sh
@@ -9,6 +9,7 @@ yarn concurrently \
   -c "yellow.bold,blue.bold,magenta.bold" \
   "'scripts/deploy/deploy.sh demo'" \
   "'scripts/deploy/deploy.sh somerville'" \
+  "'scripts/deploy/deploy.sh bedford'" \
   "'scripts/deploy/deploy.sh new-bedford'"
 
 echo "🚢  Done."


### PR DESCRIPTION
# Who is this PR for?

Bedford Public Schools.

# What problem does this PR fix?

Our newest school district, Bedford, needs to be added to our per-district config files.

If we launch a Heroku instance for Bedford without these changes, I would expect it to crash server-side because this line keeps us from launching an instance without setting a valid district key: 

```
raise_not_handled! unless VALID_DISTRICT_KEYS.include?(@district_key)
```

# What does this PR do?

Add Bedford to PerDistrict files so that we can launch a minimal Heroku instance. 

Also adds the "bedford" remote to our deploy script so that code will automatically deploy there.