### PR TITLE
Force vertical scrollbars on profile v3, even if not enough content

### DIFF
--- a/app/assets/javascripts/helpers/globalStylingWorkarounds.js
+++ b/app/assets/javascripts/helpers/globalStylingWorkarounds.js
@@ -20,3 +20,7 @@ export function updateGlobalStylesToTakeFullHeight() {
 export function updateGlobalStylesToRemoveHorizontalScrollbars() {
   window.document.body.style['min-width'] = '1000px';
 }
+
+export function alwaysShowVerticalScrollbars() {
+  window.document.body.style['overflow-y'] = 'scroll';
+}

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -253,7 +253,6 @@ export default class LightProfilePage extends React.Component {
           educatorsIndex={this.props.educatorsIndex}
           currentEducator={this.props.currentEducator}
           feed={this.props.feed}
-          transitionNotes={this.props.transitionNotes}
           actions={this.props.actions}
           requests={this.props.requests}
           showingRestrictedNotes={false}

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import _ from 'lodash';
-import {updateGlobalStylesToRemoveHorizontalScrollbars} from '../helpers/globalStylingWorkarounds';
+import {updateGlobalStylesToRemoveHorizontalScrollbars, alwaysShowVerticalScrollbars} from '../helpers/globalStylingWorkarounds';
 import * as InsightsPropTypes from '../helpers/InsightsPropTypes';
 import {toMomentFromTimestamp} from '../helpers/toMoment';
 import PerDistrictContainer from '../components/PerDistrictContainer';
@@ -26,6 +26,7 @@ import {shortLabelFromScore} from './nextGenMcasScores';
 export default class LightProfilePage extends React.Component {
   componentDidMount() {
     updateGlobalStylesToRemoveHorizontalScrollbars();
+    alwaysShowVerticalScrollbars();
   }
 
   countEventsBetween(events, daysBack) {
@@ -252,6 +253,7 @@ export default class LightProfilePage extends React.Component {
           educatorsIndex={this.props.educatorsIndex}
           currentEducator={this.props.currentEducator}
           feed={this.props.feed}
+          transitionNotes={this.props.transitionNotes}
           actions={this.props.actions}
           requests={this.props.requests}
           showingRestrictedNotes={false}


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
There's a slight jump in layout when navigating between tabs if there isn't enough vertical content (eg, no notes) to require a scrollbar.  With no scrollbar, the width changes and layout hops a bit.

# What does this PR do?
Always adds vertical scrollbar to the body on profile v3.
