### PR TITLE
Fix bug with mutating STAR scores for Highcharts

### DIFF
--- a/app/assets/javascripts/student_profile/ElaDetails.js
+++ b/app/assets/javascripts/student_profile/ElaDetails.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from 'lodash';
 import {merge} from '../helpers/merge';
 import ProfileChart from './ProfileChart';
 import ProfileChartSettings from './ProfileChartSettings';
@@ -97,7 +98,7 @@ export default class ElaDetails extends React.Component {
     const {chartData} = this.props;
 
     // HighCharts wants time series data sorted in ascending order by time:
-    const starReading = chartData.star_series_reading_percentile.reverse();
+    const starReading = _.clone(chartData.star_series_reading_percentile).reverse();
 
     return (
       <DetailsSection anchorId="Star" title="STAR Reading, last 4 years">

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import _ from 'lodash';
-import {updateGlobalStylesToRemoveHorizontalScrollbars, alwaysShowVerticalScrollbars} from '../helpers/globalStylingWorkarounds';
+import {updateGlobalStylesToRemoveHorizontalScrollbars} from '../helpers/globalStylingWorkarounds';
 import * as InsightsPropTypes from '../helpers/InsightsPropTypes';
 import {toMomentFromTimestamp} from '../helpers/toMoment';
 import PerDistrictContainer from '../components/PerDistrictContainer';
@@ -26,7 +26,6 @@ import {shortLabelFromScore} from './nextGenMcasScores';
 export default class LightProfilePage extends React.Component {
   componentDidMount() {
     updateGlobalStylesToRemoveHorizontalScrollbars();
-    alwaysShowVerticalScrollbars();
   }
 
   countEventsBetween(events, daysBack) {
@@ -452,8 +451,8 @@ function countEventsBetween(events, startMoment, endMoment) {
 const DAYS_AGO = 45;
 
 
-export function latestStar(sortedStarDataPoints, nowMoment) {
-  const starDataPoint = _.last(sortedStarDataPoints);
+export function latestStar(starDataPoints, nowMoment) {
+  const starDataPoint = _.last(_.sortBy(starDataPoints, dataPoint => toMomentFromTimestamp(dataPoint.date_taken).unix()));
   if (!starDataPoint) return {
     nDaysText: 'not yet taken',
     percentileText: '-'
@@ -461,6 +460,7 @@ export function latestStar(sortedStarDataPoints, nowMoment) {
 
   const testMoment = toMomentFromTimestamp(starDataPoint.date_taken);
   const nDaysText = testMoment.from(nowMoment);
+
   const percentile = starDataPoint.percentile_rank;
   const percentileText = (percentile)
     ? percentileWithSuffix(percentile)
@@ -500,7 +500,7 @@ function testingColumnTexts(nowMoment, chartData) {
 
 // Make text for the score and date for the latest next gen MCAS score
 function latestNextGenMcasSummary(quads, nowMoment) {
-  const latestEla = _.last(quads || []);
+  const latestEla = _.last(_.sortBy(quads || [], quad => toMoment(quad).unix()));
   const scoreText = latestEla ? shortLabelFromScore(latestEla[3]) : '-';
   const dateText = latestEla ? toMoment(latestEla).from(nowMoment) : 'not yet taken';
   return {scoreText, dateText};

--- a/app/assets/javascripts/student_profile/LightProfilePage.test.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.test.js
@@ -41,14 +41,18 @@ describe('snapshots', () => {
 });
 
 
-it('#latestStar', () => {
+it('#latestStar works regardless of initial sort order', () => {
   const nowMoment = toMomentFromTimestamp('2018-08-13T11:03:06.123Z');
   const starSeriesReadingPercentile = [
     {"percentile_rank":98,"total_time":1134,"grade_equivalent":"6.90","date_taken":"2017-04-23T06:00:00.000Z"},
     {"percentile_rank":94,"total_time":1022,"grade_equivalent":"4.80","date_taken":"2017-01-07T02:00:00.000Z"}
   ];
   expect(latestStar(starSeriesReadingPercentile, nowMoment)).toEqual({
-    nDaysText: '2 years ago',
-    percentileText: '94th'
+    nDaysText: 'a year ago',
+    percentileText: '98th'
+  });
+  expect(latestStar(starSeriesReadingPercentile.reverse(), nowMoment)).toEqual({
+    nDaysText: 'a year ago',
+    percentileText: '98th'
   });
 });

--- a/app/assets/javascripts/student_profile/MathDetails.js
+++ b/app/assets/javascripts/student_profile/MathDetails.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from 'lodash';
 import {merge} from '../helpers/merge';
 import ProfileChart from './ProfileChart';
 import ProfileChartSettings from './ProfileChartSettings';
@@ -99,7 +100,7 @@ export default class MathDetails extends React.Component {
     const {chartData} = this.props;
 
     // HighCharts wants time series data sorted in ascending order by time:
-    const starMathPercentile = chartData.star_series_math_percentile.reverse();
+    const starMathPercentile = _.clone(chartData.star_series_math_percentile).reverse();
 
     return (
       <DetailsSection anchorId="starMath" title="STAR Math, last 4 years">


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
In profile v3, clicking around the UI would change the STAR scores shown.  This was happening because `<ElaDetails />` and `<MathDetails />` were calling `#reverse()` and mutating the arrays of scores.

# What does this PR do?
Updates the details components to not mutate their arguments, and updates the tab code in `<LightProfilePage />` to not expect these to be already sorted.
