### PR TITLE
Profile v3: Include transition notes in profile, update notes tab to counts

### DIFF
--- a/app/assets/javascripts/components/Badge.js
+++ b/app/assets/javascripts/components/Badge.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 // A visual UI element for a badge indicating a particular 
 // type of data (eg, in the home page feed).
-function Badge({text, backgroundColor, style}) {
+export default function Badge({text, backgroundColor, style}) {
   const mergedStyle = {
     ...styles.badge,
     backgroundColor,
@@ -25,5 +25,3 @@ const styles = {
     opacity: 0.5
   }
 };
-
-export default Badge;

--- a/app/assets/javascripts/helpers/FeedHelpers.js
+++ b/app/assets/javascripts/helpers/FeedHelpers.js
@@ -22,7 +22,13 @@ export function mergedNotes(feed) {
     };
   });
 
-  const mergedNotes = eventNotes.concat.apply(eventNotes, [deprecatedInterventions]);
+  const transitionNotes = [];
+
+  const mergedNotes = [
+    ...eventNotes,
+    ...deprecatedInterventions,
+    ...transitionNotes
+  ];
   return _.sortBy(mergedNotes, 'sort_timestamp').reverse();
 }
 

--- a/app/assets/javascripts/helpers/FeedHelpers.js
+++ b/app/assets/javascripts/helpers/FeedHelpers.js
@@ -22,7 +22,14 @@ export function mergedNotes(feed) {
     };
   });
 
-  const transitionNotes = [];
+  // optional
+  const transitionNotes = (feed.transition_notes || []).map(transitionNote => {
+    return {
+      ...transitionNote,
+      type: 'transition_notes',
+      sort_timestamp: transitionNote.created_at
+    };
+  });
 
   const mergedNotes = [
     ...eventNotes,

--- a/app/assets/javascripts/helpers/FeedHelpers.js
+++ b/app/assets/javascripts/helpers/FeedHelpers.js
@@ -38,13 +38,3 @@ export function mergedNotes(feed) {
   ];
   return _.sortBy(mergedNotes, 'sort_timestamp').reverse();
 }
-
-export function matchesMergedNoteType(mergedNote, mergedNoteType, mergedNoteTypeId) {
-  if (mergedNote.type !== mergedNoteType) return false;
-  switch (mergedNote.type) {
-  case 'event_notes': return (mergedNote.event_note_type_id === mergedNoteTypeId);
-  case 'deprecated_interventions': return (mergedNote.intervention_type_id === mergedNoteTypeId);
-  }
-
-  return false;
-}

--- a/app/assets/javascripts/helpers/FeedHelpers.test.js
+++ b/app/assets/javascripts/helpers/FeedHelpers.test.js
@@ -1,0 +1,42 @@
+import * as FeedHelpers from './FeedHelpers';
+
+function testFeed() {
+  return {
+    deprecated: {
+      interventions: [{
+        fooIntervention: 'y',
+        start_date_timestamp: '2018-12-19T00:00:00.000Z'
+      }]
+    },
+    event_notes: [{
+      fooEventNote: 'bar',
+      recorded_at: '2018-12-13T00:00:00.000Z'
+    }],
+    transition_notes: [{
+      fooTransitionNote: 'z',
+      created_at: '2018-12-16T00:00:00.000Z'
+    }]
+  };
+}
+
+describe('#mergedNotes', () => {
+  it('puts notes of different types in order', () => {
+    const feed = testFeed();
+    expect(FeedHelpers.mergedNotes(feed)).toEqual([{
+      fooIntervention: "y",
+      start_date_timestamp: "2018-12-19T00:00:00.000Z",
+      sort_timestamp: "2018-12-19T00:00:00.000Z",
+      type: "deprecated_interventions",
+    }, {  
+      created_at: "2018-12-16T00:00:00.000Z",
+      fooTransitionNote: "z",
+      sort_timestamp: "2018-12-16T00:00:00.000Z",
+      type: "transition_notes",
+    }, {
+      fooEventNote: "bar",
+      sort_timestamp: "2018-12-13T00:00:00.000Z",
+      recorded_at: "2018-12-13T00:00:00.000Z",
+      type: "event_notes",
+    }]);
+  });
+});

--- a/app/assets/javascripts/helpers/InsightsPropTypes.js
+++ b/app/assets/javascripts/helpers/InsightsPropTypes.js
@@ -25,6 +25,7 @@ export const api = PropTypes.shape({
 // The feed of all notes and data entered in Student Insights for
 // a student.
 export const feed = PropTypes.shape({
+  transition_notes: PropTypes.array,
   event_notes: PropTypes.array.isRequired,
   services: PropTypes.shape({
     active: PropTypes.array.isRequired,

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -24,6 +24,7 @@ import {shortLabelFromScore} from './nextGenMcasScores';
 
 
 // Prototype of profile v3
+const DAYS_AGO = 45;
 export default class LightProfilePage extends React.Component {
   componentDidMount() {
     updateGlobalStylesToRemoveHorizontalScrollbars();
@@ -468,7 +469,8 @@ const styles = {
 
 
 function findTopRecentTags(eventNotes, nowMoment) {
-  const thresholdInDays = 100000; // should be 45, this is for testing locally, where dates are busted
+  // this branching is for testing locally, where demo dates aren't realistic
+  const thresholdInDays = (process.env.NODE_ENV === 'production') ? DAYS_AGO : 100000; // eslint-disable-line no-undef
   const recentNotes = eventNotes.filter(e => nowMoment.clone().diff(toMomentFromTimestamp(e.recorded_at), 'days') < thresholdInDays);
   const recentNotesText = recentNotes.map(e => e.text).join(' ');
   const recentTags = tags(recentNotesText);
@@ -482,7 +484,6 @@ function countEventsBetween(events, startMoment, endMoment) {
   }).length;
 }
 
-const DAYS_AGO = 45;
 
 
 export function latestStar(starDataPoints, nowMoment) {

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import _ from 'lodash';
-import {updateGlobalStylesToRemoveHorizontalScrollbars} from '../helpers/globalStylingWorkarounds';
+import {updateGlobalStylesToRemoveHorizontalScrollbars, alwaysShowVerticalScrollbars} from '../helpers/globalStylingWorkarounds';
 import * as InsightsPropTypes from '../helpers/InsightsPropTypes';
 import {toMomentFromTimestamp} from '../helpers/toMoment';
 import PerDistrictContainer from '../components/PerDistrictContainer';
@@ -26,6 +26,7 @@ import {shortLabelFromScore} from './nextGenMcasScores';
 export default class LightProfilePage extends React.Component {
   componentDidMount() {
     updateGlobalStylesToRemoveHorizontalScrollbars();
+    alwaysShowVerticalScrollbars();
   }
 
   countEventsBetween(events, daysBack) {

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -125,7 +125,7 @@ export default class LightProfilePage extends React.Component {
         fadedColor="#ededed"
         text="Notes">
           <LightShoutNumber number={recentNotes.length}>
-            <div>notes taken</div>
+            <div>{recentNotes.length === 1 ? 'note taken' : 'notes taken'}</div>
             <div>last {DAYS_AGO} days</div>
           </LightShoutNumber>
         </LightProfileTab>

--- a/app/assets/javascripts/student_profile/NoteCard.js
+++ b/app/assets/javascripts/student_profile/NoteCard.js
@@ -35,7 +35,7 @@ export default class NoteCard extends React.Component {
       <div className="wrapper" style={styles.wrapper}>
         {this.renderStudentCard()}
         <div className="NoteCard" style={styles.note}>
-          <div>
+          <div style={styles.titleLine}>
             <span className="date" style={styles.date}>
               {this.props.noteMoment.format('MMMM D, YYYY')}
             </span>
@@ -198,6 +198,10 @@ const styles = {
     marginTop: 10,
     marginBottom: 10,
     width: '100%'
+  },
+  titleLine: {
+    display: 'flex',
+    justifyContent: 'space-between'
   },
   date: {
     display: 'inline-block',

--- a/app/assets/javascripts/student_profile/NotesList.js
+++ b/app/assets/javascripts/student_profile/NotesList.js
@@ -5,7 +5,6 @@ import moment from 'moment';
 import {toMomentFromRailsDate} from '../helpers/toMoment';
 import * as InsightsPropTypes from '../helpers/InsightsPropTypes';
 import * as FeedHelpers from '../helpers/FeedHelpers';
-import Badge from '../components/Badge';
 import {eventNoteTypeText} from '../helpers/eventNoteType';
 import NoteCard from './NoteCard';
 
@@ -32,6 +31,14 @@ export default class NotesList extends React.Component {
     );
   }
 
+  renderEventNoteTypeBadge(eventNoteTypeId) {
+    return (
+      <span style={styles.badge}>
+        {eventNoteTypeText(eventNoteTypeId)}
+      </span>
+    );
+  }
+
   renderEventNote(eventNote) {
     return (
       <NoteCard
@@ -40,7 +47,7 @@ export default class NotesList extends React.Component {
         student={eventNote.student}          
         eventNoteTypeId={eventNote.event_note_type_id}
         noteMoment={moment.utc(eventNote.recorded_at)}
-        badge={<Badge style={styles.badge} text={eventNoteTypeText(eventNote.event_note_type_id)} backgroundColor="#666" />}
+        badge={this.renderEventNoteTypeBadge(eventNote.event_note_type_id)}
         educatorId={eventNote.educator_id}
         text={eventNote.text || ''}
         numberOfRevisions={eventNote.event_note_revisions.length}
@@ -59,7 +66,7 @@ export default class NotesList extends React.Component {
       <NoteCard
         key={['deprecated_intervention', deprecatedIntervention.id].join()}
         noteMoment={moment.utc(deprecatedIntervention.start_date_timestamp, 'MMMM-YY-DD')}
-        badge={<Badge style={styles.badge} text="Old intervention" backgroundColor="#666" />}
+        badge={<span style={styles.badge}>Old intervention</span>}
         educatorId={deprecatedIntervention.educator_id}
         text={_.compact([deprecatedIntervention.name, deprecatedIntervention.comment, deprecatedIntervention.goal]).join('\n')}
         educatorsIndex={this.props.educatorsIndex}
@@ -73,7 +80,7 @@ export default class NotesList extends React.Component {
       <NoteCard
         key={['transition_note', transitionNote.id].join()}
         noteMoment={toMomentFromRailsDate(transitionNote.created_at)}
-        badge={<Badge style={styles.badge} text="Transition note" backgroundColor="#666" />}
+        badge={<span style={styles.badge}>Transition note</span>}
         educatorId={transitionNote.educator_id}
         text={transitionNote.text}
         educatorsIndex={this.props.educatorsIndex}
@@ -94,7 +101,11 @@ const styles = {
   },
   badge: {
     display: 'inline-block',
-    width: '11em',
-    textAlign: 'center'
+    background: '#eee',
+    outline: '3px solid #eee',
+    width: '10em',
+    textAlign: 'center',
+    marginLeft: 10,
+    marginRight: 10
   }
 };

--- a/app/assets/javascripts/student_profile/NotesList.js
+++ b/app/assets/javascripts/student_profile/NotesList.js
@@ -2,37 +2,33 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import moment from 'moment';
+import {toMomentFromRailsDate} from '../helpers/toMoment';
 import * as InsightsPropTypes from '../helpers/InsightsPropTypes';
 import * as FeedHelpers from '../helpers/FeedHelpers';
+import Badge from '../components/Badge';
 import {eventNoteTypeText} from '../helpers/eventNoteType';
 import NoteCard from './NoteCard';
 
 
 /*
-Renders the list of notes.
+Renders the list of notes, including the different types of notes (eg, deprecated
+interventions, transition notes).
 */
 export default class NotesList extends React.Component {
   render() {
     const mergedNotes = FeedHelpers.mergedNotes(this.props.feed);
     return (
       <div className="NotesList">
-        {(mergedNotes.length === 0) ? <div style={styles.noItems}>
-          No notes
-        </div> : mergedNotes.map(mergedNote => {
-          switch (mergedNote.type) {
-          case 'event_notes': return this.renderEventNote(mergedNote);
-          case 'deprecated_interventions': return this.renderDeprecatedIntervention(mergedNote);
-          }
-        })}
+        {(mergedNotes.length === 0)
+          ? <div style={styles.noItems}>No notes</div>
+          : mergedNotes.map(mergedNote => {
+            switch (mergedNote.type) {
+            case 'event_notes': return this.renderEventNote(mergedNote);
+            case 'transition_notes': return this.renderTransitionNote(mergedNote);
+            case 'deprecated_interventions': return this.renderDeprecatedIntervention(mergedNote);
+            }
+          })}
       </div>
-    );
-  }
-
-  renderEventNoteTypeBadge(eventNoteTypeId) {
-    return (
-      <span style={styles.badge}>
-        {eventNoteTypeText(eventNoteTypeId)}
-      </span>
     );
   }
 
@@ -44,7 +40,7 @@ export default class NotesList extends React.Component {
         student={eventNote.student}          
         eventNoteTypeId={eventNote.event_note_type_id}
         noteMoment={moment.utc(eventNote.recorded_at)}
-        badge={this.renderEventNoteTypeBadge(eventNote.event_note_type_id)}
+        badge={<Badge style={styles.badge} text={eventNoteTypeText(eventNote.event_note_type_id)} backgroundColor="#666" />}
         educatorId={eventNote.educator_id}
         text={eventNote.text || ''}
         numberOfRevisions={eventNote.event_note_revisions.length}
@@ -63,11 +59,24 @@ export default class NotesList extends React.Component {
       <NoteCard
         key={['deprecated_intervention', deprecatedIntervention.id].join()}
         noteMoment={moment.utc(deprecatedIntervention.start_date_timestamp, 'MMMM-YY-DD')}
-        badge={<span style={styles.badge}>Old intervention</span>}
+        badge={<Badge style={styles.badge} text="Old intervention" backgroundColor="#666" />}
         educatorId={deprecatedIntervention.educator_id}
         text={_.compact([deprecatedIntervention.name, deprecatedIntervention.comment, deprecatedIntervention.goal]).join('\n')}
         educatorsIndex={this.props.educatorsIndex}
         // deprecated interventions have no attachments
+        attachments={[]} />
+    );
+  }
+
+  renderTransitionNote(transitionNote) {
+    return (
+      <NoteCard
+        key={['transition_note', transitionNote.id].join()}
+        noteMoment={toMomentFromRailsDate(transitionNote.created_at)}
+        badge={<Badge style={styles.badge} text="Transition note" backgroundColor="#666" />}
+        educatorId={transitionNote.educator_id}
+        text={transitionNote.text}
+        educatorsIndex={this.props.educatorsIndex}
         attachments={[]} />
     );
   }
@@ -85,11 +94,7 @@ const styles = {
   },
   badge: {
     display: 'inline-block',
-    background: '#eee',
-    outline: '3px solid #eee',
-    width: '10em',
-    textAlign: 'center',
-    marginLeft: 10,
-    marginRight: 10
+    width: '11em',
+    textAlign: 'center'
   }
 };

--- a/app/assets/javascripts/student_profile/NotesList.test.js
+++ b/app/assets/javascripts/student_profile/NotesList.test.js
@@ -30,11 +30,12 @@ it.only('renders everything on the happy path', () => {
   const noteTimestamps = readNoteTimestamps(el);
   expect(_.head(noteTimestamps)).toBeGreaterThan(_.last(noteTimestamps));
   expect(_.sortBy(noteTimestamps).reverse()).toEqual(noteTimestamps);
-  expect($(el).find('.NoteCard').length).toEqual(4);
+  expect($(el).find('.NoteCard').length).toEqual(5);
+
   expect(el.innerHTML).toContain('Behavior Plan');
   expect(el.innerHTML).toContain('Attendance Officer');
   expect(el.innerHTML).toContain('MTSS Meeting');
-
+  expect(el.innerHTML).toContain('Transition note');
   expect(el.innerHTML).not.toContain('SST Meeting');
 
   // Notes attachments expectations

--- a/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
@@ -3314,24 +3314,46 @@ exports[`snapshots works for aladdin grades 1`] = `
           }
         >
           <div>
-            “
-            placement
-            ”
-          </div>
-          <div>
-            “
-            attendance
-            ”
-          </div>
-          <div>
-            “
-            tardies
-            ”
-          </div>
-          <div>
-            “
-            attendance contract
-            ”
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "fontSize": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 10,
+                }
+              }
+            >
+              0
+            </div>
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "color": "#333",
+                  "display": "flex",
+                  "flexDirection": "column",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "textAlign": "center",
+                  }
+                }
+              >
+                <div>
+                  notes taken
+                </div>
+                <div>
+                  last 
+                  45
+                   days
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -4320,24 +4342,46 @@ exports[`snapshots works for aladdin notes 1`] = `
           }
         >
           <div>
-            “
-            placement
-            ”
-          </div>
-          <div>
-            “
-            attendance
-            ”
-          </div>
-          <div>
-            “
-            tardies
-            ”
-          </div>
-          <div>
-            “
-            attendance contract
-            ”
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "fontSize": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 10,
+                }
+              }
+            >
+              0
+            </div>
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "color": "#333",
+                  "display": "flex",
+                  "flexDirection": "column",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "textAlign": "center",
+                  }
+                }
+              >
+                <div>
+                  notes taken
+                </div>
+                <div>
+                  last 
+                  45
+                   days
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -5326,24 +5370,46 @@ exports[`snapshots works for aladdin testing 1`] = `
           }
         >
           <div>
-            “
-            placement
-            ”
-          </div>
-          <div>
-            “
-            attendance
-            ”
-          </div>
-          <div>
-            “
-            tardies
-            ”
-          </div>
-          <div>
-            “
-            attendance contract
-            ”
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "fontSize": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 10,
+                }
+              }
+            >
+              0
+            </div>
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "color": "#333",
+                  "display": "flex",
+                  "flexDirection": "column",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "textAlign": "center",
+                  }
+                }
+              >
+                <div>
+                  notes taken
+                </div>
+                <div>
+                  last 
+                  45
+                   days
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -8779,14 +8845,46 @@ exports[`snapshots works for olaf math 1`] = `
           }
         >
           <div>
-            “
-            yelling
-            ”
-          </div>
-          <div>
-            “
-            disruptive
-            ”
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "fontSize": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 10,
+                }
+              }
+            >
+              0
+            </div>
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "color": "#333",
+                  "display": "flex",
+                  "flexDirection": "column",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "textAlign": "center",
+                  }
+                }
+              >
+                <div>
+                  notes taken
+                </div>
+                <div>
+                  last 
+                  45
+                   days
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -9718,14 +9816,46 @@ exports[`snapshots works for olaf notes 1`] = `
           }
         >
           <div>
-            “
-            yelling
-            ”
-          </div>
-          <div>
-            “
-            disruptive
-            ”
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "fontSize": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 10,
+                }
+              }
+            >
+              0
+            </div>
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "color": "#333",
+                  "display": "flex",
+                  "flexDirection": "column",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "textAlign": "center",
+                  }
+                }
+              >
+                <div>
+                  notes taken
+                </div>
+                <div>
+                  last 
+                  45
+                   days
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -10657,14 +10787,46 @@ exports[`snapshots works for olaf reading 1`] = `
           }
         >
           <div>
-            “
-            yelling
-            ”
-          </div>
-          <div>
-            “
-            disruptive
-            ”
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "fontSize": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 10,
+                }
+              }
+            >
+              0
+            </div>
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "color": "#333",
+                  "display": "flex",
+                  "flexDirection": "column",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "textAlign": "center",
+                  }
+                }
+              >
+                <div>
+                  notes taken
+                </div>
+                <div>
+                  last 
+                  45
+                   days
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -14311,9 +14473,46 @@ exports[`snapshots works for pluto attendance 1`] = `
           }
         >
           <div>
-            “
-            referral
-            ”
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "fontSize": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 10,
+                }
+              }
+            >
+              0
+            </div>
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "color": "#333",
+                  "display": "flex",
+                  "flexDirection": "column",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "textAlign": "center",
+                  }
+                }
+              >
+                <div>
+                  notes taken
+                </div>
+                <div>
+                  last 
+                  45
+                   days
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -15263,9 +15462,46 @@ exports[`snapshots works for pluto behavior 1`] = `
           }
         >
           <div>
-            “
-            referral
-            ”
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "fontSize": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 10,
+                }
+              }
+            >
+              0
+            </div>
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "color": "#333",
+                  "display": "flex",
+                  "flexDirection": "column",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "textAlign": "center",
+                  }
+                }
+              >
+                <div>
+                  notes taken
+                </div>
+                <div>
+                  last 
+                  45
+                   days
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -16215,9 +16451,46 @@ exports[`snapshots works for pluto notes 1`] = `
           }
         >
           <div>
-            “
-            referral
-            ”
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "fontSize": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 10,
+                }
+              }
+            >
+              0
+            </div>
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "color": "#333",
+                  "display": "flex",
+                  "flexDirection": "column",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "textAlign": "center",
+                  }
+                }
+              >
+                <div>
+                  notes taken
+                </div>
+                <div>
+                  last 
+                  45
+                   days
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
@@ -1831,7 +1831,14 @@ exports[`snapshots works for aladdin 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -1940,7 +1947,14 @@ exports[`snapshots works for aladdin 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -2049,7 +2063,14 @@ exports[`snapshots works for aladdin 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -2158,7 +2179,14 @@ exports[`snapshots works for aladdin 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -2267,7 +2295,14 @@ exports[`snapshots works for aladdin 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -2376,7 +2411,14 @@ exports[`snapshots works for aladdin 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -2485,7 +2527,14 @@ exports[`snapshots works for aladdin 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -7508,7 +7557,14 @@ exports[`snapshots works for olaf 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -7595,7 +7651,14 @@ Reduce behavior.
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -7682,7 +7745,14 @@ Increase how often the student is engaged in positive behaviors.
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -7769,7 +7839,14 @@ Reduce behavior.
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -7878,7 +7955,14 @@ Reduce behavior.
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -7965,7 +8049,14 @@ Increase how often the student is engaged in positive behaviors.
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -12656,7 +12747,14 @@ exports[`snapshots works for pluto 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -12765,7 +12863,14 @@ exports[`snapshots works for pluto 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -12874,7 +12979,14 @@ exports[`snapshots works for pluto 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -12983,7 +13095,14 @@ exports[`snapshots works for pluto 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -13092,7 +13211,14 @@ exports[`snapshots works for pluto 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={

--- a/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
@@ -1831,7 +1831,14 @@ exports[`snapshots works for aladdin 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -1940,7 +1947,14 @@ exports[`snapshots works for aladdin 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -2049,7 +2063,14 @@ exports[`snapshots works for aladdin 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -2158,7 +2179,14 @@ exports[`snapshots works for aladdin 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -2267,7 +2295,14 @@ exports[`snapshots works for aladdin 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -2376,7 +2411,14 @@ exports[`snapshots works for aladdin 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -2485,7 +2527,14 @@ exports[`snapshots works for aladdin 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -4490,7 +4539,14 @@ exports[`snapshots works for olaf 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -4577,7 +4633,14 @@ Reduce behavior.
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -4664,7 +4727,14 @@ Increase how often the student is engaged in positive behaviors.
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -4751,7 +4821,14 @@ Reduce behavior.
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -4860,7 +4937,14 @@ Reduce behavior.
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -4947,7 +5031,14 @@ Increase how often the student is engaged in positive behaviors.
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -6821,7 +6912,14 @@ exports[`snapshots works for pluto 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -6930,7 +7028,14 @@ exports[`snapshots works for pluto 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -7039,7 +7144,14 @@ exports[`snapshots works for pluto 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -7148,7 +7260,14 @@ exports[`snapshots works for pluto 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={
@@ -7257,7 +7376,14 @@ exports[`snapshots works for pluto 1`] = `
                 }
               }
             >
-              <div>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
                 <span
                   className="date"
                   style={

--- a/app/assets/javascripts/student_profile/fixtures/fixtures.js
+++ b/app/assets/javascripts/student_profile/fixtures/fixtures.js
@@ -5,6 +5,18 @@ import serviceTypesIndex from '../../testing/fixtures/serviceTypesIndex';
 export const nowMoment = moment('2016-02-11T10:15:00');
 
 export const feedForTestingNotes = {
+  "transition_notes": [
+    {
+      "id": 1,
+      "created_at": "2016-08-20T11:52:47.814Z",
+      "updated_at": "2016-08-20T11:52:47.814Z",
+      "educator_id": 1,
+      "student_id": 5,
+      "text": "What are this student's strengths?\neverything!\n\nWhat is this student's involvement in the school community like?\nreally good\n\nHow does this student relate to their peers?\nnot sure\n\nWho is the student's primary guardian?\nokay\n\nAny additional comments or good things to know about this student?\nnope :)",
+      "recorded_at": null,
+      "is_restricted": false
+    }
+  ],
   "event_notes": [
     {
       "id": 3,
@@ -86,7 +98,7 @@ export const feedForTestingNotes = {
         "educator_id": 1
       }
     ]
-  }
+  },
 };
 
 export const currentEducator = {

--- a/app/assets/javascripts/student_profile/lightQuotes.js
+++ b/app/assets/javascripts/student_profile/lightQuotes.js
@@ -26,7 +26,7 @@ export function quotesFrom(transitionNotes, educatorsIndex, style) {
   const safeNotes = transitionNotes.filter(transitionNote => !transitionNote.is_restricted);
 
   return _.flatten(safeNotes.map(note => {
-    const dateText = toMomentFromTimestamp(note.recorded_at).format('M/D/YY');
+    const dateText = toMomentFromTimestamp(note.created_at).format('M/D/YY');
     const educator = educatorsIndex[note.educator_id] || educatorsIndex[_.keys(educatorsIndex)[0]];
     const tagline = <span>from <Educator style={style} educator={educator} /></span>;
     const source = (

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -202,6 +202,8 @@ class StudentsController < ApplicationController
       event_notes: student.event_notes
         .select {|note| note.is_restricted == restricted_notes}
         .map {|event_note| EventNoteSerializer.new(event_note).serialize_event_note },
+      transition_notes: student.transition_notes
+        .select {|note| note.is_restricted == restricted_notes},
       services: {
         active: student.services.active.map {|service| ServiceSerializer.new(service).serialize_service },
         discontinued: student.services.discontinued.map {|service| ServiceSerializer.new(service).serialize_service }

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -451,7 +451,7 @@ describe StudentsController, :type => :controller do
 
     it 'returns services' do
       feed = controller.send(:student_feed, student)
-      expect(feed.keys).to contain_exactly([:event_notes, :services, :deprecated, :transition_notes])
+      expect(feed.keys).to contain_exactly(:event_notes, :services, :deprecated, :transition_notes)
       expect(feed[:services].keys).to eq [:active, :discontinued]
       expect(feed[:services][:discontinued].first[:id]).to eq service.id
     end

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -65,8 +65,14 @@ describe StudentsController, :type => :controller do
           expect(serialized_data[:dibels]).to eq []
           expect(serialized_data[:feed]).to eq ({
             event_notes: [],
-            services: {active: [], discontinued: []},
-            deprecated: {interventions: []}
+            transition_notes: [],
+            services: {
+              active: [],
+              discontinued: []
+            },
+            deprecated: {
+              interventions: []
+            }
           })
 
           expect(serialized_data[:service_types_index]).to eq({
@@ -445,7 +451,7 @@ describe StudentsController, :type => :controller do
 
     it 'returns services' do
       feed = controller.send(:student_feed, student)
-      expect(feed.keys).to eq([:event_notes, :services, :deprecated])
+      expect(feed.keys).to contain_exactly([:event_notes, :services, :deprecated, :transition_notes])
       expect(feed[:services].keys).to eq [:active, :discontinued]
       expect(feed[:services][:discontinued].first[:id]).to eq service.id
     end


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
Transition notes don't appear in the notes list right now.  Also, the notes summary tab shows various keywords, but these need more work than we can probably do this week to make sure they show students in the best light (and at the beginning of school they'd be empty anyway).

# What does this PR do?
Adds transition notes into the `feed` in the controller response, and render them in the `<NotesList />` UI.  Also fix a bug with the date for transition notes in "insights" section. 
 Separately, replace the keywords in the notes tab with simple note counts, and we can revisit that later in the fall.

# Screenshot (if adding a client-side feature)
### transition note shown in `<NotesList />`
<img width="757" alt="screen shot 2018-08-20 at 8 05 19 am" src="https://user-images.githubusercontent.com/1056957/44345813-584d2080-a462-11e8-8b6c-7aeb81fc09b1.png">

### fix date on transition note insight
<img width="315" alt="screen shot 2018-08-20 at 8 18 46 am" src="https://user-images.githubusercontent.com/1056957/44345784-44092380-a462-11e8-98a9-7d690f3f0e45.png">

### remove keywords for notes summary tab
<img width="430" alt="screen shot 2018-08-20 at 10 18 51 am" src="https://user-images.githubusercontent.com/1056957/44345865-77e44900-a462-11e8-8925-b525865a90f7.png">

### allow keywords if `tags` in URL
<img width="408" alt="screen shot 2018-08-20 at 10 19 11 am" src="https://user-images.githubusercontent.com/1056957/44345878-83377480-a462-11e8-89a1-6a69462644da.png">

# Checklists
+ [x] Author checked latest in IE - Student Profile
+ [x] Author checked latest in IE - My notes
+ [x] Author included specs for new code
