### PR TITLE
Profile v3: Parse and reformat transition note whitespace

### DIFF
--- a/app/assets/javascripts/components/HelpBubble.js
+++ b/app/assets/javascripts/components/HelpBubble.js
@@ -2,7 +2,7 @@ import ReactModal from 'react-modal';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-class HelpBubble extends React.Component {
+export default class HelpBubble extends React.Component {
 
   constructor(props){
     super(props);
@@ -44,16 +44,17 @@ class HelpBubble extends React.Component {
   }
 
   renderModal(){
+    const {title, content, modalStyle} = this.props;
     // There are three ways to close a modal dialog: click on one of the close buttons,
     // click outside the bounds, or press Escape.
     return (
-      <ReactModal isOpen={this.state.modalIsOpen} onRequestClose={this.closeModal}>
+      <ReactModal isOpen={this.state.modalIsOpen} onRequestClose={this.closeModal} style={modalStyle}>
         {// Every help box has a title and two close buttons. The content is free-form HTML.
         <div className="modal-help">
           <div
             style={{borderBottom: '1px solid #333', paddingBottom: 10, marginBottom: 20}}>
             <h1 style={{display: 'inline-block'}}>
-              {this.props.title}
+              {title}
             </h1>
             <a
               href="#"
@@ -63,7 +64,7 @@ class HelpBubble extends React.Component {
             </a>
           </div>
           <div>
-            {this.props.content}
+            {content}
           </div>
           {// Fills the empty space
           <div style={{flex: 1, minHeight: 20}}>
@@ -85,8 +86,6 @@ HelpBubble.propTypes = {
   content: PropTypes.node.isRequired, // React DOM objects which will be displayed in the modal text box.
   teaser: PropTypes.node.isRequired, // text displayed before the user clicks, e.g. 'Find out more.'
   style: PropTypes.object,
-  linkStyle: PropTypes.object
+  linkStyle: PropTypes.object,
+  modalStyle: PropTypes.object
 };
-
-export default HelpBubble;
-

--- a/app/assets/javascripts/student_profile/NotesList.js
+++ b/app/assets/javascripts/student_profile/NotesList.js
@@ -109,3 +109,5 @@ const styles = {
     marginRight: 10
   }
 };
+
+export const badgeStyle = styles.badge;

--- a/app/assets/javascripts/student_profile/NotesList.js
+++ b/app/assets/javascripts/student_profile/NotesList.js
@@ -7,7 +7,7 @@ import * as InsightsPropTypes from '../helpers/InsightsPropTypes';
 import * as FeedHelpers from '../helpers/FeedHelpers';
 import {eventNoteTypeText} from '../helpers/eventNoteType';
 import NoteCard from './NoteCard';
-
+import {parseAndReRender} from './lightTransitionNotes';
 
 /*
 Renders the list of notes, including the different types of notes (eg, deprecated
@@ -82,7 +82,7 @@ export default class NotesList extends React.Component {
         noteMoment={toMomentFromRailsDate(transitionNote.created_at)}
         badge={<span style={styles.badge}>Transition note</span>}
         educatorId={transitionNote.educator_id}
-        text={transitionNote.text}
+        text={parseAndReRender(transitionNote.text)}
         educatorsIndex={this.props.educatorsIndex}
         attachments={[]} />
     );

--- a/app/assets/javascripts/student_profile/lightQuotes.js
+++ b/app/assets/javascripts/student_profile/lightQuotes.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import _ from 'lodash';
 import moment from 'moment';
-import {toMomentFromTimestamp} from '../helpers/toMoment';
+import {toMomentFromRailsDate, toMomentFromTimestamp} from '../helpers/toMoment';
 import Educator from '../components/Educator';
 import HelpBubble from '../components/HelpBubble';
-import {parseTransitionNoteText} from './lightTransitionNotes';
-
+import NoteCard from './NoteCard';
+import {badgeStyle} from './NotesList';
+import {parseTransitionNoteText, parseAndReRender} from './lightTransitionNotes';
 
 export function sampleQuotes(style) {  
   const quotes = [
@@ -34,10 +35,12 @@ export function quotesFrom(transitionNotes, educatorsIndex, style) {
         <span>in</span>
         <HelpBubble
           style={{marginLeft: 5, marginRight: 5}}
+          modalStyle={{content: {right: 40, bottom: 'auto', left: 'auto'}}} // styling to be above this part of the page
           linkStyle={style}
           teaser="Transition note"
           title="Transition note"
-          content={renderTransitionNote(note.text, dateText, <Educator educator={educator} />)} />
+          content={renderTransitionNote(note, educator)}
+        />
         <span>on {dateText}</span>
       </span>
     );
@@ -73,18 +76,15 @@ export function upsellQuotes(student, style) {
 }
 
 
-function renderTransitionNote(text, dateText, educatorEl) {
+// Look similar to profile view
+function renderTransitionNote(transitionNote, educator) {
   return (
-    <div>
-      <div style={{
-        whiteSpace: 'pre',
-        marginBottom: 10,
-        padding: 20,
-        border: '1px solid #ccc',
-        background: '#eee'
-      }}>{text}</div>
-      <div>by {educatorEl}</div>
-      <div>on {dateText}</div>
-    </div>
+    <NoteCard
+      noteMoment={toMomentFromRailsDate(transitionNote.created_at)}
+      badge={<span style={badgeStyle}>Transition note</span>}
+      educatorId={educator.id}
+      text={parseAndReRender(transitionNote.text)}
+      educatorsIndex={{[educator.id]: educator}}
+      attachments={[]} />
   );
 }

--- a/app/assets/javascripts/student_profile/lightTransitionNotes.js
+++ b/app/assets/javascripts/student_profile/lightTransitionNotes.js
@@ -33,3 +33,16 @@ export function parseTransitionNoteText(transitionNoteText) {
     other: extractOne(transitionNoteText, OTHER_PROMPT)
   };
 }
+
+// Parse and re-render as text with whitespace etc. in a standard format.
+export function parseAndReRender(transitionNoteText) {
+  const {strengths, community, peers, guardian, other} = parseTransitionNoteText(transitionNoteText);
+  const NEWLINE = "\n";
+  return [
+    STRENGTHS_PROMPT, NEWLINE, strengths, NEWLINE, NEWLINE,
+    COMMUNITY_PROMPT, NEWLINE, community, NEWLINE, NEWLINE,
+    PEERS_PROMPT, NEWLINE, peers, NEWLINE, NEWLINE,
+    GUARDIAN_PROMPT, NEWLINE, guardian, NEWLINE, NEWLINE,
+    OTHER_PROMPT, NEWLINE, other, NEWLINE, NEWLINE
+  ].join('');
+}

--- a/app/lib/env.rb
+++ b/app/lib/env.rb
@@ -19,7 +19,6 @@ class Env
     default_env['ROLLBAR_JS_ACCESS_TOKEN'] = 'foo';
 
     # feature switches
-    default_env['ENABLE_CLASS_LISTS'] = 'true'
     default_env['ENABLE_COUNSELOR_BASED_FEED'] = 'true'
     default_env['HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8'] = 'true'
     ENV['ENABLE_MASQUERADING'] = 'true'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,6 +5,7 @@ Rails.application.configure do
     ENV[key.to_s] = value
   end if File.exists?(env_file)
   Env.set_for_development_and_test!
+  ENV['ENABLE_CLASS_LISTS'] = 'false'
   ENV['USE_PLACEHOLDER_STUDENT_PHOTO'] = 'true'
 
   config.cache_classes = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -2,6 +2,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
   # Set env variables
   Env.set_for_development_and_test!
+  ENV['ENABLE_CLASS_LISTS'] = 'true'
 
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that


### PR DESCRIPTION
# Who is this PR for?

# What problem does this PR fix?
Part of https://github.com/studentinsights/studentinsights/issues/1990.  This standardizes the display of transition notes in the profile page and popup, both in terms of the UI component and the literal text within the component.

# What does this PR do?


# Screenshot (if adding a client-side feature)
### before: note, unformatted
<img width="495" alt="screen shot 2018-08-20 at 11 49 06 am" src="https://user-images.githubusercontent.com/1056957/44357520-3f536800-a480-11e8-90bd-7532c7b41c12.png">

### after: note, formatted
<img width="501" alt="screen shot 2018-08-20 at 11 48 29 am" src="https://user-images.githubusercontent.com/1056957/44357534-44b0b280-a480-11e8-93bb-2ed82d8e9e5c.png">

### before: popup, larger, unformatted
<img width="918" alt="screen shot 2018-08-20 at 12 06 24 pm" src="https://user-images.githubusercontent.com/1056957/44357507-38c4f080-a480-11e8-9105-abfa4cc78db7.png">

### after: popup, smaller, formatted
<img width="998" alt="screen shot 2018-08-20 at 12 17 57 pm" src="https://user-images.githubusercontent.com/1056957/44357442-0dda9c80-a480-11e8-9fb6-f23943dbf0dc.png">


# Checklists
+ [x] Author checked latest in IE - Student Profile
