### PR TITLE
Validate educators assigned to correct homerooms

### DIFF
--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -87,7 +87,8 @@ class EducatorsImporter
       return
     end
 
-    # Update homeroom
+    # Update homeroom: homerooms guaranteed to be uniqe on {name, school}
+    # by the index_homerooms_on_school_id_and_name database index
     homeroom = Homeroom.find_by(name: row[:homeroom], school: educator.school)
     if homeroom.nil?
       @ignored_unknown_homeroom_count = @ignored_unknown_homeroom_count + 1

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -88,7 +88,7 @@ class EducatorsImporter
     end
 
     # Update homeroom
-    homeroom = Homeroom.find_by_name(row[:homeroom])
+    homeroom = Homeroom.find_by(name: row[:homeroom], school: educator.school)
     if homeroom.nil?
       @ignored_unknown_homeroom_count = @ignored_unknown_homeroom_count + 1
       return

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -70,11 +70,6 @@ class Educator < ActiveRecord::Base
     educator_labels.map(&:label_key)
   end
 
-  def default_homeroom
-    return homeroom if homeroom.present?
-    raise Exceptions::NoAssignedHomeroom
-  end
-
   def default_section
     return sections[0] if sections.present?
     raise Exceptions::NoAssignedSections

--- a/app/models/homeroom.rb
+++ b/app/models/homeroom.rb
@@ -12,7 +12,7 @@ class Homeroom < ActiveRecord::Base
   def school_matches_educator_school
     if educator.present? && educator.school.present?
       if educator.school != school
-        error.add(:school, 'does not match educator\'s school')
+        errors.add(:school, 'does not match educator\'s school')
       end
     end
   end

--- a/app/models/homeroom.rb
+++ b/app/models/homeroom.rb
@@ -7,6 +7,15 @@ class Homeroom < ActiveRecord::Base
   has_many :students, after_add: :update_grade
   belongs_to :educator, optional: true
   belongs_to :school
+  validate :school_matches_educator_school
+
+  def school_matches_educator_school
+    if educator.present? && educator.school.present?
+      if educator.school != school
+        error.add(:school, 'does not match educator\'s school')
+      end
+    end
+  end
 
   def update_grade(student)
     # Set homeroom grade level to be first student's grade level, since

--- a/db/migrate/20180820193329_index_homeroom_on_school_and_name.rb
+++ b/db/migrate/20180820193329_index_homeroom_on_school_and_name.rb
@@ -1,0 +1,5 @@
+class IndexHomeroomOnSchoolAndName < ActiveRecord::Migration[5.2]
+  def change
+    add_index(:homerooms, [:school_id, :name], unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_09_175409) do
+ActiveRecord::Schema.define(version: 2018_08_20_193329) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -208,6 +208,7 @@ ActiveRecord::Schema.define(version: 2018_08_09_175409) do
     t.string "grade"
     t.integer "school_id"
     t.index ["educator_id"], name: "index_homerooms_on_educator_id"
+    t.index ["school_id", "name"], name: "index_homerooms_on_school_id_and_name", unique: true
     t.index ["slug"], name: "index_homerooms_on_slug", unique: true
   end
 

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -171,7 +171,7 @@ describe ProfileController, :type => :controller do
 
       context 'educator has homeroom access' do
         let(:educator) { FactoryBot.create(:educator, school: school) }
-        before { homeroom.update(educator: educator) }
+        before { homeroom.update(educator: educator, school: school) }
 
         it 'is successful' do
           make_request(educator, student.id)

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -158,7 +158,7 @@ describe StudentsController, :type => :controller do
 
       context 'educator has homeroom access' do
         let(:educator) { FactoryBot.create(:educator, school: school) }
-        before { homeroom.update(educator: educator) }
+        before { homeroom.update(educator: educator, school: school) }
 
         it 'is successful' do
           make_request({ student_id: student.id, format: :html })

--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
 
     factory :educator_with_homeroom do
       after(:create) do |educator|
-        create(:homeroom, educator: educator)
+        create(:homeroom, educator: educator, school: educator.school)
       end
     end
 

--- a/spec/factories/homerooms.rb
+++ b/spec/factories/homerooms.rb
@@ -1,10 +1,5 @@
 FactoryBot.define do
-
   sequence(:name) { |n| n.to_s }
-
-  trait :named_hea_100 do
-    name "HEA 100"
-  end
 
   factory :homeroom do
     name { FactoryBot.generate(:name) }

--- a/spec/importers/file_importers/educators_importer_spec.rb
+++ b/spec/importers/file_importers/educators_importer_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe EducatorsImporter do
 
       context 'name of homeroom that exists' do
         let!(:homeroom) {
-          Homeroom.create!(name: 'HEA 100',school: school)
+          Homeroom.create!(name: 'HEA 100', school: school)
         }
 
         it 'assigns the homeroom to the educator' do

--- a/spec/importers/file_importers/educators_importer_spec.rb
+++ b/spec/importers/file_importers/educators_importer_spec.rb
@@ -219,17 +219,25 @@ RSpec.describe EducatorsImporter do
 
   end
 
-  describe '#update_homeroom' do
+  describe 'update homeroom' do
     let!(:school) { FactoryBot.create(:healey) }
 
     context 'row with homeroom name' do
       let(:row) {
-        { state_id: "500", full_name: "Young, Jenny",
-          homeroom: "HEA 100", login_name: "jyoung", school_local_id: "HEA" }
+        {
+          login_name: 'jyoung',
+          school_local_id: 'HEA',
+          homeroom: 'HEA 100',
+          full_name: 'Young, Jenny',
+          state_id: '500',
+        }
       }
 
       context 'name of homeroom that exists' do
-        let!(:homeroom) { FactoryBot.create(:homeroom, :named_hea_100) }
+        let!(:homeroom) {
+          Homeroom.create!(name: 'HEA 100',school: school)
+        }
+
         it 'assigns the homeroom to the educator' do
           make_educators_importer.import_row(row)
           expect(Educator.last.homeroom).to eq homeroom

--- a/spec/importers/file_importers/students_importer_spec.rb
+++ b/spec/importers/file_importers/students_importer_spec.rb
@@ -19,11 +19,6 @@ RSpec.describe StudentsImporter do
       let!(:brown) { School.create(local_id: 'BRN') }
 
       context 'no existing students in database' do
-
-        it 'creates Student records' do
-          expect { import }.to change { Student.count }.by(4)
-        end
-
         it 'does not import students with far future registration dates' do
           import
           expect(Student.count).to eq 4

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -156,27 +156,6 @@ RSpec.describe Educator do
 
   end
 
-  describe '#default_homeroom' do
-    context 'educator assigned a homeroom' do
-      let(:educator) { FactoryBot.create(:educator) }
-      let!(:homeroom) { FactoryBot.create(:homeroom, educator: educator) }
-
-      it 'raises an error' do
-        expect(educator.default_homeroom).to eq homeroom
-      end
-    end
-
-    context 'educator not assigned a homeroom' do
-      let!(:homeroom) { FactoryBot.create(:homeroom) }
-      let(:educator) { FactoryBot.create(:educator) }
-
-      it 'raises an error' do
-        expect { educator.default_homeroom }.to raise_error Exceptions::NoAssignedHomeroom
-      end
-    end
-
-  end
-
   describe '#allowed_homerooms' do
     let!(:school) { FactoryBot.create(:healey) }
     let!(:other_school) { FactoryBot.create(:brown) }

--- a/spec/models/homeroom_spec.rb
+++ b/spec/models/homeroom_spec.rb
@@ -2,6 +2,21 @@ require 'rails_helper'
 
 RSpec.describe Homeroom do
 
+  describe '#school_matches_educator_school' do
+    let!(:pals) { TestPals.create! }
+
+    context 'school is different from educator school' do
+      let(:healey_kindergarten_homeroom) { pals.healey_kindergarten_homeroom }
+      let(:west) { pals.west }
+
+      it 'is invalid' do
+        healey_kindergarten_homeroom.school = west
+        expect(healey_kindergarten_homeroom).to be_invalid
+        expect(healey_kindergarten_homeroom.errors[:school]).to eq ["does not match educator's school"]
+      end
+    end
+  end
+
   describe '#grade' do
     context 'with PK student' do
       let(:homeroom) { FactoryBot.create(:homeroom_with_pre_k_student) }
@@ -16,6 +31,7 @@ RSpec.describe Homeroom do
       end
     end
   end
+
   describe '.destroy_empty_homerooms' do
     context 'one homeroom with no students' do
       let!(:homeroom) { FactoryBot.create(:homeroom) }


### PR DESCRIPTION
# What problem does this PR fix?

+ Educators at our new school district deployment assigned to incorrect homerooms.

# What does this PR do?

+ Changes the import process to select the correct homeroom for each educator based on `{name,school}`.

+ Adds a new index with `unique: true` to verify that all homerooms in the database are unique on `{name,school}`, so that there can only be one per combination. 

  + I verified that there are no duplicate homerooms on `{name,school}` in any of our databases, so this is a guard against data quality regression in the future. 

# Deployment

+ The migration should deploy without errors on all of our instances, since there are no homeroom duplicates on `{name,school}` in our instances. 

+ The import process should heal all incorrect homeroom assignments. 

```
# educators_importer.rb

# this line will now select the correct homeroom:
[92] homeroom = Homeroom.find_by(name: row[:homeroom], school: educator.school) 
...
# this line will heal the mis-assigned educator ids:
[97] homeroom.update!(educator: educator) 
```