### PR TITLE
Fix layout regression in App.js from SessionRenewal

### DIFF
--- a/ui/App.js
+++ b/ui/App.js
@@ -34,7 +34,7 @@ import LoginActivityPageContainer from '../app/assets/javascripts/login_activity
 // This is the top-level component, only handling routing.
 // The core model is still "new page, new load," this just
 // handles routing on initial page load for JS code.
-class App extends React.Component {
+export default class App extends React.Component {
   componentDidMount() {
     measurePageLoad(info => console.log(JSON.stringify(info, null, 2))); // eslint-disable-line no-console
   }
@@ -57,7 +57,7 @@ class App extends React.Component {
     return (
       <NowContainer nowFn={() => moment.utc()}>
         <PerDistrictContainer districtKey={districtKey}>
-          <div className="App-content">
+          <div className="App-content" style={styles.flexVertical}>
             {sessionTimeoutInSeconds && this.renderSessionRenewal(sessionTimeoutInSeconds)}
             {this.renderRoutes()}
           </div>
@@ -267,4 +267,10 @@ App.propTypes = {
   sessionTimeoutInSeconds: PropTypes.number
 };
 
-export default App;
+const styles = {
+  flexVertical: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1
+  }
+};


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
https://github.com/studentinsights/studentinsights/pull/1980 regressed the layout for pages that try to use the whole vertical height (eg, "my students" or the absences analysis page).

# What does this PR do?
Fixes it by flexing the `App-content` container.

# Screenshot (if adding a client-side feature)
### before
<img width="1021" alt="screen shot 2018-08-21 at 1 19 30 pm" src="https://user-images.githubusercontent.com/1056957/44418015-38425d80-a545-11e8-8595-580fdcb592d7.png">

<img width="1023" alt="screen shot 2018-08-21 at 1 18 48 pm" src="https://user-images.githubusercontent.com/1056957/44418019-3bd5e480-a545-11e8-9136-ce281cd4dff3.png">

### after
<img width="994" alt="screen shot 2018-08-21 at 1 18 54 pm" src="https://user-images.githubusercontent.com/1056957/44418028-3ed0d500-a545-11e8-8422-fbf5a3af4ae2.png">
<img width="1023" alt="screen shot 2018-08-21 at 1 19 13 pm" src="https://user-images.githubusercontent.com/1056957/44418032-41332f00-a545-11e8-9d12-20e74c684aaa.png">
<img width="1004" alt="screen shot 2018-08-21 at 1 19 03 pm" src="https://user-images.githubusercontent.com/1056957/44418037-44c6b600-a545-11e8-8c9d-758185f0401a.png">



# Checklists
+ [x] Author checked latest in IE - Home page
+ [x] Author checked latest in IE - Student profile
+ [x] Author checked latest in IE - School Overview
+ [x] Author checked latest in IE - Absences dashboard
