### PR TITLE
Change default sort order for sections to order by term enrollment

### DIFF
--- a/app/assets/javascripts/student_profile/StudentSectionsRoster.js
+++ b/app/assets/javascripts/student_profile/StudentSectionsRoster.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import {baseSortByString, sortByNumber} from '../helpers/SortHelpers';
+import {baseSortByString, sortByNumber, sortByCustomEnum} from '../helpers/SortHelpers';
 import FlexibleRoster from '../components/FlexibleRoster';
 import * as Routes from '../helpers/Routes';
 
@@ -25,6 +25,14 @@ export default class StudentSectionsRoster extends React.Component {
     return baseSortByString(educatorNamesA, educatorNamesB);
   }
 
+  sortTerm(a, b, sortBy) {
+    return sortByCustomEnum(a, b, sortBy, [
+      '9', 'FY',  // all year
+      '1', 'S1', 'Q1', 'Q2', // first semester or first two quarters
+      '2', 'S2', 'Q3', 'Q4' // second semester of last two quarters
+    ]);
+  }
+
   render() {
     const sections = this.props.sections;
     
@@ -35,14 +43,14 @@ export default class StudentSectionsRoster extends React.Component {
       {label: 'Schedule', key: 'schedule'},
       {label: 'Educators', key: 'educators', cell: this.renderEducators, sortFunc: this.sortEducatorNames},
       {label: 'Room', key: 'room_number'},
-      {label: 'Term', key: 'term_local_id'}
+      {label: 'Term', key: 'term_local_id', sortFunc: this.sortTerm}
     ];
     
     return (
       <FlexibleRoster className="StudentSectionsRoster"
         rows={sections}
         columns={columns}
-        initialSortIndex={0}/>
+        initialSortIndex={6}/>
     );
   }
 

--- a/app/assets/javascripts/student_profile/StudentSectionsRoster.story.js
+++ b/app/assets/javascripts/student_profile/StudentSectionsRoster.story.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import StudentSectionsRoster from './StudentSectionsRoster';
+import {testProps} from './StudentSectionsRoster.test';
+
+
+storiesOf('profile/StudentSectionsRoster', module) // eslint-disable-line no-undef
+  .add('all', () => {
+    const props = testProps();
+    return <StudentSectionsRoster {...props} />;
+  });

--- a/app/assets/javascripts/student_profile/StudentSectionsRoster.test.js
+++ b/app/assets/javascripts/student_profile/StudentSectionsRoster.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import renderer from 'react-test-renderer';
+import StudentSectionsRoster from './StudentSectionsRoster';
+
+
+export function testProps(props) {
+  return {
+    linkableSections: [1,2,3,4,5,6],
+    sections: [{
+      "id":6,
+      "section_number":"SCI-201B",
+      "term_local_id":"S1",
+      "schedule":"5(M,W,F)",
+      "room_number":"306W",
+      "created_at":"2018-07-23T22:14:24.365Z",
+      "updated_at":"2018-07-23T22:14:24.365Z",
+      "course_id":3,
+      "grade_numeric":"60.0",
+      "course_description":"PHYSICS 1",
+      "educators":[{"full_name":"Teacher, Fatima"}],
+    }, {
+      "id":7,
+      "section_number":"BIO-302",
+      "term_local_id":"9",
+      "schedule":"5(M,W,F)",
+      "room_number":"206W",
+      "created_at":"2018-07-23T22:14:24.365Z",
+      "updated_at":"2018-07-23T22:14:24.365Z",
+      "course_id":5,
+      "grade_numeric":"75.0",
+      "course_description":"BIOLOGY 1",
+      "educators":[{"full_name":"Teacher, Bill"}],
+    }],
+    text: "hello",
+    ...props
+  };
+}
+
+it('renders without crashing', () => {
+  const el = document.createElement('div');
+  ReactDOM.render(<StudentSectionsRoster {...testProps()} />, el);
+});
+
+it('snapshots view', () => {
+  const tree = renderer
+    .create(<StudentSectionsRoster {...testProps()} />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/assets/javascripts/student_profile/TakeNotes.story.js
+++ b/app/assets/javascripts/student_profile/TakeNotes.story.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
+import PerDistrictContainer from '../components/PerDistrictContainer';
 import TakeNotes from './TakeNotes';
 import {testProps} from './TakeNotes.test';
 
@@ -17,9 +18,17 @@ function storyProps(props = {}) {
   };
 }
 
-storiesOf('profile/TakeNotes', module) // eslint-disable-line no-undef
-  .add('all', () => (
+function storyRender(props, context) {
+  const {districtKey} = context;
+  return (
     <div style={{display: 'flex', flexDirection: 'column', margin: 20, width: 470}}>
-      <TakeNotes {...storyProps()} />
+      <PerDistrictContainer districtKey={districtKey}>
+        <TakeNotes {...props} />
+      </PerDistrictContainer>
     </div>
-  ));
+  );
+}
+
+storiesOf('profile/TakeNotes', module) // eslint-disable-line no-undef
+  .add('somerville', () => storyRender(storyProps(), {districtKey: 'somerville'}))
+  .add('new_bedford', () => storyRender(storyProps(), {districtKey: 'new_bedford'}));

--- a/app/assets/javascripts/student_profile/__snapshots__/StudentSectionsRoster.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/StudentSectionsRoster.test.js.snap
@@ -108,9 +108,11 @@ exports[`snapshots view 1`] = `
         }
       >
         <td>
-          <p>
+          <a
+            href="/sections/6"
+          >
             SCI-201B
-          </p>
+          </a>
         </td>
         <td>
           PHYSICS 1

--- a/app/assets/javascripts/student_profile/__snapshots__/StudentSectionsRoster.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/StudentSectionsRoster.test.js.snap
@@ -1,0 +1,139 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshots view 1`] = `
+<div
+  className="FlexibleRoster"
+>
+  <table
+    className="roster-table"
+    id="roster-table"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
+  >
+    <thead>
+      <tr
+        className="column-groups"
+      />
+      <tr
+        id="roster-header"
+      >
+        <th
+          className="sort-header"
+          onClick={[Function]}
+        >
+          Section Number
+        </th>
+        <th
+          className="sort-header"
+          onClick={[Function]}
+        >
+          Course Description
+        </th>
+        <th
+          className="sort-header"
+          onClick={[Function]}
+        >
+          Grade
+        </th>
+        <th
+          className="sort-header"
+          onClick={[Function]}
+        >
+          Schedule
+        </th>
+        <th
+          className="sort-header"
+          onClick={[Function]}
+        >
+          Educators
+        </th>
+        <th
+          className="sort-header"
+          onClick={[Function]}
+        >
+          Room
+        </th>
+        <th
+          className="sort-header sort-down"
+          onClick={[Function]}
+        >
+          Term
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      id="roster-data"
+    >
+      <tr
+        style={
+          Object {
+            "backgroundColor": "#FFFFFF",
+          }
+        }
+      >
+        <td>
+          <p>
+            BIO-302
+          </p>
+        </td>
+        <td>
+          BIOLOGY 1
+        </td>
+        <td>
+          75.0
+        </td>
+        <td>
+          5(M,W,F)
+        </td>
+        <td>
+          <p>
+            Teacher, Bill
+          </p>
+        </td>
+        <td>
+          206W
+        </td>
+        <td>
+          9
+        </td>
+      </tr>
+      <tr
+        style={
+          Object {
+            "backgroundColor": "#F7F7F7",
+          }
+        }
+      >
+        <td>
+          <p>
+            SCI-201B
+          </p>
+        </td>
+        <td>
+          PHYSICS 1
+        </td>
+        <td>
+          60.0
+        </td>
+        <td>
+          5(M,W,F)
+        </td>
+        <td>
+          <p>
+            Teacher, Fatima
+          </p>
+        </td>
+        <td>
+          306W
+        </td>
+        <td>
+          S1
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/ui/config/.storybook/config.js
+++ b/ui/config/.storybook/config.js
@@ -21,6 +21,7 @@ function loadStories() {
   require('../../../app/assets/javascripts/student_profile/TakeNotes.story');
   require('../../../app/assets/javascripts/student_profile/RecordService.story');
   require('../../../app/assets/javascripts/student_profile/StudentProfilePage.story');
+  require('../../../app/assets/javascripts/student_profile/StudentSectionsRoster.story');
 
   // student profile v3
   require('../../../app/assets/javascripts/student_profile/LightProfilePage.story');


### PR DESCRIPTION
# Who is this PR for?
HS educators

# What problem does this PR fix?
The section enrollment panel doesn't visualize the schedule (which would be great and parity with what it looks like in Aspen directly), but it isn't even sorted by term.

# What does this PR do?
Sort enrollment by term.  Also adds a story and test for this component.

Separately, update the `TakeNotes` story for two districts since it had broken.

# Screenshot (if adding a client-side feature)
from the story:
<img width="899" alt="screen shot 2018-08-23 at 12 27 33 pm" src="https://user-images.githubusercontent.com/1056957/44538699-217c4200-a6d0-11e8-9bd6-90ceca055cc9.png">


# Checklists
+ [x] Author checked latest in IE - Student Profile
+ [x] Author checked latest in IE - Student Profile v3
+ [x] Author included specs for new code
