### PR TITLE
Fixup migration for Section timestamps, add migration to require timestamps

### DIFF
--- a/db/migrate/20180823190757_require_timestamps_for_section_join_tables.rb
+++ b/db/migrate/20180823190757_require_timestamps_for_section_join_tables.rb
@@ -1,0 +1,8 @@
+class RequireTimestampsForSectionJoinTables < ActiveRecord::Migration[5.2]
+  def change
+    change_column :student_section_assignments, :created_at, :datetime, null: false
+    change_column :student_section_assignments, :updated_at, :datetime, null: false
+    change_column :educator_section_assignments, :created_at, :datetime, null: false
+    change_column :educator_section_assignments, :updated_at, :datetime, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_21_152930) do
+ActiveRecord::Schema.define(version: 2018_08_23_190757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,8 +119,8 @@ ActiveRecord::Schema.define(version: 2018_08_21_152930) do
   create_table "educator_section_assignments", force: :cascade do |t|
     t.integer "section_id"
     t.integer "educator_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["educator_id"], name: "index_educator_section_assignments_on_educator_id"
     t.index ["section_id"], name: "index_educator_section_assignments_on_section_id"
   end
@@ -394,8 +394,8 @@ ActiveRecord::Schema.define(version: 2018_08_21_152930) do
     t.integer "student_id"
     t.decimal "grade_numeric"
     t.string "grade_letter"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["section_id"], name: "index_student_section_assignments_on_section_id"
     t.index ["student_id"], name: "index_student_section_assignments_on_student_id"
   end

--- a/lib/tasks/data_migrations/timestamps_for_section_join_tables.rake
+++ b/lib/tasks/data_migrations/timestamps_for_section_join_tables.rake
@@ -4,11 +4,11 @@ namespace :data_migration do
     # See also 20180821152930 AddTimestamps migration, this is intended to
     # be run after.
     time_now = Time.now
-    all_records = StudentSectionAssignments.all + EducatorSectionAssignments.all
+    all_records = StudentSectionAssignment.all + EducatorSectionAssignment.all
     puts "Going to update timestamps to #{time_now} for all #{all_records.size} records..."
     all_records.each_with_index do |record, index|
       record.update!(created_at: time_now, updated_at: time_now)
-      put "Processed #{index} records." if index > 0 && index % 100
+      puts "Processed #{index} records." if index > 0 && index % 100 == 0
     end
     puts "Done."
   end


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Follow-on to https://github.com/studentinsights/studentinsights/pull/1995.  Fixes bug in the rake task migration.

# What does this PR do?
After running this for Somerville successfully on the console, this enforces timestamps on these join tables.
