### PR TITLE
Revise SessionRenewal to reload and re-use existing guards

### DIFF
--- a/app/assets/javascripts/components/SessionRenewal-One.test.js
+++ b/app/assets/javascripts/components/SessionRenewal-One.test.js
@@ -9,7 +9,7 @@ export function testProps(props = {}) {
   return {
     sessionTimeoutInSeconds: 2,
     warningTimeoutInSeconds: 1,
-    doNavigate: jest.fn(),
+    forceReload: jest.fn(),
     ...props
   };
 }
@@ -24,7 +24,6 @@ export function resetFetchMock() {
   fetchMock.reset();
   fetchMock.restore();
   fetchMock.get('/educators/reset', {});
-  fetchMock.delete('/educators/sign_out', {});
 }
 
 export function callUrls() {

--- a/app/assets/javascripts/components/SessionRenewal-Three.test.js
+++ b/app/assets/javascripts/components/SessionRenewal-Three.test.js
@@ -1,16 +1,15 @@
-import {testProps, testRender, resetFetchMock, callUrls} from './SessionRenewal-One.test';
+import {testProps, testRender, resetFetchMock} from './SessionRenewal-One.test';
 
 
 beforeEach(resetFetchMock);
 
-it('after TIMED_OUT, shows message, signs out, and calls doNavigate', done => {
+it('after TIMED_OUT, shows message, signs out, and calls forceReload', done => {
   const props = testProps();
   const el = testRender(props);
 
   setTimeout(() => {
     expect($(el).text()).toEqual('Your session has timed out due to inactivity.');
-    expect(callUrls()).toContain('/educators/sign_out');
-    expect(props.doNavigate).toHaveBeenCalled();
+    expect(props.forceReload).toHaveBeenCalled();
     done();
   }, 2500);
 });

--- a/app/assets/javascripts/helpers/apiFetchJson.js
+++ b/app/assets/javascripts/helpers/apiFetchJson.js
@@ -1,6 +1,3 @@
-import qs from 'query-string';
-
-
 // Fetch with common headers
 function apiFetch(url, options = {}) {
   const fetchOptions = {
@@ -34,27 +31,5 @@ export function apiPostJson(url, body, options = {}) {
       'Content-Type': 'application/json',
       'X-CSRF-Token': csrfToken
     }
-  });
-}
-
-// This relies on a Rails CSRF token being rendered on the page
-export function signOut(options = {}) {
-  const url = '/educators/sign_out';
-  const csrfToken = options.csrfToken || $('meta[name="csrf-token"]').attr('content');
-  return fetch(url, {
-    method: 'DELETE',
-    credentials: 'same-origin',
-    body: qs.stringify({
-      _method: 'delete',
-      authenticity_token: csrfToken,
-      ...(options.body || {})
-    }),
-    headers: {
-      'Accept': 'text/html',
-      'Content-Type': 'text/html',
-      'X-CSRF-Token': csrfToken,
-      ...(options.headers || {})
-    },
-    ...options
   });
 }


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
The semantics in https://github.com/studentinsights/studentinsights/pull/1980 are a bit confusing, and by forcing a signout in each browser process, this can lead to confusing behavior with multiple open tabs.

This will also help clarify what's happening in testing the behavior of Devise::Timeoutable.

#  What does this PR do?
Changes the forced sign out to a reload, which accomplishes the same effect if the server session has expired (ie, clearing the screen of student data, clearly showing actions on the current would not be successful).  If the server session is still active, this reloads the page.

# Checklists
+ [x] Author included specs for new code
