### PR TITLE
Add student photos, remove test data from Homeroom view for start of school year 

### DIFF
--- a/app/assets/javascripts/homeroom/HomeroomPage.js
+++ b/app/assets/javascripts/homeroom/HomeroomPage.js
@@ -6,7 +6,6 @@ import SectionHeading from '../components/SectionHeading';
 import HomeroomTable from './HomeroomTable';
 import HomeroomNavigator from './HomeroomNavigator';
 
-
 /*
 Homeroom page, for K8 classroom teachers.  Most meaningful the first week or two of school.
 */
@@ -35,7 +34,7 @@ export default class HomeroomPage extends React.Component {
   }
 
   renderHomeroom(json) {
-    const {homeroom, rows, school, homerooms} = json;    
+    const {homeroom, rows, school, homerooms} = json;
     return (
       <div style={styles.flexVertical}>
         <SectionHeading>Homeroom: {homeroom.name}</SectionHeading>

--- a/app/assets/javascripts/homeroom/HomeroomTable.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import _ from 'lodash';
 import {
   sortByString,
   sortByNumber,

--- a/app/assets/javascripts/homeroom/HomeroomTable.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.js
@@ -11,7 +11,7 @@ import {
 import {eventNoteTypeTextMini} from '../helpers/eventNoteType';
 import {studentTableEventNoteTypeIds} from '../helpers/PerDistrict';
 import {mergeLatestNoteDateTextFields} from '../helpers/latestNote';
-import Cookies from 'js-cookie';
+import StudentPhoto from '../components/StudentPhoto';
 
 
 // Shows a homeroom roster, for K8 and HS homerooms.
@@ -20,19 +20,11 @@ export default class HomeroomTable extends React.Component {
   constructor(props) {
     super(props);
 
-    const initialColumns = this.getInitialColumnsDisplayed();
     this.state = {
-      columnsDisplayed: initialColumns,
-      showColumnPicker: false,
       sortBy: 'first_name',
       sortType: 'string',
       sortDesc: true
     };
-
-    this.onClickHeader = this.onClickHeader.bind(this);
-    this.openColumnPicker = this.openColumnPicker.bind(this);
-    this.closeColumnPicker = this.closeColumnPicker.bind(this);
-    this.toggleColumn = this.toggleColumn.bind(this);
   }
 
   eventNoteTypeIds() {
@@ -82,82 +74,16 @@ export default class HomeroomTable extends React.Component {
     }
   }
 
-  openColumnPicker() {
-    this.setState({ showColumnPicker: true });
-  }
-
-  closeColumnPicker() {
-    this.setState({ showColumnPicker: false });
-  }
-
-  toggleColumn(columnKey) {
-    const columnsDisplayed = _.clone(this.state.columnsDisplayed);
-    const columnKeyIndex = _.indexOf(columnsDisplayed, columnKey);
-
-    const isColumnDisplayed = (columnKeyIndex > -1);
-
-    if (isColumnDisplayed) {
-      columnsDisplayed.splice(columnKeyIndex, 1);
-    } else {
-      columnsDisplayed.push(columnKey);
-    }
-
-    Cookies.set("columnsDisplayed", columnsDisplayed);
-
-    this.setState({ columnsDisplayed: columnsDisplayed });
-  }
-
-  columnKeysToNames() {
-    return {
-      'supports': 'Supports',
-      'program': 'Program',
-      'sped': 'SPED & Disability',
-      'language': 'Language',
-      'star': 'STAR',
-      'mcas': 'MCAS',
-    };
-  }
-
-  columnKeys() {
-    return Object.keys(this.columnKeysToNames());
-  }
-
-  columnNames() {
-    return _.values(this.columnKeysToNames());
-  }
-
-  getInitialColumnsDisplayed() {
-    return (
-      Cookies.getJSON("columnsDisplayed") || this.columnKeys()
-    );
-  }
-
   mergedStudentRows() {
     const eventNoteTypeIds = this.eventNoteTypeIds();
     return this.props.rows
-      .map(student => mergeLatestNoteDateTextFields(student, student.event_notes_without_restricted, eventNoteTypeIds));
+      .map(student => mergeLatestNoteDateTextFields(
+        student, student.event_notes_without_restricted, eventNoteTypeIds)
+      );
   }
 
   visitStudentProfile(id) {
     window.location.href = `/students/${id}`;
-  }
-
-  showStar() {
-    const {grade} = this.props;
-    const columnsDisplayed = this.state.columnsDisplayed;
-    const starDisplayed = _.indexOf(columnsDisplayed, 'star') > -1;
-
-    if (starDisplayed === false) return false;
-    return (grade && grade >= 2);
-  }
-
-  showMcas() {
-    const {grade} = this.props;    
-
-    const columnsDisplayed = this.state.columnsDisplayed;
-    const mcasDisplayed = _.indexOf(columnsDisplayed, 'mcas') > -1;
-    if (mcasDisplayed === false) return false;
-    return (grade && grade >= 3) ;
   }
 
   onClickHeader(sortBy, sortType) {
@@ -171,7 +97,6 @@ export default class HomeroomTable extends React.Component {
   render() {
     return (
       <div className="HomeroomTable">
-        {this.renderColumnPickerArea()}
         <table id="roster-table" cellSpacing="0" cellPadding="5" className="sort-default">
           {this.renderHeaders()}
           {this.renderRows()}
@@ -180,120 +105,7 @@ export default class HomeroomTable extends React.Component {
     );
   }
 
-  renderStarHeaders() {
-    return (
-    [
-      <td colSpan="1" key="star_math_header">
-          <p className="smalltype">
-            STAR: Math
-          </p>
-        </td>,
-      <td colSpan="1" key="star_reading_header">
-          <p className="smalltype">
-            STAR: Reading
-          </p>
-        </td>
-    ]
-    );
-  }
-
-  renderStarSubHeaders() {
-    return (
-    [
-      <th className="sortable_header" key="star_math_sub_header"
-          onClick={this.onClickHeader.bind(null, 'most_recent_star_math_percentile', 'number')}>
-          <span className="table-header">Percentile</span>
-        </th>,
-      <th className="sortable_header" key="star_reading_sub_header"
-          onClick={this.onClickHeader.bind(null, 'most_recent_star_reading_percentile', 'number')}>
-          <span className="table-header">Percentile</span>
-        </th>
-    ]
-    );
-  }
-
-  renderMcasHeaders() {
-    return (
-    [
-      <td colSpan="2" key="mcas_math_header">
-          <p className="smalltype">
-            MCAS: Math
-          </p>
-        </td>,
-      <td colSpan="2" key="mcas_ela_header">
-          <p className="smalltype">
-            MCAS: ELA
-          </p>
-        </td>
-    ]
-    );
-  }
-
-  renderMcasSubHeaders() {
-    return (
-    [
-      <th className="sortable_header" key="mcas_math_sub_header_perf"
-          onClick={this.onClickHeader.bind(null, 'most_recent_mcas_math_performance', 'string')}>
-          <span className="table-header">Performance</span>
-        </th>,
-      <th className="sortable_header" key="mcas_math_sub_header_score"
-          onClick={this.onClickHeader.bind(null, 'most_recent_mcas_math_scaled', 'number')}>
-          <span className="table-header">Score</span>
-        </th>,
-      <th className="sortable_header" key="mcas_ela_sub_header_perf"
-          onClick={this.onClickHeader.bind(null, 'most_recent_mcas_ela_performance', 'string')}>
-          <span className="table-header">Performance</span>
-        </th>,
-      <th className="sortable_header" key="mcas_ela_sub_header_score"
-          onClick={this.onClickHeader.bind(null, 'most_recent_mcas_ela_scaled', 'number')}>
-          <span className="table-header">Score</span>
-        </th>
-    ]
-    );
-  }
-
-  renderStarData(row) {
-    if (!this.showStar()) return null;
-
-    return (
-    [
-      <td key="star_math_percentile_rank">
-          {row['most_recent_star_math_percentile'] || '—'}
-        </td>,
-      <td key="star_reading_percentile_rank">
-          {row['most_recent_star_reading_percentile'] || '—'}
-        </td>
-    ]
-    );
-  }
-
-  renderMcasData(row) {
-    if (!this.showMcas()) return null;
-
-    return (
-    [
-      <td key="mcas_math_performance_level">
-          {row['most_recent_mcas_math_performance'] || '—'}
-        </td>,
-      <td key="mcas_math_scaled">
-          {row['most_recent_mcas_math_scaled'] || '—'}
-        </td>,
-      <td key="mcas_ela performance_level">
-          {row['most_recent_mcas_ela_performance'] || '—'}
-        </td>,
-      <td key="mcas_ela_scaled">
-          {row['most_recent_mcas_ela_scaled'] || '—'}
-        </td>
-    ]
-    );
-  }
-
   renderSubHeader(columnKey, label, sortBy, sortType) {
-    const columnsDisplayed = this.state.columnsDisplayed;
-    const columnKeyIndex = _.indexOf(columnsDisplayed, columnKey);
-
-    if (columnKeyIndex === -1) return null;
-
     return (
       <th
         key={sortBy}
@@ -305,11 +117,6 @@ export default class HomeroomTable extends React.Component {
   }
 
   renderSuperHeader(columnKey, columnSpan, label) {
-    const columnsDisplayed = this.state.columnsDisplayed;
-    const columnKeyIndex = _.indexOf(columnsDisplayed, columnKey);
-
-    if (columnKeyIndex === -1) return null;
-
     if (!label) return (
       <td colSpan={columnSpan}></td>
     );
@@ -339,6 +146,11 @@ export default class HomeroomTable extends React.Component {
       <tr className="column-names">
         {/* COLUMN HEADERS */}
         {this.renderNameSubheader()}
+        <th>
+          <span className="table-header">
+            Photo
+          </span>
+        </th>
         {this.eventNoteTypeIds().map(eventNoteTypeId => (
           this.renderSubHeader('supports', `Last ${eventNoteTypeTextMini(eventNoteTypeId)}`, `latest_note_${eventNoteTypeId}_date_text`, 'date')
         ))}
@@ -360,8 +172,6 @@ export default class HomeroomTable extends React.Component {
         {this.renderSubHeader(
           'language', 'Home Language', 'home_language', 'string'
         )}
-        {(this.showStar()) ? this.renderStarSubHeaders() : null}
-        {(this.showMcas()) ? this.renderMcasSubHeaders() : null}
       </tr>
     );
   }
@@ -373,13 +183,12 @@ export default class HomeroomTable extends React.Component {
         <tr className="column-groups">
           {/*  TOP-LEVEL COLUMN GROUPS */}
           <td colSpan="1"></td>
+          <td colSpan="1"></td>
           {this.renderSuperHeader('supports', supportColumnCount, 'Supports')}
           {this.renderSuperHeader('program', '1')}
           {this.renderSuperHeader('sped', '3', 'SPED & Disability')}
           {this.renderSuperHeader('language', '2', 'Language')}
           {this.renderSuperHeader('free-reduced', '1')}
-          {(this.showStar()) ? this.renderStarHeaders() : null}
-          {(this.showMcas()) ? this.renderMcasHeaders() : null}
         </tr>
         {this.renderSubHeaders()}
       </thead>
@@ -387,11 +196,6 @@ export default class HomeroomTable extends React.Component {
   }
 
   renderDataCell(columnKey, data, options = {}) {
-    const columnsDisplayed = this.state.columnsDisplayed;
-    const columnKeyIndex = _.indexOf(columnsDisplayed, columnKey);
-
-    if (columnKeyIndex === -1) return null;
-
     return (
       <td key={options.key}>{data || '—'}</td>
     );
@@ -421,6 +225,9 @@ export default class HomeroomTable extends React.Component {
           key={id}
           style={style}>
         <td className="name">{fullName}</td>
+        <td>
+          <StudentPhoto student={row} width={40} height={40} />
+        </td>
         {this.eventNoteTypeIds().map(eventNoteTypeId => {
           const key = `latest_note_${eventNoteTypeId}_date_text`;
           return this.renderDataCell('supports', row[key], {key});
@@ -431,8 +238,6 @@ export default class HomeroomTable extends React.Component {
         {this.renderDataCell('sped', row['plan_504'])}
         {this.renderDataCell('language', row['limited_english_proficiency'])}
         {this.renderDataCell('language', row['home_language'])}
-        {this.renderStarData(row)}
-        {this.renderMcasData(row)}
       </tr>
     );
   }
@@ -448,84 +253,8 @@ export default class HomeroomTable extends React.Component {
       </tbody>
     );
   }
-
-  renderMenu() {
-    return (
-      <svg width="24px" height="6px" viewBox="0 0 24 6" version="1.1" >
-        <g id="Roster" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" >
-          <g id="Roster---home---add-1" transform="translate(-930.000000, -416.000000)" fill="#555555">
-            <g id="menu" transform="translate(930.000000, 416.000000)">
-              <circle id="Oval-137" cx="3" cy="3" r="3"></circle>
-              <path d="M12,6 C13.6568542,6 15,4.65685425 15,3 C15,1.34314575 13.6568542,0 12,0 C10.3431458,0 9,1.34314575 9,3 C9,4.65685425 10.3431458,6 12,6 Z" id="Oval-138"></path>
-              <circle id="Oval-139" cx="21" cy="3" r="3"></circle>
-            </g>
-          </g>
-        </g>
-      </svg>
-    );
-  }
-
-  renderColumnPickerArea() {
-    return (
-      <div>
-        <div onClick={this.openColumnPicker} id="column-picker-toggle">
-          {this.renderMenu()}
-        </div>
-        {this.renderColumnPickerMenu()}
-      </div>
-    );
-  }
-
-  renderColumnSelect(columnKey) {
-    const columnKeysToNames = this.columnKeysToNames();
-    const columnName = columnKeysToNames[columnKey];
-
-    const onToggleColumn = this.toggleColumn.bind(null, columnKey);
-
-    const columnsDisplayed = this.state.columnsDisplayed;
-    const isColumnDisplayed = (_.indexOf(columnsDisplayed, columnKey) > -1);
-
-    if (isColumnDisplayed) return (
-      <div key={columnKey}>
-        <input type="checkbox" defaultChecked onClick={onToggleColumn}/>
-        <label>{columnName}</label>
-      </div>
-    );
-
-    return (
-      <div key={columnKey}>
-        <input type="checkbox" onClick={onToggleColumn}/>
-        <label>{columnName}</label>
-      </div>
-    );
-  }
-
-  renderColumnSelectors() {
-    const columnKeys = this.columnKeys();
-
-    return columnKeys.map((key) => { return this.renderColumnSelect(key); });
-  }
-
-  renderColumnPickerMenu() {
-    if (this.state.showColumnPicker === false) return null;
-
-    return (
-      <div id="column-picker">
-        <p>
-          Select columns
-          <span className="close" onClick={this.closeColumnPicker}>
-            close
-          </span>
-        </p>
-        <form id="column-listing">
-          <div id="column-template">
-            {this.renderColumnSelectors()}
-          </div>
-        </form>
-      </div>
-    );
-  }
 }
+
 HomeroomTable.contextTypes = {
   districtKey: PropTypes.string.isRequired
 };

--- a/app/assets/javascripts/homeroom/HomeroomTable.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.js
@@ -25,6 +25,8 @@ export default class HomeroomTable extends React.Component {
       sortType: 'string',
       sortDesc: true
     };
+
+    this.onClickHeader = this.onClickHeader.bind(this);
   }
 
   eventNoteTypeIds() {

--- a/app/assets/javascripts/homeroom/HomeroomTable.test.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.test.js
@@ -38,34 +38,13 @@ function sstAndMtssDateTexts(el) {
 }
 
 describe('high-level integration test', () => {
-  // Prevent test pollution
-  beforeEach(() => Cookies.remove('columnsDisplayed'));
 
   it('renders the table', () => {
-
     const {el} = testRender(testProps());
 
     expect($(el).find('thead > tr').length).toEqual(2);
     expect($(el).find('tbody > tr').length).toEqual(6);
     expect(el.innerHTML).toContain('Aladdin Kenobi');
-  });
-
-  it('opens column picker when clicking on column picker toggle ', () => {
-
-    const {el} = testRender(testProps());
-
-    ReactTestUtils.Simulate.click($(el).find('#column-picker-toggle').get(0));
-    expect($(el).find('#column-picker').length).toEqual(1);
-  });
-
-  it('able to remove a column when unchecking an item on the column picker menu  ', () => {
-
-    const {el} = testRender(testProps());
-
-    ReactTestUtils.Simulate.click($(el).find('#column-picker-toggle').get(0));
-    expect($(el).find('span.table-header').length).toEqual(9);
-    ReactTestUtils.Simulate.click($(el).find('input[type=checkbox]').get(0));
-    expect($(el).find('span.table-header').length).toEqual(7);
   });
 
   it('renders SST and MTSS dates correctly for Somerville grade 2 as a happy path test case', () => {
@@ -152,14 +131,5 @@ describe('high-level integration test', () => {
       'Fluency',
       'Home Language'
     ]);
-  });
-
-  it('closes column picker when clicking close on an opened column picker ', () => {
-
-    const {el} = testRender(testProps());
-
-    $(el).find('#column-picker-toggle').click();
-    $(el).find('.close').click();
-    expect($(el).find('#column-picker').length).toEqual(0);
   });
 });

--- a/app/assets/javascripts/homeroom/HomeroomTable.test.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.test.js
@@ -80,6 +80,7 @@ describe('high-level integration test', () => {
     const {el} = testRender(props, context);
     expect(headerTexts(el)).toEqual([
       'Name',
+      'Photo',
       'Last BBST',
       'Program Assigned',
       'Disability',
@@ -87,12 +88,6 @@ describe('high-level integration test', () => {
       '504 Plan',
       'Fluency',
       'Home Language',
-      'Percentile',
-      'Percentile',
-      'Performance',
-      'Score',
-      'Performance',
-      'Score'
     ]);
   });
 
@@ -100,6 +95,7 @@ describe('high-level integration test', () => {
     const {el} = testRender(testProps({ grade: '6'}));
     expect(headerTexts(el)).toEqual([
       'Name',
+      'Photo',
       'Last SST',
       'Last MTSS',
       'Program Assigned',
@@ -108,12 +104,6 @@ describe('high-level integration test', () => {
       '504 Plan',
       'Fluency',
       'Home Language',
-      'Percentile',
-      'Percentile',
-      'Performance',
-      'Score',
-      'Performance',
-      'Score'
     ]);
   });
 
@@ -121,6 +111,7 @@ describe('high-level integration test', () => {
     const {el} = testRender(testProps({ school: shs() }));
     expect(headerTexts(el)).toEqual([
       'Name',
+      'Photo',
       'Last SST',
       'Last NGE',
       'Last 10GE',

--- a/app/assets/javascripts/homeroom/HomeroomTable.test.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.test.js
@@ -49,12 +49,12 @@ describe('high-level integration test', () => {
   it('renders SST and MTSS dates correctly for Somerville grade 2 as a happy path test case', () => {
     const {el} = testRender(testProps());
     expect(sstAndMtssDateTexts(el)).toEqual([
-      ["Aladdin Kenobi", "—", '—'],
-      ["Chip Pan", "2/16/11", '—'],
-      ["Pluto Poppins", "9/2/11", '6/5/11'],
-      ["Rapunzel Duck", "1/2/11", '8/6/11'],
-      ["Snow Skywalker", "10/31/10", '—'],
-      ["Snow Kenobi", "8/29/11", '7/27/11']
+      ["Aladdin Kenobi", "", "—", '—'],
+      ["Chip Pan", "", "2/16/11", '—'],
+      ["Pluto Poppins", "", "9/2/11", '6/5/11'],
+      ["Rapunzel Duck", "", "1/2/11", '8/6/11'],
+      ["Snow Skywalker", "", "10/31/10", '—'],
+      ["Snow Kenobi", "", "8/29/11", '7/27/11']
     ]);
   });
 

--- a/app/assets/javascripts/homeroom/HomeroomTable.test.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.test.js
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-addons-test-utils';
 import {SOMERVILLE, NEW_BEDFORD} from '../helpers/PerDistrict';
 import PerDistrictContainer from '../components/PerDistrictContainer';
-import Cookies from 'js-cookie';
 import HomeroomTable from './HomeroomTable';
 import {healey, shs, students} from './HomeroomTable.fixtures';
 

--- a/app/assets/javascripts/homeroom/HomeroomTable.test.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.test.js
@@ -63,6 +63,7 @@ describe('high-level integration test', () => {
     const {el} = testRender(testProps());
     expect(headerTexts(el)).toEqual([
       'Name',
+      'Photo',
       'Last SST',
       'Last MTSS',
       'Program Assigned',

--- a/app/assets/javascripts/homeroom/HomeroomTable.test.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ReactTestUtils from 'react-addons-test-utils';
 import {SOMERVILLE, NEW_BEDFORD} from '../helpers/PerDistrict';
 import PerDistrictContainer from '../components/PerDistrictContainer';
 import HomeroomTable from './HomeroomTable';

--- a/app/assets/javascripts/homeroom/HomeroomTable.test.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.test.js
@@ -32,7 +32,7 @@ function headerTexts(el) {
 
 function sstAndMtssDateTexts(el) {
   return $(el).find('table tbody tr').toArray().map(el => {
-    return $(el).find('td').toArray().slice(0, 3).map(el => $(el).text());
+    return $(el).find('td').toArray().slice(0, 4).map(el => $(el).text());
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "highcharts": "^6.0.2",
     "jest-fetch-mock": "^1.4.2",
     "jquery": "^3.2.1",
-    "js-cookie": "^2.1.4",
     "lodash": "4.17.10",
     "mixpanel-browser": "^2.22.4",
     "moment": "2.19.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4848,10 +4848,6 @@ js-base64@^2.1.9:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.3.tgz#2e545ec2b0f2957f41356510205214e98fad6582"
 
-js-cookie@^2.1.4:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
-
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"


### PR DESCRIPTION
# Who is this PR for?

K8 Educators. 

# What does this PR do?

+ Adds student photos to Homeroom roster.
+ Removes MCAS and STAR data from Homeroom Roster. (To show students in their best light, we don't want to show them as a grid of numbers.) This can be added back later with a default-off "Show More Data" button or a "Download Assessment Data" button.
+ Remove confusing column toggle UI and code. 

# Screenshot (demo data)

![screen shot 2018-08-24 at 3 20 08 pm](https://user-images.githubusercontent.com/3209501/44606048-48f70b80-a7b1-11e8-92f4-3cbd1eb394b6.png)

# Screenshot (HS, shows different columns, demo data)

![screen shot 2018-08-24 at 3 28 16 pm](https://user-images.githubusercontent.com/3209501/44606348-6678a500-a7b2-11e8-8334-126bd5cd4b92.png)

# Notes

This PR addresses the notes about student photo and STAR/MCAS data in #1939. It leaves sorting improvements for a future PR, leaves the possibility of a "Download w/Assessment Data" for a future PR, and does not touch the Section roster page.