### PR TITLE
Tweak student photo height in Homeroom Table

### DIFF
--- a/app/assets/javascripts/homeroom/HomeroomTable.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.js
@@ -227,7 +227,7 @@ export default class HomeroomTable extends React.Component {
           style={style}>
         <td className="name">{fullName}</td>
         <td>
-          <StudentPhoto student={row} width={40} height={40} />
+          <StudentPhoto student={row} height={60} />
         </td>
         {this.eventNoteTypeIds().map(eventNoteTypeId => {
           const key = `latest_note_${eventNoteTypeId}_date_text`;

--- a/app/assets/javascripts/homeroom/HomeroomTable.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.js
@@ -227,7 +227,7 @@ export default class HomeroomTable extends React.Component {
           style={style}>
         <td className="name">{fullName}</td>
         <td>
-          <StudentPhoto student={row} height={60} />
+          <StudentPhoto student={row} height={65} />
         </td>
         {this.eventNoteTypeIds().map(eventNoteTypeId => {
           const key = `latest_note_${eventNoteTypeId}_date_text`;


### PR DESCRIPTION
# Who is this PR for?

K8 homeroom teachers!

# What does this PR do?

Setting `height` and `width` to the same value creates a squished square photo. Also 40px tall thumbnail is a bit too small to see the student well.