### PR TITLE
Improve sorting students by name on K8 Homeroom pages

### DIFF
--- a/app/assets/javascripts/homeroom/HomeroomTable.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.js
@@ -20,7 +20,7 @@ export default class HomeroomTable extends React.Component {
     super(props);
 
     this.state = {
-      sortBy: 'first_name',
+      sortBy: 'last_name',
       sortType: 'string',
       sortDesc: true
     };
@@ -134,7 +134,7 @@ export default class HomeroomTable extends React.Component {
   renderNameSubheader() {
     return (
       <th className="name sortable_header"
-          onClick={this.onClickHeader.bind(null, 'first_name', 'string')}>
+          onClick={this.onClickHeader.bind(null, 'last_name', 'string')}>
         <span className="table-header">
           Name
         </span>
@@ -214,7 +214,7 @@ export default class HomeroomTable extends React.Component {
   }
 
   renderRow(row, index) {
-    const fullName = `${row['first_name']} ${row['last_name']}`;
+    const fullName = `${row['last_name']}, ${row['first_name']}`;
     const id = row["id"];
     const style = (index % 2 === 0)
                     ? { backgroundColor: '#FFFFFF' }

--- a/app/assets/javascripts/homeroom/HomeroomTable.test.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.test.js
@@ -49,12 +49,12 @@ describe('high-level integration test', () => {
   it('renders SST and MTSS dates correctly for Somerville grade 2 as a happy path test case', () => {
     const {el} = testRender(testProps());
     expect(sstAndMtssDateTexts(el)).toEqual([
-      ["Aladdin Kenobi", "", "—", '—'],
-      ["Chip Pan", "", "2/16/11", '—'],
-      ["Pluto Poppins", "", "9/2/11", '6/5/11'],
-      ["Rapunzel Duck", "", "1/2/11", '8/6/11'],
-      ["Snow Skywalker", "", "10/31/10", '—'],
-      ["Snow Kenobi", "", "8/29/11", '7/27/11']
+      ["Duck, Rapunzel", "", "1/2/11", '8/6/11'],
+      ["Kenobi, Aladdin", "", "—", '—'],
+      ["Kenobi, Snow", "", "8/29/11", '7/27/11'],
+      ["Pan, Chip", "", "2/16/11", '—'],
+      ["Poppins, Pluto", "", "9/2/11", '6/5/11'],
+      ["Skywalker, Snow", "", "10/31/10", '—'],
     ]);
   });
 


### PR DESCRIPTION
# Who is this PR for?

K8 classroom techers. 

# What does this PR do?

Presents students in `last_name, first_name` format and sorts on last name: this matches the school overview page and is a more intuitive way to sort. 

# GIF (fake data)

![homeroom-sort](https://user-images.githubusercontent.com/3209501/44608724-611f5880-a7ba-11e8-8c79-d72ae0025ea9.gif)
