### PR TITLE
Profile v3: Show restricted transition notes in profile page notes when access

### DIFF
--- a/app/assets/javascripts/student_profile/Api.js
+++ b/app/assets/javascripts/student_profile/Api.js
@@ -37,7 +37,7 @@ class Api {
   }
 
   saveTransitionNote(studentId, noteParams) {
-    return this._post('/students/' + studentId + '/update_transition_note', {
+    return this._post('/api/students/' + studentId + '/update_transition_note', {
       text: noteParams.text,
       is_restricted: noteParams.is_restricted,
     });

--- a/app/assets/javascripts/student_profile/NoteCard.js
+++ b/app/assets/javascripts/student_profile/NoteCard.js
@@ -70,7 +70,7 @@ export default class NoteCard extends React.Component {
 
   // The student name may or not be present.
   renderRestrictedNoteRedaction() {
-    const {eventNoteId, student, canUserAccessRestrictedNotes} = this.props;
+    const {student, urlForRestrictedNoteContent} = this.props;
     const educatorName = formatEducatorName(this.educator());
     const educatorFirstNameOrEmail = educatorName.indexOf(' ') !== -1
       ? educatorName.split(' ')[0]
@@ -78,10 +78,9 @@ export default class NoteCard extends React.Component {
     
     return (
       <RestrictedNotePresence
-        eventNoteId={eventNoteId}
         studentFirstName={student ? student.first_name : null}
         educatorName={educatorFirstNameOrEmail}
-        allowViewing={canUserAccessRestrictedNotes}
+        urlForRestrictedNoteContent={urlForRestrictedNoteContent}
       />
     );
   }
@@ -215,15 +214,21 @@ NoteCard.propTypes = {
   educatorsIndex: PropTypes.object.isRequired,
   noteMoment: PropTypes.instanceOf(moment).isRequired,
   text: PropTypes.string.isRequired,
+
+  // For editing eventNote only
   eventNoteId: PropTypes.number,
   eventNoteTypeId: PropTypes.number,
   numberOfRevisions: PropTypes.number,
-  showRestrictedNoteRedaction: PropTypes.bool,
-  canUserAccessRestrictedNotes: PropTypes.bool,
-  includeStudentPanel: PropTypes.bool,
   onEventNoteAttachmentDeleted: PropTypes.func,
   onSave: PropTypes.func,
-  student: PropTypes.object,
+
+  // Configuring for different uses
+  showRestrictedNoteRedaction: PropTypes.bool,
+  urlForRestrictedNoteContent: PropTypes.string,
+  
+  // For side panel for my notes page
+  includeStudentPanel: PropTypes.bool,
+  student: PropTypes.object
 };
 NoteCard.defaultProps = {
   numberOfRevisions: 0

--- a/app/assets/javascripts/student_profile/NotesList.js
+++ b/app/assets/javascripts/student_profile/NotesList.js
@@ -8,6 +8,7 @@ import * as FeedHelpers from '../helpers/FeedHelpers';
 import {eventNoteTypeText} from '../helpers/eventNoteType';
 import NoteCard from './NoteCard';
 import {parseAndReRender} from './lightTransitionNotes';
+import {urlForRestrictedEventNoteContent, urlForRestrictedTransitionNoteContent} from './RestrictedNotePresence';
 
 /*
 Renders the list of notes, including the different types of notes (eg, deprecated
@@ -56,6 +57,9 @@ export default class NotesList extends React.Component {
       isRedacted ||
       (eventNote.is_restricted && !allowDirectEditingOfRestrictedNoteText)
     );
+    const urlForRestrictedNoteContent = (canUserAccessRestrictedNotes)
+      ? urlForRestrictedEventNoteContent(eventNote)
+      : null;
     return (
       <NoteCard
         key={['event_note', eventNote.id].join()}
@@ -71,7 +75,7 @@ export default class NotesList extends React.Component {
         educatorsIndex={educatorsIndex}
         showRestrictedNoteRedaction={isRedacted}
         includeStudentPanel={includeStudentPanel}
-        canUserAccessRestrictedNotes={canUserAccessRestrictedNotes}
+        urlForRestrictedNoteContent={urlForRestrictedNoteContent}
         onSave={isReadonly ? null : onSaveNote}
         onEventNoteAttachmentDeleted={isReadonly ? null : onEventNoteAttachmentDeleted} />
     );
@@ -97,6 +101,9 @@ export default class NotesList extends React.Component {
   renderTransitionNote(transitionNote) {
     const {showRestrictedNoteContent, canUserAccessRestrictedNotes} = this.props;
     const isRedacted = transitionNote.is_restricted && !showRestrictedNoteContent;
+    const urlForRestrictedNoteContent = (canUserAccessRestrictedNotes)
+      ? urlForRestrictedTransitionNoteContent(transitionNote)
+      : null;
     return (
       <NoteCard
         key={['transition_note', transitionNote.id].join()}
@@ -106,7 +113,7 @@ export default class NotesList extends React.Component {
         text={parseAndReRender(transitionNote.text)}
         educatorsIndex={this.props.educatorsIndex}
         showRestrictedNoteRedaction={isRedacted}
-        canUserAccessRestrictedNotes={canUserAccessRestrictedNotes}
+        urlForRestrictedNoteContent={urlForRestrictedNoteContent}
         attachments={[]} />
     );
   }

--- a/app/assets/javascripts/student_profile/NotesList.js
+++ b/app/assets/javascripts/student_profile/NotesList.js
@@ -95,6 +95,8 @@ export default class NotesList extends React.Component {
   }
 
   renderTransitionNote(transitionNote) {
+    const {showRestrictedNoteContent, canUserAccessRestrictedNotes} = this.props;
+    const isRedacted = transitionNote.is_restricted && !showRestrictedNoteContent;
     return (
       <NoteCard
         key={['transition_note', transitionNote.id].join()}
@@ -103,6 +105,8 @@ export default class NotesList extends React.Component {
         educatorId={transitionNote.educator_id}
         text={parseAndReRender(transitionNote.text)}
         educatorsIndex={this.props.educatorsIndex}
+        showRestrictedNoteRedaction={isRedacted}
+        canUserAccessRestrictedNotes={canUserAccessRestrictedNotes}
         attachments={[]} />
     );
   }

--- a/app/assets/javascripts/student_profile/RestrictedNotePresence.js
+++ b/app/assets/javascripts/student_profile/RestrictedNotePresence.js
@@ -20,8 +20,8 @@ export default class RestrictedNotePresence extends React.Component {
   }
 
   fetchRestrictedContent() {
-    const {eventNoteId} = this.props;
-    return apiFetchJson(`/api/event_notes/${eventNoteId}/restricted_note_json`);
+    const {urlForRestrictedNoteContent} = this.props;
+    return apiFetchJson(urlForRestrictedNoteContent);
   }
 
   onViewClicked(e) {
@@ -30,10 +30,10 @@ export default class RestrictedNotePresence extends React.Component {
   }
 
   render() {
-    const {isViewing, allowViewing} = this.state;
+    const {isViewing, urlForRestrictedNoteContent} = this.state;
     return (
       <div className="RestrictedNotePresence">
-        {isViewing && !allowViewing
+        {isViewing && !urlForRestrictedNoteContent
           ? this.renderViewing()
           : this.renderRedaction()}
       </div>
@@ -41,7 +41,7 @@ export default class RestrictedNotePresence extends React.Component {
   }
 
   renderRedaction() {
-    const {studentFirstName, educatorName, allowViewing} = this.props;
+    const {studentFirstName, educatorName, urlForRestrictedNoteContent} = this.props;
     const studentFirstNameOrTheir = (studentFirstName)
       ? `${studentFirstName}'s`
       : 'their';
@@ -52,7 +52,7 @@ export default class RestrictedNotePresence extends React.Component {
           style={styles.restrictedNoteRedaction}
           text={`To respect ${studentFirstNameOrTheir} privacy, ${educatorName || 'the author'} marked this note as restricted.`}
         />
-        {allowViewing && 
+        {urlForRestrictedNoteContent && 
           <a
             href="#"
             style={styles.showLink}
@@ -82,13 +82,9 @@ export default class RestrictedNotePresence extends React.Component {
   }
 }
 RestrictedNotePresence.propTypes = {
-  eventNoteId: PropTypes.number.isRequired,
   studentFirstName: PropTypes.string,
   educatorName: PropTypes.string,
-  allowViewing: PropTypes.bool
-};
-RestrictedNotePresence.defaultProps = {
-  allowViewing: false
+  urlForRestrictedNoteContent: PropTypes.string
 };
 
 const styles = {
@@ -107,3 +103,11 @@ const styles = {
     paddingTop: 5
   }
 };
+
+export function urlForRestrictedTransitionNoteContent(transitionNote) {
+  return `/api/students/${transitionNote.student_id}/restricted_transition_note_json`;
+}
+
+export function urlForRestrictedEventNoteContent(eventNote) {
+  return `/api/event_notes/${eventNote.id}/restricted_note_json`;
+}

--- a/app/assets/javascripts/student_profile/RestrictedNotePresence.js
+++ b/app/assets/javascripts/student_profile/RestrictedNotePresence.js
@@ -20,8 +20,8 @@ export default class RestrictedNotePresence extends React.Component {
   }
 
   fetchRestrictedContent() {
-    const {urlForRestrictedContentText} = this.props;
-    return apiFetchJson(urlForRestrictedContentText);
+    const {eventNoteId} = this.props;
+    return apiFetchJson(`/api/event_notes/${eventNoteId}/restricted_note_json`);
   }
 
   onViewClicked(e) {
@@ -82,7 +82,7 @@ export default class RestrictedNotePresence extends React.Component {
   }
 }
 RestrictedNotePresence.propTypes = {
-  urlForRestrictedContentText: PropTypes.string.isRequired,
+  eventNoteId: PropTypes.number.isRequired,
   studentFirstName: PropTypes.string,
   educatorName: PropTypes.string,
   allowViewing: PropTypes.bool

--- a/app/assets/javascripts/student_profile/RestrictedNotePresence.js
+++ b/app/assets/javascripts/student_profile/RestrictedNotePresence.js
@@ -20,8 +20,8 @@ export default class RestrictedNotePresence extends React.Component {
   }
 
   fetchRestrictedContent() {
-    const {eventNoteId} = this.props;
-    return apiFetchJson(`/api/event_notes/${eventNoteId}/restricted_note_json`);
+    const {urlForRestrictedContentText} = this.props;
+    return apiFetchJson(urlForRestrictedContentText);
   }
 
   onViewClicked(e) {
@@ -82,7 +82,7 @@ export default class RestrictedNotePresence extends React.Component {
   }
 }
 RestrictedNotePresence.propTypes = {
-  eventNoteId: PropTypes.number.isRequired,
+  urlForRestrictedContentText: PropTypes.string.isRequired,
   studentFirstName: PropTypes.string,
   educatorName: PropTypes.string,
   allowViewing: PropTypes.bool

--- a/app/assets/javascripts/student_profile/RestrictedNotePresence.test.js
+++ b/app/assets/javascripts/student_profile/RestrictedNotePresence.test.js
@@ -8,10 +8,9 @@ import RestrictedNotePresence from './RestrictedNotePresence';
 
 export function testProps(props = {}) {
   return {
-    eventNoteId: 42,
     studentFirstName: 'Cassandra',
     educatorName: 'Darnell',
-    allowViewing: false,
+    urlForRestrictedNoteContent: null,
     ...props
   };
 }
@@ -21,6 +20,9 @@ export function mockFetch() {
   fetchMock.get('express:/api/event_notes/:id/restricted_note_json', {
     text: 'RESTRICTED-text',
     event_note_attachments: [{url: 'https://website.com/RESTRICTED-url'}]
+  });
+  fetchMock.get('express:/api/students/:student_id/restricted_transition_note_json', {
+    text: 'RESTRICTED-transition-note-text'
   });
 }
 
@@ -32,12 +34,13 @@ it('renders without crashing', () => {
   const el = document.createElement('div');
   const props = testProps();
   ReactDOM.render(testEl(props), el);
-  expect(el.innerHTML).not.toContain('RESTRICTED-text');
+  expect(el.innerHTML).not.toContain('RESTRICTED');
 });
 
-it('allows viewing', done => {
+it('allows viewing by EventNote URL', done => {
   mockFetch();
-  const props = testProps({allowViewing: true});
+  const urlForRestrictedNoteContent = '/api/event_notes/42/restricted_note_json';
+  const props = testProps({urlForRestrictedNoteContent});
   const el = document.createElement('div');
   ReactDOM.render(testEl(props), el);
   expect(el.innerHTML).toContain('show restricted note');
@@ -46,6 +49,23 @@ it('allows viewing', done => {
   setTimeout(() => {
     expect(el.innerHTML).not.toContain('show restricted note');
     expect(el.innerHTML).toContain('RESTRICTED-text');
+    expect(el.innerHTML).toContain('This is a restricted note');
+    done();
+  }, 0);
+});
+
+it('allows viewing TransitionNote', done => {
+  mockFetch();
+  const urlForRestrictedNoteContent = '/api/students/73/restricted_transition_note_json';
+  const props = testProps({urlForRestrictedNoteContent});
+  const el = document.createElement('div');
+  ReactDOM.render(testEl(props), el);
+  expect(el.innerHTML).toContain('show restricted note');
+
+  ReactTestUtils.Simulate.click($(el).find('a').get(0));
+  setTimeout(() => {
+    expect(el.innerHTML).not.toContain('show restricted note');
+    expect(el.innerHTML).toContain('RESTRICTED-transition-note-text');
     expect(el.innerHTML).toContain('This is a restricted note');
     done();
   }, 0);

--- a/app/controllers/event_notes_controller.rb
+++ b/app/controllers/event_notes_controller.rb
@@ -1,7 +1,7 @@
 class EventNotesController < ApplicationController
   def restricted_note_json
-    restricted_json_params = params.permit(:id)
-    event_note = authorized_or_raise! { EventNote.find(restricted_json_params[:id]) }
+    safe_params = params.permit(:id)
+    event_note = authorized_or_raise! { EventNote.find(safe_params[:id]) }
     raise Exceptions::EducatorNotAuthorized unless event_note.is_restricted
 
     json = event_note.as_json({

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -6,18 +6,17 @@ class ProfileController < ApplicationController
   def json
     student = Student.find(params[:id])
     chart_data = StudentProfileChart.new(student).chart_data
-    can_see_transition_notes = current_educator.is_authorized_to_see_transition_notes
 
     render json: {
       current_educator: current_educator.as_json(methods: [:labels]),
       student: serialize_student_for_profile(student),          # School homeroom, most recent school year attendance/discipline counts
-      feed: student_feed(student, restricted_notes: false),     # Notes, services
+      feed: student_feed(student),
       chart_data: chart_data,                                   # STAR, MCAS, discipline, attendance charts
       dibels: student.dibels_results.select(:id, :date_taken, :benchmark),
       service_types_index: ServiceSerializer.service_types_index,
       educators_index: Educator.to_index,
       access: student.latest_access_results,
-      transition_notes: (can_see_transition_notes ? student.transition_notes : []),
+      transition_notes: student.transition_notes,
       iep_document: student.iep_document,
       sections: serialize_student_sections_for_profile(student),
       current_educator_allowed_sections: current_educator.allowed_sections.map(&:id),
@@ -59,12 +58,11 @@ class ProfileController < ApplicationController
     student.sections_with_grades.as_json({:include => { :educators => {:only => :full_name}}, :methods => :course_description})
   end
 
-  def student_feed(student, restricted_notes: false)
+  def student_feed(student)
     {
       event_notes: student.event_notes
         .map {|event_note| EventNoteSerializer.safe(event_note).serialize_event_note },
-      transition_notes: student.transition_notes
-        .select {|note| note.is_restricted == restricted_notes},
+      transition_notes: student.transition_notes,
       services: {
         active: student.services.active.map {|service| ServiceSerializer.new(service).serialize_service },
         discontinued: student.services.discontinued.map {|service| ServiceSerializer.new(service).serialize_service }

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -16,7 +16,6 @@ class StudentsController < ApplicationController
     return redirect_to(v3_student_path(student)) if should_redirect_to_profile_v3?(params)
 
     chart_data = StudentProfileChart.new(student).chart_data
-    can_see_transition_notes = current_educator.is_authorized_to_see_transition_notes
     @serialized_data = {
       current_educator: current_educator.as_json(methods: [:labels]),
       student: serialize_student_for_profile(student),          # School homeroom, most recent school year attendance/discipline counts
@@ -26,7 +25,7 @@ class StudentsController < ApplicationController
       service_types_index: ServiceSerializer.service_types_index,
       educators_index: Educator.to_index,
       access: student.latest_access_results,
-      transition_notes: (can_see_transition_notes ? student.transition_notes : []),
+      transition_notes: [], # removing to prevent authorization hole during migration
       iep_document: student.iep_document,
       sections: serialize_student_sections_for_profile(student),
       current_educator_allowed_sections: current_educator.allowed_sections.map(&:id),

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -15,6 +15,7 @@ class StudentsController < ApplicationController
     student = Student.find(params[:id])
     return redirect_to(v3_student_path(student)) if should_redirect_to_profile_v3?(params)
 
+    can_access_restricted_transition_notes = authorizer.is_authorized_to_write_transition_notes?
     chart_data = StudentProfileChart.new(student).chart_data
     @serialized_data = {
       current_educator: current_educator.as_json(methods: [:labels]),
@@ -25,7 +26,7 @@ class StudentsController < ApplicationController
       service_types_index: ServiceSerializer.service_types_index,
       educators_index: Educator.to_index,
       access: student.latest_access_results,
-      transition_notes: [], # removing to prevent authorization hole during migration
+      transition_notes: student.transition_notes.as_json(dangerously_include_restricted_note_text: can_access_restricted_transition_notes),
       iep_document: student.iep_document,
       sections: serialize_student_sections_for_profile(student),
       current_educator_allowed_sections: current_educator.allowed_sections.map(&:id),

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -15,7 +15,7 @@ class StudentsController < ApplicationController
     student = Student.find(params[:id])
     return redirect_to(v3_student_path(student)) if should_redirect_to_profile_v3?(params)
 
-    can_access_restricted_transition_notes = authorizer.is_authorized_to_write_transition_notes?
+    can_access_restricted_transition_notes = authorizer.is_authorized_for_deprecated_transition_note_ui?
     chart_data = StudentProfileChart.new(student).chart_data
     @serialized_data = {
       current_educator: current_educator.as_json(methods: [:labels]),

--- a/app/lib/authorized_dispatcher.rb
+++ b/app/lib/authorized_dispatcher.rb
@@ -49,6 +49,8 @@ class AuthorizedDispatcher
       check_value(model, @authorizer.is_authorized_for_student?(model))
     elsif model.class == EventNote
       check_value(model, @authorizer.is_authorized_for_note?(model))
+    elsif model.class == TransitionNote
+      check_value(model, @authorizer.is_authorized_for_note?(model))
     else
       unchecked_value(model)
     end

--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -147,16 +147,17 @@ class Authorizer
     false
   end
 
+  # Works for EventNote or TransitionNote
   def is_authorized_for_note?(event_note)
     return false unless is_authorized_for_student?(event_note.student)
     return false if event_note.is_restricted && !@educator.can_view_restricted_notes
     true
   end
 
-  def is_authorized_to_see_transition_notes?
-    return true if @educator.labels.include?('k8_counselor')
-    return true if @educator.labels.include?('high_school_house_master')
-    return false
+  def is_authorized_to_write_transition_notes?
+    return false unless @educator.labels.include?('k8_counselor')
+    return false unless @educator.can_view_restricted_notes
+    true
   end
 
   # TODO(kr) remove implementation

--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -155,9 +155,10 @@ class Authorizer
   end
 
   def is_authorized_to_write_transition_notes?
-    return false unless @educator.labels.include?('k8_counselor')
     return false unless @educator.can_view_restricted_notes
-    true
+    return true if @educator.labels.include?('k8_counselor')
+    return true if @educator.labels.include?('high_school_house_master')
+    false
   end
 
   # TODO(kr) remove implementation

--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -154,11 +154,18 @@ class Authorizer
     true
   end
 
-  def is_authorized_to_write_transition_notes?
+  # deprecated
+  def is_authorized_for_deprecated_transition_note_ui?
     return false unless @educator.can_view_restricted_notes
     return true if @educator.labels.include?('k8_counselor')
     return true if @educator.labels.include?('high_school_house_master')
     false
+  end
+
+  def is_authorized_to_write_transition_notes?
+    return false unless @educator.can_view_restricted_notes
+    return false unless @educator.labels.include?('k8_counselor')
+    true
   end
 
   # TODO(kr) remove implementation

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -48,10 +48,6 @@ class Educator < ActiveRecord::Base
     Authorizer.new(self).is_authorized_for_section?(section)
   end
 
-  def is_authorized_to_see_transition_notes
-    Authorizer.new(self).is_authorized_to_see_transition_notes?
-  end
-
   def students_for_school_overview(*additional_includes)
     students = Authorizer.new(self).students_for_school_overview
 

--- a/app/models/transition_note.rb
+++ b/app/models/transition_note.rb
@@ -9,6 +9,28 @@ class TransitionNote < ApplicationRecord
   validate :only_one_regular_note, on: :create
   validate :cannot_change_is_restricted, on: :update
 
+  # override
+  # Ensures that text for restricted notes don't get accidentally serialized
+  # without explicitly asking for them.  The text for restricted notes will always be
+  # redacted, regardless of the user, unless it is explicitly asked for.
+  # See also EventNote#as_json and EventNoteRevision#as_json.
+  def as_json(options = {})
+    json = super(options)
+
+    # unrestricted notes are safe to serialize
+    return json unless self.is_restricted
+
+    # if a restricted note isn't serializing the text content it's okay
+    return json unless json.has_key?('text')
+
+    # allow a dangerous manual override
+    return json if options[:dangerously_include_restricted_note_text]
+
+    # redact text content
+    json.merge('text' => '<redacted>')
+  end
+
+  private
   def only_one_restricted_note
     if is_restricted && student.present? && student.transition_notes.where(is_restricted: true).count > 0
       errors.add(:student, 'cannot have more than one restricted note')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,11 +51,16 @@ Rails.application.routes.draw do
   # student profile
   get '/api/students/:id/profile_json' => 'profile#json'
 
+  # transition notes: creating/updating, or reading restricted notes
+  post '/api/students/:student_id/update_transition_note' => 'transition_notes#update'
+  get '/api/students/:student_id/restricted_transition_note_json' => 'transition_notes#restricted_transition_note_json'
+
   # event_notes: creating/updating notes, or reading restricted notes
   post '/api/event_notes' => 'event_notes#create'
   patch '/api/event_notes/:id' => 'event_notes#update'
   get '/api/event_notes/:id/restricted_note_json' => 'event_notes#restricted_note_json'
   delete '/api/event_notes/attachments/:event_note_attachment_id' => 'event_notes#destroy_attachment'
+
 
   ### experimental
   # HS tiers
@@ -107,7 +112,6 @@ Rails.application.routes.draw do
 
   get '/students/names' => 'students#names'
   get '/students/lasids' => 'students#lasids'
-  post '/students/:student_id/update_transition_note' => 'transition_notes#update'
 
   resources :students, only: [:show] do
     member do

--- a/spec/controllers/transition_notes_controller_spec.rb
+++ b/spec/controllers/transition_notes_controller_spec.rb
@@ -14,6 +14,51 @@ RSpec.describe TransitionNotesController, type: :controller do
     }
   }
 
+  describe '#restricted_transition_note_json' do
+    let!(:student) { pals.west_eighth_ryan }
+
+    def get_restricted_transition_note_json(student_id)
+      request.env['HTTPS'] = 'on'
+      get :restricted_transition_note_json, params: {
+        format: :json,
+        student_id: student_id
+      }
+    end
+
+    def create_restricted_transition_note_for(student)
+      FactoryBot.create(:transition_note, {
+        student_id: student.id,
+        is_restricted: true,
+        text: 'RESTRICTED-original-text'
+      })
+    end
+
+    it 'permits access, and only sends down :text and :event_note_attachments' do
+      create_restricted_transition_note_for(student)
+      sign_in(pals.rich_districtwide)
+      get_restricted_transition_note_json(student.id)
+      expect(response.status).to eq 200
+      json = JSON.parse(response.body)
+      expect(json).to eq({
+        "text" => "RESTRICTED-original-text"
+      })
+    end
+
+    it 'guards access based on student' do
+      create_restricted_transition_note_for(student)
+      sign_in(pals.healey_laura_principal)
+      get_restricted_transition_note_json(student.id)
+      expect(response.status).to eq 403
+    end
+
+    it 'guards access based on can_view_restricted_notes' do
+      create_restricted_transition_note_for(student)
+      sign_in(pals.shs_jodi)
+      get_restricted_transition_note_json(student.id)
+      expect(response.status).to eq 403
+    end
+  end
+
   describe '#update' do
     def update(params)
       request.env['HTTPS'] = 'on'

--- a/spec/factories/transition_note.rb
+++ b/spec/factories/transition_note.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+
+  factory :transition_note do
+    recorded_at DateTime.new(2016, 4, 9)
+    association :educator
+    association :student
+    sequence :text do |n|
+      "This is some factory note text for transition note ##{n} in the factory."
+    end
+    is_restricted false
+  end
+end

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -361,4 +361,16 @@ RSpec.describe Authorizer do
       end
     end
   end
+
+  describe '#is_authorized_for_deprecated_transition_note_ui??' do
+    it 'only allows K8 counselor with label and access to deprecated restricted notes UI' do
+      authorized_educators = [pals.west_counselor, pals.shs_harry_housemaster]
+      authorized_educators.each do |educator|
+        expect(Authorizer.new(educator).is_authorized_for_deprecated_transition_note_ui?).to eq true
+      end
+      (Educator.all - authorized_educators).each do |educator|
+        expect(Authorizer.new(educator).is_authorized_to_write_transition_notes?).to eq false
+      end
+    end
+  end
 end

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -204,6 +204,68 @@ RSpec.describe Authorizer do
       end
     end
 
+    describe 'TransitionNote' do
+      let!(:healey_public_note) { FactoryBot.create(:transition_note, student: pals.healey_kindergarten_student) }
+      let!(:healey_restricted_note) { FactoryBot.create(:transition_note, student: pals.healey_kindergarten_student, is_restricted: true) }
+      let!(:shs_public_note) { FactoryBot.create(:transition_note, student: pals.shs_freshman_mari) }
+      let!(:shs_restricted_note) { FactoryBot.create(:transition_note, student: pals.shs_freshman_mari, is_restricted: true) }
+
+      it 'limits access for relation' do
+        expect(authorized(pals.uri) { TransitionNote.all }).to eq [
+          healey_public_note,
+          healey_restricted_note,
+          shs_public_note,
+          shs_restricted_note
+        ]
+        expect(authorized(pals.healey_vivian_teacher) { TransitionNote.all }).to eq [
+          healey_public_note
+        ]
+        expect(authorized(pals.shs_bill_nye) { TransitionNote.all }).to eq [
+          shs_public_note
+        ]
+      end
+
+      it 'limits access for array' do
+        all_notes = [
+          healey_public_note,
+          healey_restricted_note,
+          shs_public_note,
+          shs_restricted_note
+        ]
+        expect(authorized(pals.uri) { all_notes }).to eq [
+          healey_public_note,
+          healey_restricted_note,
+          shs_public_note,
+          shs_restricted_note
+        ]
+        expect(authorized(pals.healey_vivian_teacher) { all_notes }).to eq [
+          healey_public_note
+        ]
+        expect(authorized(pals.shs_bill_nye) { all_notes }).to eq [
+          shs_public_note
+        ]
+      end
+
+      it 'limits access for model' do
+        def is_authorized(educator, note)
+          authorized(educator) { note } == note # check that they can access it
+        end
+
+        expect(is_authorized(pals.uri, healey_public_note)).to eq true
+        expect(is_authorized(pals.uri, healey_restricted_note)).to eq true
+        expect(is_authorized(pals.uri, shs_public_note)).to eq true
+        expect(is_authorized(pals.uri, shs_restricted_note)).to eq true
+        expect(is_authorized(pals.healey_vivian_teacher, healey_public_note)).to eq true
+        expect(is_authorized(pals.healey_vivian_teacher, healey_restricted_note)).to eq false
+        expect(is_authorized(pals.healey_vivian_teacher, shs_public_note)).to eq false
+        expect(is_authorized(pals.healey_vivian_teacher, shs_restricted_note)).to eq false
+        expect(is_authorized(pals.shs_bill_nye, healey_public_note)).to eq false
+        expect(is_authorized(pals.shs_bill_nye, healey_restricted_note)).to eq false
+        expect(is_authorized(pals.shs_bill_nye, shs_public_note)).to eq true
+        expect(is_authorized(pals.shs_bill_nye, shs_restricted_note)).to eq false
+      end
+    end
+
     describe 'other models' do
       it 'raises on calls with unchecked models' do
         expect { authorized(pals.uri) { Educator.all } }.to raise_error(Exceptions::EducatorNotAuthorized)
@@ -287,6 +349,15 @@ RSpec.describe Authorizer do
         expect(authorized_students_when_viewing_as(pals.shs_bill_nye, pals.uri)).to match_array [
           pals.shs_freshman_mari
         ]
+      end
+    end
+  end
+
+  describe '#is_authorized_to_write_transition_notes?' do
+    it 'only allows K8 counselor with label and access to restricted notes' do
+      expect(Authorizer.new(pals.west_counselor).is_authorized_to_write_transition_notes?).to eq true
+      (Educator.all - [pals.west_counselor]).each do |educator|
+        expect(Authorizer.new(educator).is_authorized_to_write_transition_notes?).to eq false
       end
     end
   end

--- a/spec/models/transition_note_spec.rb
+++ b/spec/models/transition_note_spec.rb
@@ -52,4 +52,133 @@ RSpec.describe ClassList do
       })
     end
   end
+
+  # See also EventNote#as_json
+  describe '#as_json' do
+    def create_note(text, is_restricted)
+      FactoryBot.create(:transition_note, text: text, is_restricted: is_restricted)
+    end
+
+    def test_relation
+      create_note('foo-safe', false)
+      create_note('bar-RESTRICTED', true)
+      create_note('whatever-safe', false)
+      TransitionNote.all
+    end
+
+    def note_texts(notes_json)
+      notes_json.map {|json| json['text'] }
+    end
+
+    describe 'with a model of a normal note' do
+      it 'works normally when :text is not included' do
+        note = create_note('foo-safe', false)
+        json = note.as_json(only: [:student_id])
+        expect(json).to eq({'student_id' => note.student_id})
+      end
+
+      it 'works normally regardless of :dangerously_include_restricted_note_text' do
+        json = create_note('foo-safe', false).as_json(dangerously_include_restricted_note_text: true)
+        expect(json['text']).to eq 'foo-safe'
+      end
+
+      it 'serializes :text by default' do
+        expect(create_note('foo-safe', false).as_json['text']).to eq 'foo-safe'
+      end
+
+      it 'serializes :text when asked explicitly' do
+        expect(create_note('foo-safe', false).as_json(only: [:text])['text']).to eq 'foo-safe'
+      end
+    end
+
+    describe 'with a model of a restricted note' do
+      it 'works normally when :text is not included' do
+        note = create_note('bar-RESTRICTED', true)
+        json = note.as_json(only: [:student_id])
+        expect(json).to eq({'student_id' => note.student_id})
+      end
+
+      it 'does not serialize :text by default' do
+        expect(create_note('bar-RESTRICTED', true).as_json['text']).to eq EventNote::REDACTED
+      end
+
+      it 'does not serialize :text even when asked explicitly' do
+        expect(create_note('bar-RESTRICTED', true).as_json(only: [:text])['text']).to eq EventNote::REDACTED
+      end
+
+      it 'does not serializes :text just based on :dangerously_include_restricted_note_text key' do
+        json = create_note('bar-RESTRICTED', true).as_json(dangerously_include_restricted_note_text: false)
+        expect(json['text']).to eq EventNote::REDACTED
+      end
+
+      it 'serializes :text only when given :dangerously_include_restricted_note_text: true' do
+        json = create_note('bar-RESTRICTED', true).as_json(dangerously_include_restricted_note_text: true)
+        expect(json['text']).to eq 'bar-RESTRICTED'
+      end
+    end
+
+    describe 'with a relation including a restricted note' do
+      it 'works normally when :text is not included' do
+        relation = test_relation
+        json = relation.as_json(only: [:student_id])
+        expect(json).to eq([
+          {"student_id"=>relation[0].student_id},
+          {"student_id"=>relation[1].student_id},
+          {"student_id"=>relation[2].student_id}
+        ])
+      end
+
+      it 'does not serialize :text for restricted notes by default' do
+        json = test_relation.as_json
+        expect(note_texts(json)).to eq(['foo-safe', EventNote::REDACTED, 'whatever-safe'])
+      end
+
+      it 'does not serialize :text even when asked explicitly' do
+        json = test_relation.as_json(only: [:text])
+        expect(note_texts(json)).to eq(['foo-safe', EventNote::REDACTED, 'whatever-safe'])
+      end
+
+      it 'does not serializes :text just based on :dangerously_include_restricted_note_text key' do
+        json = test_relation.as_json(dangerously_include_restricted_note_text: false)
+        expect(note_texts(json)).to eq(['foo-safe', EventNote::REDACTED, 'whatever-safe'])
+      end
+
+      it 'serializes :text only when given :dangerously_include_restricted_note_text: true' do
+        json = test_relation.as_json(dangerously_include_restricted_note_text: true)
+        expect(note_texts(json)).to eq(['foo-safe', 'bar-RESTRICTED', 'whatever-safe'])
+      end
+    end
+
+    describe 'with an array including a restricted note' do
+      it 'works normally when :text is not included' do
+        array = test_relation.to_a
+        json = array.as_json(only: [:student_id])
+        expect(json).to eq([
+          {"student_id"=>array[0].student_id},
+          {"student_id"=>array[1].student_id},
+          {"student_id"=>array[2].student_id}
+        ])
+      end
+
+      it 'does not serialize :text for restricted notes by default' do
+        json = test_relation.to_a.as_json
+        expect(note_texts(json)).to eq(['foo-safe', EventNote::REDACTED, 'whatever-safe'])
+      end
+
+      it 'does not serialize :text even when asked explicitly' do
+        json = test_relation.to_a.as_json(only: [:text])
+        expect(note_texts(json)).to eq(['foo-safe', EventNote::REDACTED, 'whatever-safe'])
+      end
+
+      it 'does not serializes :text just based on :dangerously_include_restricted_note_text key' do
+        json = test_relation.to_a.as_json(dangerously_include_restricted_note_text: false)
+        expect(note_texts(json)).to eq(['foo-safe', EventNote::REDACTED, 'whatever-safe'])
+      end
+
+      it 'serializes :text only when given :dangerously_include_restricted_note_text: true' do
+        json = test_relation.to_a.as_json(dangerously_include_restricted_note_text: true)
+        expect(note_texts(json)).to eq(['foo-safe', 'bar-RESTRICTED', 'whatever-safe'])
+      end
+    end
+  end
 end

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -237,7 +237,8 @@ class TestPals
       email: 'harry@demo.studentinsights.org',
       full_name: 'Housemaster, Harry',
       school: @shs,
-      schoolwide_access: true
+      schoolwide_access: true,
+      can_view_restricted_notes: true
     )
     EducatorLabel.create!({
       educator: @shs_harry_housemaster,

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -181,6 +181,7 @@ class TestPals
       full_name: "Counselor, Les",
       local_id: '551',
       school: @west,
+      can_view_restricted_notes: true,
       schoolwide_access: true
     )
     EducatorLabel.create!(


### PR DESCRIPTION
Follow on to https://github.com/studentinsights/studentinsights/pull/2004, part of https://github.com/studentinsights/studentinsights/issues/1998 and https://github.com/studentinsights/studentinsights/issues/1990.

# Who is this PR for?
HS counselors and housemasters

# What problem does this PR fix?
With the changes to the profile page to move restricted notes inline, and to move transition notes into the profile notes list, restricted transition notes hadn't been included yet.

# What does this PR do?
This copies code from `EventNote` into `TransitionNote` to use the same guards for the content of restricted notes on the model.  It updates `Authorizer` to handle `TransitionNote` models (copying from the code handling `EventNote` models) and updates the authorizer method about reading transition notes to apply more narrowly to who can write transition notes.  Note that the UI path for writing transition notes will be removed when profile v2 is removed, and there's not yet a replacement.

Relatedly, refactors `<RestrictedNotePresence />` to require a URL for fetching the restricted note content, and update the various call sites to parameterize this for `EventNote` or `TransitionNote` data.

# Screenshot (if adding a client-side feature)
### with access, profile v3 showing both transition notes
<img width="519" alt="screen shot 2018-08-24 at 4 42 33 pm" src="https://user-images.githubusercontent.com/1056957/44606936-c5431c00-a7bc-11e8-9d2a-6246e8c4c161.png">

### with access, profile v3 click to fetch restricted transition note text
<img width="518" alt="screen shot 2018-08-24 at 4 42 37 pm" src="https://user-images.githubusercontent.com/1056957/44606946-cecc8400-a7bc-11e8-95fb-6d463d1df711.png">

### with access, profile v3 click to fetch event note restricted text (unchanged)
<img width="493" alt="screen shot 2018-08-24 at 4 44 13 pm" src="https://user-images.githubusercontent.com/1056957/44606999-fc193200-a7bc-11e8-9ef9-371431b3c1ff.png">

### with access, profile v2 
<img width="998" alt="screen shot 2018-08-24 at 5 29 08 pm" src="https://user-images.githubusercontent.com/1056957/44608824-3ede0880-a7c3-11e8-8b29-159221cf3004.png">

# Checklists
+ [x] Author checked latest in IE - Student Profile v2
+ [x] Author checked latest in IE - Student Profile v3
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code
