### PR TITLE
Profile v3: Update HS testing tab to show old MCAS scores as well

### DIFF
--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -19,9 +19,8 @@ import LightNotesHelpContext from './LightNotesHelpContext';
 import StudentSectionsRoster from './StudentSectionsRoster';
 import {tags} from './lightTagger';
 import DetailsSection from './DetailsSection';
-import {toMoment} from './QuadConverter';
-import {shortLabelFromNextGenMcasScore, shortLabelFromOldMcasScore} from './mcasScores';
 import FullCaseHistory from './FullCaseHistory';
+import testingColumnTexts from './testingColumnTexts';
 
 
 // Prototype of profile v3
@@ -526,49 +525,4 @@ function percentileWithSuffix(percentile) {
     3: 'rd'
   }[lastDigit] || 'th';
   return `${percentile}${suffix}`;
-}
-
-
-// Look at ELA and Math next gen MCAS scores and make the different texts for the 'testing'
-// column summary for HS.  If those don't exist, fall back to old-school MCAS.
-function testingColumnTexts(nowMoment, chartData) {
-  const ela = (
-    latestMcasScoreSummary(chartData.next_gen_mcas_ela_scaled, shortLabelFromNextGenMcasScore, nowMoment) ||
-    latestMcasScoreSummary(chartData.mcas_series_ela_scaled, shortLabelFromOldMcasScore, nowMoment) ||
-    missingMcasSummary()
-  );
-  const math = (
-    latestMcasScoreSummary(chartData.next_gen_mcas_mathematics_scaled, shortLabelFromNextGenMcasScore, nowMoment) ||
-    latestMcasScoreSummary(chartData.mcas_series_math_scaled, shortLabelFromOldMcasScore, nowMoment) ||
-    missingMcasSummary()
-  );
-
-  const scoreText = ela.scoreText === math.scoreText
-    ? ela.scoreText
-    : `${ela.scoreText} / ${math.scoreText}`;
-  const testText = ela.scoreText === math.scoreText
-    ? 'ELA and Math MCAS'
-    : 'ELA / Math MCAS';
-  const dateText = (ela.dateText === math.dateText)
-    ? ela.dateText
-    : `${ela.dateText} / ${math.dateText}`;
-
-  return {scoreText, testText, dateText};
-}
-
-// Make text for the score and date for the latest MCAS score (either next gen
-// or old, depending on `scoreTextFn`).
-function latestMcasScoreSummary(quads, scoreTextFn, nowMoment) {
-  const latestEla = _.last(_.sortBy(quads || [], quad => toMoment(quad).unix()));
-  if (!latestEla) return null;
-
-  const scoreText = scoreTextFn(latestEla[3]);
-  const dateText = toMoment(latestEla).from(nowMoment);
-  return {scoreText, dateText};
-}
-
-function missingMcasSummary() {
-  const scoreText = '-';
-  const dateText = 'not yet taken';
-  return {scoreText, dateText};
 }

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -538,7 +538,7 @@ function testingColumnTexts(nowMoment, chartData) {
     missingMcasSummary()
   );
   const math = (
-    latestMcasScoreSummary(chartData.next_gen_mcas_math_scaled, shortLabelFromNextGenMcasScore, nowMoment) ||
+    latestMcasScoreSummary(chartData.next_gen_mcas_mathematics_scaled, shortLabelFromNextGenMcasScore, nowMoment) ||
     latestMcasScoreSummary(chartData.mcas_series_math_scaled, shortLabelFromOldMcasScore, nowMoment) ||
     missingMcasSummary()
   );

--- a/app/assets/javascripts/student_profile/mcasScores.js
+++ b/app/assets/javascripts/student_profile/mcasScores.js
@@ -1,0 +1,15 @@
+export function shortLabelFromNextGenMcasScore(score) {
+  if (score >= 400 && score < 450) return 'NM'; // Not Meeting Expectations
+  if (score >= 450 && score < 500) return 'PM'; // Partially Meeting
+  if (score >= 500 && score < 550) return 'M'; // Meeting Expectations
+  if (score >= 550 && score < 600) return 'E'; // Exceeding Expectations
+  return null;
+}
+  
+export function shortLabelFromOldMcasScore(score) {
+  if (score >= 200 && score < 218) return 'W'; // Warning
+  if (score >= 220 && score < 238) return 'NI'; // Needs Improvement
+  if (score >= 240 && score < 258) return 'P'; // Proficient
+  if (score >= 260 && score < 280) return 'E'; // Advanced
+  return null;
+}

--- a/app/assets/javascripts/student_profile/nextGenMcasScores.js
+++ b/app/assets/javascripts/student_profile/nextGenMcasScores.js
@@ -1,7 +1,0 @@
-export function shortLabelFromScore(score) {
-  if (score >= 400 && score < 450) return 'NM'; // Not Meeting Expectations
-  if (score >= 450 && score < 500) return 'PM'; // Partially Meeting
-  if (score >= 500 && score < 550) return 'M'; // Meeting Expectations
-  if (score >= 550 && score < 600) return 'E'; // Exceeding Expectations
-  return null;
-}

--- a/app/assets/javascripts/student_profile/testingColumnTexts.js
+++ b/app/assets/javascripts/student_profile/testingColumnTexts.js
@@ -1,0 +1,48 @@
+import _ from 'lodash';
+import {toMoment} from './QuadConverter';
+import {shortLabelFromNextGenMcasScore, shortLabelFromOldMcasScore} from './mcasScores';
+
+
+// Look at ELA and Math next gen MCAS scores and make the different texts for the 'testing'
+// column summary for HS.  If those don't exist, fall back to old-school MCAS.
+export default function testingColumnTexts(nowMoment, chartData) {
+  const ela = (
+    latestMcasScoreSummary(chartData.next_gen_mcas_ela_scaled, shortLabelFromNextGenMcasScore, nowMoment) ||
+    latestMcasScoreSummary(chartData.mcas_series_ela_scaled, shortLabelFromOldMcasScore, nowMoment) ||
+    missingMcasSummary()
+  );
+  const math = (
+    latestMcasScoreSummary(chartData.next_gen_mcas_mathematics_scaled, shortLabelFromNextGenMcasScore, nowMoment) ||
+    latestMcasScoreSummary(chartData.mcas_series_math_scaled, shortLabelFromOldMcasScore, nowMoment) ||
+    missingMcasSummary()
+  );
+
+  const scoreText = ela.scoreText === math.scoreText
+    ? ela.scoreText
+    : `${ela.scoreText} / ${math.scoreText}`;
+  const testText = ela.scoreText === math.scoreText
+    ? 'ELA and Math MCAS'
+    : 'ELA / Math MCAS';
+  const dateText = (ela.dateText === math.dateText)
+    ? ela.dateText
+    : `${ela.dateText} / ${math.dateText}`;
+
+  return {scoreText, testText, dateText};
+}
+
+// Make text for the score and date for the latest MCAS score (either next gen
+// or old, depending on `scoreTextFn`).
+function latestMcasScoreSummary(quads, scoreTextFn, nowMoment) {
+  const latestEla = _.last(_.sortBy(quads || [], quad => toMoment(quad).unix()));
+  if (!latestEla) return null;
+
+  const scoreText = scoreTextFn(latestEla[3]);
+  const dateText = toMoment(latestEla).from(nowMoment);
+  return {scoreText, dateText};
+}
+
+function missingMcasSummary() {
+  const scoreText = '-';
+  const dateText = 'not yet taken';
+  return {scoreText, dateText};
+}


### PR DESCRIPTION
Part of https://github.com/studentinsights/studentinsights/issues/1990.

# Who is this PR for?
HS educators

# What problem does this PR fix?
The profile v3 page only shows next-gen MCAS scores in the testing summary tab.  Not all students have taken that, since tests are taken on two year cycles and the next gen has only been released for one year.

# What does this PR do?
Updates to fall back to old MCAS scores if there's no nex gen scores.

# Screenshot (if adding a client-side feature)
Some examples:
<img width="288" alt="screen shot 2018-08-24 at 5 43 58 pm" src="https://user-images.githubusercontent.com/1056957/44610009-3e943c00-a7c8-11e8-9a9c-de79a105ffd3.png">
<img width="227" alt="screen shot 2018-08-24 at 5 43 41 pm" src="https://user-images.githubusercontent.com/1056957/44610010-3e943c00-a7c8-11e8-8d82-4201a91bacbc.png">
<img width="287" alt="screen shot 2018-08-24 at 5 41 39 pm" src="https://user-images.githubusercontent.com/1056957/44610011-3e943c00-a7c8-11e8-987e-f43215d85515.png">

# Checklists
+ [x] Author checked latest in IE - Student Profile v3
+ [x] Author included specs for new code