### PR TITLE
Profile v3: Release feature

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -149,7 +149,7 @@ class StudentsController < ApplicationController
 
   def should_redirect_to_profile_v3?(params)
     return false if params.has_key?(:please)
-    EnvironmentVariable.is_true('ENABLE_STUDENT_PROFILE_V3')
+    !EnvironmentVariable.is_true('DISABLE_STUDENT_PROFILE_V3')
   end
 
   def serialize_student_for_profile(student)

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -31,7 +31,8 @@ describe StudentsController, :type => :controller do
       request.env['HTTPS'] = 'on'
       get :show, params: {
         id: options[:student_id],
-        format: options[:format]
+        format: options[:format],
+        please: true # force request, regardless of ENV feature switches
       }
     end
 


### PR DESCRIPTION
Part of https://github.com/studentinsights/studentinsights/issues/1990, releasing it to all users and districts

# Who is this PR for?
educators

# What problem does this PR fix?
a bunch!

# What does this PR do?
Redirects all requests for v2 profile to v3 profile.  This can be disabled by `DISABLE_STUDENT_PROFILE_V3` instead of being previously enabled by `ENABLE_STUDENT_PROFILE_V3`.  The `please` query string param will force loading the v2 profile page for QA and troubleshooting.
