### PR TITLE
Update old MCAS score names to be inclusive ranges

### DIFF
--- a/app/assets/javascripts/student_profile/mcasScores.js
+++ b/app/assets/javascripts/student_profile/mcasScores.js
@@ -7,9 +7,9 @@ export function shortLabelFromNextGenMcasScore(score) {
 }
   
 export function shortLabelFromOldMcasScore(score) {
-  if (score >= 200 && score < 218) return 'W'; // Warning
-  if (score >= 220 && score < 238) return 'NI'; // Needs Improvement
-  if (score >= 240 && score < 258) return 'P'; // Proficient
-  if (score >= 260 && score < 280) return 'E'; // Advanced
+  if (score >= 200 && score <= 218) return 'W'; // Warning
+  if (score >= 220 && score <= 238) return 'NI'; // Needs Improvement
+  if (score >= 240 && score <= 258) return 'P'; // Proficient
+  if (score >= 260 && score <= 280) return 'E'; // Advanced
   return null;
 }


### PR DESCRIPTION
Follow on to https://github.com/studentinsights/studentinsights/pull/2009.

# Who is this PR for?
HS educators

# What problem does this PR fix?
These score ranges should be inclusive.  Confirmed in http://www.doe.mass.edu/mcas/2016/results/spring-conversion.pdf

<img width="282" alt="screen shot 2018-08-24 at 6 39 56 pm" src="https://user-images.githubusercontent.com/1056957/44611030-24109180-a7cd-11e8-9e38-e7eea112df4e.png">

# What does this PR do?
Fixes that.
