### PR TITLE
Profile v3: Clean slate for discipline incidents, only look back one school year

### DIFF
--- a/app/assets/javascripts/components/HighchartsWrapper.js
+++ b/app/assets/javascripts/components/HighchartsWrapper.js
@@ -6,7 +6,7 @@ import 'highcharts';
 // options as props, and it bridges calling into the library.
 
 export default class HighchartsWrapper extends React.Component {
-  componentDidMount(props, state) {
+  componentDidMount() {
     $(this.chartEl).highcharts(this.props);
   }
 
@@ -14,7 +14,7 @@ export default class HighchartsWrapper extends React.Component {
     $(this.chartEl).highcharts(newProps);
   }
 
-  componentWillUnmount(props, state) {
+  componentWillUnmount() {
     delete this.chartEl;
   }
 

--- a/app/assets/javascripts/student_profile/LightBehaviorDetails.js
+++ b/app/assets/javascripts/student_profile/LightBehaviorDetails.js
@@ -1,61 +1,177 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {toMomentFromTimestamp, toMomentFromRailsDate} from '../helpers/toMoment';
+import {toSchoolYear, firstDayOfSchool} from '../helpers/schoolYear';
+import IncidentCard from '../components/IncidentCard';
 import DetailsSection from './DetailsSection';
 import ProfileBarChart, {servicePhaselines} from './ProfileBarChart';
-import IncidentCard from '../components/IncidentCard';
 
 
 export default class LightBehaviorDetails extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isViewingFullHistory: false,
+      schoolYearsBack: {
+        number: 1,
+        textYears: 'one year'
+      }
+    };
+    this.onToggleCaseHistory = this.onToggleCaseHistory.bind(this);
+  }
+
+  filterCutoffMoment() {
+    const {nowFn} = this.context;
+    const {schoolYearsBack} = this.state;
+    const nowMoment = nowFn();
+    const pastSchoolYear = toSchoolYear(nowMoment) - schoolYearsBack.number;
+    return firstDayOfSchool(pastSchoolYear);
+  }
+
+  filteredIncidents() {
+    const {isViewingFullHistory} = this.state;
+    const {disciplineIncidents} = this.props;
+    if (isViewingFullHistory) return disciplineIncidents;
+
+    const cutoffMoment = this.filterCutoffMoment();
+    return disciplineIncidents.filter(incident => {
+      const incidentMoment = toMomentFromTimestamp(incident.occurred_at);
+      return incidentMoment.isAfter(cutoffMoment);
+    });
+  }
+
+  filteredDataPhaselines() {
+    const {isViewingFullHistory, schoolYearsBack} = this.state;
+    if (isViewingFullHistory) return [];
+
+    const momentUTC = this.filterCutoffMoment();
+    const text = `Only ${schoolYearsBack.textYears} of data is shown to respect privacy`;
+    return [{momentUTC, text}];
+  }
+
+  servicePhaselines() {
+    const {activeServices, serviceTypesIndex} = this.props;
+    const cutoffMoment = this.filterCutoffMoment();
+    const filteredPhaselines = activeServices.filter(service => {
+      const phaselineMoment = toMomentFromRailsDate(service.date_started);
+      return phaselineMoment.isAfter(cutoffMoment);
+    });
+    return servicePhaselines(filteredPhaselines, serviceTypesIndex);
+  }
+
+  onToggleCaseHistory(e) {
+    e.preventDefault();
+    const {isViewingFullHistory} = this.state;
+    this.setState({isViewingFullHistory: !isViewingFullHistory});
+  }
+
   render() {
+    const filteredDisciplineIncidents = this.filteredIncidents();
+
     return (
       <div className="LightBehaviorDetails">
-        {this.renderDisciplineIncidents()}
-        {this.renderIncidentHistory()}
+        {this.renderDisciplineIncidents(filteredDisciplineIncidents)}
+        {this.renderCleanSlateMessage()}
+        {this.renderIncidentHistory(filteredDisciplineIncidents)}
       </div>
     );
   }
 
-  renderDisciplineIncidents() {
-    const {disciplineIncidents, activeServices, serviceTypesIndex} = this.props;
-    const phaselines = servicePhaselines(activeServices, serviceTypesIndex);
+  renderCleanSlateMessage() {
+    const {canViewFullHistory} = this.props;
+    const {schoolYearsBack} = this.state;
+
+    return (
+      <div style={styles.cleanSlateMessage}>
+        <div style={{fontWeight: 'bold'}}>A note about student privacy</div>
+          <span>To respect student privacy, this page only shows {schoolYearsBack.textYears} of data by default.  </span>
+          {canViewFullHistory
+            ? this.renderCleanStateMessageForAdmin()
+            : <span>If you need to know more about the student's case history, talk with an administrator who will have access to this data.</span>
+          }
+      </div>
+    );
+  }
+
+  renderCleanStateMessageForAdmin() {
+    const {isViewingFullHistory} = this.state;
+
+    return (
+      <span>
+        <span>Before accessing older data, consider the balance between learning
+        from these records and giving students a chance to start each year with a
+        clean slate.</span>
+        <a className="LightBehaviorDetails-show-history-link" href="#" style={styles.showLink} onClick={this.onToggleCaseHistory}>
+          {isViewingFullHistory ? 'hide full case history' : 'show full case history'}
+        </a>
+      </span>
+    );
+  }
+
+  renderDisciplineIncidents(filteredDisciplineIncidents) {
+    const phaselines = this.servicePhaselines().concat(this.filteredDataPhaselines());
+
     return (
       <ProfileBarChart
-        events={disciplineIncidents}
+        events={filteredDisciplineIncidents}
         titleText="Discipline Incidents"
         id="disciplineChart"
-        monthsBack={48}
+        monthsBack={48} // always show 4 years for consistent scale and layout, regardless of filtering
         phaselines={phaselines} />
     );
   }
 
-  renderIncidentHistory() {
-    const {disciplineIncidents} = this.props;
+  renderIncidentHistory(filteredDisciplineIncidents) {
     return (
-      <DetailsSection anchorId="history" title="Incident History">
-        <div style={{paddingTop: 20}}>{disciplineIncidents.length > 0
-          ? this.renderIncidents(disciplineIncidents)
-          : <div>No Incidents</div>
-        }</div>
-      </DetailsSection>
+      <div>
+        <DetailsSection anchorId="history" title="Incident History">
+          <div style={{paddingTop: 20}}>{filteredDisciplineIncidents.length > 0
+            ? this.renderIncidents(filteredDisciplineIncidents)
+            : <div>No incident data.</div>
+          }</div>
+        </DetailsSection>
+        {this.renderCleanSlateMessage()}
+      </div>
     );
   }
 
-  renderIncidents(disciplineIncidents) {
+  renderIncidents(filteredDisciplineIncidents) {
     return (
       <div>
-        {disciplineIncidents.map(incident => {
+        {filteredDisciplineIncidents.map(incident => {
           return <IncidentCard key={incident.id} incident={incident} />;
         })}
       </div>
     );
   }
 }
-
 LightBehaviorDetails.propTypes = {
   disciplineIncidents: PropTypes.array.isRequired,
   activeServices: PropTypes.arrayOf(PropTypes.shape({
     service_type_id: PropTypes.number.isRequired,
     date_started: PropTypes.string.isRequired
   })).isRequired,
-  serviceTypesIndex: PropTypes.object.isRequired
+  serviceTypesIndex: PropTypes.object.isRequired,
+  canViewFullHistory: PropTypes.bool.isRequired
+};
+LightBehaviorDetails.contextTypes = {
+  nowFn: PropTypes.func.isRequired
+};
+
+const styles = {
+  cleanSlateMessage: {
+    padding: 10,
+    paddingTop: 15,
+    paddingBottom: 0
+  },
+  showLink: {
+    display: 'inline-block',
+    paddingLeft: 5,
+    cursor: 'pointer',
+    color: '#999'
+  },
+  privacyForFullList: {
+    paddingTop: 20
+  }
 };

--- a/app/assets/javascripts/student_profile/LightBehaviorDetails.test.js
+++ b/app/assets/javascripts/student_profile/LightBehaviorDetails.test.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactTestUtils from 'react-addons-test-utils';
+import LightBehaviorDetails from './LightBehaviorDetails';
+import {withDefaultNowContext} from '../testing/NowContainer';
+import serviceTypesIndex from '../testing/fixtures/serviceTypesIndex';
+
+
+function testProps(props = {}) {
+  return {
+    disciplineIncidents: testIncidents(),
+    activeServices: [],
+    canViewFullHistory: false,
+    serviceTypesIndex,
+    ...props
+  };
+}
+
+function testIncidents() {
+  return [{
+    "id": 45,
+    "incident_code": "ABC",
+    "created_at": "2018-03-01T14:22:11.437Z",
+    "updated_at": "2018-03-01T14:22:11.437Z",
+    "incident_location": "Classroom",
+    "incident_description": "Something happened recently.",
+    "occurred_at": "2018-03-02T08:22:11.437Z",
+    "has_exact_time": true,
+    "student_id": 42
+  }, {
+    "id": 46,
+    "incident_code": "XYZ",
+    "created_at": "2016-02-22T14:22:11.437Z",
+    "updated_at": "2016-02-22T14:22:11.437Z",
+    "incident_location": "Classroom",
+    "incident_description": "Something else happened a long time ago...",
+    "occurred_at": "2016-02-24T08:10:11.543Z",
+    "has_exact_time": true,
+    "student_id": 42
+  }];
+}
+
+function testRender(props) {
+  const el = document.createElement('div');
+  ReactDOM.render(withDefaultNowContext(<LightBehaviorDetails {...props} />), el);
+  return el;
+}
+
+it('renders empty data without crashing', () => {
+  testRender(testProps());
+});
+
+it('renders clean slate note when cannot access', () => {
+  const el = testRender(testProps());
+  expect($(el).text()).toContain('talk with an administrator');
+});
+
+it('renders note to show full case history when access', () => {
+  const el = testRender(testProps({canViewFullHistory: true}));
+  expect($(el).text()).toContain('show full case history');
+});
+
+it('always hides older data by default', () => {
+  const el = testRender(testProps({canViewFullHistory: true}));
+  expect($(el).text()).toContain('A note about student privacy');
+  expect($(el).html()).toContain('Something happened recently');
+  expect($(el).html()).not.toContain('Something else happened a long time ago...');
+  expect($(el).find('svg').length).toEqual(1);
+  // test setup isn't working for highcharts contents
+});
+
+it('allows showing older data when access', () => {
+  const el = testRender(testProps({canViewFullHistory: true}));
+  expect($(el).text()).toContain('show full case history');
+  ReactTestUtils.Simulate.click($(el).find('.LightBehaviorDetails-show-history-link').get(0));
+  expect($(el).text()).toContain('hide full case history');
+  expect($(el).html()).toContain('Something else happened a long time ago...');
+});

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -374,10 +374,12 @@ export default class LightProfilePage extends React.Component {
   }
 
   renderBehavior() {
+    const {currentEducator} = this.props;
     return (
       <LightBehaviorDetails
         className="LightProfilePage-behavior"
         disciplineIncidents={this.props.attendanceData.discipline_incidents}
+        canViewFullHistory={currentEducator.can_view_restricted_notes}
         activeServices={this.props.feed.services.active}
         serviceTypesIndex={this.props.serviceTypesIndex} />
     );
@@ -404,7 +406,8 @@ LightProfilePage.propTypes = {
   // context
   nowMomentFn: PropTypes.func.isRequired,
   currentEducator: PropTypes.shape({
-    labels: PropTypes.arrayOf(PropTypes.string).isRequired
+    labels: PropTypes.arrayOf(PropTypes.string).isRequired,
+    can_view_restricted_notes: PropTypes.bool.isRequired
   }).isRequired,
   districtKey: PropTypes.string.isRequired,
 

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -21,9 +21,9 @@ class ProfileController < ApplicationController
       sections: serialize_student_sections_for_profile(student),
       current_educator_allowed_sections: current_educator.allowed_sections.map(&:id),
       attendance_data: {
-        discipline_incidents: student.discipline_incidents.order(occurred_at: :desc),
-        tardies: student.tardies.order(occurred_at: :desc),
-        absences: student.absences.order(occurred_at: :desc)
+        discipline_incidents: filtered_events(student.discipline_incidents),
+        tardies: filtered_events(student.tardies),
+        absences: filtered_events(student.absences)
       }
     }
   end
@@ -71,5 +71,12 @@ class ProfileController < ApplicationController
         interventions: student.interventions.map { |intervention| DeprecatedInterventionSerializer.new(intervention).serialize_intervention }
       }
     }
+  end
+
+  def filtered_events(mixed_events, options = {})
+    time_now = options.fetch(:time_now, Time.now)
+    months_back = options.fetch(:months_back, 48)
+    cutoff_time = time_now - months_back.months
+    mixed_events.where('occurred_at >= ? ', cutoff_time).order(occurred_at: :desc)
   end
 end


### PR DESCRIPTION
Part of https://github.com/studentinsights/studentinsights/issues/1990.

# Who is this PR for?
students, educators

# What problem does this PR fix?
For students with discipline incidents, making their full record visible for several years can influence how educators perceive these students.  Ideally students would have a "clean slate" and chance to start each year without any kind of stigma or bias associated with past behavioral challenges.  At the same time, it's helpful for educators, counselors and administrators to know about a student's case history and what has happened in the past, or ways that have been successful or unsuccessful in supporting a student.

# What does this PR do?
Makes discipline incidents only visible for the current school year and the past school year.  If the educator has access to view restricted notes, they can also click to see data looking back for the last four years (as before).  If they do not have access, they can't see older data at all.

# Screenshot (if adding a client-side feature)
### with access, chart by default
<img width="1131" alt="screen shot 2018-08-26 at 12 34 53 pm" src="https://user-images.githubusercontent.com/1056957/44631168-74573300-a936-11e8-868d-34a3eece1be4.png">

### with access, chart after clicking "show full history"
<img width="1126" alt="screen shot 2018-08-26 at 12 34 49 pm" src="https://user-images.githubusercontent.com/1056957/44631170-7faa5e80-a936-11e8-97aa-09fbbdc90d8f.png">

### with access, incident txt after clicking "show full history"
<img width="1135" alt="screen shot 2018-08-26 at 12 34 43 pm" src="https://user-images.githubusercontent.com/1056957/44631171-82a54f00-a936-11e8-9b01-b1e82120ef42.png">

### empty case
<img width="1001" alt="screen shot 2018-08-26 at 12 33 31 pm" src="https://user-images.githubusercontent.com/1056957/44631176-a4063b00-a936-11e8-9e29-2b18ecb4fa82.png">

# Checklists
+ [x] Author checked latest in IE - Student Profile v3
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code
