### PR TITLE
Profile v3: Minimal queue about insight box to start the year

### DIFF
--- a/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
@@ -2296,22 +2296,26 @@ exports[`snapshots works for aladdin grades 1`] = `
               }
             >
               <div>
-                <div>
-                  Share an insight!
-                </div>
-                <textarea
-                  placeholder="What's one of Aladdin's strengths?"
-                  rows={3}
+                <div
                   style={
                     Object {
-                      "background": "#f9f9f9",
-                      "border": 0,
-                      "fontSize": 12,
-                      "marginTop": 10,
-                      "width": "100%",
+                      "fontSize": 18,
+                      "marginBottom": 5,
                     }
                   }
-                />
+                >
+                  Share an insight about 
+                  Aladdin
+                </div>
+                <div
+                  style={
+                    Object {
+                      "fontSize": 12,
+                    }
+                  }
+                >
+                  This is being piloted at Somervile High School to start the school year.
+                </div>
               </div>
             </div>
           </div>
@@ -2339,33 +2343,46 @@ exports[`snapshots works for aladdin grades 1`] = `
                 }
               >
                 <div>
-                  
+                  <span>
+                    If you're curious, talk with 
+                    <a
+                      href="mailto:uharel@k12.somerville.ma.us"
+                      style={
+                        Object {
+                          "fontSize": 12,
+                        }
+                      }
+                    >
+                      Uri
+                    </a>
+                     or check out 
+                  </span>
                 </div>
                 <div>
                   <span>
-                    See 
-                    <a
-                      href="#"
+                    an 
+                    <div
                       style={
                         Object {
-                          "fontSize": 12,
+                          "display": "inline",
+                          "marginLeft": 0,
                         }
                       }
                     >
-                      Ileana
-                    </a>
-                     or 
-                    <a
-                      href="#"
-                      style={
-                        Object {
-                          "fontSize": 12,
+                      <a
+                        href="#"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "fontSize": 12,
+                            "outline": "none",
+                          }
                         }
-                      }
-                    >
-                      Manuel
-                    </a>
-                     for examples.
+                      >
+                        example
+                      </a>
+                    </div>
+                    .
                   </span>
                 </div>
               </div>
@@ -3297,22 +3314,26 @@ exports[`snapshots works for aladdin notes 1`] = `
               }
             >
               <div>
-                <div>
-                  Share an insight!
-                </div>
-                <textarea
-                  placeholder="What's one of Aladdin's strengths?"
-                  rows={3}
+                <div
                   style={
                     Object {
-                      "background": "#f9f9f9",
-                      "border": 0,
-                      "fontSize": 12,
-                      "marginTop": 10,
-                      "width": "100%",
+                      "fontSize": 18,
+                      "marginBottom": 5,
                     }
                   }
-                />
+                >
+                  Share an insight about 
+                  Aladdin
+                </div>
+                <div
+                  style={
+                    Object {
+                      "fontSize": 12,
+                    }
+                  }
+                >
+                  This is being piloted at Somervile High School to start the school year.
+                </div>
               </div>
             </div>
           </div>
@@ -3340,33 +3361,46 @@ exports[`snapshots works for aladdin notes 1`] = `
                 }
               >
                 <div>
-                  
+                  <span>
+                    If you're curious, talk with 
+                    <a
+                      href="mailto:uharel@k12.somerville.ma.us"
+                      style={
+                        Object {
+                          "fontSize": 12,
+                        }
+                      }
+                    >
+                      Uri
+                    </a>
+                     or check out 
+                  </span>
                 </div>
                 <div>
                   <span>
-                    See 
-                    <a
-                      href="#"
+                    an 
+                    <div
                       style={
                         Object {
-                          "fontSize": 12,
+                          "display": "inline",
+                          "marginLeft": 0,
                         }
                       }
                     >
-                      Ileana
-                    </a>
-                     or 
-                    <a
-                      href="#"
-                      style={
-                        Object {
-                          "fontSize": 12,
+                      <a
+                        href="#"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "fontSize": 12,
+                            "outline": "none",
+                          }
                         }
-                      }
-                    >
-                      Manuel
-                    </a>
-                     for examples.
+                      >
+                        example
+                      </a>
+                    </div>
+                    .
                   </span>
                 </div>
               </div>
@@ -4298,22 +4332,26 @@ exports[`snapshots works for aladdin testing 1`] = `
               }
             >
               <div>
-                <div>
-                  Share an insight!
-                </div>
-                <textarea
-                  placeholder="What's one of Aladdin's strengths?"
-                  rows={3}
+                <div
                   style={
                     Object {
-                      "background": "#f9f9f9",
-                      "border": 0,
-                      "fontSize": 12,
-                      "marginTop": 10,
-                      "width": "100%",
+                      "fontSize": 18,
+                      "marginBottom": 5,
                     }
                   }
-                />
+                >
+                  Share an insight about 
+                  Aladdin
+                </div>
+                <div
+                  style={
+                    Object {
+                      "fontSize": 12,
+                    }
+                  }
+                >
+                  This is being piloted at Somervile High School to start the school year.
+                </div>
               </div>
             </div>
           </div>
@@ -4341,33 +4379,46 @@ exports[`snapshots works for aladdin testing 1`] = `
                 }
               >
                 <div>
-                  
+                  <span>
+                    If you're curious, talk with 
+                    <a
+                      href="mailto:uharel@k12.somerville.ma.us"
+                      style={
+                        Object {
+                          "fontSize": 12,
+                        }
+                      }
+                    >
+                      Uri
+                    </a>
+                     or check out 
+                  </span>
                 </div>
                 <div>
                   <span>
-                    See 
-                    <a
-                      href="#"
+                    an 
+                    <div
                       style={
                         Object {
-                          "fontSize": 12,
+                          "display": "inline",
+                          "marginLeft": 0,
                         }
                       }
                     >
-                      Ileana
-                    </a>
-                     or 
-                    <a
-                      href="#"
-                      style={
-                        Object {
-                          "fontSize": 12,
+                      <a
+                        href="#"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "fontSize": 12,
+                            "outline": "none",
+                          }
                         }
-                      }
-                    >
-                      Manuel
-                    </a>
-                     for examples.
+                      >
+                        example
+                      </a>
+                    </div>
+                    .
                   </span>
                 </div>
               </div>
@@ -7196,22 +7247,26 @@ exports[`snapshots works for olaf math 1`] = `
               }
             >
               <div>
-                <div>
-                  Share an insight!
-                </div>
-                <textarea
-                  placeholder="What's one of Olaf's strengths?"
-                  rows={3}
+                <div
                   style={
                     Object {
-                      "background": "#f9f9f9",
-                      "border": 0,
-                      "fontSize": 12,
-                      "marginTop": 10,
-                      "width": "100%",
+                      "fontSize": 18,
+                      "marginBottom": 5,
                     }
                   }
-                />
+                >
+                  Share an insight about 
+                  Olaf
+                </div>
+                <div
+                  style={
+                    Object {
+                      "fontSize": 12,
+                    }
+                  }
+                >
+                  This is being piloted at Somervile High School to start the school year.
+                </div>
               </div>
             </div>
           </div>
@@ -7239,33 +7294,46 @@ exports[`snapshots works for olaf math 1`] = `
                 }
               >
                 <div>
-                  
+                  <span>
+                    If you're curious, talk with 
+                    <a
+                      href="mailto:uharel@k12.somerville.ma.us"
+                      style={
+                        Object {
+                          "fontSize": 12,
+                        }
+                      }
+                    >
+                      Uri
+                    </a>
+                     or check out 
+                  </span>
                 </div>
                 <div>
                   <span>
-                    See 
-                    <a
-                      href="#"
+                    an 
+                    <div
                       style={
                         Object {
-                          "fontSize": 12,
+                          "display": "inline",
+                          "marginLeft": 0,
                         }
                       }
                     >
-                      Ileana
-                    </a>
-                     or 
-                    <a
-                      href="#"
-                      style={
-                        Object {
-                          "fontSize": 12,
+                      <a
+                        href="#"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "fontSize": 12,
+                            "outline": "none",
+                          }
                         }
-                      }
-                    >
-                      Manuel
-                    </a>
-                     for examples.
+                      >
+                        example
+                      </a>
+                    </div>
+                    .
                   </span>
                 </div>
               </div>
@@ -8144,22 +8212,26 @@ exports[`snapshots works for olaf notes 1`] = `
               }
             >
               <div>
-                <div>
-                  Share an insight!
-                </div>
-                <textarea
-                  placeholder="What's one of Olaf's strengths?"
-                  rows={3}
+                <div
                   style={
                     Object {
-                      "background": "#f9f9f9",
-                      "border": 0,
-                      "fontSize": 12,
-                      "marginTop": 10,
-                      "width": "100%",
+                      "fontSize": 18,
+                      "marginBottom": 5,
                     }
                   }
-                />
+                >
+                  Share an insight about 
+                  Olaf
+                </div>
+                <div
+                  style={
+                    Object {
+                      "fontSize": 12,
+                    }
+                  }
+                >
+                  This is being piloted at Somervile High School to start the school year.
+                </div>
               </div>
             </div>
           </div>
@@ -8187,33 +8259,46 @@ exports[`snapshots works for olaf notes 1`] = `
                 }
               >
                 <div>
-                  
+                  <span>
+                    If you're curious, talk with 
+                    <a
+                      href="mailto:uharel@k12.somerville.ma.us"
+                      style={
+                        Object {
+                          "fontSize": 12,
+                        }
+                      }
+                    >
+                      Uri
+                    </a>
+                     or check out 
+                  </span>
                 </div>
                 <div>
                   <span>
-                    See 
-                    <a
-                      href="#"
+                    an 
+                    <div
                       style={
                         Object {
-                          "fontSize": 12,
+                          "display": "inline",
+                          "marginLeft": 0,
                         }
                       }
                     >
-                      Ileana
-                    </a>
-                     or 
-                    <a
-                      href="#"
-                      style={
-                        Object {
-                          "fontSize": 12,
+                      <a
+                        href="#"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "fontSize": 12,
+                            "outline": "none",
+                          }
                         }
-                      }
-                    >
-                      Manuel
-                    </a>
-                     for examples.
+                      >
+                        example
+                      </a>
+                    </div>
+                    .
                   </span>
                 </div>
               </div>
@@ -9092,22 +9177,26 @@ exports[`snapshots works for olaf reading 1`] = `
               }
             >
               <div>
-                <div>
-                  Share an insight!
-                </div>
-                <textarea
-                  placeholder="What's one of Olaf's strengths?"
-                  rows={3}
+                <div
                   style={
                     Object {
-                      "background": "#f9f9f9",
-                      "border": 0,
-                      "fontSize": 12,
-                      "marginTop": 10,
-                      "width": "100%",
+                      "fontSize": 18,
+                      "marginBottom": 5,
                     }
                   }
-                />
+                >
+                  Share an insight about 
+                  Olaf
+                </div>
+                <div
+                  style={
+                    Object {
+                      "fontSize": 12,
+                    }
+                  }
+                >
+                  This is being piloted at Somervile High School to start the school year.
+                </div>
               </div>
             </div>
           </div>
@@ -9135,33 +9224,46 @@ exports[`snapshots works for olaf reading 1`] = `
                 }
               >
                 <div>
-                  
+                  <span>
+                    If you're curious, talk with 
+                    <a
+                      href="mailto:uharel@k12.somerville.ma.us"
+                      style={
+                        Object {
+                          "fontSize": 12,
+                        }
+                      }
+                    >
+                      Uri
+                    </a>
+                     or check out 
+                  </span>
                 </div>
                 <div>
                   <span>
-                    See 
-                    <a
-                      href="#"
+                    an 
+                    <div
                       style={
                         Object {
-                          "fontSize": 12,
+                          "display": "inline",
+                          "marginLeft": 0,
                         }
                       }
                     >
-                      Ileana
-                    </a>
-                     or 
-                    <a
-                      href="#"
-                      style={
-                        Object {
-                          "fontSize": 12,
+                      <a
+                        href="#"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "fontSize": 12,
+                            "outline": "none",
+                          }
                         }
-                      }
-                    >
-                      Manuel
-                    </a>
-                     for examples.
+                      >
+                        example
+                      </a>
+                    </div>
+                    .
                   </span>
                 </div>
               </div>
@@ -12226,22 +12328,26 @@ exports[`snapshots works for pluto attendance 1`] = `
               }
             >
               <div>
-                <div>
-                  Share an insight!
-                </div>
-                <textarea
-                  placeholder="What's one of Pluto's strengths?"
-                  rows={3}
+                <div
                   style={
                     Object {
-                      "background": "#f9f9f9",
-                      "border": 0,
-                      "fontSize": 12,
-                      "marginTop": 10,
-                      "width": "100%",
+                      "fontSize": 18,
+                      "marginBottom": 5,
                     }
                   }
-                />
+                >
+                  Share an insight about 
+                  Pluto
+                </div>
+                <div
+                  style={
+                    Object {
+                      "fontSize": 12,
+                    }
+                  }
+                >
+                  This is being piloted at Somervile High School to start the school year.
+                </div>
               </div>
             </div>
           </div>
@@ -12269,33 +12375,46 @@ exports[`snapshots works for pluto attendance 1`] = `
                 }
               >
                 <div>
-                  
+                  <span>
+                    If you're curious, talk with 
+                    <a
+                      href="mailto:uharel@k12.somerville.ma.us"
+                      style={
+                        Object {
+                          "fontSize": 12,
+                        }
+                      }
+                    >
+                      Uri
+                    </a>
+                     or check out 
+                  </span>
                 </div>
                 <div>
                   <span>
-                    See 
-                    <a
-                      href="#"
+                    an 
+                    <div
                       style={
                         Object {
-                          "fontSize": 12,
+                          "display": "inline",
+                          "marginLeft": 0,
                         }
                       }
                     >
-                      Ileana
-                    </a>
-                     or 
-                    <a
-                      href="#"
-                      style={
-                        Object {
-                          "fontSize": 12,
+                      <a
+                        href="#"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "fontSize": 12,
+                            "outline": "none",
+                          }
                         }
-                      }
-                    >
-                      Manuel
-                    </a>
-                     for examples.
+                      >
+                        example
+                      </a>
+                    </div>
+                    .
                   </span>
                 </div>
               </div>
@@ -13189,22 +13308,26 @@ exports[`snapshots works for pluto behavior 1`] = `
               }
             >
               <div>
-                <div>
-                  Share an insight!
-                </div>
-                <textarea
-                  placeholder="What's one of Pluto's strengths?"
-                  rows={3}
+                <div
                   style={
                     Object {
-                      "background": "#f9f9f9",
-                      "border": 0,
-                      "fontSize": 12,
-                      "marginTop": 10,
-                      "width": "100%",
+                      "fontSize": 18,
+                      "marginBottom": 5,
                     }
                   }
-                />
+                >
+                  Share an insight about 
+                  Pluto
+                </div>
+                <div
+                  style={
+                    Object {
+                      "fontSize": 12,
+                    }
+                  }
+                >
+                  This is being piloted at Somervile High School to start the school year.
+                </div>
               </div>
             </div>
           </div>
@@ -13232,33 +13355,46 @@ exports[`snapshots works for pluto behavior 1`] = `
                 }
               >
                 <div>
-                  
+                  <span>
+                    If you're curious, talk with 
+                    <a
+                      href="mailto:uharel@k12.somerville.ma.us"
+                      style={
+                        Object {
+                          "fontSize": 12,
+                        }
+                      }
+                    >
+                      Uri
+                    </a>
+                     or check out 
+                  </span>
                 </div>
                 <div>
                   <span>
-                    See 
-                    <a
-                      href="#"
+                    an 
+                    <div
                       style={
                         Object {
-                          "fontSize": 12,
+                          "display": "inline",
+                          "marginLeft": 0,
                         }
                       }
                     >
-                      Ileana
-                    </a>
-                     or 
-                    <a
-                      href="#"
-                      style={
-                        Object {
-                          "fontSize": 12,
+                      <a
+                        href="#"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "fontSize": 12,
+                            "outline": "none",
+                          }
                         }
-                      }
-                    >
-                      Manuel
-                    </a>
-                     for examples.
+                      >
+                        example
+                      </a>
+                    </div>
+                    .
                   </span>
                 </div>
               </div>
@@ -14152,22 +14288,26 @@ exports[`snapshots works for pluto notes 1`] = `
               }
             >
               <div>
-                <div>
-                  Share an insight!
-                </div>
-                <textarea
-                  placeholder="What's one of Pluto's strengths?"
-                  rows={3}
+                <div
                   style={
                     Object {
-                      "background": "#f9f9f9",
-                      "border": 0,
-                      "fontSize": 12,
-                      "marginTop": 10,
-                      "width": "100%",
+                      "fontSize": 18,
+                      "marginBottom": 5,
                     }
                   }
-                />
+                >
+                  Share an insight about 
+                  Pluto
+                </div>
+                <div
+                  style={
+                    Object {
+                      "fontSize": 12,
+                    }
+                  }
+                >
+                  This is being piloted at Somervile High School to start the school year.
+                </div>
               </div>
             </div>
           </div>
@@ -14195,33 +14335,46 @@ exports[`snapshots works for pluto notes 1`] = `
                 }
               >
                 <div>
-                  
+                  <span>
+                    If you're curious, talk with 
+                    <a
+                      href="mailto:uharel@k12.somerville.ma.us"
+                      style={
+                        Object {
+                          "fontSize": 12,
+                        }
+                      }
+                    >
+                      Uri
+                    </a>
+                     or check out 
+                  </span>
                 </div>
                 <div>
                   <span>
-                    See 
-                    <a
-                      href="#"
+                    an 
+                    <div
                       style={
                         Object {
-                          "fontSize": 12,
+                          "display": "inline",
+                          "marginLeft": 0,
                         }
                       }
                     >
-                      Ileana
-                    </a>
-                     or 
-                    <a
-                      href="#"
-                      style={
-                        Object {
-                          "fontSize": 12,
+                      <a
+                        href="#"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "fontSize": 12,
+                            "outline": "none",
+                          }
                         }
-                      }
-                    >
-                      Manuel
-                    </a>
-                     for examples.
+                      >
+                        example
+                      </a>
+                    </div>
+                    .
                   </span>
                 </div>
               </div>

--- a/app/assets/javascripts/student_profile/lightQuotes.js
+++ b/app/assets/javascripts/student_profile/lightQuotes.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import _ from 'lodash';
-import moment from 'moment';
 import {toMomentFromRailsDate, toMomentFromTimestamp} from '../helpers/toMoment';
 import Educator from '../components/Educator';
 import HelpBubble, {modalFromRight} from '../components/HelpBubble';
@@ -16,9 +15,9 @@ export function sampleQuotes(style) {
     'Very social; gets along well w/adults and most kids'
   ];
   return quotes.map(quote => {
-    const dateText = moment.utc().subtract(Math.random() * 30, 'days').format('M/D/YY');
-    const tagline = <span><a href="#" style={style}>Samwise Gamgee</a>, Counselor</span>;
-    const source = <span><a href="#" style={{fontSize: 12}}>Transition note</a> on {dateText}</span>;
+    const dateText = '6/15/18';
+    const tagline = <span>from <b>Samwise Gamgee</b>, Counselor</span>;
+    const source = <span>in <b>Transition note</b> on {dateText}</span>;
     return {quote, tagline, source};
   });
 }
@@ -59,22 +58,53 @@ export function upsellQuotes(student, style) {
   return [{
     quote: (
       <div>
-        <div>Share an insight!</div>
-        <textarea rows={3} style={{
-          border: 0,
-          background: '#f9f9f9',
-          fontSize: 12,
-          width: '100%',
-          marginTop: 10
-        }} placeholder={`What's one of ${student.first_name}'s strengths?`} />
+        <div style={{fontSize: 18, marginBottom: 5}}>Share an insight about {student.first_name}</div>
+        <div style={style}>This is being piloted at Somervile High School to start the school year.</div>
       </div>
     ),
     withoutQuotes: true,
-    source: <span>See <a href="#" style={style}>Ileana</a> or <a href="#" style={style}>Manuel</a> for examples.</span>,
-    tagline: ''
+    tagline: <span>If you're curious, talk with <a style={style} href="mailto:uharel@k12.somerville.ma.us">Uri</a> or check out </span>,
+    source: (
+      <span>an <HelpBubble
+        style={{marginLeft: 0}}
+        modalStyle={modalFromRight}
+        linkStyle={style}
+        teaser="example"
+        title="Example insight"
+        content={renderSample(sampleQuotes(style)[2], style)}
+      />.</span>
+    )
   }];
 }
 
+function renderSample(quoteItem, style) {
+  const {quote, tagline, source, withoutQuotes} = quoteItem;
+  const quoted = (withoutQuotes) ? quote : `“${quote}”`;
+  return (
+    <div style={{display: 'flex', flex: 1, flexDirection: 'column', justifyContent: 'space-between', ...style}}>
+      <div style={{flex: 1, margin: 20, marginBottom: 0, marginTop: 15, display: 'flex'}}>
+        <div style={{flex: 1, fontSize: 20, overflowY: 'hidden'}}>{quoted}</div>
+      </div>
+      <div style={{
+        fontSize: 12,
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'flex-end',
+        margin: 20,
+        marginTop: 10,
+        marginBottom: 15
+      }}>
+        <div>
+          <div style={{fontSize: 12, color: '#333'}}>
+            <div>{tagline}</div>
+            <div>{source}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 // Look similar to profile view
 function renderTransitionNote(transitionNote, educator) {


### PR DESCRIPTION
# Who is this PR for?
educators, primarily K8

# What problem does this PR fix?
The insight box doesn't work yet, and rather than making it work, it'd be better to avoid putting prominent "asks" in the product without an expectation or support for them used.

# What does this PR do?
This rolls back the "share an insight" box, which communicated intent about design previously, and for now only shows a "coming soon" kind of box if there are no insights for the student.

# Screenshot (if adding a client-side feature)
<img width="1006" alt="screen shot 2018-08-27 at 8 42 45 am" src="https://user-images.githubusercontent.com/1056957/44661237-03685780-a9d8-11e8-8d6d-b1b751ac50c0.png">

# Checklists
+ [x] Author checked latest in IE - Student profile v3
+ [x] Author included specs for new code
