### PR TITLE
Fix bug with looking up Homeroom when ambiguous param given

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -42,9 +42,6 @@ class HomeController < ApplicationController
     time_threshold = InsightStudentsWithHighAbsences.time_threshold_capped_to_school_year(time_now, 45.days)
     absences_threshold = 4
 
-    puts 'time_threshold'
-    puts time_threshold
-
     insight = InsightStudentsWithHighAbsences.new(educator)
     students_with_high_absences_json = insight.students_with_high_absences_json(time_now, time_threshold, absences_threshold)
     render json: {

--- a/app/controllers/homerooms_controller.rb
+++ b/app/controllers/homerooms_controller.rb
@@ -2,7 +2,8 @@ class HomeroomsController < ApplicationController
   include StudentsQueryHelper
 
   def homeroom_json
-    homeroom = authorize_and_assign_homeroom!(params[:id])
+    homeroom_id_or_slug = params.permit(:id)[:id]
+    homeroom = authorize_and_assign_homeroom!(homeroom_id_or_slug)
 
     rows = eager_students(homeroom).map {|student| fat_student_hash(student) }
 
@@ -38,8 +39,22 @@ class HomeroomsController < ApplicationController
   end
 
   def authorize_and_assign_homeroom!(homeroom_id_or_slug)
-    homeroom = Homeroom.friendly.find(homeroom_id_or_slug)
+    homeroom = find_homeroom_by_id_or_slug(homeroom_id_or_slug)
     raise Exceptions::EducatorNotAuthorized unless current_educator.allowed_homerooms.include? homeroom
     homeroom
+  end
+
+  # Calling `Homeroom.friendly.find` with a string version of an id will first
+  # not match on id, and will match on the name for another homeroom with that
+  # same value.  Be explicit here that we match first on id (with type coercion) and
+  # then if not we look to match on the slug (with type coercion).
+  def find_homeroom_by_id_or_slug(homeroom_id_or_slug)
+    homeroom_by_id = Homeroom.find_by_id(homeroom_id_or_slug)
+    return homeroom_by_id unless homeroom_by_id.nil?
+
+    homeroom_by_slug = Homeroom.find_by_slug(homeroom_id_or_slug)
+    return homeroom_by_slug unless homeroom_by_slug.nil?
+
+    raise ActiveRecord::RecordNotFound
   end
 end

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -18,6 +18,7 @@ describe HomeroomsController, :type => :controller do
 
       it 'returns the right shape of data' do
         make_request(educator.homeroom.slug)
+        expect(response.status).to eq 200
         json = JSON.parse(response.body)
         expect(json['rows'].length).to eq 1
         expect(json['rows'].first.keys).to match_array([
@@ -64,6 +65,13 @@ describe HomeroomsController, :type => :controller do
           "interventions",
           "sped_data",
         ])
+      end
+
+      it 'works with an id instead of slug' do
+        make_request(educator.homeroom.id)
+        expect(response.status).to eq 200
+        json = JSON.parse(response.body)
+        expect(json['rows'].length).to eq 1
       end
     end
 


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
When linking to a homeroom by id (eg, from the profile page), the page doesn't load.  This is because the lookup process with `Homeroom.friendly.find(id_or_slug)` doesn't match as expected with the string version of an id.  As a guess, it looks first on the name field and so if any homeroom name matches the string version of an id, it will match that first rather than matching by id.  Alternately, perhaps it's doing a stricter lookup than `Homeroom.find` and failing to match on a string version of the id, the way that `#find` would.

# What does this PR do?
Fixes it by making explicit the lookup order, and removing the use of `friendly` to make queries.
