### PR TITLE
Remove destroying empty homerooms

### DIFF
--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -173,9 +173,6 @@ class ImportTask
     begin
       log('Calling Student.update_recent_student_assessments...')
       Student.update_recent_student_assessments
-
-      log('Homeroom.destroy_empty_homerooms...')
-      Homeroom.destroy_empty_homerooms
     rescue => error
       Rollbar.error('ImportTask#run_update_tasks', error)
       raise error

--- a/app/models/homeroom.rb
+++ b/app/models/homeroom.rb
@@ -26,9 +26,4 @@ class Homeroom < ActiveRecord::Base
     return if student.grade.blank?
     update_attribute(:grade, student.grade)
   end
-
-  def self.destroy_empty_homerooms
-    Homeroom.where(students_count: 0).destroy_all
-  end
-
 end

--- a/spec/models/homeroom_spec.rb
+++ b/spec/models/homeroom_spec.rb
@@ -32,19 +32,4 @@ RSpec.describe Homeroom do
     end
   end
 
-  describe '.destroy_empty_homerooms' do
-    context 'one homeroom with no students' do
-      let!(:homeroom) { FactoryBot.create(:homeroom) }
-      it 'deletes the homeroom' do
-        expect { Homeroom.destroy_empty_homerooms }.to change(Homeroom, :count).by(-1)
-      end
-    end
-    context 'zero homerooms with no student' do
-      let!(:homeroom) { FactoryBot.create(:homeroom_with_student) }
-      it 'does nothing' do
-        expect { Homeroom.destroy_empty_homerooms }.to change(Homeroom, :count).by 0
-      end
-    end
-  end
-
 end


### PR DESCRIPTION
Follow-on to https://github.com/studentinsights/studentinsights/pull/2023.

# Who is this PR for?
developers, I think

# What problem does this PR fix?
I noticed this validating https://github.com/studentinsights/studentinsights/pull/2023.  I don't think there's any harm in empty Homerooms, and having this extra step complicate the semantics of "Insights says what the SIS says."  If we do want to add back in that we delete Homerooms like this, we should do it in the importer sync code, not elsewhere as a separate step of `ImportTask`.

# What does this PR do?
Removes this.