### PR TITLE
Allow forcibly enabling class lists for particular educator_ids, for internal team

### DIFF
--- a/app/controllers/class_lists_controller.rb
+++ b/app/controllers/class_lists_controller.rb
@@ -245,6 +245,9 @@ class ClassListsController < ApplicationController
   end
 
   def ensure_feature_enabled_for_district!
-    raise Exceptions::EducatorNotAuthorized unless PerDistrict.new.enabled_class_lists?
+    override_educator_ids = ENV.fetch('FORCE_ENABLE_CLASS_LISTS_FOR_EDUCATOR_IDS', '').split(',')
+    is_override_enabled = current_educator.can_set_districtwide_access && override_educator_ids.include?(current_educator.id)
+    is_enabled = PerDistrict.new.enabled_class_lists?
+    raise Exceptions::EducatorNotAuthorized unless is_enabled || is_override_enabled
   end
 end

--- a/app/controllers/class_lists_controller.rb
+++ b/app/controllers/class_lists_controller.rb
@@ -245,9 +245,8 @@ class ClassListsController < ApplicationController
   end
 
   def ensure_feature_enabled_for_district!
-    override_educator_ids = ENV.fetch('FORCE_ENABLE_CLASS_LISTS_FOR_EDUCATOR_IDS', '').split(',')
-    is_override_enabled = current_educator.can_set_districtwide_access && override_educator_ids.include?(current_educator.id)
+    is_override_enabled = current_educator.labels.include?('enable_class_lists_override')
     is_enabled = PerDistrict.new.enabled_class_lists?
-    raise Exceptions::EducatorNotAuthorized unless is_enabled || is_override_enabled
+    raise Exceptions::EducatorNotAuthorized if !is_enabled && !is_override_enabled
   end
 end

--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -12,7 +12,8 @@ class EducatorLabel < ActiveRecord::Base
         'k8_counselor',
         'high_school_house_master',
         'class_list_maker_finalizer_principal',
-        'use_counselor_based_feed'
+        'use_counselor_based_feed',
+        'enable_class_lists_override'
       ]
     }
   }


### PR DESCRIPTION
# Who is this PR for?
developers, folks at WH potentially

# What problem does this PR fix?
Class lists are disabled, but folks want to recover some data.

# What does this PR do?
Let's individual users access class lists through an `EducatorLabel`.