### PR TITLE
Profile v3: Fix bug with counting events in absences and discipline events tab

### DIFF
--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -31,10 +31,11 @@ export default class LightProfilePage extends React.Component {
     alwaysShowVerticalScrollbars();
   }
 
-  countEventsBetween(events, daysBack) {
+  countEventsSince(events, daysBack) {
     const {nowMomentFn} = this.props;
-    const startMoment = nowMomentFn().startOf('day');
-    const endMoment = startMoment.clone().subtract(daysBack, 'days');
+    const nowMoment = nowMomentFn();
+    const endMoment = nowMoment.endOf('day');
+    const startMoment = nowMoment.clone().subtract(daysBack, 'days').startOf('day');
     return countEventsBetween(events, startMoment, endMoment);
   }
 
@@ -242,7 +243,7 @@ export default class LightProfilePage extends React.Component {
   renderAttendanceColumn() {
     const {selectedColumnKey} = this.props;
     const columnKey = 'attendance';
-    const count = this.countEventsBetween(this.props.attendanceData.absences, DAYS_AGO);
+    const count = this.countEventsSince(this.props.attendanceData.absences, DAYS_AGO);
     return (
       <LightProfileTab
         style={styles.tab}
@@ -262,7 +263,7 @@ export default class LightProfilePage extends React.Component {
   renderBehaviorColumn() {
     const {selectedColumnKey} = this.props;
     const columnKey = 'behavior';
-    const count = this.countEventsBetween(this.props.attendanceData.discipline_incidents, DAYS_AGO);
+    const count = this.countEventsSince(this.props.attendanceData.discipline_incidents, DAYS_AGO);
 
     return (
       <LightProfileTab

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -34,9 +34,7 @@ export default class LightProfilePage extends React.Component {
   countEventsSince(events, daysBack) {
     const {nowMomentFn} = this.props;
     const nowMoment = nowMomentFn();
-    const endMoment = nowMoment.endOf('day');
-    const startMoment = nowMoment.clone().subtract(daysBack, 'days').startOf('day');
-    return countEventsBetween(events, startMoment, endMoment);
+    return countEventsSince(nowMoment, events, daysBack);
   }
 
   onColumnClicked(columnKey) {
@@ -495,13 +493,13 @@ function findTopRecentTags(eventNotes, nowMoment) {
   return recentTags.slice(0, 4);
 }
 
-
-function countEventsBetween(events, startMoment, endMoment) {
+export function countEventsSince(nowMoment, events, daysBack) {
+  const endMoment = nowMoment.endOf('day');
+  const startMoment = nowMoment.clone().subtract(daysBack, 'days').startOf('day');
   return events.filter(event => {
     return moment.utc(event.occurred_at).isBetween(startMoment, endMoment);
   }).length;
 }
-
 
 
 export function latestStar(starDataPoints, nowMoment) {

--- a/app/assets/javascripts/student_profile/LightProfilePage.test.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import renderer from 'react-test-renderer';
-import {toMomentFromTimestamp} from '../helpers/toMoment';
+import {toMoment, toMomentFromTimestamp} from '../helpers/toMoment';
 import {withDefaultNowContext} from '../testing/NowContainer';
-import LightProfilePage, {latestStar} from './LightProfilePage';
+import LightProfilePage, {latestStar, countEventsSince} from './LightProfilePage';
 import {
   testPropsForPlutoPoppins,
   testPropsForOlafWhite,
@@ -47,22 +47,6 @@ describe('snapshots', () => {
   it('works for aladdin testing', () => expectSnapshot(testPropsForAladdinMouse({selectedColumnKey: 'testing'})));
 });
 
-
-it('#latestStar works regardless of initial sort order', () => {
-  const nowMoment = toMomentFromTimestamp('2018-08-13T11:03:06.123Z');
-  const starSeriesReadingPercentile = [
-    {"percentile_rank":98,"total_time":1134,"grade_equivalent":"6.90","date_taken":"2017-04-23T06:00:00.000Z"},
-    {"percentile_rank":94,"total_time":1022,"grade_equivalent":"4.80","date_taken":"2017-01-07T02:00:00.000Z"}
-  ];
-  expect(latestStar(starSeriesReadingPercentile, nowMoment)).toEqual({
-    nDaysText: 'a year ago',
-    percentileText: '98th'
-  });
-  expect(latestStar(starSeriesReadingPercentile.reverse(), nowMoment)).toEqual({
-    nDaysText: 'a year ago',
-    percentileText: '98th'
-  });
-});
 
 describe('HS testing tab', () => {
   it('works when missing', () => {
@@ -118,4 +102,30 @@ describe('HS testing tab', () => {
       '9 months ago'
     ]);
   });
+});
+
+
+it('#latestStar works regardless of initial sort order', () => {
+  const nowMoment = toMomentFromTimestamp('2018-08-13T11:03:06.123Z');
+  const starSeriesReadingPercentile = [
+    {"percentile_rank":98,"total_time":1134,"grade_equivalent":"6.90","date_taken":"2017-04-23T06:00:00.000Z"},
+    {"percentile_rank":94,"total_time":1022,"grade_equivalent":"4.80","date_taken":"2017-01-07T02:00:00.000Z"}
+  ];
+  expect(latestStar(starSeriesReadingPercentile, nowMoment)).toEqual({
+    nDaysText: 'a year ago',
+    percentileText: '98th'
+  });
+  expect(latestStar(starSeriesReadingPercentile.reverse(), nowMoment)).toEqual({
+    nDaysText: 'a year ago',
+    percentileText: '98th'
+  });
+});
+
+it('#countEventsSince works', () => {
+  const absences = [
+    {id: 217, occurred_at: "2018-07-23", student_id:42},
+    {id: 219, occurred_at: "2018-05-12", student_id:42},
+    {id: 216, occurred_at: "2018-05-11", student_id:42}
+  ];
+  expect(countEventsSince(toMoment('8/28/2018'), absences, 45)).toEqual(1);
 });


### PR DESCRIPTION
Part of https://github.com/studentinsights/studentinsights/issues/1990.

# Who is this PR for?
all educators, this is impacting folks in New Bedford most now

# What problem does this PR fix?
The "last 45 days" counts for absences and discipline incidents are wrong from a bug in the filtering.  This wasn't obvious because the counts should have been 0 for everyone for a while, but a few of the NB schools started a few weeks ago, and looking at those surfaced it.

# What does this PR do?
Fixes the bug.

# Screenshot (if adding a client-side feature)
### before
<img width="292" alt="screen shot 2018-08-28 at 11 14 06 am" src="https://user-images.githubusercontent.com/1056957/44732771-0d5f8880-aab4-11e8-87a8-c6fe39c17d01.png">

### after
<img width="289" alt="screen shot 2018-08-28 at 11 14 12 am" src="https://user-images.githubusercontent.com/1056957/44732774-0e90b580-aab4-11e8-90b3-57c98aa593f2.png">

# Checklists
- [x] Author checked latest in IE - Student Profile v3
- [x] Author improved specs for code in need of better test coverage