### PR TITLE
Switch class lists UI to text, allowing users to explore more

### DIFF
--- a/app/assets/javascripts/class_lists/ClassListsViewPage.js
+++ b/app/assets/javascripts/class_lists/ClassListsViewPage.js
@@ -111,7 +111,7 @@ export class ClassListsViewPageView extends React.Component {
                   {classList.submitted && <SuccessLabel style={{padding: 5}} text="submitted" />}
                 </td>
                 <td style={tableStyles.cell}>
-                  <a style={{padding: 10}} href={`/classlists/${classList.workspace_id}`}>open</a>
+                  <a style={{padding: 10}} href={`/classlists/${classList.workspace_id}/text`}>view text</a>
                 </td>
               </tr>
             );

--- a/app/assets/javascripts/class_lists/__snapshots__/ClassListsViewPage.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ClassListsViewPage.test.js.snap
@@ -240,14 +240,14 @@ exports[`snapshots view 1`] = `
             }
           >
             <a
-              href="/classlists/63055567-a2e1-49b3-a6da-655658445177"
+              href="/classlists/63055567-a2e1-49b3-a6da-655658445177/text"
               style={
                 Object {
                   "padding": 10,
                 }
               }
             >
-              open
+              view text
             </a>
           </td>
         </tr>
@@ -338,14 +338,14 @@ exports[`snapshots view 1`] = `
             }
           >
             <a
-              href="/classlists/191c6264-0352-453e-a495-481e93e19c80"
+              href="/classlists/191c6264-0352-453e-a495-481e93e19c80/text"
               style={
                 Object {
                   "padding": 10,
                 }
               }
             >
-              open
+              view text
             </a>
           </td>
         </tr>
@@ -436,14 +436,14 @@ exports[`snapshots view 1`] = `
             }
           >
             <a
-              href="/classlists/294f6a1e-42db-4fbb-b283-0acd6c328f4b"
+              href="/classlists/294f6a1e-42db-4fbb-b283-0acd6c328f4b/text"
               style={
                 Object {
                   "padding": 10,
                 }
               }
             >
-              open
+              view text
             </a>
           </td>
         </tr>
@@ -550,14 +550,14 @@ exports[`snapshots view 1`] = `
             }
           >
             <a
-              href="/classlists/1ffe068d-6c62-4e1f-81b6-180b334f6d93"
+              href="/classlists/1ffe068d-6c62-4e1f-81b6-180b334f6d93/text"
               style={
                 Object {
                   "padding": 10,
                 }
               }
             >
-              open
+              view text
             </a>
           </td>
         </tr>
@@ -664,14 +664,14 @@ exports[`snapshots view 1`] = `
             }
           >
             <a
-              href="/classlists/9115a670-b0dc-4b31-bdfd-64ef73bf34e1"
+              href="/classlists/9115a670-b0dc-4b31-bdfd-64ef73bf34e1/text"
               style={
                 Object {
                   "padding": 10,
                 }
               }
             >
-              open
+              view text
             </a>
           </td>
         </tr>
@@ -762,14 +762,14 @@ exports[`snapshots view 1`] = `
             }
           >
             <a
-              href="/classlists/fda99ce2-99be-4f39-a56e-86c16a790caf"
+              href="/classlists/fda99ce2-99be-4f39-a56e-86c16a790caf/text"
               style={
                 Object {
                   "padding": 10,
                 }
               }
             >
-              open
+              view text
             </a>
           </td>
         </tr>
@@ -856,14 +856,14 @@ exports[`snapshots view 1`] = `
             }
           >
             <a
-              href="/classlists/06d32485-77a5-4724-8780-d55df3aedebf"
+              href="/classlists/06d32485-77a5-4724-8780-d55df3aedebf/text"
               style={
                 Object {
                   "padding": 10,
                 }
               }
             >
-              open
+              view text
             </a>
           </td>
         </tr>
@@ -954,14 +954,14 @@ exports[`snapshots view 1`] = `
             }
           >
             <a
-              href="/classlists/8893e4a1-b57c-47e6-89b6-1d767aef5d21"
+              href="/classlists/8893e4a1-b57c-47e6-89b6-1d767aef5d21/text"
               style={
                 Object {
                   "padding": 10,
                 }
               }
             >
-              open
+              view text
             </a>
           </td>
         </tr>
@@ -1048,14 +1048,14 @@ exports[`snapshots view 1`] = `
             }
           >
             <a
-              href="/classlists/a0f1dcb2-96f6-4b6f-bbf7-a21a0fa2225c"
+              href="/classlists/a0f1dcb2-96f6-4b6f-bbf7-a21a0fa2225c/text"
               style={
                 Object {
                   "padding": 10,
                 }
               }
             >
-              open
+              view text
             </a>
           </td>
         </tr>


### PR DESCRIPTION
# Who is this PR for?
WH educators

# What problem does this PR fix?
They're not finding what they expect for class lists; communicating about this might be hard without the visual.

# What does this PR do?
Changes links on the `/classlists` page to view the text version of lists rather than the full UI (which doesn't work for lists retrospectively to past years).
