### PR TITLE
Add login_name to EducatorSectionAssignment export SQL

### DIFF
--- a/x2_export/courses_sections_export.sql
+++ b/x2_export/courses_sections_export.sql
@@ -25,7 +25,7 @@ LEFT JOIN course_school
   ON schedule_master.MST_CSK_OID = course_school.CSK_OID
 INNER JOIN school
   ON course_school.CSK_SKL_OID = school.SKL_OID
-AND CTX_SCHOOL_YEAR=2019
+AND CTX_SCHOOL_YEAR=2019 # when does the school year end?
   INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/courses_sections_export.txt"
   FIELDS TERMINATED BY ','
   ENCLOSED BY '"'

--- a/x2_export/courses_sections_export.sql
+++ b/x2_export/courses_sections_export.sql
@@ -25,7 +25,7 @@ LEFT JOIN course_school
   ON schedule_master.MST_CSK_OID = course_school.CSK_OID
 INNER JOIN school
   ON course_school.CSK_SKL_OID = school.SKL_OID
-AND CTX_SCHOOL_YEAR=2019 # when does the school year end?
+AND CTX_SCHOOL_YEAR=2019 -- when does the school year end?
   INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/courses_sections_export.txt"
   FIELDS TERMINATED BY ','
   ENCLOSED BY '"'

--- a/x2_export/courses_sections_export.sql
+++ b/x2_export/courses_sections_export.sql
@@ -25,7 +25,7 @@ LEFT JOIN course_school
   ON schedule_master.MST_CSK_OID = course_school.CSK_OID
 INNER JOIN school
   ON course_school.CSK_SKL_OID = school.SKL_OID
-AND CTX_SCHOOL_YEAR=2018
+AND CTX_SCHOOL_YEAR=2019
   INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/courses_sections_export.txt"
   FIELDS TERMINATED BY ','
   ENCLOSED BY '"'

--- a/x2_export/educator_section_assignment_export.sql
+++ b/x2_export/educator_section_assignment_export.sql
@@ -31,7 +31,7 @@ INNER JOIN person
   ON staff.STF_PSN_OID=person.PSN_OID
 INNER JOIN user_info
   ON person.PSN_OID=user_info.USR_PSN_OID
-AND CTX_SCHOOL_YEAR=2018
+AND CTX_SCHOOL_YEAR=2019
   INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/educator_section_assignment_export.txt"
   FIELDS TERMINATED BY ','
   ENCLOSED BY '"'

--- a/x2_export/educator_section_assignment_export.sql
+++ b/x2_export/educator_section_assignment_export.sql
@@ -31,7 +31,7 @@ INNER JOIN person
   ON staff.STF_PSN_OID=person.PSN_OID
 INNER JOIN user_info
   ON person.PSN_OID=user_info.USR_PSN_OID
-AND CTX_SCHOOL_YEAR=2019
+AND CTX_SCHOOL_YEAR=2019 # when does the school year end?
   INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/educator_section_assignment_export.txt"
   FIELDS TERMINATED BY ','
   ENCLOSED BY '"'

--- a/x2_export/educator_section_assignment_export.sql
+++ b/x2_export/educator_section_assignment_export.sql
@@ -31,7 +31,7 @@ INNER JOIN person
   ON staff.STF_PSN_OID=person.PSN_OID
 INNER JOIN user_info
   ON person.PSN_OID=user_info.USR_PSN_OID
-AND CTX_SCHOOL_YEAR=2019 # when does the school year end?
+AND CTX_SCHOOL_YEAR=2019 -- when does the school year end?
   INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/educator_section_assignment_export.txt"
   FIELDS TERMINATED BY ','
   ENCLOSED BY '"'

--- a/x2_export/educator_section_assignment_export.sql
+++ b/x2_export/educator_section_assignment_export.sql
@@ -1,6 +1,7 @@
 use x2data
 SELECT
   'local_id',
+  'login_name',
   'course_number',
   'school_local_id',
   'section_number',
@@ -8,6 +9,7 @@ SELECT
 UNION ALL
 SELECT
   STF_ID_LOCAL,
+  USR_LOGIN_NAME,
   CSK_COURSE_NUMBER,
   SKL_SCHOOL_ID,
   MST_COURSE_VIEW,
@@ -25,6 +27,10 @@ INNER JOIN school
   ON course_school.CSK_SKL_OID = school.SKL_OID
 INNER JOIN staff
   ON schedule_master_teacher.MTC_STF_OID = staff.STF_OID
+INNER JOIN person
+  ON staff.STF_PSN_OID=person.PSN_OID
+INNER JOIN user_info
+  ON person.PSN_OID=user_info.USR_PSN_OID
 AND CTX_SCHOOL_YEAR=2018
   INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/educator_section_assignment_export.txt"
   FIELDS TERMINATED BY ','

--- a/x2_export/student_section_assignment_export.sql
+++ b/x2_export/student_section_assignment_export.sql
@@ -25,7 +25,7 @@ INNER JOIN student_schedule
   ON schedule_master.MST_OID = student_schedule.SSC_MST_OID
 INNER JOIN student
   ON student_schedule.SSC_STD_OID = student.STD_OID
-AND CTX_SCHOOL_YEAR=2019
+AND CTX_SCHOOL_YEAR=2019 # when does the school year end?
   INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/student_section_assignment_export.txt"
   FIELDS TERMINATED BY ','
   ENCLOSED BY '"'

--- a/x2_export/student_section_assignment_export.sql
+++ b/x2_export/student_section_assignment_export.sql
@@ -25,7 +25,7 @@ INNER JOIN student_schedule
   ON schedule_master.MST_OID = student_schedule.SSC_MST_OID
 INNER JOIN student
   ON student_schedule.SSC_STD_OID = student.STD_OID
-AND CTX_SCHOOL_YEAR=2019 # when does the school year end?
+AND CTX_SCHOOL_YEAR=2019 -- when does the school year end?
   INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/student_section_assignment_export.txt"
   FIELDS TERMINATED BY ','
   ENCLOSED BY '"'

--- a/x2_export/student_section_assignment_export.sql
+++ b/x2_export/student_section_assignment_export.sql
@@ -25,7 +25,7 @@ INNER JOIN student_schedule
   ON schedule_master.MST_OID = student_schedule.SSC_MST_OID
 INNER JOIN student
   ON student_schedule.SSC_STD_OID = student.STD_OID
-AND CTX_SCHOOL_YEAR=2018
+AND CTX_SCHOOL_YEAR=2019
   INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/student_section_assignment_export.txt"
   FIELDS TERMINATED BY ','
   ENCLOSED BY '"'


### PR DESCRIPTION
Addressing part of https://github.com/studentinsights/studentinsights/issues/2034.

# Who is this PR for?
HS teachers

# What problem does this PR fix?
This will help remove some friction for new staff, who get an Aspen record and `login_name` before a `local_id`, which is a slower process done through HR.

# What does this PR do?
Includes `login_name` as well, so we can cut over to that after confirming we get it and looking at how it changes things.