### PR TITLE
Use inclusive date ranges when querying for students with absences and in dashboards

### DIFF
--- a/app/lib/insight_students_with_high_absences.rb
+++ b/app/lib/insight_students_with_high_absences.rb
@@ -22,7 +22,8 @@ class InsightStudentsWithHighAbsences
   # classroom teachers, the intended actions are to talk with
   # the student, parent, or refer for SST.
   #
-  # absences_threshold is "greater than or equal to"
+  # time_threshold and absences_threshold are both inclusive ("greater
+  # than or equal to")
   #
   # This method returns hashes that are the shape of what is needed
   # in the product.
@@ -61,7 +62,7 @@ class InsightStudentsWithHighAbsences
       .includes(:student)
       .where(student_id: student_ids)
       .where(excused: excused_values)
-      .where('occurred_at > ?', time_threshold)
+      .where('occurred_at >= ?', time_threshold)
       .group(:student)
       .count
     pairs = absence_count_map.map do |student, count|
@@ -80,7 +81,7 @@ class InsightStudentsWithHighAbsences
     recent_notes = EventNote
       .where(is_restricted: false)
       .where(student_id: student_ids)
-      .where('recorded_at > ?', time_threshold)
+      .where('recorded_at >= ?', time_threshold)
     recent_notes.map(&:student_id).uniq
   end
 


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
The date range for these queries is exclusive and not inclusive.  In the profile v2 UI this was the case as well, and so the problem never surfaced.  Profile v3 fixed this to be inclusive and made this more visible by using the same "last 45 days" time window, which wasn't visible in the profile page before.

# What does this PR do?
Updates `InsightStudentsWithHighAbsences` to query with an inclusive time range, and updates `DashboardQueries` to do the same (at the response level, not the database query level).
