### PR TITLE
Limit data for absences dashboard

### DIFF
--- a/app/lib/dashboard_queries.rb
+++ b/app/lib/dashboard_queries.rb
@@ -16,7 +16,7 @@ class DashboardQueries
       .where(student_id: students.map(&:id))
       .where('occurred_at >= ?', @cutoff_time)
 
-    # serialize and merge
+    # serialize
     all_absences_json = absences.as_json(only: [
       :student_id,
       :occurred_at,
@@ -34,12 +34,14 @@ class DashboardQueries
         :latest_note
       ]
     })
+
+    # merge
+    absences_json_by_student_id = all_absences_json.group_by {|a| a['student_id'] }
     students_with_events = students_json.map do |student_json|
       student_id = student_json['id']
       student = students.find {|s| s.id == student_id }
-      absences_json = all_absences_json.select {|a| a['student_id'] == student_id}
       student_json.merge({
-        absences: absences_json,
+        absences: absences_json_by_student_id[student_id],
         homeroom_label: homeroom_label(student.homeroom)
       })
     end

--- a/app/lib/perf_test.rb
+++ b/app/lib/perf_test.rb
@@ -1,4 +1,15 @@
 class PerfTest
+  # querying and serializing data for absence dashboard at a particular school
+  def self.absences_dashboard(percentage, options = ())
+    school_id = options[:school_id] || School.all.first.id
+    school = School.find(school_id)
+    time_now = Time.at(1536589824)
+    PerfTest.new.simple(percentage, options) do |educator|
+      queries = DashboardQueries.new(educator, time_now: time_now)
+      queries.absence_dashboard_data(school)
+    end
+  end
+
   def self.tiering_detailed(percentage, options = {})
     timer = PerfTest.new.run_with_tags(percentage, options) do |t, educator|
       time_now = Time.at(1529067553)

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -26,13 +26,6 @@ class Student < ActiveRecord::Base
   has_many :star_reading_results, -> { order(date_taken: :desc) }, dependent: :destroy
   has_many :dibels_results, -> { order(date_taken: :desc) }, dependent: :destroy
 
-  has_many :dashboard_tardies, -> {
-    where('occurred_at >= ?', 1.year.ago)
-  }, class_name: "Tardy"
-  has_many :dashboard_absences, -> {
-    where('occurred_at >= ?', 1.year.ago)
-  }, class_name: "Absence"
-
   validates_presence_of :local_id
   validates_uniqueness_of :local_id
   validates :first_name, presence: true

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -77,6 +77,7 @@ class Student < ActiveRecord::Base
     ).count
   end
 
+  # deprecated
   # Maybe include a restricted note, but cannot return any restricted data
   def latest_note
     event_notes.order(recorded_at: :desc).limit(1).first.as_json(only: [:event_note_type_id, :recorded_at])

--- a/spec/lib/dashboard_queries_spec.rb
+++ b/spec/lib/dashboard_queries_spec.rb
@@ -5,9 +5,41 @@ RSpec.describe DashboardQueries do
     let!(:pals) { TestPals.create! }
     let!(:student) { FactoryBot.create(:student, school: pals.healey)}
 
+    def create_recent_absence!(student_id)
+      Absence.create!({
+        student_id: student_id,
+        occurred_at: Time.now - 4.days,
+        excused: false,
+        dismissed: false
+      })
+    end
+
     it '#absence_dashboard_data shape of data' do
       json = DashboardQueries.new(pals.healey_laura_principal).absence_dashboard_data(pals.healey)
       expect(json.keys.map(&:to_sym)).to contain_exactly(:students_with_events, :school)
+    end
+
+    it '#absence_dashboard_data has expected fields' do
+      create_recent_absence!(pals.healey.students.first.id)
+      json = DashboardQueries.new(pals.healey_laura_principal).absence_dashboard_data(pals.healey)
+      expect(json[:students_with_events].size).to eq pals.healey.students.size
+      expect(json[:students_with_events].first.keys.map(&:to_sym)).to contain_exactly(*[
+        :absences,
+        :first_name,
+        :grade,
+        :homeroom_label,
+        :id,
+        :last_name,
+        :latest_note
+      ])
+
+      absences_in_response_json = json[:students_with_events].map {|student| student[:absences] }
+      expect(absences_in_response_json.flatten.first.keys.map(&:to_sym)).to contain_exactly(*[
+        :occurred_at,
+        :student_id,
+        :dismissed,
+        :excused
+      ])
     end
 
     it '#tardies_dashboard_data shape of data' do
@@ -18,19 +50,6 @@ RSpec.describe DashboardQueries do
     it '#discipline_dashboard_data shape of data' do
       json = DashboardQueries.new(pals.healey_laura_principal).discipline_dashboard_data(pals.healey)
       expect(json.keys.map(&:to_sym)).to contain_exactly(:students_with_events, :school)
-    end
-
-    it '#individual_student_absence_data has expected fields' do
-      json = DashboardQueries.new(pals.healey_laura_principal).send(:individual_student_absence_data, student)
-      expect(json.keys.map(&:to_sym)).to contain_exactly(*[
-        :absences,
-        :first_name,
-        :grade,
-        :id,
-        :last_name,
-        :homeroom_label,
-        :latest_note
-      ])
     end
 
     it '#individual_student_tardies_data has expected fields' do


### PR DESCRIPTION
# Who is this PR for?
admin

# What problem does this PR fix?
Initially this was an attempt at reducing the date range for the query, but we also want to speed this up for larger schools.

# What does this PR do?
Reworks the querying so there are two database queries, and that these are minimal for the data needed (eg, no old data that will be filtered out in JS, remove older `event_notes`).

# Checklists
+ [x] Author included specs for new code
