### PR TITLE
Profile v3: Mute colors for services

### DIFF
--- a/app/assets/javascripts/helpers/serviceColor.js
+++ b/app/assets/javascripts/helpers/serviceColor.js
@@ -7,14 +7,14 @@ export default function serviceColor(serviceTypeId) {
   };
 
   const map = {
-    507: Colors.orange,
-    502: Colors.green,
-    503: Colors.green,
-    504: Colors.green,
+    507: Colors.gray,
+    502: Colors.gray,
+    503: Colors.gray,
+    504: Colors.gray,
     505: Colors.gray,
     506: Colors.gray,
-    508: Colors.purple
+    508: Colors.gray
   };
 
-  return map[serviceTypeId] || null;
+  return map[serviceTypeId] || Colors.gray;
 }

--- a/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
@@ -11650,7 +11650,7 @@ exports[`snapshots works for pluto 1`] = `
           <div
             style={
               Object {
-                "background": null,
+                "background": "#eee",
                 "border": "1px solid #eee",
                 "marginBottom": 10,
                 "marginTop": 10,
@@ -11724,7 +11724,7 @@ exports[`snapshots works for pluto 1`] = `
           <div
             style={
               Object {
-                "background": "#ffe7d6",
+                "background": "#eee",
                 "border": "1px solid #eee",
                 "marginBottom": 10,
                 "marginTop": 10,
@@ -11798,7 +11798,7 @@ exports[`snapshots works for pluto 1`] = `
           <div
             style={
               Object {
-                "background": null,
+                "background": "#eee",
                 "border": "1px solid #eee",
                 "marginBottom": 10,
                 "marginTop": 10,
@@ -11869,7 +11869,7 @@ exports[`snapshots works for pluto 1`] = `
           <div
             style={
               Object {
-                "background": "#e8fce8",
+                "background": "#eee",
                 "border": "1px solid #eee",
                 "marginBottom": 10,
                 "marginTop": 10,
@@ -11940,7 +11940,7 @@ exports[`snapshots works for pluto 1`] = `
           <div
             style={
               Object {
-                "background": "#e8fce8",
+                "background": "#eee",
                 "border": "1px solid #eee",
                 "marginBottom": 10,
                 "marginTop": 10,

--- a/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/StudentProfilePage.test.js.snap
@@ -5707,7 +5707,7 @@ exports[`snapshots works for pluto 1`] = `
           <div
             style={
               Object {
-                "background": null,
+                "background": "#eee",
                 "border": "1px solid #eee",
                 "marginBottom": 10,
                 "marginTop": 10,
@@ -5781,7 +5781,7 @@ exports[`snapshots works for pluto 1`] = `
           <div
             style={
               Object {
-                "background": "#ffe7d6",
+                "background": "#eee",
                 "border": "1px solid #eee",
                 "marginBottom": 10,
                 "marginTop": 10,
@@ -5855,7 +5855,7 @@ exports[`snapshots works for pluto 1`] = `
           <div
             style={
               Object {
-                "background": null,
+                "background": "#eee",
                 "border": "1px solid #eee",
                 "marginBottom": 10,
                 "marginTop": 10,
@@ -5926,7 +5926,7 @@ exports[`snapshots works for pluto 1`] = `
           <div
             style={
               Object {
-                "background": "#e8fce8",
+                "background": "#eee",
                 "border": "1px solid #eee",
                 "marginBottom": 10,
                 "marginTop": 10,
@@ -5997,7 +5997,7 @@ exports[`snapshots works for pluto 1`] = `
           <div
             style={
               Object {
-                "background": "#e8fce8",
+                "background": "#eee",
                 "border": "1px solid #eee",
                 "marginBottom": 10,
                 "marginTop": 10,


### PR DESCRIPTION
Part of https://github.com/studentinsights/studentinsights/issues/1990.

# Who is this PR for?
educators

# What problem does this PR fix?
Services had an old color scheme that I don't think ever meant much to anyone, and it was only partially implemented for some services.  With the profile v3 changes, the semantic meaning of the colors don't match the meaning elsewhere on profile v3, and these aren't in the same palette either.

# What does this PR do?
Mutes the colors for services to gray.

# Screenshot (if adding a client-side feature)
<img width="495" alt="screen shot 2018-08-30 at 3 51 59 pm" src="https://user-images.githubusercontent.com/1056957/44875899-750d0380-ac6d-11e8-9ea6-b9d99a82b235.png">
<img width="1016" alt="screen shot 2018-08-30 at 3 51 42 pm" src="https://user-images.githubusercontent.com/1056957/44875901-776f5d80-ac6d-11e8-8aa4-0b0beec4420a.png">

# Checklists
+ [x] Author checked latest in IE - Student Profile v3
+ [x] Author included specs for new code
