### PR TITLE
Filter out long hyphens when parsing transition note

### DIFF
--- a/app/lib/transition_note_parser.rb
+++ b/app/lib/transition_note_parser.rb
@@ -35,6 +35,6 @@ class TransitionNoteParser
   end
 
   def clean(text)
-    text.strip.gsub('[\—\-\_]', '')
+    text.strip.gsub(/[—\-\_]/, '').strip
   end
 end

--- a/spec/lib/transition_note_parser_spec.rb
+++ b/spec/lib/transition_note_parser_spec.rb
@@ -12,5 +12,16 @@ RSpec.describe TransitionNoteParser do
         :other => "nope :)"
       })
     end
+
+    it 'filters out long hyphens' do
+      text = "What are this student's strengths?\n——————————\neverything!\n\nWhat is this student's involvement in the school community like?\n——————————\nreally good\n\n\n\n\nHow does this student relate to their peers?\n——————————\nnot sure\n\nWho is the student's primary guardian?\n——————————\nokay\n\nAny additional comments or good things to know about this student?\n——————————\nnope :)"
+      expect(TransitionNoteParser.new.parse_text(text)).to eq({
+        :strengths => "everything!",
+        :community => "really good",
+        :peers => "not sure",
+        :guardian => "okay",
+        :other => "nope :)"
+      })
+    end
   end
 end


### PR DESCRIPTION
Follow-on to https://github.com/studentinsights/studentinsights/pull/2049.

# Who is this PR for?
HS students, educators

# What problem does this PR fix?
In https://github.com/studentinsights/studentinsights/pull/2049, I updated the regex parsing in reaction a Robocop warning but did this wrong; so long hyphens aren't filtered out in parsing anymore.

# What does this PR do?
Fixes the regex, adds a test case.

# Checklists
+ [x] Author included specs for new code
