### PR TITLE
Fix JS transition note parsing to trim after replacing

### DIFF
--- a/app/assets/javascripts/student_profile/LightInsightTransitionNoteStrength.js
+++ b/app/assets/javascripts/student_profile/LightInsightTransitionNoteStrength.js
@@ -6,7 +6,7 @@ import Educator from '../components/Educator';
 import NoteCard from './NoteCard';
 import {badgeStyle} from './NotesList';
 import LightInsightQuote, {fontSizeStyle} from './LightInsightQuote';
-import {parseAndReRender} from './lightTransitionNotes';
+import {parseAndReRender} from './transitionNoteParser';
 
 
 // Render an insight about a strength from a transition note

--- a/app/assets/javascripts/student_profile/NotesList.js
+++ b/app/assets/javascripts/student_profile/NotesList.js
@@ -8,7 +8,7 @@ import * as FeedHelpers from '../helpers/FeedHelpers';
 import {eventNoteTypeText} from '../helpers/eventNoteType';
 import {toSchoolYear, firstDayOfSchool} from '../helpers/schoolYear';
 import NoteCard from './NoteCard';
-import {parseAndReRender} from './lightTransitionNotes';
+import {parseAndReRender} from './transitionNoteParser';
 import {urlForRestrictedEventNoteContent, urlForRestrictedTransitionNoteContent} from './RestrictedNotePresence';
 import CleanSlateMessage from './CleanSlateMessage';
 

--- a/app/assets/javascripts/student_profile/transitionNoteParser.js
+++ b/app/assets/javascripts/student_profile/transitionNoteParser.js
@@ -44,6 +44,6 @@ export function parseAndReRender(transitionNoteText) {
     COMMUNITY_PROMPT, NEWLINE, community, NEWLINE, NEWLINE,
     PEERS_PROMPT, NEWLINE, peers, NEWLINE, NEWLINE,
     GUARDIAN_PROMPT, NEWLINE, guardian, NEWLINE, NEWLINE,
-    OTHER_PROMPT, NEWLINE, other, NEWLINE, NEWLINE
+    OTHER_PROMPT, NEWLINE, other
   ].join('');
 }

--- a/app/assets/javascripts/student_profile/transitionNoteParser.js
+++ b/app/assets/javascripts/student_profile/transitionNoteParser.js
@@ -10,7 +10,7 @@ function escapeToUseAsRegexLiteral(x) {
 }
 
 function clean(text) {
-  return text.trim().replace(/[\—\-\_]/g, '');
+  return text.trim().replace(/[\—\-\_]/g, '').trim();
 }
 
 function extractOne(text, beforeText, afterText = undefined) {
@@ -24,7 +24,8 @@ function extractOne(text, beforeText, afterText = undefined) {
   return clean(matches[1]);
 }
 
-export function parseTransitionNoteText(transitionNoteText) {
+// See transition_note_parser.rb
+function parseTransitionNoteText(transitionNoteText) {
   return {
     strengths: extractOne(transitionNoteText, STRENGTHS_PROMPT, COMMUNITY_PROMPT),
     community: extractOne(transitionNoteText, COMMUNITY_PROMPT, PEERS_PROMPT),

--- a/app/assets/javascripts/student_profile/transitionNoteParser.test.js
+++ b/app/assets/javascripts/student_profile/transitionNoteParser.test.js
@@ -1,0 +1,44 @@
+import {parseAndReRender} from './transitionNoteParser';
+
+describe('#parseAndReRender', () => {
+  it('works', () => {
+    const text = (
+`What are this student's strengths?
+——————————
+is awesome.
+
+What is this student's involvement in the school community like?
+——————————
+plays on sports teams.
+
+How does this student relate to their peers?
+——————————
+gets along well.
+
+Who is the student's primary guardian?
+——————————
+mother.
+Any additional comments or good things to know about this student?
+———————
+is good at negotiating for what he wants
+Transition comments: Doesn't have concerns`
+    );
+    expect(parseAndReRender(text)).toEqual(
+`What are this student's strengths?
+is awesome.
+
+What is this student's involvement in the school community like?
+plays on sports teams.
+
+How does this student relate to their peers?
+gets along well.
+
+Who is the student's primary guardian?
+mother.
+
+Any additional comments or good things to know about this student?
+is good at negotiating for what he wants
+Transition comments: Doesn't have concerns`
+    );
+  });
+});

--- a/app/lib/transition_note_parser.rb
+++ b/app/lib/transition_note_parser.rb
@@ -1,3 +1,4 @@
+# See transitionNoteParser.js
 class TransitionNoteParser
   STRENGTHS_PROMPT = "What are this student's strengths?"
   COMMUNITY_PROMPT = "What is this student's involvement in the school community like?"


### PR DESCRIPTION
Follow on to https://github.com/studentinsights/studentinsights/pull/2051

# Who is this PR for?
HS students, educators

# What problem does this PR fix?
newlines mixed in with separators.

# Checklists
+ [x] Author included specs for new code
