### PR TITLE
Revise FitText to limit bounds in insights box, and update story

### DIFF
--- a/app/assets/javascripts/components/FitText.js
+++ b/app/assets/javascripts/components/FitText.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from 'lodash';
 
 
 // Resize the fontSize of text to fit within the container bounds.
@@ -17,8 +18,9 @@ export default class FitText extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const {text, maxFontSize} = this.props;
-    if (prevProps.text !== text || prevProps.maxFontSize !== maxFontSize) {
+    const {maxFontSize} = this.props;
+    const havePropsChanged = !_.isEqual(prevProps, this.props);
+    if (havePropsChanged) {
       this.setState({isSized: false, fontSize: maxFontSize});
     } else {
       this.measureAndResize();
@@ -27,7 +29,7 @@ export default class FitText extends React.Component {
 
   measureAndResize() {
     const {isSized, fontSize} = this.state;
-    const {maxFontSize, minFontSize, fontSizeStep} = this.props;
+    const {minFontSize, fontSizeStep} = this.props;
 
     // Resize in font size in steps until the element size is less than `targetHeight`
     const elHeight = this.realEl.offsetHeight;
@@ -39,15 +41,10 @@ export default class FitText extends React.Component {
       return;
     }
 
-    // previously sized but now not - start the resizing process over
-    if (isSized && elHeight > targetHeight) {
-      this.setState({isSized: false, fontSize: maxFontSize});
-      return;
-    }
-
     // if we'd go below minFontSize, stop
     if (!isSized && (fontSize - fontSizeStep < minFontSize)) {
       this.setState({isSized: true});
+      return;
     }
 
     // not sized but space to try a smaller font, so try shrinking the font

--- a/app/assets/javascripts/components/FitText.story.js
+++ b/app/assets/javascripts/components/FitText.story.js
@@ -8,7 +8,7 @@ function storyContainerStyles() {
     { display: 'flex', width: 80, height: 40, border: '1px solid black' },
     { display: 'flex', width: 200, height: 80, border: '1px solid black' },
     { display: 'flex', width: 300, height: 100, border: '1px solid black' },
-    { display: 'flex', width: 400, height: 300, border: '1px solid black'}
+    { display: 'flex', width: 420, height: 300, border: '1px solid black'}
   ];
 }
 
@@ -16,12 +16,23 @@ function storyContainerStyles() {
 storiesOf('components/FitText', module) // eslint-disable-line no-undef
   .add('all', () => {
     return (
-      <div style={{padding: 20}}>
-        {storyContainerStyles().map(containerStyle => (
-          <div style={containerStyle} key={JSON.stringify(containerStyle)}>
-            <FitText text="when there is too much work and I don't know what to do" />
-          </div>
-        ))}
+      <div style={{display: 'flex', padding: 10}}>
+        <div style={{flex: 1, padding: 10}}>
+          <code>default</code>
+          {storyContainerStyles().map(containerStyle => (
+            <div style={{...containerStyle, marginBottom: 20}} key={JSON.stringify(containerStyle)}>
+              <FitText text="this resizes the font size to fit, within bounds" />
+            </div>
+          ))}
+        </div>
+        <div style={{flex: 1, padding: 10}}>
+          <code>minFontSize: 0, maxFontSize:120</code>
+          {storyContainerStyles().map(containerStyle => (
+            <div style={{...containerStyle, marginBottom: 20}} key={JSON.stringify(containerStyle)}>
+              <FitText maxFontSize={120} minFontSize={0} text="this resizes the font size to fit, within bounds" />
+            </div>
+          ))}
+        </div>
       </div>
     );
   });

--- a/app/assets/javascripts/student_profile/LightInsightStudentVoiceSurveyResponse.js
+++ b/app/assets/javascripts/student_profile/LightInsightStudentVoiceSurveyResponse.js
@@ -25,7 +25,11 @@ export default class LightInsightStudentVoiceSurveyResponse extends React.Compon
           <div style={{flex: 1, display: 'flex', flexDirection: 'column'}}>
             <div style={fontSizeStyle}>{promptText}</div>
             <div style={{marginTop: 5, flex: 1, display: 'flex', flexDirection: 'column'}}>
-              <FitText text={`“${responseText}”`} />
+              <FitText
+                minFontSize={12}
+                maxFontSize={48}
+                fontSizeStep={6}
+                text={`“${responseText}”`} />
             </div>
           </div>
         }


### PR DESCRIPTION
Follow on to https://github.com/studentinsights/studentinsights/pull/2050

# Who is this PR for?
HS students, educators

# What problem does this PR fix?
Some students have quite long and quite short responses, and the bounds cap didn't work before.

# What does this PR do?
This fixes the bounds checking on `<FitText />` and updates the bounds for the insights box use.

# Screenshot (if adding a client-side feature)
<img width="928" alt="screen shot 2018-09-04 at 5 08 23 pm" src="https://user-images.githubusercontent.com/1056957/45058022-65266280-b065-11e8-9390-e50237413bee.png">
