### PR TITLE
Update LDAP strategy to grab timeout from env

### DIFF
--- a/app/lib/ldap_authenticatable_tiny/strategy.rb
+++ b/app/lib/ldap_authenticatable_tiny/strategy.rb
@@ -22,8 +22,8 @@ module Devise
           fail!(:invalid) and return unless is_authorized_by_ldap?(ldap_class, email, password)
           success!(educator) and return
         rescue => error
-          Rollbar.error('LdapAuthenticatableTiny error', error)
-          logger.error "LdapAuthenticatableTiny, error: #{error}"
+          Rollbar.error('LdapAuthenticatableTiny error caught', error)
+          logger.error "LdapAuthenticatableTiny, error caught: #{error}"
           fail!(:error) and return
         end
         nil
@@ -40,7 +40,7 @@ module Devise
 
         if !is_authorized
           ldap_error = ldap.get_operation_result
-          logger.error "LdapAuthenticatableTiny, ldap_error: #{ldap_error}"
+          logger.error "LdapAuthenticatableTiny, ldap_error from get_operation_result: #{ldap_error}"
         end
 
         is_authorized
@@ -56,7 +56,7 @@ module Devise
         {
           host: host,
           port: port,
-          connect_timeout: 10, # seconds
+          connect_timeout: ENV.fetch('DISTRICT_LDAP_TIMEOUT_IN_SECONDS', '30').to_i,
           auth: {
             :method => :simple,
             :username => email,

--- a/spec/lib/ldap_authenticatable_tiny_spec.rb
+++ b/spec/lib/ldap_authenticatable_tiny_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe 'LdapAuthenticatableTiny' do
       allow(ENV).to receive(:[]).with('DISTRICT_LDAP_HOST').and_return('foo.com')
       allow(ENV).to receive(:[]).with('DISTRICT_LDAP_PORT').and_return('12345.com')
       allow(ENV).to receive(:[]).with('DISTRICT_LDAP_ENCRYPTION_TLS_OPTIONS_JSON').and_return(test_tls_options_text)
+      allow(ENV).to receive(:[]).with('DISTRICT_LDAP_TIMEOUT_IN_SECONDS').and_return('30')
    end
 
     it 'respects environment variables' do
@@ -106,7 +107,7 @@ RSpec.describe 'LdapAuthenticatableTiny' do
           :username=>"foo",
           :password=>"bar"
         },
-        :connect_timeout => 10,
+        :connect_timeout => 30,
         :encryption => {
           :method=>:simple_tls,
           :tls_options=>{


### PR DESCRIPTION
# Who is this PR for?
developers, so this is more easily tunable.  also bumps to 30 seconds to rule out this in connectivity issues.

I updated the env for Somerville and New Bedford (but not Bedford, since it's not using this setup yet cc @alexsoble).