### PR TITLE
Release "low grades" box on home page for all HS teachers 

### DIFF
--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -64,11 +64,10 @@ export function renderSlicePanelsDisabilityTable(districtKey, options = {}) {
   return renderTableFn({items, title: 'Disability'});
 }
 
-// Check educator labels to see if the educator belongs to
-// the NGE and 10GE experience teams.  This label only applies to
-// Somerville.
-export function inExperienceTeam(educatorLabels) {
-  return (educatorLabels.indexOf('shs_experience_team') !== -1);
+// Check educator labels to see if the educator should be shown 
+// info about students in their courses with low grades.
+export function shouldShowLowGradesBox(educatorLabels) {
+  return (educatorLabels.indexOf('should_show_low_grades_box') !== -1);
 }
 
 
@@ -155,6 +154,7 @@ export function eventNoteTypeIdForAbsenceSupportMeeting(districtKey) {
 
   return 300;
 }
+
 
 // What choices do educators have for taking notes in the product?
 export function takeNotesChoices(districtKey) {

--- a/app/assets/javascripts/helpers/PerDistrict.test.js
+++ b/app/assets/javascripts/helpers/PerDistrict.test.js
@@ -1,13 +1,13 @@
 import {
-  inExperienceTeam,
+  shouldShowLowGradesBox,
   sortSchoolSlugsByGrade,
   studentTableEventNoteTypeIds
 } from './PerDistrict';
 
-it('#inExperienceTeam', () => {
-  expect(inExperienceTeam([])).toEqual(false);
-  expect(inExperienceTeam(['foo'])).toEqual(false);
-  expect(inExperienceTeam(['foo', 'shs_experience_team'])).toEqual(true);
+it('#shouldShowLowGradesBox', () => {
+  expect(shouldShowLowGradesBox([])).toEqual(false);
+  expect(shouldShowLowGradesBox(['foo'])).toEqual(false);
+  expect(shouldShowLowGradesBox(['foo', 'should_show_low_grades_box'])).toEqual(true);
 });
 
 it('#sortSchoolSlugsByGrade', () => {

--- a/app/assets/javascripts/home/CheckStudentsWithLowGrades.js
+++ b/app/assets/javascripts/home/CheckStudentsWithLowGrades.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import qs from 'query-string';
-import Card from '../components/Card';
-import Section from '../components/Section';
 import GenericLoader from '../components/GenericLoader';
 import {apiFetchJson} from '../helpers/apiFetchJson';
+import CheckStudentsWithLowGradesBox from './CheckStudentsWithLowGradesBox';
 
 
 // On the home page, show users the answers to their most important questions.
-class CheckStudentsWithLowGrades extends React.Component {
+// This fetches data about students with low grades.  The copy will change depending
+// on the role.
+export default class CheckStudentsWithLowGrades extends React.Component {
   constructor(props) {
     super(props);
     this.fetchStudentsWithLowGrades = this.fetchStudentsWithLowGrades.bind(this);
@@ -39,7 +40,7 @@ class CheckStudentsWithLowGrades extends React.Component {
       totalCount: json.total_count,
       studentsWithLowGrades: json.students_with_low_grades
     };
-    return <CheckStudentsWithLowGradesView {...props} />;
+    return <CheckStudentsWithLowGradesBox {...props} />;
   }
 }
 CheckStudentsWithLowGrades.propTypes = {
@@ -50,126 +51,6 @@ CheckStudentsWithLowGrades.defaultProps = {
   limit: 100
 };
 
-
-// Pure UI component, for showing a high school teacher
-// which of their students have low grades but haven't been
-// discussed in NGE or 10GE.  The intention is that this list of
-// students to check in on is immediately actionable.
-export class CheckStudentsWithLowGradesView extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      uiLimit: 4
-    };
-    this.onMoreStudents = this.onMoreStudents.bind(this);
-  }
-
-  onMoreStudents(e) {
-    e.preventDefault();
-    const {uiLimit} = this.state;
-    this.setState({ uiLimit: uiLimit + 4 });
-  }
-
-  render() {
-    const {studentsWithLowGrades, totalCount} = this.props;
-    const {uiLimit} = this.state;
-    const truncatedStudentsWithLowGrades = studentsWithLowGrades.slice(0, uiLimit);
-
-    return (
-      <div className="CheckStudentsWithLowGrades">
-        <div style={styles.cardTitle}>NGE and 10GE students to check in on</div>
-        <Card style={{border: 'none'}}>
-           <div>There {this.renderAreHowManyStudents(totalCount)} in your classes who have a D or an F right now but no one has mentioned in NGE or 10GE for the last 45 days.</div>
-          {this.renderList(truncatedStudentsWithLowGrades)}
-          {this.renderMore(truncatedStudentsWithLowGrades)}
-        </Card>
-      </div>
-    );
-  }
-
-  renderAreHowManyStudents(totalCount) {
-    if (totalCount === 0) return <span>are <b>no students</b></span>;
-    if (totalCount === 1) return <span>is <b>one student</b></span>;
-    return <span>are <b>{totalCount} students</b></span>;
-  }
-
-  renderList(truncatedStudentsWithLowGrades) {
-    if (truncatedStudentsWithLowGrades.length === 0) return null;
-    return (
-      <div style={{paddingTop: 10, paddingBottom: 10}}>
-        {truncatedStudentsWithLowGrades.map(studentWithLowGrades => {
-          const {student, assignments} = studentWithLowGrades;
-          return (
-            <div key={student.id} style={styles.line}>
-              <span><a style={styles.person} href={`/students/${student.id}`}>{student.first_name} {student.last_name}</a></span>
-              {this.renderCourseGrades(assignments)}
-            </div>
-          );
-        })}
-      </div>
-    );
-  }
-
-  renderCourseGrades(assignments) {
-    return (
-      <span>{assignments.map(assignment => {
-        const {section} = assignment;
-        const hasAnText = (assignment.grade_letter === 'F')
-          ? 'has an'
-          : 'has a';
-        return (
-          <span key={assignment.id}>
-            <span style={styles.middleText}>{hasAnText} {assignment.grade_letter} in</span>
-            <Section
-              id={section.id}
-              courseDescription={section.course_description}
-              sectionNumber={section.section_number} />
-          </span>
-        );
-      })}</span>
-    );
-  }
-
-  renderMore(truncatedStudentsWithLowGrades) {
-    const {totalCount, limit, studentsWithLowGrades} = this.props;
-
-    if (truncatedStudentsWithLowGrades.length !== studentsWithLowGrades.length) {
-      return <div><a href="#" onClick={this.onMoreStudents}>See more</a></div>;
-    }
-
-    if (studentsWithLowGrades.length < totalCount) {
-      return <div>There are {totalCount} students total.  Start with checking in on these first {limit} students.</div>;
-    }
-
-    return null;
-  }
-}
-
-CheckStudentsWithLowGradesView.propTypes = {
-  limit: PropTypes.number.isRequired,
-  totalCount: PropTypes.number.isRequired,
-  studentsWithLowGrades: PropTypes.arrayOf(PropTypes.shape({
-    student: PropTypes.shape({
-      id: PropTypes.number.isRequired,
-      first_name: PropTypes.string.isRequired,
-      last_name: PropTypes.string.isRequired,
-      grade: PropTypes.string.isRequired,
-      house: PropTypes.string
-    }).isRequired,
-    assignments: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.number.isRequired,
-      grade_letter: PropTypes.string.isRequired,
-      grade_numeric: PropTypes.string.isRequired,
-      section: PropTypes.shape({
-        id: PropTypes.number.isRequired,
-        section_number: PropTypes.string.isRequired,
-        educators: PropTypes.arrayOf(PropTypes.object).isRequired
-      }).isRequired
-    }))
-  })).isRequired
-};
-
-
 const styles = {
   root: {
     fontSize: 14
@@ -179,29 +60,5 @@ const styles = {
     marginTop: 20,
     border: '1px solid #ccc',
     borderRadius: 3
-  },
-  cardTitle: {
-    backgroundColor: '#eee',
-    padding: 10,
-    color: 'black',
-    borderBottom: '1px solid #ccc'
-  },
-  person: {
-    fontWeight: 'bold'
-  },
-  line: {
-    paddingLeft: 10,
-    paddingRight: 10,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap'
-  },
-  middleText: {
-    display: 'inline-block',
-    paddingLeft: 5,
-    paddingRight: 5
   }
 };
-
-
-export default CheckStudentsWithLowGrades;

--- a/app/assets/javascripts/home/CheckStudentsWithLowGrades.test.js
+++ b/app/assets/javascripts/home/CheckStudentsWithLowGrades.test.js
@@ -1,27 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import renderer from 'react-test-renderer';
 import fetchMock from 'fetch-mock/es5/client';
-import CheckStudentsWithLowGrades, {CheckStudentsWithLowGradesView} from './CheckStudentsWithLowGrades';
+import CheckStudentsWithLowGrades from './CheckStudentsWithLowGrades';
 import studentsWithLowGradesJson from './home_students_with_low_grades_json';
-
-function renderIntoEl(element) {
-  const el = document.createElement('div');
-  ReactDOM.render(element, el);
-  return el;
-}
 
 function testProps() {
   return {
     educatorId: 9999
-  };
-}
-
-function pureTestPropsForN(n) {
-  return {
-    limit: 10,
-    totalCount: n,
-    studentsWithLowGrades: studentsWithLowGradesJson.students_with_low_grades.slice(0, n)
   };
 }
 
@@ -47,38 +32,5 @@ describe('CheckStudentsWithLowGrades', () => {
       expect($(el).text()).toContain('There are 7 students in your classes');
       done();
     }, 0);
-  });
-});
-
-describe('CheckStudentsWithLowGradesView', () => {
-  it('renders zero, singular and plural states', () => {
-    expect($(renderIntoEl(<CheckStudentsWithLowGradesView {...pureTestPropsForN(0)} />)).text()).toContain('There are no students');
-    expect($(renderIntoEl(<CheckStudentsWithLowGradesView {...pureTestPropsForN(1)} />)).text()).toContain('There is one student');
-    expect($(renderIntoEl(<CheckStudentsWithLowGradesView {...pureTestPropsForN(4)} />)).text()).toContain('There are 4 students');
-  });
-
-  it('pure component matches snapshot', () => {
-    const props = {
-      limit: studentsWithLowGradesJson.limit,
-      totalCount: studentsWithLowGradesJson.total_count,
-      studentsWithLowGrades: studentsWithLowGradesJson.students_with_low_grades
-    };
-    const tree = renderer
-      .create(<CheckStudentsWithLowGradesView {...props} />)
-      .toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-
-
-  it('handles when limit reached', () => {
-    const props = {
-      limit: 3,
-      totalCount: 129,
-      studentsWithLowGrades: studentsWithLowGradesJson.students_with_low_grades.slice(0, 3)
-    };
-    const tree = renderer
-      .create(<CheckStudentsWithLowGradesView {...props} />)
-      .toJSON();
-    expect(tree).toMatchSnapshot();
   });
 });

--- a/app/assets/javascripts/home/CheckStudentsWithLowGradesBox.js
+++ b/app/assets/javascripts/home/CheckStudentsWithLowGradesBox.js
@@ -1,0 +1,170 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Card from '../components/Card';
+import Section from '../components/Section';
+import HelpBubble from '../components/HelpBubble';
+
+
+// Pure UI component, for showing a high school teacher
+// which of their students have low grades but haven't been
+// discussed in NGE or 10GE.  The intention is that this list of
+// students to check in on is immediately actionable.
+export default class CheckStudentsWithLowGradesBox extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      uiLimit: 4
+    };
+    this.onMoreStudents = this.onMoreStudents.bind(this);
+  }
+
+  onMoreStudents(e) {
+    e.preventDefault();
+    const {uiLimit} = this.state;
+    this.setState({ uiLimit: uiLimit + 4 });
+  }
+
+  render() {
+    const {studentsWithLowGrades, totalCount} = this.props;
+    const {uiLimit} = this.state;
+    const truncatedStudentsWithLowGrades = studentsWithLowGrades.slice(0, uiLimit);
+
+    return (
+      <div className="CheckStudentsWithLowGradesBox">
+        <div style={styles.cardTitle}>
+          Students to check in on
+          <HelpBubble
+            teaser={<span style={styles.helpTeaser}>what does this mean?</span>}
+            title="Students to check in on"
+            content={this.renderHelpContent()} />
+        </div>
+        <Card style={{border: 'none'}}>
+           <div>There {this.renderAreHowManyStudents(totalCount)} in your classes who have a D or an F right now but no one has mentioned for the last 45 days.</div>
+          {this.renderList(truncatedStudentsWithLowGrades)}
+          {this.renderMore(truncatedStudentsWithLowGrades)}
+        </Card>
+      </div>
+    );
+  }
+
+  renderHelpContent() {
+    return (
+      <div>
+        <p style={styles.helpContent}>These are all the students in courses that you teach who have a D or F right now, but {"haven't"} been mentioned recently.</p>
+        <p style={styles.helpContent}>This means there aren't any notes about them from support meetings, parent conversations, or anything else in Student Insights.  The threshold for being included in this list is to have one or more grade that is below a 69 right now.</p>
+        <p style={styles.helpContent}>You could talk directly with the student or reach out to the family.  Or you could connect with a colleague who can provide support services (eg, academic support, tutoring, counselors).</p>
+      </div>
+    );
+  }
+
+  renderAreHowManyStudents(totalCount) {
+    if (totalCount === 0) return <span>are <b>no students</b></span>;
+    if (totalCount === 1) return <span>is <b>one student</b></span>;
+    return <span>are <b>{totalCount} students</b></span>;
+  }
+
+  renderList(truncatedStudentsWithLowGrades) {
+    if (truncatedStudentsWithLowGrades.length === 0) return null;
+    return (
+      <div style={{paddingTop: 10, paddingBottom: 10}}>
+        {truncatedStudentsWithLowGrades.map(studentWithLowGrades => {
+          const {student, assignments} = studentWithLowGrades;
+          return (
+            <div key={student.id} style={styles.line}>
+              <span><a style={styles.person} href={`/students/${student.id}`}>{student.first_name} {student.last_name}</a></span>
+              {this.renderCourseGrades(assignments)}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  renderCourseGrades(assignments) {
+    return (
+      <span>{assignments.map(assignment => {
+        const {section} = assignment;
+        const hasAnText = (assignment.grade_letter === 'F')
+          ? 'has an'
+          : 'has a';
+        return (
+          <span key={assignment.id}>
+            <span style={styles.middleText}>{hasAnText} {assignment.grade_letter} in</span>
+            <Section
+              id={section.id}
+              courseDescription={section.course_description}
+              sectionNumber={section.section_number} />
+          </span>
+        );
+      })}</span>
+    );
+  }
+
+  renderMore(truncatedStudentsWithLowGrades) {
+    const {totalCount, limit, studentsWithLowGrades} = this.props;
+
+    if (truncatedStudentsWithLowGrades.length !== studentsWithLowGrades.length) {
+      return <div><a href="#" onClick={this.onMoreStudents}>See more</a></div>;
+    }
+
+    if (studentsWithLowGrades.length < totalCount) {
+      return <div>There are {totalCount} students total.  Start with checking in on these first {limit} students.</div>;
+    }
+
+    return null;
+  }
+}
+
+CheckStudentsWithLowGradesBox.propTypes = {
+  limit: PropTypes.number.isRequired,
+  totalCount: PropTypes.number.isRequired,
+  studentsWithLowGrades: PropTypes.arrayOf(PropTypes.shape({
+    student: PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      first_name: PropTypes.string.isRequired,
+      last_name: PropTypes.string.isRequired,
+      grade: PropTypes.string.isRequired,
+      house: PropTypes.string
+    }).isRequired,
+    assignments: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      grade_letter: PropTypes.string.isRequired,
+      grade_numeric: PropTypes.string.isRequired,
+      section: PropTypes.shape({
+        id: PropTypes.number.isRequired,
+        section_number: PropTypes.string.isRequired,
+        educators: PropTypes.arrayOf(PropTypes.object).isRequired
+      }).isRequired
+    }))
+  })).isRequired
+};
+
+
+const styles = {
+  cardTitle: {
+    backgroundColor: '#eee',
+    padding: 10,
+    color: 'black',
+    borderBottom: '1px solid #ccc',
+    display: 'flex',
+    justifyContent: 'space-between'
+  },
+  person: {
+    fontWeight: 'bold'
+  },
+  line: {
+    paddingLeft: 10,
+    paddingRight: 10,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap'
+  },
+  middleText: {
+    display: 'inline-block',
+    paddingLeft: 5,
+    paddingRight: 5
+  },
+  helpContent: {
+    margin: 10
+  }
+};

--- a/app/assets/javascripts/home/CheckStudentsWithLowGradesBox.test.js
+++ b/app/assets/javascripts/home/CheckStudentsWithLowGradesBox.test.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import renderer from 'react-test-renderer';
+import CheckStudentsWithLowGradesBox from './CheckStudentsWithLowGradesBox';
+import studentsWithLowGradesJson from './home_students_with_low_grades_json';
+
+function renderIntoEl(element) {
+  const el = document.createElement('div');
+  ReactDOM.render(element, el);
+  return el;
+}
+
+function pureTestPropsForN(n) {
+  return {
+    limit: 10,
+    totalCount: n,
+    studentsWithLowGrades: studentsWithLowGradesJson.students_with_low_grades.slice(0, n)
+  };
+}
+
+describe('CheckStudentsWithLowGradesBox', () => {
+  it('renders zero, singular and plural states', () => {
+    expect($(renderIntoEl(<CheckStudentsWithLowGradesBox {...pureTestPropsForN(0)} />)).text()).toContain('There are no students');
+    expect($(renderIntoEl(<CheckStudentsWithLowGradesBox {...pureTestPropsForN(1)} />)).text()).toContain('There is one student');
+    expect($(renderIntoEl(<CheckStudentsWithLowGradesBox {...pureTestPropsForN(4)} />)).text()).toContain('There are 4 students');
+  });
+
+  it('pure component matches snapshot', () => {
+    const props = {
+      limit: studentsWithLowGradesJson.limit,
+      totalCount: studentsWithLowGradesJson.total_count,
+      studentsWithLowGrades: studentsWithLowGradesJson.students_with_low_grades
+    };
+    const tree = renderer
+      .create(<CheckStudentsWithLowGradesBox {...props} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+
+  it('handles when limit reached', () => {
+    const props = {
+      limit: 3,
+      totalCount: 129,
+      studentsWithLowGrades: studentsWithLowGradesJson.students_with_low_grades.slice(0, 3)
+    };
+    const tree = renderer
+      .create(<CheckStudentsWithLowGradesBox {...props} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/app/assets/javascripts/home/HomeInsights.js
+++ b/app/assets/javascripts/home/HomeInsights.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Card from '../components/Card';
 import CheckStudentsWithLowGrades from './CheckStudentsWithLowGrades';
 import CheckStudentsWithHighAbsences from './CheckStudentsWithHighAbsences';
-import {inExperienceTeam} from '../helpers/PerDistrict';
+import {shouldShowLowGradesBox} from '../helpers/PerDistrict';
 
 
 // On the home page, show users the answers to their most
@@ -13,7 +13,7 @@ class HomeInsights extends React.Component {
     const {educatorId, educatorLabels} = this.props;
     return (
       <div className="HomeInsights" style={styles.root}>
-        {inExperienceTeam(educatorLabels) &&
+        {shouldShowLowGradesBox(educatorLabels) &&
           <CheckStudentsWithLowGrades educatorId={educatorId} />}
         <CheckStudentsWithHighAbsences educatorId={educatorId} />
         {this.renderPlaceholder()}

--- a/app/assets/javascripts/home/HomeInsights.test.js
+++ b/app/assets/javascripts/home/HomeInsights.test.js
@@ -29,8 +29,8 @@ it('shallow renders', () => {
   expect(wrapper.find(CheckStudentsWithLowGrades).length).toEqual(0);
 });
 
-it('shallow renders NGE/10GE box when labels include experience team', () => {
-  const props = testProps({ educatorLabels: ['shs_experience_team'] });
+it('shallow renders low grades box when correct label is set', () => {
+  const props = testProps({ educatorLabels: ['should_show_low_grades_box'] });
   const wrapper = shallow(<HomeInsights {...props} />);
   expect(wrapper.contains(<CheckStudentsWithLowGrades educatorId={9999} />)).toEqual(true);
 });

--- a/app/assets/javascripts/home/__snapshots__/CheckStudentsWithLowGradesBox.test.js.snap
+++ b/app/assets/javascripts/home/__snapshots__/CheckStudentsWithLowGradesBox.test.js.snap
@@ -1,0 +1,544 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CheckStudentsWithLowGradesBox handles when limit reached 1`] = `
+<div
+  className="CheckStudentsWithLowGradesBox"
+>
+  <div
+    style={
+      Object {
+        "backgroundColor": "#eee",
+        "borderBottom": "1px solid #ccc",
+        "color": "black",
+        "display": "flex",
+        "justifyContent": "space-between",
+        "padding": 10,
+      }
+    }
+  >
+    Students to check in on
+    <div
+      style={
+        Object {
+          "display": "inline",
+          "marginLeft": 10,
+        }
+      }
+    >
+      <a
+        href="#"
+        onClick={[Function]}
+        style={
+          Object {
+            "fontSize": 12,
+            "outline": "none",
+          }
+        }
+      >
+        <span>
+          what does this mean?
+        </span>
+      </a>
+    </div>
+  </div>
+  <div
+    className="Card "
+    style={
+      Object {
+        "border": "none",
+        "borderRadius": 3,
+        "padding": 10,
+      }
+    }
+  >
+    <div>
+      There 
+      <span>
+        are 
+        <b>
+          129
+           students
+        </b>
+      </span>
+       in your classes who have a D or an F right now but no one has mentioned for the last 45 days.
+    </div>
+    <div
+      style={
+        Object {
+          "paddingBottom": 10,
+          "paddingTop": 10,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "overflow": "hidden",
+            "paddingLeft": 10,
+            "paddingRight": 10,
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        <span>
+          <a
+            href="/students/66"
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Chip
+             
+            Duck
+          </a>
+        </span>
+        <span>
+          <span>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingLeft": 5,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              has a
+               
+              D
+               in
+            </span>
+            <a
+              className="Section"
+              href="/sections/1"
+              style={Object {}}
+            >
+              BIOLOGY 1 HONORS
+               (
+              SHS-BIO-TUES
+              )
+            </a>
+          </span>
+        </span>
+      </div>
+      <div
+        style={
+          Object {
+            "overflow": "hidden",
+            "paddingLeft": 10,
+            "paddingRight": 10,
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        <span>
+          <a
+            href="/students/2"
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Mari
+             
+            Kenobi
+          </a>
+        </span>
+        <span>
+          <span>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingLeft": 5,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              has a
+               
+              D
+               in
+            </span>
+            <a
+              className="Section"
+              href="/sections/1"
+              style={Object {}}
+            >
+              BIOLOGY 1 HONORS
+               (
+              SHS-BIO-TUES
+              )
+            </a>
+          </span>
+        </span>
+      </div>
+      <div
+        style={
+          Object {
+            "overflow": "hidden",
+            "paddingLeft": 10,
+            "paddingRight": 10,
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        <span>
+          <a
+            href="/students/69"
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Aladdin
+             
+            Poppins
+          </a>
+        </span>
+        <span>
+          <span>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingLeft": 5,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              has a
+               
+              D
+               in
+            </span>
+            <a
+              className="Section"
+              href="/sections/1"
+              style={Object {}}
+            >
+              BIOLOGY 1 HONORS
+               (
+              SHS-BIO-TUES
+              )
+            </a>
+          </span>
+        </span>
+      </div>
+    </div>
+    <div>
+      There are 
+      129
+       students total.  Start with checking in on these first 
+      3
+       students.
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CheckStudentsWithLowGradesBox pure component matches snapshot 1`] = `
+<div
+  className="CheckStudentsWithLowGradesBox"
+>
+  <div
+    style={
+      Object {
+        "backgroundColor": "#eee",
+        "borderBottom": "1px solid #ccc",
+        "color": "black",
+        "display": "flex",
+        "justifyContent": "space-between",
+        "padding": 10,
+      }
+    }
+  >
+    Students to check in on
+    <div
+      style={
+        Object {
+          "display": "inline",
+          "marginLeft": 10,
+        }
+      }
+    >
+      <a
+        href="#"
+        onClick={[Function]}
+        style={
+          Object {
+            "fontSize": 12,
+            "outline": "none",
+          }
+        }
+      >
+        <span>
+          what does this mean?
+        </span>
+      </a>
+    </div>
+  </div>
+  <div
+    className="Card "
+    style={
+      Object {
+        "border": "none",
+        "borderRadius": 3,
+        "padding": 10,
+      }
+    }
+  >
+    <div>
+      There 
+      <span>
+        are 
+        <b>
+          7
+           students
+        </b>
+      </span>
+       in your classes who have a D or an F right now but no one has mentioned for the last 45 days.
+    </div>
+    <div
+      style={
+        Object {
+          "paddingBottom": 10,
+          "paddingTop": 10,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "overflow": "hidden",
+            "paddingLeft": 10,
+            "paddingRight": 10,
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        <span>
+          <a
+            href="/students/66"
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Chip
+             
+            Duck
+          </a>
+        </span>
+        <span>
+          <span>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingLeft": 5,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              has a
+               
+              D
+               in
+            </span>
+            <a
+              className="Section"
+              href="/sections/1"
+              style={Object {}}
+            >
+              BIOLOGY 1 HONORS
+               (
+              SHS-BIO-TUES
+              )
+            </a>
+          </span>
+        </span>
+      </div>
+      <div
+        style={
+          Object {
+            "overflow": "hidden",
+            "paddingLeft": 10,
+            "paddingRight": 10,
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        <span>
+          <a
+            href="/students/2"
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Mari
+             
+            Kenobi
+          </a>
+        </span>
+        <span>
+          <span>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingLeft": 5,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              has a
+               
+              D
+               in
+            </span>
+            <a
+              className="Section"
+              href="/sections/1"
+              style={Object {}}
+            >
+              BIOLOGY 1 HONORS
+               (
+              SHS-BIO-TUES
+              )
+            </a>
+          </span>
+        </span>
+      </div>
+      <div
+        style={
+          Object {
+            "overflow": "hidden",
+            "paddingLeft": 10,
+            "paddingRight": 10,
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        <span>
+          <a
+            href="/students/69"
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Aladdin
+             
+            Poppins
+          </a>
+        </span>
+        <span>
+          <span>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingLeft": 5,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              has a
+               
+              D
+               in
+            </span>
+            <a
+              className="Section"
+              href="/sections/1"
+              style={Object {}}
+            >
+              BIOLOGY 1 HONORS
+               (
+              SHS-BIO-TUES
+              )
+            </a>
+          </span>
+        </span>
+      </div>
+      <div
+        style={
+          Object {
+            "overflow": "hidden",
+            "paddingLeft": 10,
+            "paddingRight": 10,
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        <span>
+          <a
+            href="/students/67"
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Aladdin
+             
+            Kenobi
+          </a>
+        </span>
+        <span>
+          <span>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingLeft": 5,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              has a
+               
+              D
+               in
+            </span>
+            <a
+              className="Section"
+              href="/sections/1"
+              style={Object {}}
+            >
+              BIOLOGY 1 HONORS
+               (
+              SHS-BIO-TUES
+              )
+            </a>
+          </span>
+        </span>
+      </div>
+    </div>
+    <div>
+      <a
+        href="#"
+        onClick={[Function]}
+      >
+        See more
+      </a>
+    </div>
+  </div>
+</div>
+`;

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -20,13 +20,15 @@ class HomeController < ApplicationController
   # the student hasn't been commented on in NGE or 10GE yet.  High-school only.
   # Response should include everything UI needs.
   def students_with_low_grades_json
-    educator = current_educator_or_doppleganger(params[:educator_id])
-    time_now = time_now_or_param(params[:time_now])
-    limit = params[:limit].to_i
+    safe_params = params.permit(:educator_id, :time_now, :limit, :event_note_type_ids)
+    educator = current_educator_or_doppleganger(safe_params[:educator_id])
+    time_now = time_now_or_param(safe_params[:time_now])
+    limit = safe_params[:limit].to_i
     time_threshold = time_now - 45.days
     grade_threshold = 69
+    event_note_type_ids = safe_params[:event_note_type_ids] || [305, 306]
 
-    insight = InsightStudentsWithLowGrades.new(educator)
+    insight = InsightStudentsWithLowGrades.new(educator, event_note_type_ids: event_note_type_ids)
     students_with_low_grades_json = insight.students_with_low_grades_json(time_now, time_threshold, grade_threshold)
     render json: {
       limit: limit,

--- a/app/lib/feed_filter.rb
+++ b/app/lib/feed_filter.rb
@@ -23,7 +23,7 @@ class FeedFilter
   # Check global env flag, then per-educator flag.
   def use_counselor_based_feed?
     return false unless PerDistrict.new.enable_counselor_based_feed?
-    return false unless EducatorLabel.has_label?(@educator.id, 'use_counselor_based_feed')
+    return false unless EducatorLabel.has_static_label?(@educator.id, 'use_counselor_based_feed')
     true
   end
 

--- a/app/lib/insight_students_with_low_grades.rb
+++ b/app/lib/insight_students_with_low_grades.rb
@@ -4,7 +4,7 @@ class InsightStudentsWithLowGrades
   def initialize(educator, options = {})
     @educator = educator
     @authorizer = Authorizer.new(@educator)
-    @event_note_type_id_ids = options.fetch(:event_note_type_ids, EventNoteType.all.pluck(:id))
+    @event_note_type_ids = options.fetch(:event_note_type_ids, EventNoteType.all.pluck(:id))
   end
 
   # High-school only.  Returns a list of students in the educator's

--- a/app/lib/insight_students_with_low_grades.rb
+++ b/app/lib/insight_students_with_low_grades.rb
@@ -1,9 +1,10 @@
 class InsightStudentsWithLowGrades
   EXPERIENCE_TEAM_GRADES = ['9', '10']
 
-  def initialize(educator)
+  def initialize(educator, options = {})
     @educator = educator
     @authorizer = Authorizer.new(@educator)
+    @event_note_type_id_ids = options.fetch(:event_note_type_ids, EventNoteType.all.pluck(:id))
   end
 
   # High-school only.  Returns a list of students in the educator's
@@ -69,7 +70,7 @@ class InsightStudentsWithLowGrades
       .where(is_restricted: false)
       .where(student_id: student_ids)
       .where('recorded_at > ?', time_threshold)
-      .where(event_note_type_id: [305, 306])
+      .where(event_note_type_id: @event_note_type_ids)
     recent_notes.map(&:student_id).uniq
   end
 

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -62,7 +62,7 @@ class Educator < ActiveRecord::Base
   end
 
   def labels
-    educator_labels.map(&:label_key)
+    EducatorLabel.labels(self)
   end
 
   def default_section

--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -35,7 +35,7 @@ class EducatorLabel < ActiveRecord::Base
     authorized_sections = educator.sections.select do |section|
       authorizer.is_authorized_for_section?(section)
     end
-    if authorized_sections.size > 0
+    if authorized_sections.size > 0 && educator.school.is_high_school?
       dynamic_labels << 'should_show_low_grades_box'
     end
 

--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -8,7 +8,7 @@ class EducatorLabel < ActiveRecord::Base
     uniqueness: { scope: [:label_key, :educator] },
     inclusion: {
       in: [
-        'shs_experience_team',
+        'shs_experience_team', # deprecated
         'k8_counselor',
         'high_school_house_master',
         'class_list_maker_finalizer_principal',
@@ -19,7 +19,30 @@ class EducatorLabel < ActiveRecord::Base
     }
   }
 
-  def self.has_label?(educator_id, label_key)
+  # Static labels are set by records in the database.  Dynamic labels are
+  # computed at read time here based on some other property of the educator.
+  def self.labels(educator)
+    static_labels = educator.educator_labels.map(&:label_key)
+    dynamic_labels = self.dynamic_labels_for_educator(educator)
+
+    static_labels + dynamic_labels
+  end
+
+  def self.dynamic_labels_for_educator(educator)
+    dynamic_labels = []
+
+    authorizer = Authorizer.new(educator)
+    authorized_sections = educator.sections.select do |section|
+      authorizer.is_authorized_for_section?(section)
+    end
+    if authorized_sections.size > 0
+      dynamic_labels << 'should_show_low_grades_box'
+    end
+
+    dynamic_labels
+  end
+
+  def self.has_static_label?(educator_id, label_key)
     EducatorLabel.find_by(educator_id: educator_id, label_key: label_key).present?
   end
 end

--- a/spec/controllers/ui_controller_spec.rb
+++ b/spec/controllers/ui_controller_spec.rb
@@ -32,7 +32,7 @@ describe UiController, :type => :controller do
           "id" => pals.shs_bill_nye.id,
           "admin" => false,
           "school_id" => pals.shs.id,
-          "labels" => ['shs_experience_team']
+          "labels" => ['shs_experience_team', 'should_show_low_grades_box']
         }
       }.deep_stringify_keys)
     end

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -322,7 +322,7 @@ RSpec.describe Educator do
   describe '#labels' do
     let!(:pals) { TestPals.create! }
     it 'works' do
-      expect(pals.shs_bill_nye.labels).to eq ['shs_experience_team']
+      expect(pals.shs_bill_nye.labels).to eq ['shs_experience_team', 'should_show_low_grades_box']
       expect(pals.shs_jodi.labels).to eq ['shs_experience_team', 'can_upload_student_voice_surveys']
       expect(pals.uri.labels).to eq ['can_upload_student_voice_surveys']
     end


### PR DESCRIPTION
# Who is this PR for?
HS classroom teachers

# What problem does this PR fix?
This was built for NGE/10GE teachers initially, but other folks have asked for this, and NGE/10GE teachers thought others would have the same features as them.

# What does this PR do?
Releases this to all HS teachers across districts.  The UI copy is changed to be more generic and remove specific references to NGE or 10GE.  `EducatorLabel` is revised to allow "dynamic labels" which are computed based on other attributes related to the educator - here `should_show_low_grades_box` is computed based on whether they have any sections they teach themself, and are in a high school.  This punts releasing to MS teachers since we haven't looked at that data yet, but that would be a good future step.

# Screenshot (if adding a client-side feature)
### teacher seeing feature
<img width="500" alt="screen shot 2018-09-06 at 9 59 31 am" src="https://user-images.githubusercontent.com/1056957/45163443-759e2080-b1be-11e8-978d-f1e978045b2d.png">

### clicking into help
<img width="934" alt="screen shot 2018-09-06 at 10 00 07 am" src="https://user-images.githubusercontent.com/1056957/45163434-70d96c80-b1be-11e8-9708-9ed1de3bb391.png">

### districtwide admin (no changes, not shown feature)
<img width="496" alt="screen shot 2018-09-06 at 9 51 35 am" src="https://user-images.githubusercontent.com/1056957/45163444-759e2080-b1be-11e8-9aff-c828bf0a4b54.png">

# Checklists
+ [x] Author checked latest in IE - Home page
+ [x] Author included specs for new code
