### PR TITLE
Allow STAR Math/Reading importers to skip and log invalid rows

### DIFF
--- a/app/importers/file_importers/star_math_importer.rb
+++ b/app/importers/file_importers/star_math_importer.rb
@@ -3,6 +3,7 @@ class StarMathImporter
   def initialize(options:)
     @school_scope = options.fetch(:school_scope)
     @log = options.fetch(:log)
+    @invalid_rows_count = 0
   end
 
   def import
@@ -25,6 +26,8 @@ class StarMathImporter
         import_row(row) if filter.include?(row.fetch('SchoolLocalID'))
         @log.puts("processed #{index} rows.") if index % 1000 == 0
       end
+
+      log("skipped #{@invalid_rows_count} invalid rows.")
     end
   end
 
@@ -82,6 +85,12 @@ class StarMathImporter
       grade_equivalent: row.fetch('GradeEquivalent'),
       total_time: row.fetch('TotalTime'),
     )
+
+    if test_result.invalid?
+      @invalid_rows_count += 1
+      log("error: #{test_result.errors.full_messages}")
+      return nil
+    end
 
     test_result.save!
   end

--- a/app/importers/file_importers/star_reading_importer.rb
+++ b/app/importers/file_importers/star_reading_importer.rb
@@ -3,6 +3,7 @@ class StarReadingImporter
   def initialize(options:)
     @school_scope = options.fetch(:school_scope)
     @log = options.fetch(:log)
+    @invalid_rows_count = 0
   end
 
   def import
@@ -25,6 +26,8 @@ class StarReadingImporter
         import_row(row) if filter.include?(row.fetch('SchoolLocalID'))
         log("processed #{index} rows.") if index % 1000 == 0
       end
+
+      log("skipped #{@invalid_rows_count} invalid rows.")
     end
   end
 
@@ -83,6 +86,12 @@ class StarReadingImporter
       grade_equivalent: row.fetch('GradeEquivalent'),
       total_time: row.fetch('TotalTime'),
     })
+
+    if test_result.invalid?
+      @invalid_rows_count += 1
+      log("erorr: #{test_result.errors.full_messages}")
+      return nil
+    end
 
     test_result.save!
   end

--- a/spec/importers/file_importers/star_reading_importer_spec.rb
+++ b/spec/importers/file_importers/star_reading_importer_spec.rb
@@ -52,10 +52,16 @@ RSpec.describe StarReadingImporter do
         let(:csv) { star_reading_importer.data_transformer.transform(csv_string) }
         let!(:student) { FactoryBot.create(:student, local_id: '10') }
 
-        it 'raises an error' do
-          expect { import }.to raise_error(
-            ActiveRecord::RecordInvalid, 'Validation failed: Percentile rank too high'
-          )
+        it 'does not raise an error' do
+          expect { import }.not_to raise_error
+        end
+        it 'does not import the invalid row' do
+          expect { import }.to change { StarReadingResult.count }.by 0
+        end
+        it 'increments invalid row counter' do
+          expect { import }.to change {
+            star_reading_importer.instance_variable_get(:@invalid_rows_count)
+          }.by 1
         end
       end
 


### PR DESCRIPTION
# Who is this PR for?

New Bedford STAR historical data backfill.

# What problem does this PR fix?

One of the rows in the historical STAR Math file contains a percentile rank of zero, which we considered invalid. The STAR Math and Reading importers are currently configured to blow up if they run across any invalid data, since we've never encountered invalid STAR data before in either district. 

# What does this PR do?

Instead of blowing up the STAR importer if a row is invalid, log the errors and continue importing rows. 