### PR TITLE
Update photo importer to move zip path into config

### DIFF
--- a/app/importers/photo_import/student_photo_importer.rb
+++ b/app/importers/photo_import/student_photo_importer.rb
@@ -13,7 +13,7 @@ class StudentPhotoImporter
   def initialize
     raise "import_student_photos? not enabled" unless PerDistrict.new.import_student_photos?
     raise "missing AWS keys!" if REQUIRED_KEYS.any? { |aws_key| (ENV[aws_key]).nil? }
-
+    raise "remote filename not set!" if remote_filename.nil?
     @time_now = Time.now
   end
 
@@ -22,7 +22,7 @@ class StudentPhotoImporter
 
     log('Downloading photos.zip from SFTP site...')
 
-    photos_zip_file = sftp_client.download_file('photos.zip')
+    photos_zip_file = sftp_client.download_file(remote_filename)
 
     log("Downloaded Photos ZIP file!")
 
@@ -57,6 +57,11 @@ class StudentPhotoImporter
 
     log("Created #{created_student_photos_count} StudentPhoto records")
     log("Done.")
+  end
+
+  private
+  def remote_filename
+    LoadDistrictConfig.new.remote_filenames.fetch('FILENAME_FOR_PHOTOS_ZIP', nil)
   end
 
   def sftp_client

--- a/config/district_somerville.yml
+++ b/config/district_somerville.yml
@@ -1,4 +1,5 @@
 remote_filenames:
+  # SIS data
   FILENAME_FOR_EDUCATORS_IMPORT:                    /home/jbreslin/data/educators_export.txt
   FILENAME_FOR_STUDENTS_IMPORT:                     /home/jbreslin/data/students_export.txt
   FILENAME_FOR_BEHAVIOR_IMPORT:                     /home/jbreslin/data/behavior_export.txt
@@ -8,9 +9,11 @@ remote_filenames:
   FILENAME_FOR_COURSE_SECTION_IMPORT:               /home/jbreslin/data/courses_sections_export.txt
   FILENAME_FOR_STUDENTS_SECTION_ASSIGNMENT_IMPORT:  /home/jbreslin/data/student_section_assignment_export.txt
   FILENAME_FOR_EDUCATOR_SECTION_ASSIGNMENT_IMPORT:  /home/jbreslin/data/educator_section_assignment_export.txt
-  FILENAME_FOR_STAR_READING_IMPORT:                 SR.csv
-  FILENAME_FOR_STAR_MATH_IMPORT:                    SM.csv
-  FILENAME_FOR_STAR_ZIP_FILE:                       Somerville Public Schools.zip
+  
+  # student photos, one-time batch
+  FILENAME_FOR_PHOTOS_ZIP:                          /home/jbreslin/data/photos.zip
+
+  # iep at a glance PDFs
   FILENAMES_FOR_IEP_PDF_ZIPS:   # order is important here, these need to be oldest > newest
     - /home/jbreslin/data/student-documents-6.zip
     - /home/jbreslin/data/student-documents-5.zip
@@ -18,6 +21,12 @@ remote_filenames:
     - /home/jbreslin/data/student-documents-3.zip
     - /home/jbreslin/data/student-documents-2.zip
     - /home/jbreslin/data/student-documents-1.zip
+
+  # These are for STAR
+  FILENAME_FOR_STAR_READING_IMPORT:                 SR.csv
+  FILENAME_FOR_STAR_MATH_IMPORT:                    SM.csv
+  FILENAME_FOR_STAR_ZIP_FILE:                       Somerville Public Schools.zip
+
 schools:
   -
     local_id: BRN


### PR DESCRIPTION
This was broken in making the new SFTP box and we didn't notice since this job doesn't run regularly.  In migrating the S3 storage, I ran it to verify it still works which revealed this.

Resolves https://rollbar.com/somerville-teacher-tool/somerville-teacher-tool/items/210/