### PR TITLE
Revert "Import historical STAR Math and Reading data for New Bedford"

### DIFF
--- a/config/district_new_bedford.yml
+++ b/config/district_new_bedford.yml
@@ -4,9 +4,9 @@ remote_filenames:
   FILENAME_FOR_BEHAVIOR_IMPORT:       ../newbedford/iconduct.csv
   FILENAME_FOR_ASSESSMENT_IMPORT:     ../newbedford/iassessments.csv
   FILENAME_FOR_ATTENDANCE_IMPORT:     ../newbedford/iattendance.csv
-  FILENAME_FOR_STAR_READING_IMPORT:   SR_Historical.csv
-  FILENAME_FOR_STAR_MATH_IMPORT:      SM_Historical.csv
-  FILENAME_FOR_STAR_ZIP_FILE:         KeepNew Bedford Public Schools.zip
+  FILENAME_FOR_STAR_READING_IMPORT:   SR.csv
+  FILENAME_FOR_STAR_MATH_IMPORT:      SM.csv
+  FILENAME_FOR_STAR_ZIP_FILE:         New Bedford Public Schools.zip
 schools:
   -
     name: Charles S. Ashley


### PR DESCRIPTION
Reverts studentinsights/studentinsights#2054.

Update to normal nightly STAR data import now that historical STAR has been successfully backfilled for new schools. (@kevinrobinson, see detailed email I sent about this subject: "New Bedford data import: STAR historical backfill + new schools attendance").