### PR TITLE
WIP: Separate educator login from email, handle Bedford auth system

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -132,7 +132,7 @@ class PerDistrict
   # but we want to build up full email addresses with domain names.
   # For some districts, full email addresses are used for authentication.
   # For all districts, full email address are used to populate mailto links.
-  def from_import_row_to_email(login_name, full_name)
+  def from_import_row_to_email(login_name)
     if @district_key == SOMERVILLE
       login_name + '@k12.somerville.ma.us'
     elsif @district_key == NEW_BEDFORD

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -112,6 +112,8 @@ class PerDistrict
     end
   end
 
+  # Some districts use full email addresses for login names, others use just
+  # a short login_name for each user.
   def from_import_row_to_login_name(email, login_name)
     if @district_key == SOMERVILLE
       email
@@ -126,21 +128,18 @@ class PerDistrict
     end
   end
 
-  # In the import process, we typically only get usernames
-  # as the `login_name`, but we want our user account system
-  # and our communication with district authentication systems
-  # to always be in terms of full email addresses with domain
-  # names.
+  # In the import process, we typically only get usernames as the `login_name`,
+  # but we want to build up full email addresses with domain names.
+  # For some districts, full email addresses are used for authentication.
+  # For all districts, full email address are used to populate mailto links.
   def from_import_row_to_email(login_name, full_name)
     if @district_key == SOMERVILLE
       login_name + '@k12.somerville.ma.us'
     elsif @district_key == NEW_BEDFORD
       login_name + '@newbedfordschools.org'
     elsif @district_key == BEDFORD
-      first_name = full_name.split(", ")[1].downcase
-      last_name = full_name.split(", ")[0].downcase
-
-      "#{first_name}_#{last_name}@bedfordps.org"
+      # TODO: Read in email column from Bedford Aspen/X2 export here.
+      raise 'Not yet handled'
     elsif @district_key == DEMO
       raise "PerDistrict#from_import_row_to_email not supported for district_key: {DEMO}"
     else

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -112,12 +112,26 @@ class PerDistrict
     end
   end
 
+  def from_import_row_to_login_name(email, login_name)
+    if @district_key == SOMERVILLE
+      email
+    elsif @district_key == NEW_BEDFORD
+      email
+    elsif @district_key == BEDFORD
+      login_name
+    elsif @district_key == DEMO
+      raise "PerDistrict#from_import_row_to_login_name not supported for district_key: {DEMO}"
+    else
+      raise_not_handled!
+    end
+  end
+
   # In the import process, we typically only get usernames
   # as the `login_name`, but we want our user account system
   # and our communication with district authentication systems
   # to always be in terms of full email addresses with domain
   # names.
-  def from_import_login_name_to_email(login_name, full_name)
+  def from_import_row_to_email(login_name, full_name)
     if @district_key == SOMERVILLE
       login_name + '@k12.somerville.ma.us'
     elsif @district_key == NEW_BEDFORD
@@ -128,10 +142,17 @@ class PerDistrict
 
       "#{first_name}_#{last_name}@bedfordps.org"
     elsif @district_key == DEMO
-      raise "PerDistrict#from_import_login_name_to_email not supported for district_key: {DEMO}"
+      raise "PerDistrict#from_import_row_to_email not supported for district_key: {DEMO}"
     else
       raise_not_handled!
     end
+  end
+
+  def backfill_login_names_with_emails?
+    return true if @district_key == SOMERVILLE
+    return true if @district_key == NEW_BEDFORD
+    return false if @district_key == BEDFORD
+    return false
   end
 
   def import_detailed_attendance_fields?

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -117,13 +117,16 @@ class PerDistrict
   # and our communication with district authentication systems
   # to always be in terms of full email addresses with domain
   # names.
-  def from_import_login_name_to_email(login_name)
+  def from_import_login_name_to_email(login_name, full_name)
     if @district_key == SOMERVILLE
       login_name + '@k12.somerville.ma.us'
     elsif @district_key == NEW_BEDFORD
       login_name + '@newbedfordschools.org'
     elsif @district_key == BEDFORD
-      login_name + '@bedfordps.org'
+      first_name = full_name.split(", ")[1].downcase
+      last_name = full_name.split(", ")[0].downcase
+
+      "#{first_name}_#{last_name}@bedfordps.org"
     elsif @district_key == DEMO
       raise "PerDistrict#from_import_login_name_to_email not supported for district_key: {DEMO}"
     else

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -148,7 +148,7 @@ class PerDistrict
     end
   end
 
-  def backfill_login_names_with_emails?
+  def login_educator_with_email?
     return true if @district_key == SOMERVILLE
     return true if @district_key == NEW_BEDFORD
     return false if @district_key == BEDFORD

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   force_ssl unless Rails.env.development?
 
   before_action :redirect_domain!
+  before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_educator!  # Devise method, applies to all controllers (in this app 'users' are 'educators')
 
   rescue_from ActiveRecord::RecordNotFound do
@@ -82,6 +83,11 @@ class ApplicationController < ActionController::Base
     logger.info "log_timing:end [#{message}] #{timing_ms.round}ms"
 
     return_value
+  end
+
+  protected
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_in, keys: [:login_name])
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,6 +11,16 @@ module ApplicationHelper
     @devise_mapping ||= Devise.mappings[:user]
   end
 
+  def login_field_label
+    return 'Email' if PerDistrict.new.login_educator_with_email?
+    return 'Username'
+  end
+
+  def login_field_type
+    return :email if PerDistrict.new.login_educator_with_email?
+    return :text
+  end
+
   # IE11 reports HTML1500 warnings on the console if tags are not explicitly
   # closed (like happens if you used `tag`).  Here we're rendering tags with
   # attributes and no content to be able to parse the JSON in JS.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,14 +11,15 @@ module ApplicationHelper
     @devise_mapping ||= Devise.mappings[:user]
   end
 
-  def login_field_label
-    return 'Email' if PerDistrict.new.login_educator_with_email?
-    return 'Username'
-  end
-
+  # HTML email validation for districts that use full email address as login name.
   def login_field_type
     return :email if PerDistrict.new.login_educator_with_email?
     return :text
+  end
+
+  def login_field_label
+    return 'Email' if PerDistrict.new.login_educator_with_email?
+    return 'Username'
   end
 
   # IE11 reports HTML1500 warnings on the console if tags are not explicitly

--- a/app/importers/rows/educator_row.rb
+++ b/app/importers/rows/educator_row.rb
@@ -8,9 +8,12 @@ class EducatorRow < Struct.new(:row, :school_ids_dictionary)
   def build
     return nil if row[:login_name].nil? || row[:login_name] == ''
 
+    # TODO: find_or_initialize on login_name once all active educators
+    # have a login_name set.
     educator = Educator.find_or_initialize_by(email: email)
 
     educator.assign_attributes(
+      login_name: row[:login_name],
       state_id: row[:state_id],
       full_name: row[:full_name],
       staff_type: row[:staff_type],
@@ -32,7 +35,7 @@ class EducatorRow < Struct.new(:row, :school_ids_dictionary)
   private
 
   def email
-    PerDistrict.new.from_import_login_name_to_email(row[:login_name])
+    PerDistrict.new.from_import_login_name_to_email(row[:login_name], row[:full_name])
   end
 
   def is_admin?

--- a/app/importers/rows/educator_row.rb
+++ b/app/importers/rows/educator_row.rb
@@ -8,12 +8,13 @@ class EducatorRow < Struct.new(:row, :school_ids_dictionary)
   def build
     return nil if row[:login_name].nil? || row[:login_name] == ''
 
-    # TODO: find_or_initialize on login_name once all active educators
-    # have a login_name set.
-    educator = Educator.find_or_initialize_by(email: email)
+    email = email_from_row
+    login_name = login_name_from_row(email)
+    educator = Educator.find_or_initialize_by(login_name: login_name)
 
     educator.assign_attributes(
-      login_name: row[:login_name],
+      login_name: login_name,
+      email: email,
       state_id: row[:state_id],
       full_name: row[:full_name],
       staff_type: row[:staff_type],
@@ -34,8 +35,12 @@ class EducatorRow < Struct.new(:row, :school_ids_dictionary)
 
   private
 
-  def email
-    PerDistrict.new.from_import_login_name_to_email(row[:login_name], row[:full_name])
+  def login_name_from_row(email)
+    PerDistrict.new.from_import_row_to_login_name(email, row[:login_name])
+  end
+
+  def email_from_row
+    PerDistrict.new.from_import_row_to_email(row[:login_name], row[:full_name])
   end
 
   def is_admin?

--- a/app/importers/rows/educator_row.rb
+++ b/app/importers/rows/educator_row.rb
@@ -40,7 +40,7 @@ class EducatorRow < Struct.new(:row, :school_ids_dictionary)
   end
 
   def email_from_row
-    PerDistrict.new.from_import_row_to_email(row[:login_name], row[:full_name])
+    PerDistrict.new.from_import_row_to_email(row[:login_name])
   end
 
   def is_admin?

--- a/app/lib/mock_ldap.rb
+++ b/app/lib/mock_ldap.rb
@@ -14,16 +14,16 @@ class MockLDAP
 
   def initialize(options)
     @options = options
-    @email = options[:auth][:username]
+    @login_name = options[:auth][:username]
     @password = options[:auth][:password]
   end
 
   def bind
     raise 'Mock LDAP called but ShouldUseMockLDAP false' unless ShouldUseMockLDAP.new.check
 
-    return false unless email_present?
+    return false unless login_name_present?
 
-    return true if unauthenticated_bind?
+    return true if unauthenticated_bind?  # Mock insecurely configured LDPA.
 
     return false unless password_correct?
 
@@ -35,8 +35,8 @@ class MockLDAP
 
   private
 
-  def email_present?
-    Educator.find_by_email(@email).present?
+  def login_name_present?
+    Educator.find_by_login_name(@login_name).present?
   end
 
   def unauthenticated_bind?

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -14,6 +14,7 @@ class Educator < ActiveRecord::Base
   has_many    :login_activities, as: :user
 
   validates :email, presence: true, uniqueness: true, case_sensitive: false
+  validates :login_name, presence: true, uniqueness: true, case_sensitive: false
 
   validate :validate_has_school_unless_districtwide,
            :validate_admin_gets_access_to_all_students,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,23 +22,15 @@
           </div>
         </a>
         <% if educator_signed_in? %>
-          <%= render partial: 'shared/navbar_signed_in', locals: { educator: current_educator, masquerade: masquerade } %>
+          <%= render partial: 'shared/navbar_signed_in', locals: {
+            educator: current_educator,
+            masquerade: masquerade
+          } %>
         <% else %>
-          <div class="sign-in-container">
-            <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-              <div class="sign-in-item">
-                <%= f.label :email %>
-                <%= f.email_field :email, class: 'sign-in-text', autofocus: true %>
-              </div>
-              <div class="sign-in-item">
-                <%= f.label :password %>
-                <%= f.password_field :password, class: 'sign-in-text', autocomplete: "off" %>
-              </div>
-              <div class="sign-in-item">
-                <%= f.submit "Log in", class: "btn btn-primary" %>
-              </div>
-            <% end %>
-          </div>
+          <%= render partial: 'shared/navbar_signed_out', locals: {
+            login_field_label: login_field_label,
+            login_field_type: login_field_type,
+        } %>
         <% end %>
       </div>
       <div class="flash">

--- a/app/views/shared/_navbar_signed_out.html.erb
+++ b/app/views/shared/_navbar_signed_out.html.erb
@@ -1,0 +1,19 @@
+<div class="sign-in-container">
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <div class="sign-in-item">
+      <%= f.label login_field_label %>
+      <% if login_field_type == :email %>
+        <%= f.email_field :login_name, class: 'sign-in-text', autofocus: true %>
+      <% elsif login_field_type == :text %>
+        <%= f.text_field :login_name, class: 'sign-in-text', autofocus: true %>
+      <% end %>
+    </div>
+    <div class="sign-in-item">
+      <%= f.label :password %>
+      <%= f.password_field :password, class: 'sign-in-text', autocomplete: "off" %>
+    </div>
+    <div class="sign-in-item">
+      <%= f.submit "Log in", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,6 +1,8 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+  config.authentication_keys = [:login_name]
+
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -9,11 +9,11 @@ en:
     failure:
       already_authenticated: "You are already signed in."
       inactive: "Your account is not activated yet."
-      invalid: "Invalid %{authentication_keys} or password."
+      invalid: "Invalid login name or password."
       error: "Sorry, there was an error with signing you in."
       locked: "Your account is locked."
       last_attempt: "You have one more attempt before your account is locked."
-      not_found_in_database: "Invalid %{authentication_keys} or password."
+      not_found_in_database: "Invalid login name or password."
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in before continuing."
       unconfirmed: "You have to confirm your email address before continuing."

--- a/db/migrate/20180907185759_add_login_to_educators_table.rb
+++ b/db/migrate/20180907185759_add_login_to_educators_table.rb
@@ -1,0 +1,5 @@
+class AddLoginToEducatorsTable < ActiveRecord::Migration[5.2]
+  def change
+    add_column :educators, :login_name, :string
+  end
+end

--- a/db/migrate/20180907185759_add_login_to_educators_table.rb
+++ b/db/migrate/20180907185759_add_login_to_educators_table.rb
@@ -2,7 +2,7 @@ class AddLoginToEducatorsTable < ActiveRecord::Migration[5.2]
   def change
     add_column :educators, :login_name, :string
 
-    if PerDistrict.new.backfill_login_names_with_emails? && Rails.env.production?
+    if PerDistrict.new.login_educator_with_email? && Rails.env.production?
       puts "Backfilling login_name column with emails for #{PerDistrict.new.district_key}!"
 
       Educator.find_each do |educator, index|

--- a/db/migrate/20180907185759_add_login_to_educators_table.rb
+++ b/db/migrate/20180907185759_add_login_to_educators_table.rb
@@ -1,5 +1,20 @@
 class AddLoginToEducatorsTable < ActiveRecord::Migration[5.2]
   def change
     add_column :educators, :login_name, :string
+
+    if PerDistrict.new.backfill_login_names_with_emails? && Rails.env.production?
+      puts "Backfilling login_name column with emails for #{PerDistrict.new.district_key}!"
+
+      Educator.find_each do |educator, index|
+        educator.login_name = educator.email
+        educator.save!
+
+        puts("  Updated #{index} educators.") if index > 0 && index % 100 == 0
+      end
+
+      puts "Done."
+    end
+
+    change_column :educators, :login_name, :string, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -150,7 +150,7 @@ ActiveRecord::Schema.define(version: 2018_09_07_185759) do
     t.boolean "districtwide_access", default: false, null: false
     t.boolean "can_set_districtwide_access", default: false, null: false
     t.text "student_searchbar_json"
-    t.string "login_name"
+    t.string "login_name", null: false
     t.index ["grade_level_access"], name: "index_educators_on_grade_level_access", using: :gin
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_30_143340) do
+ActiveRecord::Schema.define(version: 2018_09_07_185759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,6 +150,7 @@ ActiveRecord::Schema.define(version: 2018_08_30_143340) do
     t.boolean "districtwide_access", default: false, null: false
     t.boolean "can_set_districtwide_access", default: false, null: false
     t.text "student_searchbar_json"
+    t.string "login_name"
     t.index ["grade_level_access"], name: "index_educators_on_grade_level_access", using: :gin
   end
 

--- a/spec/config_objects/per_district_spec.rb
+++ b/spec/config_objects/per_district_spec.rb
@@ -32,11 +32,13 @@ RSpec.describe PerDistrict do
     end
   end
 
-  describe '#from_import_login_name_to_email' do
+  describe '#from_import_row_to_email' do
     it 'works' do
-      expect(for_somerville.from_import_login_name_to_email('foo')).to eq('foo@k12.somerville.ma.us')
-      expect(for_new_bedford.from_import_login_name_to_email('foo')).to eq('foo@newbedfordschools.org')
-      expect { PerDistrict.new(district_key: 'wat').from_import_login_name_to_email('foo') }.to raise_error Exceptions::DistrictKeyNotHandledError
+      expect(for_somerville.from_import_row_to_email('foo')).to eq('foo@k12.somerville.ma.us')
+      expect(for_new_bedford.from_import_row_to_email('foo')).to eq('foo@newbedfordschools.org')
+
+      # TODO: Bedford.
+      expect { PerDistrict.new(district_key: 'wat').from_import_row_to_email('foo') }.to raise_error Exceptions::DistrictKeyNotHandledError
     end
   end
 

--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -13,6 +13,9 @@ FactoryBot.define do
       last_name, first_name = full_name.split(', ')
       "#{first_name}.#{last_name}@demo.studentinsights.org"
     end
+    login_name do
+      email
+    end
     local_id { FactoryBot.generate(:staff_local_id) }
     association :school
 

--- a/spec/features/educator_admin_page_feature_spec.rb
+++ b/spec/features/educator_admin_page_feature_spec.rb
@@ -5,7 +5,7 @@ describe 'educator sign in', type: :feature do
   let!(:pals) { TestPals.create! }
 
   def grants_access?(educator)
-    sign_in_attempt(educator.email, 'demo-password')
+    sign_in_attempt(educator.login_name, 'demo-password')
     visit admin_root_url
 
     checks = []

--- a/spec/features/masquerade_feature_spec.rb
+++ b/spec/features/masquerade_feature_spec.rb
@@ -5,7 +5,7 @@ describe 'masquerading', type: :feature do
   let!(:pals) { TestPals.create! }
 
   def sign_in_as(educator)
-    sign_in_attempt(educator.email, 'demo-password')
+    sign_in_attempt(educator.login_name, 'demo-password')
   end
 
   def expect_to_allow_masquerading(page)

--- a/spec/features/sign_in_feature_spec.rb
+++ b/spec/features/sign_in_feature_spec.rb
@@ -6,7 +6,7 @@ describe 'educator sign in using Mock LDAP', type: :feature do
 
   context 'teacher signs in' do
     def expect_successful_sign_in_for(educator)
-      sign_in_attempt(educator.email, 'demo-password')
+      sign_in_attempt(educator.login_name, 'demo-password')
       expect(page).to have_content 'Search:'
     end
 

--- a/spec/lib/ldap_authenticatable_tiny_spec.rb
+++ b/spec/lib/ldap_authenticatable_tiny_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe 'LdapAuthenticatableTiny' do
   describe '#authenticate! when methods are mocked' do
     let!(:pals) { TestPals.create! }
 
-    it 'calls fail when email not found' do
+    it 'calls fail when login_name not found' do
       strategy = test_strategy
-      allow(strategy).to receive(:authentication_hash) { { email: 'foo@demo.studentinsights.org' } }
+      allow(strategy).to receive(:authentication_hash) { { login_name: 'foo@demo.studentinsights.org' } }
       strategy.authenticate!
 
       expect(strategy.result).to eq :failure
@@ -40,9 +40,9 @@ RSpec.describe 'LdapAuthenticatableTiny' do
       expect(strategy.user).to eq nil
     end
 
-    it 'calls fail when email found but not is_authorized_by_ldap?' do
+    it 'calls fail when login_name found but not is_authorized_by_ldap?' do
       strategy = test_strategy
-      allow(strategy).to receive(:authentication_hash) { { email: 'uri@demo.studentinsights.org' } }
+      allow(strategy).to receive(:authentication_hash) { { login_name: 'uri@demo.studentinsights.org' } }
       allow(strategy).to receive(:password) { 'supersecure' }
       allow(strategy).to receive(:is_authorized_by_ldap?).with(MockLDAP, 'uri@demo.studentinsights.org', 'supersecure').and_return false
 
@@ -56,7 +56,7 @@ RSpec.describe 'LdapAuthenticatableTiny' do
       expect(Rollbar).to receive(:error).with(any_args)
 
       strategy = test_strategy
-      allow(strategy).to receive(:authentication_hash) { { email: 'uri@demo.studentinsights.org' } }
+      allow(strategy).to receive(:authentication_hash) { { login_name: 'uri@demo.studentinsights.org' } }
       allow(strategy).to receive(:password) { 'supersecure' }
       allow(strategy).to receive(:is_authorized_by_ldap?).with(MockLDAP, 'uri@demo.studentinsights.org', 'supersecure').and_raise(Net::LDAP::Error)
       strategy.authenticate!
@@ -68,7 +68,7 @@ RSpec.describe 'LdapAuthenticatableTiny' do
 
     it 'calls success! even when cases are different' do
       strategy = test_strategy
-      allow(strategy).to receive(:authentication_hash) { { email: 'URI@demo.studentinsights.org' } }
+      allow(strategy).to receive(:authentication_hash) { { login_name: 'URI@demo.studentinsights.org' } }
       allow(strategy).to receive(:password) { 'supersecure' }
       allow(strategy).to receive(:is_authorized_by_ldap?).with(MockLDAP, 'URI@demo.studentinsights.org', 'supersecure').and_return true
       strategy.authenticate!
@@ -80,7 +80,7 @@ RSpec.describe 'LdapAuthenticatableTiny' do
 
     it 'calls success! when valid Educator and is_authorized_by_ldap?' do
       strategy = test_strategy
-      allow(strategy).to receive(:authentication_hash) { { email: 'uri@demo.studentinsights.org' } }
+      allow(strategy).to receive(:authentication_hash) { { login_name: 'uri@demo.studentinsights.org' } }
       allow(strategy).to receive(:password) { 'supersecure' }
       allow(strategy).to receive(:is_authorized_by_ldap?).with(MockLDAP, 'uri@demo.studentinsights.org', 'supersecure').and_return true
       strategy.authenticate!

--- a/spec/support/educator_sign_in_helpers.rb
+++ b/spec/support/educator_sign_in_helpers.rb
@@ -1,7 +1,7 @@
 # Shared method between feature tests for educator sign in
-def sign_in_attempt(email, password)
+def sign_in_attempt(login_name, password)
   visit root_url
-  fill_in 'educator_email', with: email
+  fill_in 'educator_login_name', with: login_name
   fill_in 'educator_password', with: password
   click_button 'Log in'
 end

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -67,6 +67,7 @@ class TestPals
     @uri = Educator.create!(
       id: 999999,
       email: 'uri@demo.studentinsights.org',
+      login_name: 'uri@demo.studentinsights.org',
       full_name: 'Disney, Uri',
       staff_type: 'Administrator',
       can_set_districtwide_access: true,
@@ -88,6 +89,7 @@ class TestPals
     # not project lead access.
     @rich_districtwide = Educator.create!(
       email: 'rich@demo.studentinsights.org',
+      login_name: 'rich@demo.studentinsights.org',
       full_name: 'Districtwide, Rich',
       staff_type: 'Administrator',
       can_set_districtwide_access: false,
@@ -116,6 +118,7 @@ class TestPals
 
     @healey_vivian_teacher = Educator.create!(
       email: 'vivian@demo.studentinsights.org',
+      login_name: 'vivian@demo.studentinsights.org',
       full_name: 'Teacher, Vivian',
       password: 'demo-password',
       staff_type: nil,
@@ -125,18 +128,21 @@ class TestPals
 
     @healey_ell_teacher = Educator.create!(
       email: 'alonso@demo.studentinsights.org',
+      login_name: 'alonso@demo.studentinsights.org',
       full_name: 'Teacher, Alonso',
       restricted_to_english_language_learners: true,
       school: @healey
     )
     @healey_sped_teacher = Educator.create!(
       email: 'silva@demo.studentinsights.org',
+      login_name: 'silva@demo.studentinsights.org',
       full_name: 'Teacher, Silva',
       restricted_to_sped_students: true,
       school: @healey
     )
     @healey_laura_principal = Educator.create!(
       email: 'laura@demo.studentinsights.org',
+      login_name: 'laura@demo.studentinsights.org',
       full_name: 'Principal, Laura',
       school: @healey,
       staff_type: 'Principal',
@@ -151,6 +157,7 @@ class TestPals
     )
     @healey_sarah_teacher = Educator.create!(
       email: "sarah@demo.studentinsights.org",
+      login_name: "sarah@demo.studentinsights.org",
       full_name: 'Teacher, Sarah',
       homeroom: @healey_fifth_homeroom,
       school: @healey,
@@ -175,6 +182,7 @@ class TestPals
     )
     @west_marcus_teacher = Educator.create!(
       email: "marcus@demo.studentinsights.org",
+      login_name: "marcus@demo.studentinsights.org",
       full_name: 'Teacher, Marcus',
       local_id: '550',
       homeroom: @west_fifth_homeroom,
@@ -182,6 +190,7 @@ class TestPals
     )
     @west_counselor = Educator.create!(
       email: "les@demo.studentinsights.org",
+      login_name: "les@demo.studentinsights.org",
       full_name: "Counselor, Les",
       local_id: '551',
       school: @west,
@@ -205,6 +214,7 @@ class TestPals
     @shs = School.find_by_local_id!('SHS')
     @shs_sofia_counselor = Educator.create!(
       email: 'sofia@demo.studentinsights.org',
+      login_name: 'sofia@demo.studentinsights.org',
       full_name: 'Counselor, Sofia',
       school: @shs,
       schoolwide_access: true
@@ -228,6 +238,7 @@ class TestPals
     )
     @shs_jodi = Educator.create!(
       email: 'jodi@demo.studentinsights.org',
+      login_name: 'jodi@demo.studentinsights.org',
       full_name: 'Teacher, Jodi',
       school: @shs,
       homeroom: @shs_jodi_homeroom
@@ -243,6 +254,7 @@ class TestPals
 
     @shs_harry_housemaster = Educator.create!(
       email: 'harry@demo.studentinsights.org',
+      login_name: 'harry@demo.studentinsights.org',
       full_name: 'Housemaster, Harry',
       school: @shs,
       schoolwide_access: true,
@@ -262,6 +274,7 @@ class TestPals
     )
     @shs_bill_nye = Educator.create!(
       email: 'bill@demo.studentinsights.org',
+      login_name: 'bill@demo.studentinsights.org',
       full_name: 'Teacher, Bill',
       school: @shs,
       homeroom: @shs_bill_nye_homeroom
@@ -287,6 +300,7 @@ class TestPals
     # Hugo teachers two sections of ceramics at the high school.
     @shs_hugo_art_teacher = Educator.create!(
       email: "hugo@demo.studentinsights.org",
+      login_name: "hugo@demo.studentinsights.org",
       full_name: 'Teacher, Hugo',
       local_id: '650',
       school: @shs
@@ -316,6 +330,7 @@ class TestPals
     # Fatima teaches two sections of physics at the high school.
     @shs_fatima_science_teacher = Educator.create!(
       email: "fatima@demo.studentinsights.org",
+      login_name: "fatima@demo.studentinsights.org",
       full_name: 'Teacher, Fatima',
       local_id: '750',
       school: @shs


### PR DESCRIPTION
# Who is this PR for?

Bedford Public Schools.

# What problem does this PR fix?

New Bedford and Somerville allow for querying LDAP by educator email. Bedford uses a different system which requires a separate login name or "short username". 

# What does this PR do?

Splits `email` from `login_name` in the educators table. 

+ Adds a migration that creates `login_name` as a field, auto-fills all New Bedford and Somerville educators to have login names equal to their current emails, then applies `null: false` migration.
  + This means that we can cut over to authenticating on `login_name` instead of `email` without changing anything for Somerville or New Bedford educators.
+ Updates import code to automatically set login name and email as the same for New Bedford and Somerville educators, while letting the two be different for Bedford using `PerDistrict`.

# Blockers

Still waiting on Bedford to send an example educators export CSV that will show me how to set educator emails for Bedford. 

# Deploy 

+ [ ] Merge and ship 
+ [ ] Watch the outcome of the `AddLoginToEducatorsTable` migration
+ [ ] Manually check that all New Bedford and Somerville educators have login names set