### PR TITLE
Profile v3: Show IEP document inline when possible

### DIFF
--- a/app/assets/javascripts/helpers/specialEducation.js
+++ b/app/assets/javascripts/helpers/specialEducation.js
@@ -4,7 +4,7 @@ export function hasAnySpecialEducationData(student, maybeIepDocument) {
   if (maybeIepDocument) return true;
   
   const {program, placement, disability, levelOfNeed} = cleanSpecialEducationValues(student);
-  if (program) return true;
+  if (program && isSpecialEducationProgram(program)) return true;
   if (placement) return true;
   if (disability) return true;
   if (levelOfNeed) return true;
@@ -14,7 +14,8 @@ export function hasAnySpecialEducationData(student, maybeIepDocument) {
   return false;
 }
 
-export function prettyIepTextForStudent(student) {
+// Always falls back to `IEP` at worst
+export function prettyIepTextForSpecialEducationStudent(student) {
   return prettyIepText(cleanSpecialEducationValues(student));
 }
 
@@ -32,7 +33,7 @@ export function prettyLevelOfNeedText(levelOfNeedValue) {
 // as part of special education or ELL services (the program bit is Somerville-only).
 export function prettyProgramOrPlacementText(student) {
   const {program, placement} = cleanSpecialEducationValues(student);
-  if (program && (program !== 'Sp Ed' || !placement)) return program;
+  if (!isNullProgram(program) && (!isSpecialEducationProgram(program) || !placement)) return program;
   if (placement) return placement;
   return null;
 }
@@ -76,4 +77,8 @@ function isNullLevelOfNeed(levelOfNeed) {
 // This field is only used in Somerville
 function isNullProgram(program) {
   return (['Reg Ed', null].indexOf(program) !== -1);
+}
+
+function isSpecialEducationProgram(program) {
+  return (program === 'Sp Ed');
 }

--- a/app/assets/javascripts/helpers/specialEducation.js
+++ b/app/assets/javascripts/helpers/specialEducation.js
@@ -1,7 +1,7 @@
 // This file contains functions that handle variations by district, so that they work
 // across all districts.
 export function hasAnySpecialEducationData(student, maybeIepDocument) {
-  if (maybeIepDocument !== null) return true;
+  if (maybeIepDocument) return true;
   
   const {program, placement, disability, levelOfNeed} = cleanSpecialEducationValues(student);
   if (program) return true;

--- a/app/assets/javascripts/helpers/specialEducation.test.js
+++ b/app/assets/javascripts/helpers/specialEducation.test.js
@@ -1,109 +1,133 @@
 import {
+  hasAnySpecialEducationData,
   prettyProgramOrPlacementText,
-  prettyIepTextForStudent
+  prettyIepTextForSpecialEducationStudent
 } from './specialEducation';
 
+describe('#hasAnySpecialEducationData', () => {
+  it('excludes other programs', () => {
+    expect(hasAnySpecialEducationData({
+      program_assigned: '2Way English',
+      sped_placement: null,
+      disability: null,
+      sped_level_of_need: null,
+    }, null)).toEqual(false);
+  });
+});
 
-it('#prettyProgramOrPlacementText', () => {
-  expect(prettyProgramOrPlacementText({
-    program_assigned: null,
-    sped_placement: null
-  })).toEqual(null);
-  
-  expect(prettyProgramOrPlacementText({
-    program_assigned: 'Reg Ed',
-    sped_placement: null
-  })).toEqual(null);
-  
-  expect(prettyProgramOrPlacementText({
-    program_assigned: 'Sp Ed',
-    sped_placement: null
-  })).toEqual('Sp Ed');
+describe('#prettyProgramOrPlacementText', () => {
+  it('works', () => {
+    expect(prettyProgramOrPlacementText({
+      program_assigned: null,
+      sped_placement: null
+    })).toEqual(null);
+    
+    expect(prettyProgramOrPlacementText({
+      program_assigned: 'Reg Ed',
+      sped_placement: null
+    })).toEqual(null);
+    
+    expect(prettyProgramOrPlacementText({
+      program_assigned: 'Sp Ed',
+      sped_placement: null
+    })).toEqual('Sp Ed');
 
-  expect(prettyProgramOrPlacementText({
-    program_assigned: 'Sp Ed',
-    sped_placement: 'Full Inclusion'
-  })).toEqual('Full Inclusion');
-  
-  expect(prettyProgramOrPlacementText({
-    program_assigned: 'SEIP',
-    sped_placement: null
-  })).toEqual('SEIP');
+    expect(prettyProgramOrPlacementText({
+      program_assigned: 'Sp Ed',
+      sped_placement: 'Full Inclusion'
+    })).toEqual('Full Inclusion');
+    
+    expect(prettyProgramOrPlacementText({
+      program_assigned: 'SEIP',
+      sped_placement: null
+    })).toEqual('SEIP');
 
-  expect(prettyProgramOrPlacementText({
-    program_assigned: '2Way Spanish',
-    sped_placement: 'foo'
-  })).toEqual('2Way Spanish');
+    expect(prettyProgramOrPlacementText({
+      program_assigned: '2Way Spanish',
+      sped_placement: 'foo'
+    })).toEqual('2Way Spanish');
+  });
 });
 
 /*
 These test cases are sampled across districts from:
   puts Student.active.select(:program_assigned, :sped_placement, :disability, :sped_level_of_need).as_json.uniq.to_json;nil
 */
-describe('#prettyIepTextForStudent', () => {
+describe('#prettyIepTextForSpecialEducationStudent', () => {
   it('works for typical test cases', () => {
     
-    expect(prettyIepTextForStudent({
+    expect(prettyIepTextForSpecialEducationStudent({
+      program_assigned: null,
       sped_placement: '',
       disability: 'Intellectual',
       sped_level_of_need: 'High'
     })).toEqual('IEP for Intellectual');
     
-    expect(prettyIepTextForStudent({
+    expect(prettyIepTextForSpecialEducationStudent({
+      program_assigned: null,
       sped_placement: '',
       disability: 'Communication',
       sped_level_of_need: 'Low < 2'
     })).toEqual('IEP for Communication');
     
-    expect(prettyIepTextForStudent({
+    expect(prettyIepTextForSpecialEducationStudent({
+      program_assigned: null,
       sped_placement: 'Full Inclusion',
       disability: 'Communication',
       sped_level_of_need: 'Low < 2'
     })).toEqual('IEP for Communication');
     
-    expect(prettyIepTextForStudent({
+    expect(prettyIepTextForSpecialEducationStudent({
+      program_assigned: null,
       sped_placement: 'Full Inclusion',
       disability: 'Emotional',
       sped_level_of_need: 'High'
     })).toEqual('IEP for Emotional');
     
-    expect(prettyIepTextForStudent({
+    expect(prettyIepTextForSpecialEducationStudent({
+      program_assigned: null,
       sped_placement: 'Partial Inclusion',
       disability: 'Specific LDs',
       sped_level_of_need: 'Moderate'
     })).toEqual('IEP for Specific LDs');
     
-    expect(prettyIepTextForStudent({
+    expect(prettyIepTextForSpecialEducationStudent({
+      program_assigned: null,
       sped_placement: 'Public Seperate', // typo in SIS upstream
       disability: 'Specific LDs',
       sped_level_of_need: 'Moderate'
     })).toEqual('IEP for Specific LDs');
     
-    expect(prettyIepTextForStudent({
+    expect(prettyIepTextForSpecialEducationStudent({
+      program_assigned: null,
       sped_placement: 'Substantially Separate',
       disability: 'Autism',
       sped_level_of_need: 'Moderate'
     })).toEqual('IEP for Autism');
     
-    expect(prettyIepTextForStudent({
+    expect(prettyIepTextForSpecialEducationStudent({
+      program_assigned: null,
       sped_placement: 'Public Day',
       disability: 'Health',
       sped_level_of_need: 'High'
     })).toEqual('IEP for Health');
     
-    expect(prettyIepTextForStudent({
+    expect(prettyIepTextForSpecialEducationStudent({
+      program_assigned: null,
       sped_placement: 'Not special ed',
       disability: 'Sensory (Hearing)',
       sped_level_of_need: 'Low-2+ hrs/week'
     })).toEqual('IEP for Sensory (Hearing)');
     
-    expect(prettyIepTextForStudent({
+    expect(prettyIepTextForSpecialEducationStudent({
+      program_assigned: null,
       sped_placement: 'Full Inclusion',
       disability: 'Developmental Delay',
       sped_level_of_need: 'Low-Less Than 2hrs/week'
     })).toEqual('IEP for Developmental Delay');
     
-    expect(prettyIepTextForStudent({
+    expect(prettyIepTextForSpecialEducationStudent({
+      program_assigned: null,
       sped_placement: 'Substantially Separate',
       disability: 'Multiple Disabilities',
       sped_level_of_need: 'Moderate'
@@ -111,7 +135,8 @@ describe('#prettyIepTextForStudent', () => {
   });
 
   it('shows generic IEP for "Not special ed" and "Does Not Apply"', () => {
-    expect(prettyIepTextForStudent({
+    expect(prettyIepTextForSpecialEducationStudent({
+      program_assigned: null,
       sped_placement: 'Not special ed',
       disability: 'Does Not Apply',
       sped_level_of_need: 'Does Not Apply'
@@ -119,10 +144,20 @@ describe('#prettyIepTextForStudent', () => {
   });
 
   it('shows info about "Exited this year"', () => {
-    expect(prettyIepTextForStudent({
+    expect(prettyIepTextForSpecialEducationStudent({
+      program_assigned: null,
       sped_placement: 'Exited this year',
       disability: 'Emotional',
       sped_level_of_need: 'High'
     })).toEqual('Exited SPED this year');
+  });
+
+  it('always show fallback IEP text even if mistakenly called for non-special ed program assignment', () => {
+    expect(prettyIepTextForSpecialEducationStudent({
+      program_assigned: '2Way English',
+      sped_placement: null,
+      disability: null,
+      sped_level_of_need: null,
+    })).toEqual('IEP');
   });
 });

--- a/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
+++ b/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
@@ -10,7 +10,7 @@ import {
   hasAnySpecialEducationData,
   prettyProgramOrPlacementText,
   prettyLevelOfNeedText,
-  prettyIepTextForStudent,
+  prettyIepTextForSpecialEducationStudent,
   cleanSpecialEducationValues
 } from '../helpers/specialEducation';
 import {maybeCapitalize} from '../helpers/pretty';
@@ -27,6 +27,12 @@ UI component for seconds column with extra bits about the
 student (eg, IEP, FLEP, staff contacts).
 */
 export default class LightHeaderSupportBits extends React.Component {
+  educatorNamesFromServices() {
+    const {activeServices} = this.props;
+    const rawEducatorNames = activeServices.map(service => service.provided_by_educator_name);
+    return _.compact(_.uniq(rawEducatorNames)).filter(name => name !== '');
+  }
+
   render() {
     const {style} = this.props;
 
@@ -43,6 +49,10 @@ export default class LightHeaderSupportBits extends React.Component {
   }
 
   renderEducators() {
+    const {student} = this.props;
+    const hasAnyContacts = (student.counselor || student.sped_liaison || this.educatorNamesFromServices().length > 0);
+    if (!hasAnyContacts) return <span>No educator contacts</span>;
+
     return (
       <HelpBubble
         style={{marginLeft: 0, display: 'inline-block'}}
@@ -98,9 +108,7 @@ export default class LightHeaderSupportBits extends React.Component {
   }
 
   renderOtherStaff() {
-    const {activeServices} = this.props;
-    const rawEducatorNames = activeServices.map(service => service.provided_by_educator_name);
-    const educatorNames = _.compact(_.uniq(rawEducatorNames)).filter(name => name !== '');
+    const educatorNames = this.educatorNamesFromServices();
     if (educatorNames.length === 0) return null;
 
     return (
@@ -117,7 +125,7 @@ export default class LightHeaderSupportBits extends React.Component {
     const {student, iepDocument} = this.props;
     if (!hasAnySpecialEducationData(student, iepDocument)) return null;
     
-    const specialEducationText = prettyIepTextForStudent(student);
+    const specialEducationText = prettyIepTextForSpecialEducationStudent(student);
     const shouldRenderPdfInline = canViewPdfInline();
     return (
       <HelpBubble

--- a/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
+++ b/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
@@ -188,14 +188,8 @@ export default class LightHeaderSupportBits extends React.Component {
   }
 
   renderPdfInline(iepDocumentId) {
-    const url = `/iep_documents/${iepDocumentId}`;
-
-    return (
-      <Pdf
-        style={styles.pdfInline}
-        url={url}
-      />
-    );
+    const url = `/iep_documents/${iepDocumentId}#view=FitBH`;
+    return <Pdf style={styles.pdfInline} url={url} />;
   }
 
   render504() {

--- a/app/assets/javascripts/student_profile/Pdf.js
+++ b/app/assets/javascripts/student_profile/Pdf.js
@@ -2,15 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import PDFObject from 'pdfobject';
 
-// Based on https://pdfobject.com/
 
+// Based on https://pdfobject.com/
 export default class Pdf extends React.Component {
   render() {
     const {url, style} = this.props;
-    const urlWithFragment = `${url}#view=FitBH`;
     return (
       <object
-        data={urlWithFragment}
+        data={url}
         type='application/pdf' 
         style={style}
         width='100%' 
@@ -26,5 +25,6 @@ Pdf.propTypes = {
 
 // For callers to do different layouts
 export function canViewPdfInline() {
-  return PDFObject.supportsPDFs && !window.PDF_INLINE_VIEWING_DISABLED;
+  if (window.PDF_INLINE_VIEWING_DISABLED_IN_TEST) return false;
+  return PDFObject.supportsPDFs;
 }

--- a/app/assets/javascripts/student_profile/Pdf.js
+++ b/app/assets/javascripts/student_profile/Pdf.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import PDFObject from 'pdfobject';
 
 
-// Based on https://pdfobject.com/
+// View a PDF inline if the browser supports it.  See https://pdfobject.com/
 export default class Pdf extends React.Component {
   render() {
-    const {url, style} = this.props;
+    const {url, style, fallbackEl} = this.props;
     return (
       <object
         data={url}
@@ -14,17 +13,18 @@ export default class Pdf extends React.Component {
         style={style}
         width='100%' 
         height='100%'
-      />
+      >{fallbackEl || null}</object>
     );
   }
 }
 Pdf.propTypes = {
   url: PropTypes.string.isRequired,
-  style: PropTypes.object
+  style: PropTypes.object,
+  fallbackEl: PropTypes.node
 };
 
 // For callers to do different layouts
 export function canViewPdfInline() {
   if (window.PDF_INLINE_VIEWING_DISABLED_IN_TEST) return false;
-  return PDFObject.supportsPDFs;
+  return require('pdfobject').supportsPDFs;
 }

--- a/app/assets/javascripts/student_profile/Pdf.js
+++ b/app/assets/javascripts/student_profile/Pdf.js
@@ -26,5 +26,5 @@ Pdf.propTypes = {
 
 // For callers to do different layouts
 export function canViewPdfInline() {
-  return PDFObject.supportsPDFs;
+  return PDFObject.supportsPDFs && !window.PDF_INLINE_VIEWING_DISABLED;
 }

--- a/app/assets/javascripts/student_profile/Pdf.js
+++ b/app/assets/javascripts/student_profile/Pdf.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import PDFObject from 'pdfobject';
+
+// Based on https://pdfobject.com/
+
+export default class Pdf extends React.Component {
+  render() {
+    const {url, style} = this.props;
+    const urlWithFragment = `${url}#view=FitBH`;
+    return (
+      <object
+        data={urlWithFragment}
+        type='application/pdf' 
+        style={style}
+        width='100%' 
+        height='100%'
+      />
+    );
+  }
+}
+Pdf.propTypes = {
+  url: PropTypes.string.isRequired,
+  style: PropTypes.object
+};
+
+// For callers to do different layouts
+export function canViewPdfInline() {
+  return PDFObject.supportsPDFs;
+}

--- a/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
@@ -7381,28 +7381,6 @@ exports[`snapshots works for olaf math 1`] = `
                     }
                   }
                 >
-                  IEP
-                </a>
-              </div>
-              <div
-                style={
-                  Object {
-                    "display": "block",
-                    "marginLeft": 0,
-                  }
-                }
-              >
-                <a
-                  href="#"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "fontSize": 14,
-                      "outline": "none",
-                    }
-                  }
-                >
                   <div
                     style={
                       Object {
@@ -7415,28 +7393,9 @@ exports[`snapshots works for olaf math 1`] = `
                   </div>
                 </a>
               </div>
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "marginLeft": 0,
-                  }
-                }
-              >
-                <a
-                  href="#"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "fontSize": 14,
-                      "outline": "none",
-                    }
-                  }
-                >
-                  Educator contacts
-                </a>
-              </div>
+              <span>
+                No educator contacts
+              </span>
             </div>
           </div>
         </div>
@@ -8433,28 +8392,6 @@ exports[`snapshots works for olaf notes 1`] = `
                     }
                   }
                 >
-                  IEP
-                </a>
-              </div>
-              <div
-                style={
-                  Object {
-                    "display": "block",
-                    "marginLeft": 0,
-                  }
-                }
-              >
-                <a
-                  href="#"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "fontSize": 14,
-                      "outline": "none",
-                    }
-                  }
-                >
                   <div
                     style={
                       Object {
@@ -8467,28 +8404,9 @@ exports[`snapshots works for olaf notes 1`] = `
                   </div>
                 </a>
               </div>
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "marginLeft": 0,
-                  }
-                }
-              >
-                <a
-                  href="#"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "fontSize": 14,
-                      "outline": "none",
-                    }
-                  }
-                >
-                  Educator contacts
-                </a>
-              </div>
+              <span>
+                No educator contacts
+              </span>
             </div>
           </div>
         </div>
@@ -9485,28 +9403,6 @@ exports[`snapshots works for olaf reading 1`] = `
                     }
                   }
                 >
-                  IEP
-                </a>
-              </div>
-              <div
-                style={
-                  Object {
-                    "display": "block",
-                    "marginLeft": 0,
-                  }
-                }
-              >
-                <a
-                  href="#"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "fontSize": 14,
-                      "outline": "none",
-                    }
-                  }
-                >
                   <div
                     style={
                       Object {
@@ -9519,28 +9415,9 @@ exports[`snapshots works for olaf reading 1`] = `
                   </div>
                 </a>
               </div>
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "marginLeft": 0,
-                  }
-                }
-              >
-                <a
-                  href="#"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "fontSize": 14,
-                      "outline": "none",
-                    }
-                  }
-                >
-                  Educator contacts
-                </a>
-              </div>
+              <span>
+                No educator contacts
+              </span>
             </div>
           </div>
         </div>

--- a/app/controllers/iep_documents_controller.rb
+++ b/app/controllers/iep_documents_controller.rb
@@ -7,7 +7,7 @@ class IepDocumentsController < ApplicationController
 
     file_name = iep_document.file_name
     bytes = read_iep_document_bytes(file_name)
-    send_data bytes, filename: file_name, type: :pdf
+    send_data bytes, filename: file_name, type: 'application/pdf', disposition: 'inline'
   end
 
   private

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mixpanel-browser": "^2.22.4",
     "moment": "2.19.3",
     "object-assign": "^4.1.1",
+    "pdfobject": "^2.0.201604172",
     "percentile": "^1.2.0",
     "promise-polyfill": "^6.0.2",
     "query-string": "^5.1.0",

--- a/ui/config/setupTests.js
+++ b/ui/config/setupTests.js
@@ -52,4 +52,4 @@ if (process.listeners('unhandledRejection').length === 0) { // eslint-disable-li
 }
 
 // see <Pdf />
-window.PDF_INLINE_VIEWING_DISABLED = true;
+window.PDF_INLINE_VIEWING_DISABLED_IN_TEST = true;

--- a/ui/config/setupTests.js
+++ b/ui/config/setupTests.js
@@ -50,3 +50,6 @@ if (process.listeners('unhandledRejection').length === 0) { // eslint-disable-li
     throw error;
   });
 }
+
+// see <Pdf />
+window.PDF_INLINE_VIEWING_DISABLED = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5984,6 +5984,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pdfobject@^2.0.201604172:
+  version "2.0.201604172"
+  resolved "https://registry.yarnpkg.com/pdfobject/-/pdfobject-2.0.201604172.tgz#112edf93b98be121a5e780b06e7f5f78ad31ab3f"
+
 percentile@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/percentile/-/percentile-1.2.0.tgz#fa3b05c1ffd355b35228529834e5fa37f0bd465d"


### PR DESCRIPTION
Part of https://github.com/studentinsights/studentinsights/issues/1990, follow-on to https://github.com/studentinsights/studentinsights/pull/2070.

# Who is this PR for?
educators

# What problem does this PR fix?
Some educators have said it's helpful that they can see the IEP-at-a-glance here.  But for IE users, depending on their setup, they may have to complete several steps before they can actually see the document.

### 1. confirm
<img width="1013" alt="screen shot 2018-09-11 at 2 49 10 pm" src="https://user-images.githubusercontent.com/1056957/45381376-2d726a00-b5d3-11e8-82be-1bb856f51c2f.png">

### 2. open
<img width="996" alt="screen shot 2018-09-11 at 2 49 23 pm" src="https://user-images.githubusercontent.com/1056957/45381386-319e8780-b5d3-11e8-911d-f848a67c8d05.png">

### 3. choose viewer
<img width="591" alt="screen shot 2018-09-11 at 2 49 30 pm" src="https://user-images.githubusercontent.com/1056957/45381413-411dd080-b5d3-11e8-8f18-da97ec879cf0.png">

### 4. confirm opening
<img width="425" alt="screen shot 2018-09-11 at 2 49 36 pm" src="https://user-images.githubusercontent.com/1056957/45381420-467b1b00-b5d3-11e8-8981-31e82525c2ff.png">

### 5. reader application
<img width="1017" alt="screen shot 2018-09-11 at 2 49 42 pm" src="https://user-images.githubusercontent.com/1056957/45381431-49760b80-b5d3-11e8-91dd-ab20e0561ee5.png">

# What does this PR do?
Uses `PdfObject` to detect inline PDF viewing support, and if it's available, renders the PDF inline with `<object />`.  If not, falls back to the same download link.

I experimented with https://github.com/mozilla/pdf.js a pdf, to target helping users with older unconfigured browsers, but stopped as it's not intended as a drop-in JS dependency.

# Screenshot (if adding a client-side feature)
### Firefox
<img width="878" alt="screen shot 2018-09-11 at 2 29 08 pm" src="https://user-images.githubusercontent.com/1056957/45381588-a96cb200-b5d3-11e8-9e3d-98cb4f1dd407.png">

### Safari
<img width="927" alt="screen shot 2018-09-11 at 2 30 00 pm" src="https://user-images.githubusercontent.com/1056957/45381592-ae316600-b5d3-11e8-8051-8c2827210ba0.png">

### Chrome
<img width="960" alt="screen shot 2018-09-11 at 2 28 58 pm" src="https://user-images.githubusercontent.com/1056957/45381567-9eb21d00-b5d3-11e8-93c5-4e885e97ab42.png">

### IE11, with Acrobat installled, on initial view
<img width="897" alt="screen shot 2018-09-11 at 2 50 34 pm" src="https://user-images.githubusercontent.com/1056957/45381499-74f8f600-b5d3-11e8-926a-c2647afe27ea.png">

### IE11, with Acrobat installled, on closing and re-opening dialog
This shows something different, with more Acrobat toolbars and menus, not sure why.
<img width="883" alt="screen shot 2018-09-11 at 2 51 31 pm" src="https://user-images.githubusercontent.com/1056957/45381535-8d691080-b5d3-11e8-9168-949768464846.png">

### Fallback (IE, no PDF viewer)
<img width="578" alt="screen shot 2018-09-11 at 2 53 05 pm" src="https://user-images.githubusercontent.com/1056957/45381505-76c2b980-b5d3-11e8-806e-4dbe238f73cf.png">

# Checklists
+ [x] Author checked latest in IE - Student Profile