### PR TITLE
Remove selenium-driver, update rubyzip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,12 +30,12 @@ gem 'probability'
 gem 'rollbar'
 gem 'sass-rails', '~> 5.0'
 gem 'secure_headers'
-gem 'selenium-webdriver'
 gem 'sprockets'
 gem 'thor'
 gem 'uglifier', '>= 1.3.0'
 gem 'wicked_pdf'
 gem 'wkhtmltopdf-binary'
+gem 'rubyzip', '~> 1.2.2'
 
 # used to seed demo data in production
 gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,8 +89,6 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.0)
-    childprocess (0.9.0)
-      ffi (~> 1.0, >= 1.0.11)
     choice (0.2.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
@@ -275,7 +273,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-graphviz (1.2.3)
     ruby-progressbar (1.9.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -290,9 +288,6 @@ GEM
     secure_headers (5.0.5)
       useragent (>= 0.15.0)
     selectize-rails (0.12.4.1)
-    selenium-webdriver (3.11.0)
-      childprocess (~> 0.5)
-      rubyzip (~> 1.2)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     simplecov (0.16.1)
@@ -373,9 +368,9 @@ DEPENDENCIES
   rollbar
   rspec-rails
   rubocop
+  rubyzip (~> 1.2.2)
   sass-rails (~> 5.0)
   secure_headers
-  selenium-webdriver
   shoulda-matchers
   simplecov
   spring


### PR DESCRIPTION
Our code depends on `rubyzip` but we only pull it in transitively from `selenium-driver`, which we're not actually using.