### PR TITLE
Update PDF to optimistically show inline, rather than detecting

### DIFF
--- a/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
+++ b/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
@@ -126,18 +126,17 @@ export default class LightHeaderSupportBits extends React.Component {
     if (!hasAnySpecialEducationData(student, iepDocument)) return null;
     
     const specialEducationText = prettyIepTextForSpecialEducationStudent(student);
-    const shouldRenderPdfInline = canViewPdfInline();
     return (
       <HelpBubble
         style={{marginLeft: 0, display: 'block'}}
         teaser={specialEducationText}
         linkStyle={styles.subtitleItem}
-        modalStyle={shouldRenderPdfInline ? modalFullScreenFlex : modalFromLeft}
-        dialogStyle={shouldRenderPdfInline ? dialogFullScreenFlex : {}}
+        modalStyle={modalFullScreenFlex}
+        dialogStyle={dialogFullScreenFlex}
         title={`${student.first_name}'s ${specialEducationText}`}
         withoutSpacer={true}
         withoutContentWrapper={true}
-        content={this.renderIEPDialog(shouldRenderPdfInline)}
+        content={this.renderIEPDialog()}
       />
     );
   }
@@ -152,7 +151,7 @@ export default class LightHeaderSupportBits extends React.Component {
     );
   }
 
-  renderIEPDialog(shouldRenderPdfInline) {
+  renderIEPDialog() {
     const {districtKey} = this.context;
     const {student, iepDocument} = this.props;
 
@@ -188,7 +187,7 @@ export default class LightHeaderSupportBits extends React.Component {
         {iepDocument && (
           <div style={{...styles.contactItem, ...styles.iepDocumentSection}}>
             <a href={`/iep_documents/${iepDocument.id}`} style={styles.subtitleItem}>Download IEP at a glance PDF</a>
-            {shouldRenderPdfInline && this.renderPdfInline(iepDocument.id)}
+            {this.renderPdfInline(iepDocument.id)}
           </div>
         )}
       </div>
@@ -197,7 +196,13 @@ export default class LightHeaderSupportBits extends React.Component {
 
   renderPdfInline(iepDocumentId) {
     const url = `/iep_documents/${iepDocumentId}#view=FitBH`;
-    return <Pdf style={styles.pdfInline} url={url} />;
+    return (
+      <Pdf
+        style={styles.pdfInline}
+        url={url}
+        fallbackEl={<div>Firefox, Safari and Chrome can show you this right on the page!</div>}
+      />
+    );
   }
 
   render504() {

--- a/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
+++ b/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
@@ -20,7 +20,7 @@ import HelpBubble, {
   dialogFullScreenFlex
 } from '../components/HelpBubble';
 import AccessPanel from './AccessPanel';
-import Pdf, {canViewPdfInline} from './Pdf';
+import Pdf from './Pdf';
 
 /*
 UI component for seconds column with extra bits about the
@@ -200,7 +200,12 @@ export default class LightHeaderSupportBits extends React.Component {
       <Pdf
         style={styles.pdfInline}
         url={url}
-        fallbackEl={<div>Firefox, Safari and Chrome can show you this right on the page!</div>}
+        fallbackEl={(
+          <div style={styles.pdfFallbackMessage}>
+            <div>Use Firefox, Safari, Edge or Chrome to view this PDF right on the page.</div>
+            <div>If you're using an older version of Internet Explorer, you can install Adobe Acrobat Reader.</div>
+          </div>
+        )}
       />
     );
   }
@@ -309,6 +314,16 @@ const styles = {
     marginTop: 10,
     marginBottom: 10,
     border: '1px solid #333'
+  },
+  pdfFallbackMessage: {
+    padding: 20,
+    background: '#eee',
+    color: '#333',
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center'
   },
   iepDocumentSection: {
     marginTop: 20,

--- a/app/assets/javascripts/student_profile/Pdf.js
+++ b/app/assets/javascripts/student_profile/Pdf.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import PDFObject from 'pdfobject';
 
 
 // View a PDF inline if the browser supports it.  See https://pdfobject.com/
@@ -25,6 +26,5 @@ Pdf.propTypes = {
 
 // For callers to do different layouts
 export function canViewPdfInline() {
-  if (window.PDF_INLINE_VIEWING_DISABLED_IN_TEST) return false;
-  return require('pdfobject').supportsPDFs;
+  return PDFObject.supportsPDFs;
 }

--- a/app/assets/javascripts/student_profile/Pdf.js
+++ b/app/assets/javascripts/student_profile/Pdf.js
@@ -8,13 +8,13 @@ export default class Pdf extends React.Component {
   render() {
     const {url, style, fallbackEl} = this.props;
     return (
-      <iframe
-        src={url}
+      <object
+        data={url}
         type='application/pdf' 
         style={style}
         width='100%' 
         height='100%'
-      >{fallbackEl || null}</iframe>
+      >{fallbackEl || null}</object>
     );
   }
 }

--- a/app/assets/javascripts/student_profile/Pdf.js
+++ b/app/assets/javascripts/student_profile/Pdf.js
@@ -1,20 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import PDFObject from 'pdfobject';
 
 
 // View a PDF inline if the browser supports it.  See https://pdfobject.com/
+// Unfortunately 
 export default class Pdf extends React.Component {
   render() {
     const {url, style, fallbackEl} = this.props;
     return (
-      <object
-        data={url}
+      <iframe
+        src={url}
         type='application/pdf' 
         style={style}
         width='100%' 
         height='100%'
-      >{fallbackEl || null}</object>
+      >{fallbackEl || null}</iframe>
     );
   }
 }
@@ -24,7 +24,7 @@ Pdf.propTypes = {
   fallbackEl: PropTypes.node
 };
 
-// For callers to do different layouts
+
 export function canViewPdfInline() {
-  return PDFObject.supportsPDFs;
+  return true;
 }

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -2,10 +2,10 @@ SecureHeaders::Configuration.default do |config|
   # Set these all explicitly on top of the defaults, starting from guidance in
   # https://github.com/twitter/secure_headers/blob/5c47914f9c481d8c69fb7af141ed5a79b213bfa1/README.md#configuration
   config.hsts = "max-age=#{1.week.to_i}"
-  config.x_frame_options = "sameorigin"
-  config.x_content_type_options = "nosniff"
-  config.x_xss_protection = "1; mode=block"
-  config.x_permitted_cross_domain_policies = "none"
+  config.x_frame_options = 'sameorigin'
+  config.x_content_type_options = 'nosniff'
+  config.x_xss_protection = '1; mode=block'
+  config.x_permitted_cross_domain_policies = 'none'
   config.referrer_policy = %w(origin-when-cross-origin strict-origin-when-cross-origin)
 
   # Unblock PDF downloading for student report and for IEP-at-a-glance
@@ -37,7 +37,7 @@ SecureHeaders::Configuration.default do |config|
     child_src: %w('none'),
     frame_ancestors: %w('none'),
     media_src: %w('none'),
-    object_src: %w('self' https:), # for viewing PDF inline in Chrome PDF viewing (not for downloading)
+    object_src: %w('self' https:), # for viewing report/IEP PDFs inline (not for downloading)
     worker_src: %w('none'),
     plugin_types: nil
   }

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -2,7 +2,7 @@ SecureHeaders::Configuration.default do |config|
   # Set these all explicitly on top of the defaults, starting from guidance in
   # https://github.com/twitter/secure_headers/blob/5c47914f9c481d8c69fb7af141ed5a79b213bfa1/README.md#configuration
   config.hsts = "max-age=#{1.week.to_i}"
-  config.x_frame_options = "DENY"
+  config.x_frame_options = "sameorigin"
   config.x_content_type_options = "nosniff"
   config.x_xss_protection = "1; mode=block"
   config.x_permitted_cross_domain_policies = "none"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "mixpanel-browser": "^2.22.4",
     "moment": "2.19.3",
     "object-assign": "^4.1.1",
-    "pdfobject": "^2.0.201604172",
     "percentile": "^1.2.0",
     "promise-polyfill": "^6.0.2",
     "query-string": "^5.1.0",

--- a/ui/config/setupTests.js
+++ b/ui/config/setupTests.js
@@ -50,6 +50,3 @@ if (process.listeners('unhandledRejection').length === 0) { // eslint-disable-li
     throw error;
   });
 }
-
-// shim for PDFObject
-window.navigator.mimeTypes = {};

--- a/ui/config/setupTests.js
+++ b/ui/config/setupTests.js
@@ -51,5 +51,5 @@ if (process.listeners('unhandledRejection').length === 0) { // eslint-disable-li
   });
 }
 
-// see <Pdf />
-window.PDF_INLINE_VIEWING_DISABLED_IN_TEST = true;
+// shim for PDFObject
+window.navigator.mimeTypes = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5984,10 +5984,6 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pdfobject@^2.0.201604172:
-  version "2.0.201604172"
-  resolved "https://registry.yarnpkg.com/pdfobject/-/pdfobject-2.0.201604172.tgz#112edf93b98be121a5e780b06e7f5f78ad31ab3f"
-
 percentile@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/percentile/-/percentile-1.2.0.tgz#fa3b05c1ffd355b35228529834e5fa37f0bd465d"


### PR DESCRIPTION
Follow-up to https://github.com/studentinsights/studentinsights/pull/2072.

PDFObject's detection is broken for the Firefox pdf.js viewer specifically.  So this PR updates the strategy to optimistically show the PDF inline, and removes `PDFObject` rather than trying to detect.  I must have mixed this up in testing https://github.com/studentinsights/studentinsights/pull/2072.

Also updates CSP for `X-Frame-Options` to allow sameorigin, since Firefox blocks `<object />` requests without this (which seems to not follow the CSP rule for `object-src`).

# Screenshot (if adding a client-side feature)
### Firefox
<img width="950" alt="screen shot 2018-09-11 at 6 17 33 pm" src="https://user-images.githubusercontent.com/1056957/45391114-e47cde80-b5ef-11e8-93f8-5be4c06e1778.png">

### Safari
<img width="924" alt="screen shot 2018-09-11 at 6 22 24 pm" src="https://user-images.githubusercontent.com/1056957/45391105-dc24a380-b5ef-11e8-82d9-bdc52bf39b97.png">

### Chrome
<img width="885" alt="screen shot 2018-09-11 at 6 17 45 pm" src="https://user-images.githubusercontent.com/1056957/45391121-e9419280-b5ef-11e8-8987-2982b3f1065f.png">

### IE11 with Acrobat viewer
<img width="886" alt="screen shot 2018-09-11 at 6 19 15 pm" src="https://user-images.githubusercontent.com/1056957/45391159-f8284500-b5ef-11e8-905a-3e802722137f.png">


### IE11 without, upsell
<img width="887" alt="screen shot 2018-09-11 at 6 21 58 pm" src="https://user-images.githubusercontent.com/1056957/45391134-ee9edd00-b5ef-11e8-957d-b0474502bff2.png">

