### PR TITLE
Update yarn in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ branches:
 
 before_install:
   - export TZ=America/New_York
+  - curl -o- -L https://yarnpkg.com/install.sh | bash # see https://github.com/travis-ci/travis-ci/issues/7471#issuecomment-288832948
 
 install:
   - . $HOME/.nvm/nvm.sh

--- a/app/assets/javascripts/login_activity/LoginActivityPage.test.js
+++ b/app/assets/javascripts/login_activity/LoginActivityPage.test.js
@@ -35,7 +35,7 @@ it('renders after fetching', done => {
 
   setTimeout(() => {
     expect(el.innerHTML).toContain('Login Attempts, Past 30 days');
-    expect(el.querySelectorAll('div.tooltip').length).toEqual(47);
+    expect(el.querySelectorAll('div.tooltip').length).toEqual(41);
     done();
   }, 0);
 });

--- a/app/assets/javascripts/login_activity/LoginActivityPage.test.js
+++ b/app/assets/javascripts/login_activity/LoginActivityPage.test.js
@@ -36,7 +36,6 @@ it('renders after fetching', done => {
   setTimeout(() => {
     expect(el.innerHTML).toContain('Login Attempts, Past 30 days');
     expect(el.querySelectorAll('div.tooltip').length).toEqual(47);
-    console.log('debug:', el.innerHTML); // eslint-disable-line no-console
     done();
   }, 0);
 });

--- a/app/assets/javascripts/login_activity/LoginActivityPage.test.js
+++ b/app/assets/javascripts/login_activity/LoginActivityPage.test.js
@@ -36,6 +36,7 @@ it('renders after fetching', done => {
   setTimeout(() => {
     expect(el.innerHTML).toContain('Login Attempts, Past 30 days');
     expect(el.querySelectorAll('div.tooltip').length).toEqual(47);
+    console.log('debug:', el.innerHTML); // eslint-disable-line no-console
     done();
   }, 0);
 });


### PR DESCRIPTION
I think there's something wrong with our test setup across envs (but it could be just my machine).  I think that https://github.com/studentinsights/studentinsights/pull/2067 should have started failing the build in https://travis-ci.org/studentinsights/studentinsights/builds/426721325 since the test wasn't updated.  The assertion should be finding `41` tooltip divs, not `47` as there and still on master.

But the build didn't break, that test explicitly passes:
<img width="602" alt="screen shot 2018-09-13 at 9 12 55 am" src="https://user-images.githubusercontent.com/1056957/45490488-3c712d80-b735-11e8-8b1a-741a52d35741.png">

And none of the other test runs subsequently have failed.  Yet on my machine, this fails when I check out to master and run the tests.  So something isn't right, and reading the code it looks to me like this should be failing in the same way it is locally now for me.

In looking at the Travis logs, I saw yarn was behind.  I doubt this has anything to do with anything, but updating it and fixing the version seems good.  This PR also adds a `console.log` to the particular test so on the branch & master Travis builds I can see more about what's happening.