### PR TITLE
Add Educator login_name field

### DIFF
--- a/db/migrate/20180917133015_add_login_to_educators_table.rb
+++ b/db/migrate/20180917133015_add_login_to_educators_table.rb
@@ -1,0 +1,12 @@
+class AddLoginToEducatorsTable < ActiveRecord::Migration[5.2]
+  def change
+    add_column :educators, :login_name, :text, null: true
+
+    Educator.all.each do |educator|
+      login_name = educator.email.split('@').first
+      educator.update!(login_name: login_name)
+    end
+
+    change_column :educators, :login_name, :text, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_30_143340) do
+ActiveRecord::Schema.define(version: 2018_09_17_133015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,6 +150,7 @@ ActiveRecord::Schema.define(version: 2018_08_30_143340) do
     t.boolean "districtwide_access", default: false, null: false
     t.boolean "can_set_districtwide_access", default: false, null: false
     t.text "student_searchbar_json"
+    t.text "login_name", null: false
     t.index ["grade_level_access"], name: "index_educators_on_grade_level_access", using: :gin
   end
 


### PR DESCRIPTION
This is a small part of https://github.com/studentinsights/studentinsights/pull/2071, pulled off to deploy in smaller pieces.

# Who is this PR for?
Supporting Bedford's different login process.

# What problem does this PR fix?
We transform `login_name` on import now, this migrates Somerville and New Bedford to fill this in, enabling the next step to switch the import process to use `login_name` as the primary key across districts.  This is effectively how Somerville and New Bedford both work now (the email is just a suffix), but Bedford handles these differently, so this change will make it so that this is generalized across districts, and email becomes secondary.
