### PR TITLE
Update experimental SHS levels page to include core ELL courses under ELA

### DIFF
--- a/app/assets/javascripts/tiering/Courses.js
+++ b/app/assets/javascripts/tiering/Courses.js
@@ -28,7 +28,7 @@ export function labelAssignment(assignment) {
   if (matches(text, OTHER_SUPPORT)) return 'support';
   if (matches(text, PATH_PROGRAM)) return 'support';
 
-  if (matches(text, ELL)) return 'ell';
+  if (matches(text, ELL_SUPPORT)) return 'ell';
   if (matches(text, LIFE_SKILLS)) return 'life';
 
   if (matches(text, OTHER)) return 'elective';
@@ -83,8 +83,8 @@ const OTHER = [
 ];
 
 export const ELL = [
+  'ESL', // core ELL classes are considered part of the english dept.
   'ALCS - GENERAL SUPPORT',
-  'ESL',
   'GOAL PROGRAM DAILY SEMINAR',
   'ACADEMIC LITERACY'
 ];
@@ -94,6 +94,8 @@ export const ELA = [
   'READING FOUNDATIONS',
   'CREATIVE WRITING'
 ];
+
+export const EN_OR_ELL = ELL.concat(ELA);
 
 export const HISTORY = [
   'HISTORY',

--- a/app/assets/javascripts/tiering/Courses.js
+++ b/app/assets/javascripts/tiering/Courses.js
@@ -28,7 +28,7 @@ export function labelAssignment(assignment) {
   if (matches(text, OTHER_SUPPORT)) return 'support';
   if (matches(text, PATH_PROGRAM)) return 'support';
 
-  if (matches(text, ELL_SUPPORT)) return 'ell';
+  if (matches(text, ELL)) return 'ell';
   if (matches(text, LIFE_SKILLS)) return 'life';
 
   if (matches(text, OTHER)) return 'elective';

--- a/app/assets/javascripts/tiering/StudentLevelsTable.js
+++ b/app/assets/javascripts/tiering/StudentLevelsTable.js
@@ -6,7 +6,7 @@ import {toMomentFromTimestamp} from '../helpers/toMoment';
 import {prettyProgramOrPlacementText} from '../helpers/specialEducation';
 import {
   firstMatch,
-  ELA,
+  EN_OR_ELL,
   MATH,
   HISTORY,
   SCIENCE,
@@ -65,9 +65,9 @@ export default class StudentLevelsTable extends React.Component {
               cellRenderer={this.renderDisciplineIncidents} />
             <Column
               dataKey="ela"
-              label={<span><br />ELA</span>}
+              label={<span><br />EN/ELL</span>}
               width={gradeCellWidth}
-              cellRenderer={this.renderGradeFor.bind(this, ELA)} />
+              cellRenderer={this.renderGradeFor.bind(this, EN_OR_ELL)} />
             <Column
               dataKey="history"
               label={<span>Social<br/>Studies</span>}
@@ -118,7 +118,6 @@ export default class StudentLevelsTable extends React.Component {
       </AutoSizer>
     );
   }
-
 
   renderStudent({rowData}) {
     const student = rowData;


### PR DESCRIPTION
# Who is this PR for?
HS educators

# What problem does this PR fix?
Some students take an "core ELL courses" instead of ELA courses, and these aren't included right now.

# What does this PR do?
Includes ELL courses and changes caption to EN/ELL.

# Screenshot (if adding a client-side feature)
<img width="1006" alt="screen shot 2018-09-17 at 11 33 36 am" src="https://user-images.githubusercontent.com/1056957/45633529-005c0680-ba6e-11e8-9a19-88f6cb4dd6ce.png">
