### PR TITLE
Add housemaster-based FeedFilter for home page

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -112,6 +112,17 @@ class PerDistrict
     end
   end
 
+  # If this is enabled, filter students on the home page feed
+  # based on a mapping of the `house` field on the student and a specific
+  # `Educator`.  It may be individually feature switched as well.
+  def enable_housemaster_based_feed?
+    if @district_key == SOMERVILLE || @district_key == DEMO
+      EnvironmentVariable.is_true('ENABLE_HOUSEMASTER_BASED_FEED')
+    else
+      false
+    end
+  end
+
   # In the import process, we typically only get usernames
   # as the `login_name`, and emails are the same but with a domain
   # suffix.  But for Bedford, emails are distinct and imported separately

--- a/app/lib/env.rb
+++ b/app/lib/env.rb
@@ -21,7 +21,7 @@ class Env
     # feature switches
     default_env['ENABLE_COUNSELOR_BASED_FEED'] = 'true'
     default_env['ENABLE_HOUSEMASTER_BASED_FEED'] = 'true'
-    default_env['HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8'] = 'true'
+    default_env['HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8'] = 'false'
     default_env['ENABLE_MASQUERADING'] = 'true'
     default_env['ENABLE_STUDENT_VOICE_SURVEYS_UPLOADS'] = 'true'
     default_env['STUDENT_VOICE_SURVEY_FORM_URL'] = 'https://example.com/this-is-the-survey'

--- a/app/lib/env.rb
+++ b/app/lib/env.rb
@@ -20,6 +20,7 @@ class Env
 
     # feature switches
     default_env['ENABLE_COUNSELOR_BASED_FEED'] = 'true'
+    default_env['ENABLE_HOUSEMASTER_BASED_FEED'] = 'true'
     default_env['HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8'] = 'true'
     default_env['ENABLE_MASQUERADING'] = 'true'
     default_env['ENABLE_STUDENT_VOICE_SURVEYS_UPLOADS'] = 'true'

--- a/app/lib/feed.rb
+++ b/app/lib/feed.rb
@@ -5,7 +5,9 @@ class Feed
   def self.students_for_feed(educator)
     # Start with all students they are authorized to view
     authorizer = Authorizer.new(educator)
-    authorized_students = authorizer.authorized { Student.active.select(:counselor) }
+    authorized_students = authorizer.authorized do
+      Student.active.select(:counselor, :house) # these are fetching for FeedFilter below
+    end
 
     # Filter by role (eg, for HS counselors caseload)
     FeedFilter.new(educator).filter_for_educator(authorized_students)

--- a/app/lib/feed_filter.rb
+++ b/app/lib/feed_filter.rb
@@ -5,32 +5,55 @@ class FeedFilter
 
   # Apply any student filters by role, if they are enabled.
   def filter_for_educator(students)
-    filtered_students = students
+    filters = [CounselorFilter.new, HouseFilter.new]
 
-    if use_counselor_based_feed?
-      filtered_students = by_counselor_caseload(filtered_students)
+    filtered_students = students
+    filters.each do |filter|
+      filtered_students = filter.filter(filtered_students) if filter.enabled?
     end
 
     filtered_students
   end
 
   private
-  # For filtering base on the student's counselor field.
-  def by_counselor_caseload(students)
-    students.select {|student| is_counselor_for?(student) }
+  class CounselorFilter
+    # Check global env flag, then per-educator flag.
+    def enabled?
+      return false unless PerDistrict.new.enable_counselor_based_feed?
+      return false unless EducatorLabel.has_static_label?(@educator.id, 'use_counselor_based_feed')
+      true
+    end
+
+    # For filtering base on the student's counselor field.
+    def filter(students)
+      students.select {|student| is_counselor_for?(student) }
+    end
+
+    private
+    def is_counselor_for?(student)
+      return false unless use_counselor_based_feed?
+      return false if student.counselor.nil?
+      CounselorNameMapping.has_mapping? @educator.id, student.counselor.downcase
+    end
   end
 
-  # Check global env flag, then per-educator flag.
-  def use_counselor_based_feed?
-    return false unless PerDistrict.new.enable_counselor_based_feed?
-    return false unless EducatorLabel.has_static_label?(@educator.id, 'use_counselor_based_feed')
-    true
-  end
+  class HouseFilter
+    # Check global env flag, then per-educator flag.
+    def enabled?
+      return false unless PerDistrict.new.enable_housemaster_based_feed?
+      return false unless EducatorLabel.has_static_label?(@educator.id, 'use_housemaster_based_feed')
+      true
+    end
 
-  private
-  def is_counselor_for?(student)
-    return false unless use_counselor_based_feed?
-    return false if student.counselor.nil?
-    CounselorNameMapping.has_mapping? @educator.id, student.counselor.downcase
+    def filter(students)
+      students.select {|student| is_housemaster_for?(student) }
+    end
+
+    private
+    def is_housemaster_for?(student)
+      return false unless use_housemaster_based_feed?
+      return false if student.house.nil? || student.house == ''
+      HouseEducatorMapping.has_mapping? @educator.id, student.house.downcase
+    end
   end
 end

--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -13,6 +13,7 @@ class EducatorLabel < ActiveRecord::Base
         'high_school_house_master',
         'class_list_maker_finalizer_principal',
         'use_counselor_based_feed',
+        'use_housemaster_based_feed',
         'enable_class_lists_override',
         'can_upload_student_voice_surveys'
       ]

--- a/app/models/house_educator_mapping.rb
+++ b/app/models/house_educator_mapping.rb
@@ -1,0 +1,23 @@
+# Stores a mapping from the Student `house` field to an `educator` record
+# indicating the educator belongs to that house.
+class HouseEducatorMapping < ApplicationRecord
+  belongs_to :educator
+
+  validates :educator, presence: true
+  validates :house_field_text, presence: true, uniqueness: true
+  validate :validate_downcase_house_field_text
+
+  def self.has_mapping?(educator_id, house_text)
+    HouseEducatorMapping.find_by({
+      educator_id: educator_id,
+      house_field_text: house_text.downcase
+    }).present?
+  end
+
+  private
+  def validate_downcase_house_field_text
+    if house_field_text.try(:downcase) != house_field_text
+      errors.add(:house_field_text, 'must be lowercase')
+    end
+  end
+end

--- a/db/migrate/20180917194529_add_house_educator_mapping.rb
+++ b/db/migrate/20180917194529_add_house_educator_mapping.rb
@@ -1,0 +1,10 @@
+class AddHouseEducatorMapping < ActiveRecord::Migration[5.2]
+  def change
+    create_table :house_educator_mapping do |t|
+      t.text :house_field_text
+      t.integer :educator_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180917194529_add_house_educator_mappings.rb
+++ b/db/migrate/20180917194529_add_house_educator_mappings.rb
@@ -1,6 +1,6 @@
-class AddHouseEducatorMapping < ActiveRecord::Migration[5.2]
+class AddHouseEducatorMappings < ActiveRecord::Migration[5.2]
   def change
-    create_table :house_educator_mapping do |t|
+    create_table :house_educator_mappings do |t|
       t.text :house_field_text
       t.integer :educator_id
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2018_09_17_194529) do
 
   # These are extensions that must be enabled in order to support this database
@@ -216,7 +215,7 @@ ActiveRecord::Schema.define(version: 2018_09_17_194529) do
     t.index ["slug"], name: "index_homerooms_on_slug", unique: true
   end
 
-  create_table "house_educator_mapping", force: :cascade do |t|
+  create_table "house_educator_mappings", force: :cascade do |t|
     t.text "house_field_text"
     t.integer "educator_id"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_30_143340) do
+ActiveRecord::Schema.define(version: 2018_09_17_194529) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,6 +150,7 @@ ActiveRecord::Schema.define(version: 2018_08_30_143340) do
     t.boolean "districtwide_access", default: false, null: false
     t.boolean "can_set_districtwide_access", default: false, null: false
     t.text "student_searchbar_json"
+    t.text "login_name", null: false
     t.index ["grade_level_access"], name: "index_educators_on_grade_level_access", using: :gin
   end
 
@@ -212,6 +213,13 @@ ActiveRecord::Schema.define(version: 2018_08_30_143340) do
     t.index ["educator_id"], name: "index_homerooms_on_educator_id"
     t.index ["school_id", "name"], name: "index_homerooms_on_school_id_and_name", unique: true
     t.index ["slug"], name: "index_homerooms_on_slug", unique: true
+  end
+
+  create_table "house_educator_mapping", force: :cascade do |t|
+    t.text "house_field_text"
+    t.integer "educator_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "iep_documents", id: :serial, force: :cascade do |t|

--- a/spec/controllers/educators_controller_spec.rb
+++ b/spec/controllers/educators_controller_spec.rb
@@ -64,7 +64,19 @@ describe EducatorsController, :type => :controller do
       expect(included_student_ids(response)).to contain_exactly(*Student.all.map(&:id))
     end
 
-    it 'works for Harry as an example, showing he is authorized for 8th graders' do
+    it 'works for Harry as an example with dev setup' do
+      response = get_my_students(pals.shs_harry_housemaster)
+      expect(response).to be_successful
+      expect(included_student_ids(response)).to contain_exactly(*[
+        pals.shs_freshman_mari.id,
+        pals.shs_freshman_amir.id
+      ])
+    end
+
+    it 'works for Harry as an example, showing he is authorized for 8th graders when HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8').and_return('true')
+
       response = get_my_students(pals.shs_harry_housemaster)
       expect(response).to be_successful
       expect(included_student_ids(response)).to contain_exactly(*[

--- a/spec/lib/experimental_somerville_high_tiers_spec.rb
+++ b/spec/lib/experimental_somerville_high_tiers_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ExperimentalSomervilleHighTiers do
           "last_name"=>"Solo",
           "program_assigned"=>nil,
           "sped_placement"=>nil,
-          "house"=>"Elm",
+          "house"=>"Broadway",
           "student_section_assignments"=>[{
             "id"=>pals.shs_freshman_amir.student_section_assignments.first.id,
             "grade_numeric"=>"84.0",

--- a/spec/lib/feed_filter_spec.rb
+++ b/spec/lib/feed_filter_spec.rb
@@ -4,39 +4,85 @@ RSpec.describe FeedFilter do
   let!(:pals) { TestPals.create! }
   let!(:time_now) { pals.time_now }
 
-  context 'when disabled globally' do
-    before { @enabled_counselor_based_feed = ENV['ENABLE_COUNSELOR_BASED_FEED'] }
+  describe 'housemaster-based feed only' do
+    before { @enable_counselor_based_feed = ENV['ENABLE_COUNSELOR_BASED_FEED'] }
     before { ENV['ENABLE_COUNSELOR_BASED_FEED'] = nil }
-    after { ENV['ENABLE_COUNSELOR_BASED_FEED'] = @enabled_counselor_based_feed }
+    after { ENV['ENABLE_COUNSELOR_BASED_FEED'] = @enable_counselor_based_feed }
 
-    it 'does not filter for anyone' do
-      Educator.all.each do |educator|
-        unfiltered_students = Authorizer.new(educator).authorized { Student.active }
-        puts educator.login_name
-        expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
+    context 'when disabled globally' do
+      before { @enable_housemaster_based_feed = ENV['ENABLE_HOUSEMASTER_BASED_FEED'] }
+      before { ENV['ENABLE_HOUSEMASTER_BASED_FEED'] = nil }
+      after { ENV['ENABLE_HOUSEMASTER_BASED_FEED'] = @enable_housemaster_based_feed }
+
+      it 'does not filter for anyone' do
+        Educator.all.each do |educator|
+          unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
+          expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
+        end
+      end
+    end
+
+    context 'without mapping for educator' do
+      it 'does not filter' do
+        (Educator.all - [pals.shs_harry_housemaster]).each do |educator|
+          unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
+          expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
+        end
+      end
+    end
+
+    context 'when enabled globally and there is a mapping for educator' do
+      it 'does filter' do
+        unfiltered_students = Authorizer.new(pals.shs_harry_housemaster).authorized { Student.active.to_a }
+        expect(unfiltered_students).to contain_exactly(
+          pals.shs_freshman_mari,
+          pals.shs_freshman_amir
+        )
+        expect(FeedFilter.new(pals.shs_harry_housemaster).filter_for_educator(unfiltered_students)).to contain_exactly(*[
+          pals.shs_freshman_amir
+        ])
       end
     end
   end
 
-  context 'without mapping for educator' do
-    it 'does not filter' do
-      (Educator.all - [pals.shs_sofia_counselor]).each do |educator|
-        unfiltered_students = Authorizer.new(educator).authorized { Student.active }
-        expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
+  describe 'counselor-based feed only' do
+    before { @enable_housemaster_based_feed = ENV['ENABLE_HOUSEMASTER_BASED_FEED'] }
+    before { ENV['ENABLE_HOUSEMASTER_BASED_FEED'] = nil }
+    after { ENV['ENABLE_HOUSEMASTER_BASED_FEED'] = @enable_housemaster_based_feed }
+
+    context 'when disabled globally' do
+      before { @enabled_counselor_based_feed = ENV['ENABLE_COUNSELOR_BASED_FEED'] }
+      before { ENV['ENABLE_COUNSELOR_BASED_FEED'] = nil }
+      after { ENV['ENABLE_COUNSELOR_BASED_FEED'] = @enabled_counselor_based_feed }
+
+      it 'does not filter for anyone' do
+        Educator.all.each do |educator|
+          unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
+          expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
+        end
       end
     end
-  end
 
-  context 'when enabled globally and there is a mapping for educator' do
-    it 'does filter' do
-      unfiltered_students = Authorizer.new(pals.shs_sofia_counselor).authorized { Student.active.to_a }
-      expect(unfiltered_students).to contain_exactly(
-        pals.shs_freshman_mari,
-        pals.shs_freshman_amir
-      )
-      expect(FeedFilter.new(pals.shs_sofia_counselor).filter_for_educator(unfiltered_students)).to contain_exactly(*[
-        pals.shs_freshman_mari
-      ])
+    context 'without mapping for educator' do
+      it 'does not filter' do
+        (Educator.all - [pals.shs_sofia_counselor]).each do |educator|
+          unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
+          expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
+        end
+      end
+    end
+
+    context 'when enabled globally and there is a mapping for educator' do
+      it 'does filter' do
+        unfiltered_students = Authorizer.new(pals.shs_sofia_counselor).authorized { Student.active.to_a }
+        expect(unfiltered_students).to contain_exactly(
+          pals.shs_freshman_mari,
+          pals.shs_freshman_amir
+        )
+        expect(FeedFilter.new(pals.shs_sofia_counselor).filter_for_educator(unfiltered_students)).to contain_exactly(*[
+          pals.shs_freshman_mari
+        ])
+      end
     end
   end
 end

--- a/spec/lib/feed_filter_spec.rb
+++ b/spec/lib/feed_filter_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe FeedFilter do
     it 'does not filter for anyone' do
       Educator.all.each do |educator|
         unfiltered_students = Authorizer.new(educator).authorized { Student.active }
+        puts educator.login_name
         expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
       end
     end

--- a/spec/lib/feed_spec.rb
+++ b/spec/lib/feed_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Feed do
 
     it 'does not filter when counselor-based feed switch is disabled globally' do
       mock_per_district = PerDistrict.new
-      allow(mock_per_district).to_receive(:enable_counselor_based_feed?).and_return(false)
+      allow(mock_per_district).to receive(:enable_counselor_based_feed?).and_return(false)
       allow(PerDistrict).to receive(:new).and_return(mock_per_district)
       students = Feed.students_for_feed(pals.shs_sofia_counselor)
       expect(students.map(&:id)).to contain_exactly(*[

--- a/spec/lib/feed_spec.rb
+++ b/spec/lib/feed_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Feed do
     end
 
     it 'does not filter when counselor-based feed switch is disabled globally' do
-      mock_per_district = instance_double(PerDistrict, enable_counselor_based_feed?: false)
+      mock_per_district = PerDistrict.new
+      allow(mock_per_district).to_receive(:enable_counselor_based_feed?).and_return(false)
       allow(PerDistrict).to receive(:new).and_return(mock_per_district)
       students = Feed.students_for_feed(pals.shs_sofia_counselor)
       expect(students.map(&:id)).to contain_exactly(*[

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -380,6 +380,22 @@ class TestPals
       grade_letter: 'B'
     )
 
+    @shs_darius_housemaster = Educator.create!(
+      email: 'darius@demo.studentinsights.org',
+      full_name: 'Housemaster, Darius',
+      school: @shs,
+      schoolwide_access: true
+    )
+    EducatorLabel.create!({
+      educator: @shs_darius_housemaster,
+      label_key: 'use_housemaster_based_feed'
+    })
+    CounselorNameMapping.create!({
+      house_field_text: 'broadway',
+      educator_id: @shs_darius_housemaster.id
+    })
+
+
     reindex!
     self
   end

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -264,6 +264,14 @@ class TestPals
       educator: @shs_harry_housemaster,
       label_key: 'high_school_house_master'
     })
+    EducatorLabel.create!({
+      educator: @shs_harry_housemaster,
+      label_key: 'use_housemaster_based_feed'
+    })
+    HouseEducatorMapping.create!({
+      house_field_text: 'broadway',
+      educator_id: @shs_harry_housemaster.id
+    })
 
     # Bill Nye is a biology teacher at Somerville High School.  He teaches sections
     # on Tuesday and Thursday and has a homeroom period.  And he's on the NGE team.
@@ -381,7 +389,7 @@ class TestPals
       last_name: 'Solo',
       school: @shs,
       homeroom: @shs_jodi_homeroom,
-      house: 'Elm',
+      house: 'Broadway',
       counselor: 'FISHMAN',
       grade: '9',
       date_of_birth: '2003-02-07',
@@ -394,22 +402,6 @@ class TestPals
       grade_numeric: 84,
       grade_letter: 'B'
     )
-
-    @shs_darius_housemaster = Educator.create!(
-      login_name: 'darius',
-      email: 'darius@demo.studentinsights.org',
-      full_name: 'Housemaster, Darius',
-      school: @shs,
-      schoolwide_access: true
-    )
-    EducatorLabel.create!({
-      educator: @shs_darius_housemaster,
-      label_key: 'use_housemaster_based_feed'
-    })
-    HouseEducatorMapping.create!({
-      house_field_text: 'broadway',
-      educator_id: @shs_darius_housemaster.id
-    })
 
     reindex!
     self

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -396,6 +396,7 @@ class TestPals
     )
 
     @shs_darius_housemaster = Educator.create!(
+      login_name: 'darius',
       email: 'darius@demo.studentinsights.org',
       full_name: 'Housemaster, Darius',
       school: @shs,
@@ -405,11 +406,10 @@ class TestPals
       educator: @shs_darius_housemaster,
       label_key: 'use_housemaster_based_feed'
     })
-    CounselorNameMapping.create!({
+    HouseEducatorMapping.create!({
       house_field_text: 'broadway',
       educator_id: @shs_darius_housemaster.id
     })
-
 
     reindex!
     self


### PR DESCRIPTION
# Who is this PR for?
HS housemasters

# What problem does this PR fix?
Housemasters have access to all students at the school, which they need, but they usually are focused mostly on students in their house.  The feed and suggestions boxes on the home page have too much noise by including all students.  This is similar to https://github.com/studentinsights/studentinsights/issues/1675 for HS counselors.

# What does this PR do?
Adds another `FeedFilter` that filters based on:
1. `ENABLE_HOUSEMASTER_BASED_FEED` env variable
2. `EducatorLabel` for `use_housemaster_based_feed`
3. `HouseEducatorMapping` mapping educator to particular values for the house field on student records

# Screenshot (if adding a client-side feature)
### before, all houses
<img width="528" alt="screen shot 2018-09-17 at 5 21 55 pm" src="https://user-images.githubusercontent.com/1056957/45651625-f18e4780-ba9f-11e8-813c-3ed24d5c7995.png">

### after, just Broadway
<img width="499" alt="screen shot 2018-09-17 at 5 24 27 pm" src="https://user-images.githubusercontent.com/1056957/45651620-ec30fd00-ba9f-11e8-8739-ba59ebd665de.png">

# Checklists
+ [x] Author checked latest in IE - Home page
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code
