### PR TITLE
Simplify: Remove admin attribute from Educator and from authorization path

### DIFF
--- a/app/assets/javascripts/class_lists/ClassListCreatorPage.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorPage.js
@@ -526,7 +526,6 @@ ClassListCreatorPage.contextTypes = {
 ClassListCreatorPage.propTypes = {
   currentEducator: PropTypes.shape({
     id: PropTypes.number.isRequired,
-    admin: PropTypes.bool.isRequired,
     school_id: PropTypes.number,
     labels: PropTypes.arrayOf(PropTypes.string).isRequired
   }).isRequired,

--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -24,13 +24,11 @@ module Admin
 
       @districtwide_educators = []
       @can_set_educators = []
-      @admin_educators = []
       @restricted_notes_educators = []
 
       @all_educators.each do |educator|
         @districtwide_educators << educator if educator.districtwide_access
         @can_set_educators << educator if educator.can_set_districtwide_access
-        @admin_educators << educator if educator.admin
         @restricted_notes_educators << educator if educator.can_view_restricted_notes
       end
     end

--- a/app/controllers/educators_controller.rb
+++ b/app/controllers/educators_controller.rb
@@ -23,8 +23,7 @@ class EducatorsController < ApplicationController
         :can_view_restricted_notes,
         :schoolwide_access,
         :districtwide_access,
-        :grade_level_access,
-        :admin
+        :grade_level_access
       ],
       :methods => [:labels],
       :include => {

--- a/app/controllers/import_records_controller.rb
+++ b/app/controllers/import_records_controller.rb
@@ -1,13 +1,6 @@
 class ImportRecordsController < ApplicationController
-  # Authentication by default inherited from ApplicationController.
-  before_action :authorize_for_districtwide_access_admin # Extra authentication layer
+  before_action :ensure_authorized!
   include ActionView::Helpers::DateHelper
-
-  def authorize_for_districtwide_access_admin
-    unless current_educator.admin? && current_educator.districtwide_access?
-      render json: { error: "You don't have the correct authorization." }
-    end
-  end
 
   def import_records_json
     recent_records = ImportRecord.order(created_at: :desc).take(25)
@@ -20,6 +13,9 @@ class ImportRecordsController < ApplicationController
   end
 
   private
+  def ensure_authorized!
+    raise Exceptions::EducatorNotAuthorized unless current_educator.can_set_districtwide_access?
+  end
 
   def import_record_for_page(import_record)
     if import_record.completed?

--- a/app/controllers/is_service_working_controller.rb
+++ b/app/controllers/is_service_working_controller.rb
@@ -1,11 +1,5 @@
 class IsServiceWorkingController < ApplicationController
-  before_action :authorize_for_districtwide_access_admin
-
-  def authorize_for_districtwide_access_admin
-    unless current_educator.admin? && current_educator.districtwide_access?
-      raise Exceptions::EducatorNotAuthorized
-    end
-  end
+  before_action :ensure_authorized!
 
   def is_service_working_json
     service_type_id = params[:service_type_id]
@@ -30,4 +24,8 @@ class IsServiceWorkingController < ApplicationController
     render json: { chart_data: chart_data }
   end
 
+  private
+  def ensure_authorized!
+    raise Exceptions::EducatorNotAuthorized unless current_educator.can_set_districtwide_access?
+  end
 end

--- a/app/controllers/login_activities_controller.rb
+++ b/app/controllers/login_activities_controller.rb
@@ -1,11 +1,5 @@
 class LoginActivitiesController < ApplicationController
-  before_action :authorize_for_districtwide_access_admin
-
-  def authorize_for_districtwide_access_admin
-    unless current_educator.admin? && current_educator.districtwide_access?
-      raise Exceptions::EducatorNotAuthorized
-    end
-  end
+  before_action :ensure_authorized!
 
   def index_json
     params.require(:created_at_or_before)
@@ -21,6 +15,9 @@ class LoginActivitiesController < ApplicationController
   end
 
   private
+  def ensure_authorized!
+    raise Exceptions::EducatorNotAuthorized unless current_educator.can_set_districtwide_access?
+  end
 
   def login_activity_json(created_at_or_before:, created_after:)
     LoginActivity.where('created_at > ?', created_after)

--- a/app/controllers/service_uploads_controller.rb
+++ b/app/controllers/service_uploads_controller.rb
@@ -1,13 +1,5 @@
 class ServiceUploadsController < ApplicationController
-  # Authentication by default inherited from ApplicationController.
-
-  before_action :authorize_for_districtwide_access_admin # Extra authentication layer
-
-  def authorize_for_districtwide_access_admin
-    unless current_educator.admin? && current_educator.districtwide_access?
-      render json: { error: "You don't have the correct authorization." }
-    end
-  end
+  before_action :ensure_authorized!
 
   def create
     service_upload = ServiceUpload.new(
@@ -97,6 +89,9 @@ class ServiceUploadsController < ApplicationController
   end
 
   private
+    def ensure_authorized!
+      raise Exceptions::EducatorNotAuthorized unless current_educator.can_set_districtwide_access?
+    end
 
     def past_service_upload_json
       ServiceUpload.includes(services: [:student, :service_type])

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -6,7 +6,7 @@ class StudentsController < ApplicationController
     :lasids,
     :sample_students_json
   ]
-  before_action :authorize_for_districtwide_access_admin, only: [
+  before_action :ensure_authorized_for_project_lead!, only: [
     :lasids
   ]
 
@@ -142,10 +142,8 @@ class StudentsController < ApplicationController
     raise Exceptions::EducatorNotAuthorized unless current_educator.is_authorized_for_student(student)
   end
 
-  def authorize_for_districtwide_access_admin
-    unless current_educator.admin? && current_educator.districtwide_access?
-      render json: { error: "You don't have the correct authorization." }
-    end
+  def ensure_authorized_for_project_lead!
+    raise Exceptions::EducatorNotAuthorized unless current_educator.can_set_districtwide_access?
   end
 
   def should_redirect_to_profile_v3?(params)

--- a/app/controllers/ui_controller.rb
+++ b/app/controllers/ui_controller.rb
@@ -5,7 +5,7 @@ class UiController < ApplicationController
   # run and take over rendering, fetching what data it needs, etc.
   def ui
     current_educator_json = current_educator.as_json({
-      only: [:id, :admin, :school_id],
+      only: [:id, :school_id],
       methods: [:labels]
     })
     @serialized_data = {

--- a/app/dashboards/educator_dashboard.rb
+++ b/app/dashboards/educator_dashboard.rb
@@ -59,7 +59,6 @@ class EducatorDashboard < Administrate::BaseDashboard
     :homeroom,
     :email,
     :sign_in_count,
-    :admin,
     :full_name,
     :schoolwide_access,
     :grade_level_access,

--- a/app/importers/rows/educator_row.rb
+++ b/app/importers/rows/educator_row.rb
@@ -14,10 +14,17 @@ class EducatorRow < Struct.new(:row, :school_ids_dictionary)
       staff_type: row[:staff_type],
       admin: is_admin?,
       local_id: row[:local_id],
-      school_id: school_rails_id,
-      schoolwide_access: is_admin?,
-      can_view_restricted_notes: is_admin?
+      school_id: school_rails_id
     })
+
+    # only update the attributes when creating a new record, since
+    # these are mutated and overwritten by the Insights permissions UI
+    if educator.new_record?
+      educator.assign_attributes({
+        schoolwide_access: is_admin?,
+        can_view_restricted_notes: is_admin?
+      })
+    end
 
     educator
   end

--- a/app/importers/rows/educator_row.rb
+++ b/app/importers/rows/educator_row.rb
@@ -8,43 +8,23 @@ class EducatorRow < Struct.new(:row, :school_ids_dictionary)
     # login_name is the primary key, and email is always secondary
     educator = Educator.find_or_initialize_by(login_name: login_name)
     educator.assign_attributes({
-      email: email_from_row,
       state_id: row[:state_id],
       full_name: row[:full_name],
       staff_type: row[:staff_type],
-      admin: is_admin?,
       local_id: row[:local_id],
+      email: email_from_row,
       school_id: school_rails_id
     })
-
-    # only update the attributes when creating a new record, since
-    # these are mutated and overwritten by the Insights permissions UI
-    if educator.new_record?
-      educator.assign_attributes({
-        schoolwide_access: is_admin?,
-        can_view_restricted_notes: is_admin?
-      })
-    end
-
     educator
   end
 
   private
-
   def email_from_row
     PerDistrict.new.email_from_educator_import_row(row)
   end
 
-  def is_admin?
-    row[:staff_type].present? && row[:staff_type] == 'Administrator'
-  end
-
-  def school_local_id
-    row[:school_local_id]
-  end
-
   def school_rails_id
+    school_local_id = row[:school_local_id]
     school_ids_dictionary[school_local_id] if school_local_id.present?
   end
-
 end

--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -47,8 +47,7 @@ class Authorizer
       :restricted_to_sped_students,
       :restricted_to_english_language_learners,
       :districtwide_access,
-      :school_id,
-      :admin
+      :school_id
     ]
   end
 
@@ -104,7 +103,7 @@ class Authorizer
       return false if @educator.restricted_to_english_language_learners && student.limited_english_proficiency == 'Fluent'
       return false if @educator.school_id.present? && student.school_id.present? && @educator.school_id != student.school_id
 
-      return true if @educator.schoolwide_access? || @educator.admin? # Schoolwide admin
+      return true if @educator.schoolwide_access? # Schoolwide admin
       return true if @educator.has_access_to_grade_levels? && student.grade.in?(@educator.grade_level_access) # Grade level access
 
       # The next two checks call `#to_a` as a performance optimization.
@@ -142,7 +141,7 @@ class Authorizer
 
     return false if @educator.school.present? && @educator.school != section.course.school
 
-    return true if @educator.schoolwide_access? || @educator.admin?
+    return true if @educator.schoolwide_access?
     return true if section.in?(@educator.sections)
     false
   end

--- a/app/lib/class_list_queries.rb
+++ b/app/lib/class_list_queries.rb
@@ -138,7 +138,6 @@ class ClassListQueries
     return false unless is_authorized_for_school_id?(school_id)
 
     return true if @educator.districtwide_access?
-    return true if @educator.admin?
     return true if @educator.schoolwide_access?
     return true if grade_level_now.in?(student_and_homeroom_grade_levels_now(school_id))
 

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -17,7 +17,6 @@ class Educator < ActiveRecord::Base
   validates :login_name, presence: true, uniqueness: true, case_sensitive: false
 
   validate :validate_has_school_unless_districtwide,
-           :validate_admin_gets_access_to_all_students,
            :validate_grade_level_access_is_array_of_strings,
            :validate_grade_level_strings_are_valid,
            :validate_grade_level_strings_are_uniq,
@@ -111,14 +110,6 @@ class Educator < ActiveRecord::Base
     if school.blank?
       errors.add(:school_id, 'must be assigned a school unless districtwide') unless districtwide_access?
     end
-  end
-
-  def validate_admin_gets_access_to_all_students
-    has_access_to_all_students = (
-      restricted_to_sped_students == false &&
-      restricted_to_english_language_learners == false
-    )
-    errors.add(:admin, "needs access to all students") if admin? && !has_access_to_all_students
   end
 
   def validate_grade_level_access_is_array_of_strings

--- a/app/views/admin/educators/authorization.html.erb
+++ b/app/views/admin/educators/authorization.html.erb
@@ -11,26 +11,27 @@
     <table style="margin-top: 40px; text-align: left;">
       <thead>
         <tr>
-          <th>Email</th>
           <th>Name</th>
-          <th>Can set access</th>
-          <th>Admin</th>
-          <th>Restricted notes</th>
-          <th>Districtwide</th>
-          <th>School</th>
+          <th>Insights: Can set access</th>
+          <th>Insights: Restricted notes</th>
+          <th>Insights: Districtwide</th>
+          <th>SIS: Staff type</th>
+          <th>SIS: School</th>
         </tr>
       </thead>
       <tbody>
-        <% educators = (@can_set_educators + @admin_educators + @districtwide_educators).uniq %>
+        <% educators = (@can_set_educators + @districtwide_educators + @restricted_notes_educators).uniq %>
         <% educators.map do |educator| %>
           <tr>
-            <td><%= educator.email %></td>
-            <td><%= link_to educator.full_name, "/educators/view/#{educator.id}" %></td>
+            <td>
+              <div><%= educator.email %></div>
+              <div><%= link_to educator.full_name, "/educators/view/#{educator.id}" %></div>
+            </td>
             <td><%= educator.can_set_districtwide_access %></td>
-            <td><%= educator.admin %></td>
             <td><%= educator.can_view_restricted_notes %></td>
             <td><%= educator.districtwide_access %></td>
-            <td><%= educator.school.try(:name) || "N/A" %></td>
+            <td><%= educator.staff_type || '(none)' %></td>
+            <td><%= educator.school.try(:name) || '(none)' %></td>
         <% end %>
       </tbody>
     </table>

--- a/db/migrate/20160606205352_set_restricted_notes_access_for_users_with_nil.rb
+++ b/db/migrate/20160606205352_set_restricted_notes_access_for_users_with_nil.rb
@@ -3,7 +3,6 @@ class SetRestrictedNotesAccessForUsersWithNil < ActiveRecord::Migration[4.2]
     Educator.find_each do |educator|
       if educator.can_view_restricted_notes.nil?
         educator.can_view_restricted_notes = false
-        educator.can_view_restricted_notes = true if educator.admin?
         educator.save
       end
     end

--- a/db/migrate/20180918153205_remove_educator_admin.rb
+++ b/db/migrate/20180918153205_remove_educator_admin.rb
@@ -1,0 +1,5 @@
+class RemoveEducatorAdmin < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :educators, :admin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_17_222601) do
+ActiveRecord::Schema.define(version: 2018_09_18_153205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,7 +135,6 @@ ActiveRecord::Schema.define(version: 2018_09_17_222601) do
     t.inet "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean "admin", default: false
     t.string "phone"
     t.string "full_name"
     t.string "state_id"

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -182,9 +182,9 @@ describe HomeroomsController, :type => :controller do
 
     end
 
-    context 'admin educator logged in' do
-      let(:admin_educator) { FactoryBot.create(:educator, :admin, school: school) }
-      before { sign_in(admin_educator) }
+    context 'schoolwide access educator logged in' do
+      let(:educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school) }
+      before { sign_in(educator) }
 
       context 'no homeroom params' do
         it 'raises an error' do

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -42,7 +42,7 @@ describe ProfileController, :type => :controller do
     end
 
     describe 'integration test for restricted note redactions' do
-      let(:educator) { FactoryBot.create(:educator, :admin, school: school, full_name: "Teacher, Karen") }
+      let(:educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school, full_name: "Teacher, Karen") }
 
       before do
         event_note = FactoryBot.create(:event_note, student: student, text: 'RESTRICTED-one', is_restricted: true)
@@ -61,7 +61,7 @@ describe ProfileController, :type => :controller do
     end
 
     describe 'integration test for transition note redactions' do
-      let(:educator) { FactoryBot.create(:educator, :admin, school: school, full_name: "Teacher, Karen") }
+      let(:educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school, full_name: "Teacher, Karen") }
 
       before do
         FactoryBot.create(:transition_note, student: student, text: 'RESTRICTED-transition-note', is_restricted: true)
@@ -79,7 +79,7 @@ describe ProfileController, :type => :controller do
     end
 
     describe 'integration test for profile_insights' do
-      let!(:educator) { FactoryBot.create(:educator, :admin, school: school, full_name: "Teacher, Karen") }
+      let!(:educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school, full_name: "Teacher, Karen") }
       let!(:transition_note_text) do
         "What are this student's strengths?\neverything!\n\nWhat is this student's involvement in the school community like?\nreally good\n\nHow does this student relate to their peers?\nnot sure\n\nWho is the student's primary guardian?\nokay\n\nAny additional comments or good things to know about this student?\nnope :)"
       end
@@ -144,7 +144,7 @@ describe ProfileController, :type => :controller do
       before { sign_in(educator) }
 
       context 'educator has schoolwide access' do
-        let(:educator) { FactoryBot.create(:educator, :admin, school: school, full_name: "Teacher, Karen") }
+        let(:educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school, full_name: "Teacher, Karen") }
 
         it 'is successful' do
           make_request(educator, student.id)
@@ -257,7 +257,7 @@ describe ProfileController, :type => :controller do
       end
 
       context 'educator has an associated label' do
-        let(:educator) { FactoryBot.create(:educator, :admin, school: school) }
+        let(:educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school) }
         let!(:label) { EducatorLabel.create!(label_key: 'k8_counselor', educator: educator) }
 
         it 'serializes the educator label correctly' do
@@ -407,7 +407,7 @@ describe ProfileController, :type => :controller do
 
   describe '#student_feed' do
     let(:student) { FactoryBot.create(:student) }
-    let(:educator) { FactoryBot.create(:educator, :admin) }
+    let(:educator) { FactoryBot.create(:educator) }
     let!(:service) { create_service(student, educator) }
     let!(:event_note) { create_event_note(student, educator) }
 

--- a/spec/controllers/profile_pdf_controller_spec.rb
+++ b/spec/controllers/profile_pdf_controller_spec.rb
@@ -9,7 +9,7 @@ describe ProfilePdfController, :type => :controller do
   end
 
   describe '#student_report' do
-    let(:educator) { FactoryBot.create(:educator, :admin, school: school) }
+    let(:educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school) }
     let(:school) { FactoryBot.create(:school) }
     let(:student) { FactoryBot.create(:student, school: school) }
 

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -87,7 +87,7 @@ describe SchoolsController, :type => :controller do
 
     context 'educator is an admin with schoolwide access' do
       let!(:school) { pals.healey }
-      let!(:educator) { FactoryBot.create(:educator, :admin, school: school) }
+      let!(:educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school) }
       let!(:include_me) { FactoryBot.create(:student, :registered_last_year, school: school) }
       let!(:include_me_too) { FactoryBot.create(:student, :registered_last_year, school: school) }
       let!(:include_me_not) { FactoryBot.create(:student, :registered_last_year ) }

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -231,10 +231,10 @@ describe SectionsController, :type => :controller do
           end
         end
 
-        context 'admin educator logged in' do
-          let(:admin_educator) { FactoryBot.create(:educator, :admin, school: school) }
+        context 'schoolwide_access educator logged in' do
+          let(:schoolwide_educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school) }
 
-          before { sign_in(admin_educator) }
+          before { sign_in(schoolwide_educator) }
 
           context 'when requesting a section inside their school' do
             it 'is successful' do

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -45,7 +45,7 @@ describe ServicesController, :type => :controller do
     let(:school) { FactoryBot.create(:school) }
     let(:student) { FactoryBot.create(:student, school: school) }
     let(:homeroom) { student.homeroom }
-    let(:educator) { FactoryBot.create(:educator, :admin, school: school) }
+    let(:educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school) }
     let(:service) { create_service(student, educator) }
     before { sign_in(educator) }
 

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -47,7 +47,7 @@ describe StudentsController, :type => :controller do
       before { sign_in(educator) }
 
       context 'educator has schoolwide access' do
-        let(:educator) { FactoryBot.create(:educator, :admin, school: school, full_name: "Teacher, Karen") }
+        let(:educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school, full_name: "Teacher, Karen") }
         let(:serialized_data) { assigns(:serialized_data) }
 
         it 'is successful' do
@@ -138,7 +138,7 @@ describe StudentsController, :type => :controller do
       end
 
       context 'educator has an associated label' do
-        let(:educator) { FactoryBot.create(:educator, :admin, school: school) }
+        let(:educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school) }
         let!(:label) { EducatorLabel.create!(label_key: 'k8_counselor', educator: educator) }
         let(:serialized_data) { assigns(:serialized_data) }
 
@@ -282,7 +282,7 @@ describe StudentsController, :type => :controller do
     end
 
     context 'admin educator logged in' do
-      let!(:educator) { FactoryBot.create(:educator, :admin, school: school) }
+      let!(:educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school) }
       let!(:provided_by_educator) { FactoryBot.create(:educator, school: school) }
       let!(:student) { FactoryBot.create(:student, school: school) }
 
@@ -365,7 +365,7 @@ describe StudentsController, :type => :controller do
     end
 
     context 'admin educator logged in, no cached student names' do
-      let!(:educator) { FactoryBot.create(:educator, :admin, school: school) }
+      let!(:educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school) }
       before { sign_in(educator) }
       let!(:juan) {
         FactoryBot.create(
@@ -388,8 +388,8 @@ describe StudentsController, :type => :controller do
 
     context 'admin educator logged in, cached student names' do
       let!(:educator) {
-        FactoryBot.create(
-          :educator, :admin,
+        FactoryBot.create(:educator,
+          schoolwide_access: true,
           school: school,
           student_searchbar_json: "[{\"label\":\"Juan P - HEA - 5\",\"id\":\"700\"}]"
         )
@@ -446,7 +446,7 @@ describe StudentsController, :type => :controller do
 
   describe '#student_feed' do
     let(:student) { FactoryBot.create(:student) }
-    let(:educator) { FactoryBot.create(:educator, :admin) }
+    let(:educator) { FactoryBot.create(:educator) }
     let!(:service) { create_service(student, educator) }
     let!(:event_note) { create_event_note(student, educator) }
 
@@ -489,7 +489,7 @@ describe StudentsController, :type => :controller do
       before { sign_in(educator) }
 
       context 'educator cannot view restricted notes' do
-        let(:educator) { FactoryBot.create(:educator, :admin, can_view_restricted_notes: false, school: school) }
+        let(:educator) { FactoryBot.create(:educator, can_view_restricted_notes: false, school: school) }
 
         it 'is not successful' do
           make_request(student)
@@ -507,7 +507,7 @@ describe StudentsController, :type => :controller do
       end
 
       context 'educator can view restricted notes' do
-        let(:educator) { FactoryBot.create(:educator, :admin, can_view_restricted_notes: true, school: school) }
+        let(:educator) { FactoryBot.create(:educator, can_view_restricted_notes: true, school: school) }
 
         it 'is successful' do
           make_request(student)

--- a/spec/demo_data/fake_student_spec.rb
+++ b/spec/demo_data/fake_student_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe FakeStudent do
 
   let!(:school) { FactoryBot.create(:school) }
   let!(:homeroom) { FactoryBot.create(:homeroom, grade: '5') }
-  before { FactoryBot.create(:educator, :admin) }
+  before { FactoryBot.create(:educator) }
 
   let(:student) { FakeStudent.create!(school, homeroom) }
 

--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -20,13 +20,6 @@ FactoryBot.define do
     local_id { FactoryBot.generate(:staff_local_id) }
     association :school
 
-    trait :admin do
-      admin true
-      schoolwide_access true
-      restricted_to_sped_students false
-      restricted_to_english_language_learners false
-    end
-
     trait :without_email do
       email nil
     end

--- a/spec/lib/profile_insights_spec.rb
+++ b/spec/lib/profile_insights_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ProfileInsights do
   describe '#as_json' do
     let!(:school) { FactoryBot.create(:school) }
     let!(:student) { FactoryBot.create(:student, school: school) }
-    let!(:educator) { FactoryBot.create(:educator, :admin, school: school, full_name: "Teacher, Karen") }
+    let!(:educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school, full_name: "Teacher, Karen") }
 
     describe 'on happy path' do
       let!(:transition_note_text) do

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -46,21 +46,6 @@ RSpec.describe Educator do
     end
   end
 
-  describe '#admin_gets_access_to_all_students' do
-    context 'admin with access to all students' do
-      let(:admin) { FactoryBot.build(:educator, :admin) }
-      it 'is valid' do
-        expect(admin).to be_valid
-      end
-    end
-    context 'admin without access to all students' do
-      let(:admin) { FactoryBot.build(:educator, :admin, restricted_to_sped_students: true) }
-      it 'is invalid' do
-        expect(admin).to be_invalid
-      end
-    end
-  end
-
   describe 'grade level access' do
     context 'mix of strings and not strings' do
       let(:educator) { FactoryBot.create(:educator, grade_level_access: ['3', 4]) }

--- a/spec/reports/students_spreadsheet_spec.rb
+++ b/spec/reports/students_spreadsheet_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe StudentsSpreadsheet do
   context 'with generated students' do
     let!(:pals) { TestPals.create! }
     let!(:school) { School.find_by_name('Arthur D Healey') }
-    let!(:educator) { FactoryBot.create(:educator, :admin, school: school) }
+    let!(:educator) { FactoryBot.create(:educator, schoolwide_access: school, school: school) }
     let!(:homeroom) { Homeroom.create(name: 'HEA 300', grade: '3', school: school) }
     before do
       # the test data is not deterministic (setting a seed in srand only worked on

--- a/ui/App.js
+++ b/ui/App.js
@@ -271,7 +271,6 @@ App.propTypes = {
   districtKey: PropTypes.string.isRequired,
   currentEducator: PropTypes.shape({
     id: PropTypes.number.isRequired,
-    admin: PropTypes.bool.isRequired,
     school_id: PropTypes.number,
     labels: PropTypes.arrayOf(PropTypes.string).isRequired
   }).isRequired,


### PR DESCRIPTION
# Who is this PR for?
developers and project leads

# What problem does this PR fix?
The way that `staff_type` influences permissions is complicated and the interaction between values in Aspen and Insights isn't clear in the UI or code.  This leaves open edge cases related to critical path authorization.  The first time the educator record is created, the `staff_type` value influences `schoolwide_access` and `can_view_restricted_notes` but the import process only does this once and these relationships aren't kept in sync over time if the underlying SIS `staff_type` value changes.

# What does this PR do?
Removes `admin` as a value that's computed from `staff_type` and as a result remove `staff_type` from influencing Insights authorization altogether.  This makes it an explicit steps for project leads to allow new users schoolwide access or to restricted notes, which this PR views as a security improvement.

Separately, this tightens authorization in several controllers where were using `admin+districtwide_access` in endpoints where we really should be restricting access to project leads only (and where the UI already had removed these links).

# Checklists
+ [ ] Author checked latest in IE - Home page
+ [ ] Author checked latest in IE - My Sections page
+ [ ] Author checked latest in IE - Section page
+ [ ] Author checked latest in IE - Homeroom page
+ [ ] Author checked latest in IE - Service upload
+ [ ] Author checked latest in IE - Districtwide
+ [ ] Author checked latest in IE - Is the service working
+ [ ] Author checked latest in IE - Is the service working
+ [ ] Author checked latest in IE - Student Profile
+ [ ] Author checked latest in IE - Student Report PDF
+ [ ] Author checked latest in IE - School Overview
+ [ ] Author improved specs for code in need of better test coverage
+ [ ] Author included specs for new code

(this still needs testing)