### PR TITLE
Remove School state_id, work towards tightening validations

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,11 +1,22 @@
 class School < ActiveRecord::Base
   extend FriendlyId
   friendly_id :local_id, use: :slugged
-  validates :local_id, presence: true, uniqueness: true
-  validate :validate_school_type
+
+  # These are internal to Insights, not from the SIS
+  VALID_SCHOOL_TYPES = [
+    'ECS', # early childhood
+    'ES', # elementary
+    'ESMS', # elementary and middle
+    'MS', # middle
+    'HS', # high
+    'OTHER' # anything else
+  ]
+
   has_many :students
   has_many :educators
   has_many :homerooms
+
+  validates :local_id, presence: true, uniqueness: true
 
   def self.with_students
     School.all.select { |s| s.students.count > 0 }
@@ -37,13 +48,5 @@ class School < ActiveRecord::Base
 
   def is_high_school?
     school_type == 'HS'
-  end
-
-  private
-  def validate_school_type
-    whitelist = ['ES', 'MS', 'ESMS', 'HS', nil]
-    if !whitelist.include?(school_type)
-      errors.add(:school_type, 'invalid school_type; use nil for unknown values or add to validation whitelist')
-    end
   end
 end

--- a/db/migrate/20180918174852_remove_school_state_id.rb
+++ b/db/migrate/20180918174852_remove_school_state_id.rb
@@ -1,0 +1,5 @@
+class RemoveSchoolStateId < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :schools, :state_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_17_222601) do
+ActiveRecord::Schema.define(version: 2018_09_18_174852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -299,7 +299,6 @@ ActiveRecord::Schema.define(version: 2018_09_17_222601) do
   end
 
   create_table "schools", id: :serial, force: :cascade do |t|
-    t.integer "state_id"
     t.string "school_type"
     t.string "name"
     t.datetime "created_at"
@@ -307,7 +306,6 @@ ActiveRecord::Schema.define(version: 2018_09_17_222601) do
     t.string "local_id"
     t.string "slug"
     t.index ["local_id"], name: "index_schools_on_local_id"
-    t.index ["state_id"], name: "index_schools_on_state_id"
   end
 
   create_table "sections", id: :serial, force: :cascade do |t|

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -6,19 +6,16 @@ FactoryBot.define do
   end
 
   factory :healey, class: School do
-    state_id 15
     slug 'hea'
     local_id "HEA"
   end
 
   factory :brown, class: School do
-    state_id 75
     slug 'brn'
     local_id "BRN"
   end
 
   factory :shs, class: School do
-    state_id 33
     slug 'shs'
     local_id "SHS"
     school_type "HS"


### PR DESCRIPTION
Splitting off pieces from https://github.com/studentinsights/studentinsights/pull/2088.

# Who is this PR for?
developers

# What problem does this PR fix?
There's an `state_id` field on the `School` model that we don't use and can't read in for any districts anymore, so this removes it.  The `school_type` field is similar in that we don't read it in anywhere (it was probably set manually in the past), but we do rely on this.

# What does this PR do?
In https://github.com/studentinsights/studentinsights/pull/2088 and subsequent work, the idea is to encode this manual data entry into the `yaml` files for each district.  This PR just removes the old field, and relaxes the validations on `school_type` so we can manually run a migration, then in the next PR add in more constraints and validations on `school_type`.  https://github.com/studentinsights/studentinsights/pull/2088 will ultimately move this into the `yaml` files so that we can enforce that the DB matches what's in source for these, and so that we can include this as a init task for new districts (eg, Bedford).
