### PR TITLE
Add district name to HTML head tag

### DIFF
--- a/app/views/shared/_head.html.erb
+++ b/app/views/shared/_head.html.erb
@@ -1,4 +1,4 @@
-<title>Student Insights</title>
+<title>Student Insights: <%= PerDistrict.new.district_name %></title>
 <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700,300' rel='stylesheet' type='text/css'>
 <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => false %>
 <link rel="apple-touch-icon" href="/icon.png"/>


### PR DESCRIPTION
So that the district name appears in the browser tab or window title.  Mostly for developers.