### PR TITLE
Add rake task for updating School records

### DIFF
--- a/lib/tasks/schools.rake
+++ b/lib/tasks/schools.rake
@@ -1,0 +1,32 @@
+desc 'For syncing district.yml files to School records in production'
+namespace :schools do
+  task update: :environment do
+    school_definitions = PerDistrict.new.school_definitions_for_import
+    puts "Found #{school_definitions} school_definitions..."
+
+    school_definitions.each do |school_definition|
+      local_id = school_definition['local_id']
+      puts "Checking #{local_id}..."
+      school = School.find_by_local_id(local_id)
+
+      # create
+      if school.nil?
+        puts "  Creating school #{local_id}..."
+        school.save!
+        next
+      end
+
+      # update
+      school.assign_attributes(school_definition)
+      if school.changed?
+        puts "  Updating local_id:#{local_id}... from #{school.changed_attributes.as_json} / to #{school_definition}"
+        school.save!
+        next
+      end
+
+      # unchanged
+    end
+
+    puts "Done."
+  end
+end


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Make the workflow for loading new district data more explicit.  We can use this for Bedford.

# What does this PR do?
With https://github.com/studentinsights/studentinsights/pull/2088, Schools are specified in the district yaml file.  This syncs from that yaml file to production and is intended to be run manually.  The intention is that it's harder for this to drift, and for one-off import tasks to mistakenly import data we don't need.
