### PR TITLE
Update PerDistrict handling for Bedford students

### DIFF
--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -101,6 +101,7 @@ export function sortSchoolSlugsByGrade(districtKey, slugA, slugB) {
 
 export function supportsHouse(districtKey) {
   if (districtKey === SOMERVILLE) return true;
+  if (districtKey === BEDFORD) return true;
   if (districtKey === DEMO) return true;
   return false;
 }

--- a/app/assets/javascripts/helpers/language.js
+++ b/app/assets/javascripts/helpers/language.js
@@ -1,20 +1,36 @@
-const prettyEnglishProficiencyTextMap = {
-  // Somerville
-  'Limited': 'Limited English',
-  'FLEP': 'FLEP',
+const LIMITED_ENGLISH = 'Limited English';
+const FLUENT_ENGLISH = 'Fluent English';
 
-  // New Bedford
-  'Non-English': 'Non-English',
-  'Limited English': 'Limited English',
-  'Redesignated': 'Redesignated FLEP',
-  'Native': 'Native English',
-
-  // Somerville + New Bedford
-  'Fluent': 'Fluent English'
+const somervilleMap = {
+  'Limited': LIMITED_ENGLISH,
+  'Fluent': FLUENT_ENGLISH,
+  'FLEP': 'FLEP'
 };
 
-// This varies by district, but this implementation works across
-// Somerville and New Bedford.
+const newBedfordMap = {
+  'Limited English': LIMITED_ENGLISH,
+  'Fluent': FLUENT_ENGLISH,
+  'Non-English': 'Non-English',
+  'Redesignated': 'Redesignated FLEP',
+  'Native': 'Native English'
+};
+
+const bedfordMap = {
+  'Capable': FLUENT_ENGLISH,
+  'Limited English': LIMITED_ENGLISH,
+  'Not Capable': LIMITED_ENGLISH
+};
+
+// This varies by district, but this implementation works across all districts for now.
 export function prettyEnglishProficiencyText(limitedEnglishProficiencyValue) {
-  return prettyEnglishProficiencyTextMap[limitedEnglishProficiencyValue] || 'No LEP data';
+  const prettyTextMap = {
+    ...somervilleMap,
+    ...newBedfordMap,
+    ...bedfordMap
+  };
+  return prettyTextMap[limitedEnglishProficiencyValue] || 'No LEP data';
+}
+
+export function isFluentEnglish(limitedEnglishProficiencyValue) {
+  return (prettyEnglishProficiencyText(limitedEnglishProficiencyValue) === FLUENT_ENGLISH);
 }

--- a/app/assets/javascripts/helpers/specialEducation.js
+++ b/app/assets/javascripts/helpers/specialEducation.js
@@ -21,10 +21,15 @@ export function prettyIepTextForSpecialEducationStudent(student) {
 
 export function prettyLevelOfNeedText(levelOfNeedValue) {
   switch (levelOfNeedValue) {
+  // somerville
   case 'Low < 2': return 'less than 2 hours / week';
   case 'Low >= 2': return '2-5 hours / week';
   case 'Moderate': return '6-14 hours / week';
   case 'High': return '15+ hours / week';
+
+  // bedford variants
+  case 'Low (2 hours or less)': return 'less than 2 hours / week';
+  case 'Low (2 or more hours)': return '2-5 hours / week';
   default: return null;
   }
 }
@@ -62,8 +67,12 @@ function prettyIepText({levelOfNeed, disability, placement}) {
   return 'IEP';
 }
 
+// One edge case here is "Exited this year"  This function treats that as
+// worth telling the user about, and not a "null" value.
 function isNullPlacement(placement) {
-  return (['None', 'Not Enrolled', 'Not special ed', null].indexOf(placement) !== -1);
+  if (['None', 'Not Enrolled', 'Not special ed', null].indexOf(placement) !== -1) return true;
+  if (['Not SPED Was Earlier', 'Not Sped Student 6-21'].indexOf(placement) !== -1) return true; // additional Bedford variants
+  return false;
 }
 
 function isNullDisability(disability) {
@@ -74,9 +83,10 @@ function isNullLevelOfNeed(levelOfNeed) {
   return (['Does Not Apply', null].indexOf(levelOfNeed) !== -1);
 }
 
-// This field is only used in Somerville
 function isNullProgram(program) {
-  return (['Reg Ed', null].indexOf(program) !== -1);
+  if (['Reg Ed', null].indexOf(program) !== -1) return true; // Somerville
+  if (['Not Enrolled', '(NULL)'].indexOf(program) !== -1) return true; // Bedford
+  return false;
 }
 
 function isSpecialEducationProgram(program) {

--- a/app/assets/javascripts/student_profile/LightProfileHeader.js
+++ b/app/assets/javascripts/student_profile/LightProfileHeader.js
@@ -5,8 +5,7 @@ import {AutoSizer} from 'react-virtualized';
 import * as Routes from '../helpers/Routes';
 import {
   hasStudentPhotos,
-  supportsHouse,
-  shouldDisplayHouse
+  supportsHouse
 } from '../helpers/PerDistrict';
 import HelpBubble, {
   modalFromLeft,
@@ -105,7 +104,6 @@ export default class LightProfileHeader extends React.Component {
     const {student} = this.props;
     const showHouse = (
       supportsHouse(districtKey) &&
-      shouldDisplayHouse({local_id: student.school_local_id}) &&
       student.house
     );
 

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -190,15 +190,24 @@ class PerDistrict
   end
 
   def import_student_house?
-    @district_key == SOMERVILLE || @district_key == DEMO
+    return true if @district_key == SOMERVILLE # SHS house
+    return true if @district_key == BEDFORD # MS house
+    return true if @district_key == DEMO
+    false
   end
 
   def import_student_counselor?
-    @district_key == SOMERVILLE || @district_key == DEMO
+    return true if @district_key == SOMERVILLE
+    return true if @district_key == BEDFORD
+    return true if @district_key == DEMO
+    false
   end
 
   def import_student_sped_liaison?
-    @district_key == SOMERVILLE || @district_key == DEMO
+    return true if @district_key == SOMERVILLE
+    return true if @district_key == BEDFORD
+    return true if @district_key == DEMO
+    false
   end
 
   def import_student_photos?


### PR DESCRIPTION
# Who is this PR for?
Bedford educators

# What problem does this PR fix?
Bedford exports data in a slightly different format, and includes some data we weren't expecting.

# What does this PR do?
Update `PerDistrict` to import `house` `counselor` and `sped_liaison`.  Updates UI code for the student profile around:
```
program_assigned
limited_english_proficiency
sped_placement
sped_level_of_need
```
