### PR TITLE
Update low grades endpoint to include any notes by default

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -17,7 +17,8 @@ class HomeController < ApplicationController
   end
 
   # Returns a list of `StudentSectionAssignments` with low grades where
-  # the student hasn't been commented on in NGE or 10GE yet.  High-school only.
+  # the student hasn't been commented on in Insights yet.
+  # Somerville-only and SHS only.
   # Response should include everything UI needs.
   def students_with_low_grades_json
     safe_params = params.permit(:educator_id, :time_now, :limit, :event_note_type_ids)
@@ -26,7 +27,7 @@ class HomeController < ApplicationController
     limit = safe_params[:limit].to_i
     time_threshold = time_now - 45.days
     grade_threshold = 69
-    event_note_type_ids = safe_params[:event_note_type_ids] || [305, 306]
+    event_note_type_ids = safe_params.fetch(:event_note_type_ids, nil)
 
     insight = InsightStudentsWithLowGrades.new(educator, event_note_type_ids: event_note_type_ids)
     students_with_low_grades_json = insight.students_with_low_grades_json(time_now, time_threshold, grade_threshold)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -21,15 +21,14 @@ class HomeController < ApplicationController
   # Somerville-only and SHS only.
   # Response should include everything UI needs.
   def students_with_low_grades_json
-    safe_params = params.permit(:educator_id, :time_now, :limit, :event_note_type_ids)
+    safe_params = params.permit(:educator_id, :time_now, :limit)
     educator = current_educator_or_doppleganger(safe_params[:educator_id])
     time_now = time_now_or_param(safe_params[:time_now])
     limit = safe_params[:limit].to_i
     time_threshold = time_now - 45.days
     grade_threshold = 69
-    event_note_type_ids = safe_params.fetch(:event_note_type_ids, nil)
 
-    insight = InsightStudentsWithLowGrades.new(educator, event_note_type_ids: event_note_type_ids)
+    insight = InsightStudentsWithLowGrades.new(educator)
     students_with_low_grades_json = insight.students_with_low_grades_json(time_now, time_threshold, grade_threshold)
     render json: {
       limit: limit,


### PR DESCRIPTION
# Who is this PR for?
HS educators

# What problem does this PR fix?
In https://github.com/studentinsights/studentinsights/pull/2057, I think this was the intent but the param in the controller meant this still only applied to NGE and 10GE notes.  This is different than what the copy suggests and what I remember as the intention.

# What does this PR do?
Updates controller to use whatever the insight class indicates as default.
