### PR TITLE
Store historical grades during import

### DIFF
--- a/app/importers/file_importers/student_section_grades_importer.rb
+++ b/app/importers/file_importers/student_section_grades_importer.rb
@@ -16,7 +16,7 @@ class StudentSectionGradesImporter
     'school_local_id',
     'course_number',
     'term_local_id',
-    'grade',
+    'grade'
   ]
 
   def initialize(options:)
@@ -67,5 +67,14 @@ class StudentSectionGradesImporter
     else
       @log.puts("Student Section Grade Import invalid row")
     end
+
+    # also store a historical record
+    HistoricalGrade.create!({
+      student_id: student_id,
+      section_id: section_id,
+      section_number: row[:section_number],
+      course_number: row[:course_number],
+      grade: row[:grade]
+    })
   end
 end

--- a/app/importers/file_importers/student_section_grades_importer.rb
+++ b/app/importers/file_importers/student_section_grades_importer.rb
@@ -69,12 +69,14 @@ class StudentSectionGradesImporter
     end
 
     # also store a historical record
-    HistoricalGrade.create!({
-      student_id: student_id,
-      section_id: section_id,
-      section_number: row[:section_number],
-      course_number: row[:course_number],
-      grade: row[:grade]
-    })
+    if student_id && section_id
+      HistoricalGrade.create!({
+        student_id: student_id,
+        section_id: section_id,
+        section_number: row[:section_number],
+        course_number: row[:course_number],
+        grade: row[:grade]
+      })
+    end
   end
 end

--- a/app/models/historical_grade.rb
+++ b/app/models/historical_grade.rb
@@ -1,0 +1,8 @@
+# Store a historical data point about grades for a student in a section.
+class HistoricalGrade < ActiveRecord::Base
+  belongs_to :student
+  belongs_to :section
+
+  validates :student_id, presence: true
+  validates :section_id, presence: true
+end

--- a/db/migrate/20180921195321_add_historical_grade.rb
+++ b/db/migrate/20180921195321_add_historical_grade.rb
@@ -1,0 +1,13 @@
+class AddHistoricalGrade < ActiveRecord::Migration[5.2]
+  def change
+    create_table :historical_grades do |t|
+      t.references :student
+      t.references :section
+      t.text :section_number
+      t.text :course_number
+      t.text :grade
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180921221051_add_keys_for_historical_grades.rb
+++ b/db/migrate/20180921221051_add_keys_for_historical_grades.rb
@@ -1,0 +1,6 @@
+class AddKeysForHistoricalGrades < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key "historical_grades", "sections", name: "historical_grades_section_id_fk"
+    add_foreign_key "historical_grades", "students", name: "historical_grades_student_id_fk"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_18_181103) do
+ActiveRecord::Schema.define(version: 2018_09_21_195321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -199,6 +199,18 @@ ActiveRecord::Schema.define(version: 2018_09_18_181103) do
     t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
     t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
     t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
+  end
+
+  create_table "historical_grades", force: :cascade do |t|
+    t.bigint "student_id"
+    t.bigint "section_id"
+    t.text "section_number"
+    t.text "course_number"
+    t.text "grade"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["section_id"], name: "index_historical_grades_on_section_id"
+    t.index ["student_id"], name: "index_historical_grades_on_student_id"
   end
 
   create_table "homerooms", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_21_195321) do
+ActiveRecord::Schema.define(version: 2018_09_21_221051) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -536,6 +536,8 @@ ActiveRecord::Schema.define(version: 2018_09_21_195321) do
   add_foreign_key "event_notes", "event_note_types"
   add_foreign_key "event_notes", "event_note_types", name: "event_notes_event_note_type_id_fk"
   add_foreign_key "event_notes", "students", name: "event_notes_student_id_fk"
+  add_foreign_key "historical_grades", "sections", name: "historical_grades_section_id_fk"
+  add_foreign_key "historical_grades", "students", name: "historical_grades_student_id_fk"
   add_foreign_key "homerooms", "educators", name: "homerooms_educator_id_fk"
   add_foreign_key "homerooms", "educators", name: "homerooms_for_educator_id_fk"
   add_foreign_key "homerooms", "schools", name: "homerooms_for_school_id_fk"

--- a/spec/importers/file_importers/student_section_grades_importer_spec.rb
+++ b/spec/importers/file_importers/student_section_grades_importer_spec.rb
@@ -152,5 +152,44 @@ RSpec.describe StudentSectionGradesImporter do
         expect(StudentSectionAssignment.count).to eq(1)
       end
     end
+
+    context 'stores historical grades' do
+      it 'creates new HistoricalGrade records' do
+        expect {
+          student_section_grades_importer.import_row({
+            section_number: section.section_number,
+            student_local_id: student.local_id,
+            course_number: section.course_number,
+            school_local_id: 'SHS',
+            term_local_id: 'FY',
+            grade: '85.0 B+'
+          })
+          student_section_grades_importer.import_row({
+            section_number: section.section_number,
+            student_local_id: student.local_id,
+            course_number: section.course_number,
+            school_local_id: 'SHS',
+            term_local_id: 'FY',
+            grade: '94.0 A'
+          })
+        }.to change(HistoricalGrade, :count).by(2)
+
+        historical_grades = HistoricalGrade.all.order(created_at: :asc).as_json
+        expect(historical_grades[0]).to include({
+          'student_id' => student.id,
+          'section_id' => section.id,
+          'course_number' => section.course_number,
+          'section_number' => section.section_number,
+          'grade' => '85.0 B+'
+        })
+        expect(historical_grades[1]).to include({
+          'student_id' => student.id,
+          'section_id' => section.id,
+          'course_number' => section.course_number,
+          'section_number' => section.section_number,
+          'grade' => '94.0 A'
+        })
+      end
+    end
   end
 end


### PR DESCRIPTION
# Who is this PR for?
enabling looking at this over time in the HS

# What problem does this PR fix?
nothing, it's enabling experimental work

# What does this PR do?
stores `HistoricalGrade` records during the section/grade importer.
