### PR TITLE
Update absence imported to use PerDistrict parsing of boolean fields for Bedford

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -199,6 +199,19 @@ class PerDistrict
     raise_not_handled!  # Importing attendance not handled yet for BEDFORD
   end
 
+  # eg, absence, tardy, discipline columns
+  def is_attendance_import_value_truthy?(value)
+    if @district_key == SOMERVILLE
+      value.to_i == 1
+    elsif @district_key == NEW_BEDFORD
+      value.to_i == 1
+    elsif @district_key == BEDFORD
+      value.downcase == 'true'
+    else
+      raise_not_handled!
+    end
+  end
+
   def import_student_house?
     @district_key == SOMERVILLE || @district_key == DEMO
   end

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -191,7 +191,7 @@ class PerDistrict
 
   def import_detailed_attendance_fields?
     return true if @district_key == SOMERVILLE
-
+    return true if @district_key == BEDFORD
     return false if @district_key == NEW_BEDFORD
 
     raise 'import_detailed_attendance_fields? not supported for DEMO' if @district_key == DEMO

--- a/app/importers/data_transformers/csv_row_cleaner.rb
+++ b/app/importers/data_transformers/csv_row_cleaner.rb
@@ -1,10 +1,8 @@
 class CsvRowCleaner < Struct.new :row
   DATE_HEADERS = [:event_date, :date_taken, :assessment_date]
-  BOOLEAN_VALUES = [true, false, '1', '0', 1, 0, 'true', 'false']
-  BOOLEAN_HEADER_NAMES = [:absence, :tardy, :has_exact_time]
 
   def dirty_data?
-    !clean_date? || !clean_booleans?
+    !clean_date?
   end
 
   def transform_row
@@ -19,14 +17,6 @@ class CsvRowCleaner < Struct.new :row
     return false unless parsed_date         # <= Column can't be parsed
     return false if date_out_of_range       # <= Column is out of range
     return true                             # <= Column is a parsable, reasonable date
-  end
-
-  def clean_booleans?
-    headers.each do |header|
-      next unless header.in? BOOLEAN_HEADER_NAMES
-      return false unless row[header].in? BOOLEAN_VALUES
-    end
-    true
   end
 
   def headers

--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -167,8 +167,9 @@ class AttendanceImporter
   end
 
   def attendance_event_class(row)
-    is_absence = row[:absence].to_i == 1
-    is_tardy = row[:tardy].to_i == 1
+    per_district = PerDistrict.new
+    is_absence = per_district.is_attendance_import_value_truthy?(row[:absence])
+    is_tardy = per_district.is_attendance_import_value_truthy?(row[:tardy])
 
     if is_absence && is_tardy then nil
     elsif is_absence then Absence

--- a/spec/importers/data_transformers/csv_row_cleaner_spec.rb
+++ b/spec/importers/data_transformers/csv_row_cleaner_spec.rb
@@ -85,36 +85,4 @@ RSpec.describe CsvRowCleaner do
     end
 
   end
-
-  describe '#clean_booleans?' do
-
-    context 'there is a boolean column' do
-
-      context 'is parsable' do
-        let(:row) { CSV::Row.new([:event_name, :has_exact_time], ['Pizza Party No. 2', '0']) }
-        it 'returns true' do
-          expect(row_cleaner.send(:clean_booleans?)).to eq true
-
-        end
-      end
-
-      context 'not parsable' do
-        let(:row) { CSV::Row.new([:event_name, :has_exact_time], ['Pizza Party No. 2', ':-/']) }
-        it 'returns false' do
-          expect(row_cleaner.send(:clean_booleans?)).to eq false
-        end
-      end
-
-    end
-
-    context 'there are no boolean columns' do
-      let(:row) { CSV::Row.new([:event_date, :pizza_slices_count], ['2015-13-11', '3']) }
-
-      it 'returns true' do
-        expect(row_cleaner.send(:clean_booleans?)).to eq true
-      end
-    end
-
-  end
-
 end

--- a/spec/importers/file_importers/attendance_importer_spec.rb
+++ b/spec/importers/file_importers/attendance_importer_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe AttendanceImporter do
         }
 
         before do
-          allow(ENV).to receive(:[]).with('DISTRICT_KEY').and_return("bedford")
+          allow(ENV).to receive(:[]).with('DISTRICT_KEY').and_return('bedford')
         end
 
         it 'creates an absence, parsing true/false correctly' do
@@ -136,14 +136,14 @@ RSpec.describe AttendanceImporter do
           }.by 1
         end
 
-        it 'sets the right attributes' do
+        it 'sets the right attributes for defailed fields' do
           attendance_importer.send(:import_row, row)
           absence = Absence.first
 
-          expect(absence.dismissed).to eq nil
-          expect(absence.reason).to eq nil
-          expect(absence.excused).to eq nil
-          expect(absence.comment).to eq nil
+          expect(absence.dismissed).to eq false
+          expect(absence.reason).to eq 'Medical'
+          expect(absence.excused).to eq false
+          expect(absence.comment).to eq 'Received doctor note.'
         end
       end
 

--- a/spec/importers/file_importers/attendance_importer_spec.rb
+++ b/spec/importers/file_importers/attendance_importer_spec.rb
@@ -102,7 +102,38 @@ RSpec.describe AttendanceImporter do
 
         before do
           # Default ENV['DISTRICT_KEY'] for test suite is 'somerville', see test.rb
-          expect(ENV).to receive(:[]).with('DISTRICT_KEY').and_return("new_bedford")
+          allow(ENV).to receive(:[]).with('DISTRICT_KEY').and_return("new_bedford")
+        end
+
+        it 'sets the right attributes' do
+          attendance_importer.send(:import_row, row)
+          absence = Absence.first
+
+          expect(absence.dismissed).to eq nil
+          expect(absence.reason).to eq nil
+          expect(absence.excused).to eq nil
+          expect(absence.comment).to eq nil
+        end
+      end
+
+      context 'row with absence (Bedford)' do
+        let!(:student) { FactoryBot.create(:student, local_id: '1') }
+        let(:date) { Date.parse('2005-09-16') }
+        let(:row) {
+          { event_date: date, local_id: '1', absence: 'true', tardy: 'false',
+            dismissed: 'false', reason: 'Medical', excused: '0', comment: 'Received doctor note.' }
+        }
+
+        before do
+          allow(ENV).to receive(:[]).with('DISTRICT_KEY').and_return("bedford")
+        end
+
+        it 'creates an absence, parsing true/false correctly' do
+          expect {
+            attendance_importer.send(:import_row, row)
+          }.to change {
+            Absence.count
+          }.by 1
         end
 
         it 'sets the right attributes' do


### PR DESCRIPTION
# Who is this PR for?
Bedford pals

# What problem does this PR fix?
Their export uses string values for true/false in attendance data, not integer values like others.

# What does this PR do?
Updates this to be `PerDistrict.`