### PR TITLE
Update event note types for Bedford, add STAT note

### DIFF
--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -148,6 +148,7 @@ export function supportsExcusedAbsences(districtKey) {
 // What is the eventNoteTypeId to use in user-facing text about how to support
 // students with high absences?
 export function eventNoteTypeIdForAbsenceSupportMeeting(districtKey) {
+  if (districtKey === BEDFORD) return 500; // stat
   if (districtKey === NEW_BEDFORD) return 400; // bbst
   if (districtKey === SOMERVILLE) return 300; // sst
 
@@ -164,6 +165,13 @@ export function takeNotesChoices(districtKey) {
     };
   }
 
+  if (districtKey === BEDFORD) {
+    return {
+      leftEventNoteTypeIds: [500, 302, 304],
+      rightEventNoteTypeIds: []
+    };
+  }
+
   if (districtKey === NEW_BEDFORD) {
     return {
       leftEventNoteTypeIds: [400, 302, 304],
@@ -177,6 +185,7 @@ export function takeNotesChoices(districtKey) {
 // In tables of students, what eventNoteTypeIds should be shown as columns with notes
 // about those students?
 export function studentTableEventNoteTypeIds(districtKey, schoolType) {
+  if (districtKey === BEDFORD) return [500];
   if (districtKey === NEW_BEDFORD) return [400];
   
   const isSomervilleOrDemo = (districtKey === SOMERVILLE || districtKey === DEMO);

--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -27,6 +27,13 @@ const ORDERED_DISABILITY_VALUES_MAP = {
     'Low >= 2',
     'Moderate',
     'High'
+  ],
+  [BEDFORD]: [    
+    'Does Not Apply',
+    'Low (2 hours or less)',
+    'Low (2 or more hours)',
+    'Moderate',
+    'High'
   ]
 };
 
@@ -60,8 +67,7 @@ export function renderSlicePanelsDisabilityTable(districtKey, options = {}) {
     return createItemFn(value, Filters.Equal(key, value));
   });
 
-  // Somerville uses a null value for no disability, while New Bedford
-  // uses a separate value to describe that explicitly.
+  // Somerville uses a null value for no disability instead of an explicit value.
   const items = (districtKey === SOMERVILLE)
     ? [createItemFn('None', Filters.Null(key))].concat(itemsFromValues)
     : itemsFromValues;

--- a/app/assets/javascripts/helpers/eventNoteType.js
+++ b/app/assets/javascripts/helpers/eventNoteType.js
@@ -6,7 +6,8 @@ const textMap =  {
   305: '9th Grade Experience',
   306: '10th Grade Experience',
   307: 'NEST',
-  400: 'BBST Meeting'
+  400: 'BBST Meeting',
+  500: 'STAT Meeting'
 };
 export function eventNoteTypeText(eventNoteTypeId) {
   return textMap[eventNoteTypeId] || 'Other';
@@ -20,7 +21,8 @@ const miniTextMap = {
   305: 'NGE',
   306: '10GE',
   307: 'NEST',
-  400: 'BBST'
+  400: 'BBST',
+  500: 'STAT'
 };
 export function eventNoteTypeTextMini(eventNoteTypeId) {
   return miniTextMap[eventNoteTypeId] || 'Other';
@@ -37,7 +39,8 @@ const colorMap =  {
   305: BLUE,
   306: BLUE,
   307: BLUE,
-  400: GREEN
+  400: GREEN,
+  500: GREEN
 };
 export function eventNoteTypeColor(eventNoteTypeId) {
   return colorMap[eventNoteTypeId] || '#666';

--- a/app/assets/javascripts/homeroom/HomeroomTable.test.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {SOMERVILLE, NEW_BEDFORD} from '../helpers/PerDistrict';
+import {SOMERVILLE, NEW_BEDFORD, BEDFORD} from '../helpers/PerDistrict';
 import PerDistrictContainer from '../components/PerDistrictContainer';
 import HomeroomTable from './HomeroomTable';
 import {healey, shs, students} from './HomeroomTable.fixtures';
@@ -81,6 +81,22 @@ describe('high-level integration test', () => {
     expect(headerTexts(el)).toEqual([
       'Name',
       'Last BBST',
+      'Program Assigned',
+      'Disability',
+      'Level of Need',
+      '504 Plan',
+      'Fluency',
+      'Home Language',
+    ]);
+  });
+
+  it('renders correct headers for Bedford grade 6', () => {
+    const props = testProps({ grade: '6'});
+    const context = { districtKey: BEDFORD };
+    const {el} = testRender(props, context);
+    expect(headerTexts(el)).toEqual([
+      'Name',
+      'Last STAT',
       'Program Assigned',
       'Disability',
       'Level of Need',

--- a/app/assets/javascripts/school_absences/SchoolAbsencesDashboard.test.js
+++ b/app/assets/javascripts/school_absences/SchoolAbsencesDashboard.test.js
@@ -63,6 +63,24 @@ it('does not show excused absence option for New Bedford', () => {
   expect(dash.find('SelectExcusedAbsences').length).toEqual(0);
 });
 
+it('does show excused absence option for Somerville', () => {
+  const context = testContext({districtKey: 'somerville'});
+  const el = testEl();
+  const dash = mount(elWrappedInContext(el, context));
+  expect(dash.html()).toContain('Unexcused Absences Only');
+  expect(dash.html()).toContain('All Absences');
+  expect(dash.find('SelectExcusedAbsences').length).toEqual(1);
+});
+
+it('does show excused absence option for Bedford', () => {
+  const context = testContext({districtKey: 'bedford'});
+  const el = testEl();
+  const dash = mount(elWrappedInContext(el, context));
+  expect(dash.html()).toContain('Unexcused Absences Only');
+  expect(dash.html()).toContain('All Absences');
+  expect(dash.find('SelectExcusedAbsences').length).toEqual(1);
+});
+
 describe('with testSetup', () => {
   it('renders two bar charts', () => {
     expect(renderShallow().find('DashboardBarChart').length).toEqual(2);

--- a/app/assets/javascripts/school_absences/SchoolAbsencesDashboard.test.js
+++ b/app/assets/javascripts/school_absences/SchoolAbsencesDashboard.test.js
@@ -58,8 +58,7 @@ it('does not show excused absence option for New Bedford', () => {
   const context = testContext({districtKey: 'new_bedford'});
   const el = testEl();
   const dash = mount(elWrappedInContext(el, context));
-  expect(dash.html()).not.toContain('Unexcused Absences Only');
-  expect(dash.html()).not.toContain('All Absences');
+  expect(dash.html()).not.toContain('Unexcused');
   expect(dash.find('SelectExcusedAbsences').length).toEqual(0);
 });
 
@@ -67,8 +66,7 @@ it('does show excused absence option for Somerville', () => {
   const context = testContext({districtKey: 'somerville'});
   const el = testEl();
   const dash = mount(elWrappedInContext(el, context));
-  expect(dash.html()).toContain('Unexcused Absences Only');
-  expect(dash.html()).toContain('All Absences');
+  expect(dash.html()).toContain('Unexcused');
   expect(dash.find('SelectExcusedAbsences').length).toEqual(1);
 });
 
@@ -76,8 +74,7 @@ it('does show excused absence option for Bedford', () => {
   const context = testContext({districtKey: 'bedford'});
   const el = testEl();
   const dash = mount(elWrappedInContext(el, context));
-  expect(dash.html()).toContain('Unexcused Absences Only');
-  expect(dash.html()).toContain('All Absences');
+  expect(dash.html()).toContain('Unexcused');
   expect(dash.find('SelectExcusedAbsences').length).toEqual(1);
 });
 

--- a/app/assets/javascripts/school_absences/__snapshots__/SchoolAbsencesDashboard.test.js.snap
+++ b/app/assets/javascripts/school_absences/__snapshots__/SchoolAbsencesDashboard.test.js.snap
@@ -116,7 +116,7 @@ exports[`snapshots 1`] = `
                 >
                   <span
                     className="Select-multi-value-wrapper"
-                    id="react-select-3--value"
+                    id="react-select-12--value"
                   >
                     <div
                       className="Select-value"
@@ -124,7 +124,7 @@ exports[`snapshots 1`] = `
                       <span
                         aria-selected="true"
                         className="Select-value-label"
-                        id="react-select-3--value-item"
+                        id="react-select-12--value-item"
                         role="option"
                       >
                         Unexcused
@@ -139,7 +139,7 @@ exports[`snapshots 1`] = `
                       }
                     >
                       <input
-                        aria-activedescendant="react-select-3--value"
+                        aria-activedescendant="react-select-12--value"
                         aria-expanded="false"
                         aria-haspopup="false"
                         aria-owns=""
@@ -203,7 +203,7 @@ exports[`snapshots 1`] = `
                 >
                   <span
                     className="Select-multi-value-wrapper"
-                    id="react-select-4--value"
+                    id="react-select-13--value"
                   >
                     <div
                       className="Select-placeholder"
@@ -219,7 +219,7 @@ exports[`snapshots 1`] = `
                       }
                     >
                       <input
-                        aria-activedescendant="react-select-4--value"
+                        aria-activedescendant="react-select-13--value"
                         aria-expanded="false"
                         aria-haspopup="false"
                         aria-owns=""
@@ -283,7 +283,7 @@ exports[`snapshots 1`] = `
                 >
                   <span
                     className="Select-multi-value-wrapper"
-                    id="react-select-5--value"
+                    id="react-select-14--value"
                   >
                     <div
                       className="Select-placeholder"
@@ -299,7 +299,7 @@ exports[`snapshots 1`] = `
                       }
                     >
                       <input
-                        aria-activedescendant="react-select-5--value"
+                        aria-activedescendant="react-select-14--value"
                         aria-expanded="false"
                         aria-haspopup="false"
                         aria-owns=""
@@ -363,7 +363,7 @@ exports[`snapshots 1`] = `
                 >
                   <span
                     className="Select-multi-value-wrapper"
-                    id="react-select-6--value"
+                    id="react-select-15--value"
                   >
                     <div
                       className="Select-placeholder"
@@ -379,7 +379,7 @@ exports[`snapshots 1`] = `
                       }
                     >
                       <input
-                        aria-activedescendant="react-select-6--value"
+                        aria-activedescendant="react-select-15--value"
                         aria-expanded="false"
                         aria-haspopup="false"
                         aria-owns=""
@@ -466,7 +466,7 @@ exports[`snapshots 1`] = `
                 >
                   <span
                     className="Select-multi-value-wrapper"
-                    id="react-select-7--value"
+                    id="react-select-16--value"
                   >
                     <div
                       className="Select-value"
@@ -474,14 +474,14 @@ exports[`snapshots 1`] = `
                       <span
                         aria-selected="true"
                         className="Select-value-label"
-                        id="react-select-7--value-item"
+                        id="react-select-16--value-item"
                         role="option"
                       >
                         Last 45 days
                       </span>
                     </div>
                     <div
-                      aria-activedescendant="react-select-7--value"
+                      aria-activedescendant="react-select-16--value"
                       aria-disabled="false"
                       aria-expanded={false}
                       aria-owns=""

--- a/app/assets/javascripts/school_administrator_dashboard/absences_dashboard/SchoolAbsenceDashboard.test.js
+++ b/app/assets/javascripts/school_administrator_dashboard/absences_dashboard/SchoolAbsenceDashboard.test.js
@@ -51,8 +51,7 @@ it('does not show excused absence option for New Bedford', () => {
   const context = testContext({districtKey: 'new_bedford'});
   const el = testEl();
   const dash = mount(elWrappedInContext(el, context));
-  expect(dash.html()).not.toContain('Unexcused Absences Only');
-  expect(dash.html()).not.toContain('All Absences');
+  expect(dash.html()).not.toContain('Unexcused');
   expect(dash.find('SelectExcusedAbsences').length).toEqual(0);
 });
 
@@ -60,8 +59,7 @@ it('does show excused absence option for Somerville', () => {
   const context = testContext({districtKey: 'somerville'});
   const el = testEl();
   const dash = mount(elWrappedInContext(el, context));
-  expect(dash.html()).toContain('Unexcused Absences Only');
-  expect(dash.html()).toContain('All Absences');
+  expect(dash.html()).toContain('Unexcused');
   expect(dash.find('SelectExcusedAbsences').length).toEqual(1);
 });
 
@@ -69,8 +67,7 @@ it('does show excused absence option for Bedford', () => {
   const context = testContext({districtKey: 'bedford'});
   const el = testEl();
   const dash = mount(elWrappedInContext(el, context));
-  expect(dash.html()).toContain('Unexcused Absences Only');
-  expect(dash.html()).toContain('All Absences');
+  expect(dash.html()).toContain('Unexcused');
   expect(dash.find('SelectExcusedAbsences').length).toEqual(1);
 });
 

--- a/app/assets/javascripts/school_administrator_dashboard/absences_dashboard/SchoolAbsenceDashboard.test.js
+++ b/app/assets/javascripts/school_administrator_dashboard/absences_dashboard/SchoolAbsenceDashboard.test.js
@@ -56,6 +56,24 @@ it('does not show excused absence option for New Bedford', () => {
   expect(dash.find('SelectExcusedAbsences').length).toEqual(0);
 });
 
+it('does show excused absence option for Somerville', () => {
+  const context = testContext({districtKey: 'somerville'});
+  const el = testEl();
+  const dash = mount(elWrappedInContext(el, context));
+  expect(dash.html()).toContain('Unexcused Absences Only');
+  expect(dash.html()).toContain('All Absences');
+  expect(dash.find('SelectExcusedAbsences').length).toEqual(1);
+});
+
+it('does show excused absence option for Bedford', () => {
+  const context = testContext({districtKey: 'bedford'});
+  const el = testEl();
+  const dash = mount(elWrappedInContext(el, context));
+  expect(dash.html()).toContain('Unexcused Absences Only');
+  expect(dash.html()).toContain('All Absences');
+  expect(dash.find('SelectExcusedAbsences').length).toEqual(1);
+});
+
 describe('with testSetup', () => {
   it('renders two bar charts', () => {
     expect(renderShallow().find('DashboardBarChart').length).toEqual(2);

--- a/app/assets/javascripts/school_overview/SlicePanels.test.js
+++ b/app/assets/javascripts/school_overview/SlicePanels.test.js
@@ -165,6 +165,21 @@ describe('high-level integration tests', () => {
         "High"
       ]);
     });
+
+    it('renders explicit values only for Bedford', () => {
+      const {el} = testRender(testProps({
+        districtKey: 'bedford',
+        students: FixtureStudents,
+        allStudents: FixtureStudents
+      }));
+      expect(helpers.disabilityFilters(el)).toEqual([
+        'Does Not Apply',
+        'Low (2 hours or less)',
+        'Low (2 or more hours)',
+        'Moderate',
+        'High'
+      ]);
+    });
   });
 });
 

--- a/app/assets/javascripts/student_profile/TakeNotes.story.js
+++ b/app/assets/javascripts/student_profile/TakeNotes.story.js
@@ -31,4 +31,5 @@ function storyRender(props, context) {
 
 storiesOf('profile/TakeNotes', module) // eslint-disable-line no-undef
   .add('somerville', () => storyRender(storyProps(), {districtKey: 'somerville'}))
-  .add('new_bedford', () => storyRender(storyProps(), {districtKey: 'new_bedford'}));
+  .add('new_bedford', () => storyRender(storyProps(), {districtKey: 'new_bedford'}))
+  .add('bedford', () => storyRender(storyProps(), {districtKey: 'bedford'}));

--- a/app/assets/javascripts/student_profile/TakeNotes.test.js
+++ b/app/assets/javascripts/student_profile/TakeNotes.test.js
@@ -4,7 +4,7 @@ import {
   nowMoment,
   currentEducator
 } from './fixtures/fixtures';
-import {SOMERVILLE, NEW_BEDFORD} from '../helpers/PerDistrict';
+import {SOMERVILLE, NEW_BEDFORD, BEDFORD} from '../helpers/PerDistrict';
 import PerDistrictContainer from '../components/PerDistrictContainer';
 import TakeNotes from './TakeNotes';
 
@@ -73,6 +73,15 @@ describe('buttons for taking notes', () => {
     const {el} = renderTestEl(testProps(), { districtKey: NEW_BEDFORD });
     expect(buttonTexts(el)).toEqual([
       'BBST Meeting',
+      'Parent conversation',
+      'Something else'
+    ]);
+  });
+
+  it('works for New Bedford', () => {
+    const {el} = renderTestEl(testProps(), { districtKey: BEDFORD });
+    expect(buttonTexts(el)).toEqual([
+      'STAT Meeting',
       'Parent conversation',
       'Something else'
     ]);

--- a/app/models/event_note_type.rb
+++ b/app/models/event_note_type.rb
@@ -2,7 +2,7 @@
 class EventNoteType < ActiveRecord::Base
   def self.seed_for_all_districts
     EventNoteType.destroy_all
-    EventNoteType.create([
+    EventNoteType.create!([
       { id: 300, name: 'SST Meeting' },
       { id: 301, name: 'MTSS Meeting' },
       { id: 302, name: 'Parent conversation' },
@@ -10,7 +10,8 @@ class EventNoteType < ActiveRecord::Base
       { id: 305, name: '9th Grade Experience' },
       { id: 306, name: '10th Grade Experience' },
       { id: 307, name: 'NEST' },
-      { id: 400, name: 'BBST Meeting' }
+      { id: 400, name: 'BBST Meeting' },
+      { id: 500, name: 'STAT' }
     ])
   end
 

--- a/app/models/event_note_type.rb
+++ b/app/models/event_note_type.rb
@@ -11,7 +11,7 @@ class EventNoteType < ActiveRecord::Base
       { id: 306, name: '10th Grade Experience' },
       { id: 307, name: 'NEST' },
       { id: 400, name: 'BBST Meeting' },
-      { id: 500, name: 'STAT' }
+      { id: 500, name: 'STAT Meeting' }
     ])
   end
 

--- a/db/migrate/20180924200334_stat_for_bedford.rb
+++ b/db/migrate/20180924200334_stat_for_bedford.rb
@@ -1,0 +1,7 @@
+class StatForBedford < ActiveRecord::Migration[5.2]
+  def change
+    if EventNoteType.find_by_id(500).nil?
+      EventNoteType.create!(id: 500, name: 'STAT')
+    end
+  end
+end

--- a/db/migrate/20180924200334_stat_for_bedford.rb
+++ b/db/migrate/20180924200334_stat_for_bedford.rb
@@ -1,7 +1,7 @@
 class StatForBedford < ActiveRecord::Migration[5.2]
   def change
     if EventNoteType.find_by_id(500).nil?
-      EventNoteType.create!(id: 500, name: 'STAT')
+      EventNoteType.create!(id: 500, name: 'STAT Meeting')
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_24_143156) do
+ActiveRecord::Schema.define(version: 2018_09_24_200334) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/reports/students_spreadsheet_spec.rb
+++ b/spec/reports/students_spreadsheet_spec.rb
@@ -82,7 +82,8 @@ RSpec.describe StudentsSpreadsheet do
            'Boston Breakthrough (active_service_date_started)',
            'Calculus Project (active_service_date_started)',
            'Focused Math Intervention (active_service_date_started)',
-           'Summer Explore (active_service_date_started)'
+           'Summer Explore (active_service_date_started)',
+           'STAT Meeting (active_service_date_started)'
          ].sort
         )
       end

--- a/spec/reports/students_spreadsheet_spec.rb
+++ b/spec/reports/students_spreadsheet_spec.rb
@@ -70,6 +70,11 @@ RSpec.describe StudentsSpreadsheet do
            'SomerSession (active_service_date_started)',
            'Summer Program for English Language Learners (active_service_date_started)',
            'Freedom School (active_service_date_started)',
+           'Boston Breakthrough (active_service_date_started)',
+           'Calculus Project (active_service_date_started)',
+           'Focused Math Intervention (active_service_date_started)',
+           'Summer Explore (active_service_date_started)',
+
            'BBST Meeting (last_event_note_recorded_at)',
            'SST Meeting (last_event_note_recorded_at)',
            'MTSS Meeting (last_event_note_recorded_at)',
@@ -79,11 +84,7 @@ RSpec.describe StudentsSpreadsheet do
            'X-Block (active_service_date_started)',
            '10th Grade Experience (last_event_note_recorded_at)',
            'NEST (last_event_note_recorded_at)',
-           'Boston Breakthrough (active_service_date_started)',
-           'Calculus Project (active_service_date_started)',
-           'Focused Math Intervention (active_service_date_started)',
-           'Summer Explore (active_service_date_started)',
-           'STAT Meeting (active_service_date_started)'
+           'STAT Meeting (last_event_note_recorded_at)'
          ].sort
         )
       end


### PR DESCRIPTION
# Who is this PR for?
Bedford educators

# What problem does this PR fix?
The disability types on the roster page aren't supported, so it doesn't render.  They don't have event note types set yet.

# What does this PR do?
Fixes the roster disability types to match their values, add a STAT event note.

# Screenshot (if adding a client-side feature)
<img width="189" alt="screen shot 2018-09-24 at 4 27 02 pm" src="https://user-images.githubusercontent.com/1056957/45977384-6ec53980-c017-11e8-8084-f8da0aa2d4d8.png">
<img width="587" alt="screen shot 2018-09-24 at 4 19 43 pm" src="https://user-images.githubusercontent.com/1056957/45977385-6ec53980-c017-11e8-89a3-ffe61f55b3b2.png">
<img width="394" alt="screen shot 2018-09-24 at 4 19 34 pm" src="https://user-images.githubusercontent.com/1056957/45977386-6ec53980-c017-11e8-8e9c-a8c3b51c506f.png">
<img width="550" alt="screen shot 2018-09-24 at 4 19 28 pm" src="https://user-images.githubusercontent.com/1056957/45977387-6ec53980-c017-11e8-9e7e-97a4010e75ce.png">

# Checklists
+ [x  Author checked latest in IE - Student Profile
+ [x] Author checked latest in IE - School Overview
+ [x] Author checked latest in IE - Homeroom page
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code
