### PR TITLE
Stricter date parsing in student importer

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -54,11 +54,12 @@ class PerDistrict
     end
   end
 
+  # Returns nil if strict parsing fails
   def parse_date_during_import(text)
     if @district_key == SOMERVILLE || @district_key == NEW_BEDFORD
-      Date.strptime(text, '%Y-%m-%d')
+      Date.strptime(text, '%Y-%m-%d') rescue nil
     elsif @district_key == BEDFORD
-      Date.strptime(text, '%m/%d/%Y')
+      Date.strptime(text, '%m/%d/%Y') rescue nil
     else
       raise_not_handled!
     end

--- a/app/importers/rows/student_row.rb
+++ b/app/importers/rows/student_row.rb
@@ -51,9 +51,7 @@ class StudentRow < Struct.new(:row, :homeroom_id, :school_ids_dictionary, :log)
       :sped_level_of_need,
       :plan_504,
       :student_address,
-      :registration_date,
       :free_reduced_lunch,
-      :date_of_birth,
       :race,
       :hispanic_latino,
       :gender,
@@ -84,8 +82,13 @@ class StudentRow < Struct.new(:row, :homeroom_id, :school_ids_dictionary, :log)
 
   # These are different based on the district configuration and export
   def per_district_attributes
-    included_attributes = {}
     per_district = PerDistrict.new
+
+    # date parsing
+    included_attributes = {
+      registration_date: per_district.parse_date_during_import(row[:registration_date]),
+      date_of_birth: per_district.parse_date_during_import(row[:date_of_birth])
+    }
 
     if per_district.import_student_house?
       included_attributes.merge!(house: row[:house])

--- a/spec/importers/rows/student_row_spec.rb
+++ b/spec/importers/rows/student_row_spec.rb
@@ -67,11 +67,11 @@ RSpec.describe StudentRow do
 
     context 'when PerDistrict attributes are not exported' do
       before do
-        mock_per_district = instance_double(PerDistrict)
-        expect(mock_per_district).to receive(:import_student_house?).and_return(false)
-        expect(mock_per_district).to receive(:import_student_counselor?).and_return(false)
-        expect(mock_per_district).to receive(:import_student_sped_liaison?).and_return(false)
-        expect(PerDistrict).to receive(:new).and_return(mock_per_district)
+        mock_per_district = PerDistrict.new
+        allow(mock_per_district).to receive(:import_student_house?).and_return(false)
+        allow(mock_per_district).to receive(:import_student_counselor?).and_return(false)
+        allow(mock_per_district).to receive(:import_student_sped_liaison?).and_return(false)
+        allow(PerDistrict).to receive(:new).and_return(mock_per_district)
       end
 
       it 'does not try to read and leaves them as nil' do

--- a/spec/importers/rows/student_row_spec.rb
+++ b/spec/importers/rows/student_row_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe StudentRow do
       end
     end
 
+    context 'invalid registration_date' do
+      let(:row) { { full_name: 'Hoag, George', registration_date: '02' } }
+
+      it 'sets it as nil' do
+        expect(student.registration_date).to eq nil
+      end
+    end
+
     context 'grade level KF' do
       let(:row) { { grade: 'KF', full_name: 'Lee, Nico' } }
 


### PR DESCRIPTION
# Who is this PR for?
Bedford educators

# What problem does this PR fix?
Bedford exports currently include invalid registration dates, which they're fixing, but we aren't noticing because of lax date parsing, and are setting these to incorrect dates.

# What does this PR do?
Switches to strict date parsing for dates in the student importer.
