### PR TITLE
Update valid grades for Bedford

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -54,11 +54,12 @@ class PerDistrict
     end
   end
 
+  # Returns nil if strict parsing fails
   def parse_date_during_import(text)
     if @district_key == SOMERVILLE || @district_key == NEW_BEDFORD
-      Date.strptime(text, '%Y-%m-%d')
+      Date.strptime(text, '%Y-%m-%d') rescue nil
     elsif @district_key == BEDFORD
-      Date.strptime(text, '%m/%d/%Y')
+      Date.strptime(text, '%m/%d/%Y') rescue nil
     else
       raise_not_handled!
     end

--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -10,7 +10,7 @@ module Admin
     end
 
     def edit
-      @valid_grades = %w(PK KF SP 1 2 3 4 5 6 7 8 9 10 11 12)
+      @valid_grades = GradeLevels::ORDERED_GRADE_LEVELS
       super
     end
 

--- a/app/importers/rows/student_row.rb
+++ b/app/importers/rows/student_row.rb
@@ -51,9 +51,7 @@ class StudentRow < Struct.new(:row, :homeroom_id, :school_ids_dictionary, :log)
       :sped_level_of_need,
       :plan_504,
       :student_address,
-      :registration_date,
       :free_reduced_lunch,
-      :date_of_birth,
       :race,
       :hispanic_latino,
       :gender,
@@ -84,8 +82,13 @@ class StudentRow < Struct.new(:row, :homeroom_id, :school_ids_dictionary, :log)
 
   # These are different based on the district configuration and export
   def per_district_attributes
-    included_attributes = {}
     per_district = PerDistrict.new
+
+    # date parsing
+    included_attributes = {
+      registration_date: per_district.parse_date_during_import(row[:registration_date]),
+      date_of_birth: per_district.parse_date_during_import(row[:date_of_birth])
+    }
 
     if per_district.import_student_house?
       included_attributes.merge!(house: row[:house])

--- a/app/lib/grade_levels.rb
+++ b/app/lib/grade_levels.rb
@@ -1,5 +1,7 @@
 class GradeLevels
   ORDERED_GRADE_LEVELS = [
+    'OOPK',
+    'OPK',
     'TK',
     'PPK',
     'PK',

--- a/app/lib/insight_students_with_high_absences.rb
+++ b/app/lib/insight_students_with_high_absences.rb
@@ -32,7 +32,13 @@ class InsightStudentsWithHighAbsences
       # Exclude students in younger grades like PreK since attendance isn't mandatory.
       # This means there's less consistent attendance from families, and it's less
       # of a priority to follow-up for schools.
-      students_to_consider = Student.active.where.not(grade: ['TK', 'PPK', 'PK'])
+      students_to_consider = Student.active.where.not(grade: [
+        'TK',
+        'PPK',
+        'PK',
+        'OPK',
+        'OOPK'
+      ])
 
       # Filter students to match what they see in their feed (eg, HS counselors
       # only see students on their caseload).

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -128,7 +128,7 @@ class Educator < ActiveRecord::Base
   end
 
   def validate_grade_level_strings_are_valid
-    if grade_level_access.any? { |grade| !(VALID_GRADES.include?(grade)) }
+    if grade_level_access.any? { |grade| !(GradeLevels::ORDERED_GRADE_LEVELS.include?(grade)) }
       errors.add(:grade_level_access, "invalid grade")
     end
   end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -34,9 +34,6 @@ class Student < ActiveRecord::Base
   validate :validate_registration_date_cannot_be_in_future
   validate :validate_free_reduced_lunch
 
-  VALID_GRADES = [
-    'PPK', 'PK', 'KF', 'SP', 'TK', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13'
-  ].freeze
 
   VALID_FREE_REDUCED_LUNCH_VALUES = [
     "Free Lunch",
@@ -269,7 +266,7 @@ class Student < ActiveRecord::Base
   end
 
   def validate_grade
-    errors.add(:grade, "invalid grade: #{grade}") unless grade.in?(VALID_GRADES)
+    errors.add(:grade, "invalid grade: #{grade}") unless grade.in?(GradeLevels::ORDERED_GRADE_LEVELS)
   end
 
   def validate_plan_504

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -34,7 +34,6 @@ class Student < ActiveRecord::Base
   validate :validate_registration_date_cannot_be_in_future
   validate :validate_free_reduced_lunch
 
-
   VALID_FREE_REDUCED_LUNCH_VALUES = [
     "Free Lunch",
     "Not Eligible",

--- a/spec/importers/rows/student_row_spec.rb
+++ b/spec/importers/rows/student_row_spec.rb
@@ -67,11 +67,11 @@ RSpec.describe StudentRow do
 
     context 'when PerDistrict attributes are not exported' do
       before do
-        mock_per_district = instance_double(PerDistrict)
-        expect(mock_per_district).to receive(:import_student_house?).and_return(false)
-        expect(mock_per_district).to receive(:import_student_counselor?).and_return(false)
-        expect(mock_per_district).to receive(:import_student_sped_liaison?).and_return(false)
-        expect(PerDistrict).to receive(:new).and_return(mock_per_district)
+        mock_per_district = PerDistrict.new
+        allow(mock_per_district).to receive(:import_student_house?).and_return(false)
+        allow(mock_per_district).to receive(:import_student_counselor?).and_return(false)
+        allow(mock_per_district).to receive(:import_student_sped_liaison?).and_return(false)
+        allow(PerDistrict).to receive(:new).and_return(mock_per_district)
       end
 
       it 'does not try to read and leaves them as nil' do

--- a/spec/importers/rows/student_row_spec.rb
+++ b/spec/importers/rows/student_row_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe StudentRow do
       end
     end
 
+    context 'invalid registration_date' do
+      let(:row) { { full_name: 'Hoag, George', registration_date: '02' } }
+
+      it 'sets it as nil' do
+        expect(student.registration_date).to eq nil
+      end
+    end
+
     context 'grade level KF' do
       let(:row) { { grade: 'KF', full_name: 'Lee, Nico' } }
 


### PR DESCRIPTION
# Who is this PR for?
Bedford educators

# What problem does this PR fix?
They use different codes for younger grade levels.

# What does this PR do?
Update this to be maximal across districts (rather than per-district), and refactor to remove different Ruby definitions of grade levels to all use `GradeLevels`.

