### PR TITLE
Update StudentsImporter to set nil rather than empty string values

### DIFF
--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -10,7 +10,7 @@ module Admin
     end
 
     def edit
-      @valid_grades = %w(PK KF SP 1 2 3 4 5 6 7 8 9 10 11 12)
+      @valid_grades = GradeLevels::ORDERED_GRADE_LEVELS
       super
     end
 

--- a/app/importers/rows/student_row.rb
+++ b/app/importers/rows/student_row.rb
@@ -40,7 +40,8 @@ class StudentRow < Struct.new(:row, :homeroom_id, :school_ids_dictionary, :log)
   end
 
   def demographic_attributes
-    row.to_h.slice(
+    attrs = {}
+    [
       :state_id,
       :enrollment_status,
       :home_language,
@@ -57,7 +58,18 @@ class StudentRow < Struct.new(:row, :homeroom_id, :school_ids_dictionary, :log)
       :gender,
       :primary_phone,
       :primary_email,
-    )
+    ].map do |key|
+      value = row[key]
+      if value.nil? # set nil if column not in import
+        attrs[key] = nil
+      elsif value == '' # set nil if column is in import, but there's an empty string value
+        attrs[key] = nil
+      else
+        attrs[key] = value
+      end
+    end
+
+    attrs
   end
 
   def school_attributes

--- a/app/lib/grade_levels.rb
+++ b/app/lib/grade_levels.rb
@@ -1,5 +1,7 @@
 class GradeLevels
   ORDERED_GRADE_LEVELS = [
+    'OOPK',
+    'OPK',
     'TK',
     'PPK',
     'PK',

--- a/app/lib/insight_students_with_high_absences.rb
+++ b/app/lib/insight_students_with_high_absences.rb
@@ -32,7 +32,13 @@ class InsightStudentsWithHighAbsences
       # Exclude students in younger grades like PreK since attendance isn't mandatory.
       # This means there's less consistent attendance from families, and it's less
       # of a priority to follow-up for schools.
-      students_to_consider = Student.active.where.not(grade: ['TK', 'PPK', 'PK'])
+      students_to_consider = Student.active.where.not(grade: [
+        'TK',
+        'PPK',
+        'PK',
+        'OPK',
+        'OOPK'
+      ])
 
       # Filter students to match what they see in their feed (eg, HS counselors
       # only see students on their caseload).

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -128,7 +128,7 @@ class Educator < ActiveRecord::Base
   end
 
   def validate_grade_level_strings_are_valid
-    if grade_level_access.any? { |grade| !(VALID_GRADES.include?(grade)) }
+    if grade_level_access.any? { |grade| !(GradeLevels::ORDERED_GRADE_LEVELS.include?(grade)) }
       errors.add(:grade_level_access, "invalid grade")
     end
   end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -27,12 +27,12 @@ class Student < ActiveRecord::Base
   has_many :dibels_results, -> { order(date_taken: :desc) }, dependent: :destroy
 
   validates :local_id, presence: true, uniqueness: true, with: /^[0-9]+$/
-  validates_uniqueness_of :local_id
   validates :first_name, presence: true
   validates :last_name, presence: true
-  validate :validate_grade
-  validate :validate_registration_date_cannot_be_in_future
-  validate :validate_free_reduced_lunch
+  validates :grade, inclusion: { in: GradeLevels::ORDERED_GRADE_LEVELS }
+  validates :plan_504, inclusion: { in: PerDistrict.new.valid_plan_504_values }
+  validates :validate_registration_date_cannot_be_in_future
+  validates :free_reduced_lunch, inclusion: { in: VALID_FREE_REDUCED_LUNCH_VALUES }
 
   VALID_FREE_REDUCED_LUNCH_VALUES = [
     "Free Lunch",
@@ -260,15 +260,4 @@ class Student < ActiveRecord::Base
     end
   end
 
-  def validate_free_reduced_lunch
-    errors.add(:free_reduced_lunch, "unexpected value: #{free_reduced_lunch}") unless free_reduced_lunch.in?(VALID_FREE_REDUCED_LUNCH_VALUES)
-  end
-
-  def validate_grade
-    errors.add(:grade, "invalid grade: #{grade}") unless grade.in?(GradeLevels::ORDERED_GRADE_LEVELS)
-  end
-
-  def validate_plan_504
-    errors.add(:plan_504, "invalid plan_504: #{plan_504}") unless grade.in?(PerDistrict.new.valid_plan_504_values)
-  end
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -34,9 +34,6 @@ class Student < ActiveRecord::Base
   validate :validate_registration_date_cannot_be_in_future
   validate :validate_free_reduced_lunch
 
-  VALID_GRADES = [
-    'PPK', 'PK', 'KF', 'SP', 'TK', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13'
-  ].freeze
 
   VALID_FREE_REDUCED_LUNCH_VALUES = [
     "Free Lunch",
@@ -269,7 +266,7 @@ class Student < ActiveRecord::Base
   end
 
   def validate_grade
-    errors.add(:grade, "invalid grade: #{grade}") unless grade.in?(VALID_GRADES)
+    errors.add(:grade, "invalid grade: #{grade}") unless grade.in?(GradeLevels::ORDERED_GRADE_LEVELS)
   end
 
   def validate_plan_504

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -26,14 +26,13 @@ class Student < ActiveRecord::Base
   has_many :star_reading_results, -> { order(date_taken: :desc) }, dependent: :destroy
   has_many :dibels_results, -> { order(date_taken: :desc) }, dependent: :destroy
 
-  validates_presence_of :local_id
+  validates :local_id, presence: true, uniqueness: true, with: /^[0-9]+$/
   validates_uniqueness_of :local_id
   validates :first_name, presence: true
   validates :last_name, presence: true
   validate :validate_grade
   validate :validate_registration_date_cannot_be_in_future
   validate :validate_free_reduced_lunch
-
 
   VALID_FREE_REDUCED_LUNCH_VALUES = [
     "Free Lunch",

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -1,4 +1,11 @@
 class Student < ActiveRecord::Base
+  VALID_FREE_REDUCED_LUNCH_VALUES = [
+    "Free Lunch",
+    "Not Eligible",
+    "Reduced Lunch",
+    nil
+  ].freeze
+  
   # Model for a student in the district, backed by information in the database.
   # Class methods (self.active) concern collections of students,
   # and instance methods (latest_mcas_mathematics) concern a single student.
@@ -31,15 +38,8 @@ class Student < ActiveRecord::Base
   validates :last_name, presence: true
   validates :grade, inclusion: { in: GradeLevels::ORDERED_GRADE_LEVELS }
   validates :plan_504, inclusion: { in: PerDistrict.new.valid_plan_504_values }
-  validates :validate_registration_date_cannot_be_in_future
-  validates :free_reduced_lunch, inclusion: { in: VALID_FREE_REDUCED_LUNCH_VALUES }
-
-  VALID_FREE_REDUCED_LUNCH_VALUES = [
-    "Free Lunch",
-    "Not Eligible",
-    "Reduced Lunch",
-    nil
-  ]
+  validates :free_reduced_lunch, inclusion: { in: Student::VALID_FREE_REDUCED_LUNCH_VALUES }
+  validate :validate_registration_date_cannot_be_in_future
 
   def self.with_school
     where.not(school: nil)

--- a/spec/importers/rows/student_row_spec.rb
+++ b/spec/importers/rows/student_row_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe StudentRow do
       end
     end
 
+    context 'empty string sped_placement' do
+      let(:row) { { full_name: 'Hoag, George', sped_placement: '' } }
+
+      it 'sets it as nil' do
+        expect(student.sped_placement).to eq nil
+      end
+    end
+
     context 'grade level KF' do
       let(:row) { { grade: 'KF', full_name: 'Lee, Nico' } }
 


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
If a field is missing, `StudentsImporter` will set it as nil.  If it's there, but an empty string, it will set it as `""`.  For making things with most of these enum fields, these mean the same thing.

# What does this PR do?
Updates the importer to set `""` as nil.  It also improves some `Student` validations, moving them up to use `inclusion: in` and tightening `local_id`.

# Checklists
+ [x] Author included specs for new code
