### PR TITLE
Update Educator factory to use unique login_names to avoid collisions

### DIFF
--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     end
     login_name do
       last_name, first_name = full_name.split(', ')
-      "#{first_name.first}#{last_name}"
+      "#{first_name}#{last_name}"
     end
     local_id { FactoryBot.generate(:staff_local_id) }
     association :school


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
flaky test failures like: https://travis-ci.org/studentinsights/studentinsights/builds/432947678?utm_medium=notification&utm_source=email

# What does this PR do?
Change `login_name` to be less realistic, but guarantee no collisions when generating random login_name values.
