### PR TITLE
Create assigned_homeroom_id key on Educator table, copy to bootstrap, and update importers

### DIFF
--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -76,18 +76,18 @@ class EducatorsImporter
       return
     end
 
-    # Find the matching Educator record if possible and sync it
-    maybe_educator = EducatorRow.new(row, school_ids_dictionary).match_educator_record
-    @educator_syncer.validate_mark_and_sync!(maybe_educator)
-
-    # Find the matching Homeroom record if possible and
-    # sync the `educator_id` field.
-    maybe_homeroom = match_homeroom(row, maybe_educator)
+    # Find the matching Homeroom record and sync it
+    maybe_homeroom = match_homeroom(row)
     @homeroom_syncer.validate_mark_and_sync!(maybe_homeroom)
+
+    # Find the matching Educator record if possible and sync it
+    # The Homeroom has to be synced first
+    maybe_educator = EducatorRow.new(row, maybe_homeroom.try(:id), school_ids_dictionary).match_educator_record
+    @educator_syncer.validate_mark_and_sync!(maybe_educator)
   end
 
-  # Match existing Homeroom and update reference to Educator.
-  def match_homeroom(row, maybe_educator)
+  # Match existing Homeroom if possible, or initialize new record
+  def match_homeroom(row)
     # Special case for NB magic "nil" value
     if PerDistrict.new.is_nil_homeroom_name?(row[:homeroom])
       @ignored_special_nil_homeroom_count += 1
@@ -108,16 +108,10 @@ class EducatorsImporter
     end
 
     # Match Homeroom (guaranteed to be uniqe on {name, school} by database index)
-    homeroom = Homeroom.find_or_initialize_by({
+    Homeroom.find_or_initialize_by({
       name: row[:homeroom],
       school_id: school_id
     })
-
-    # Update to reference educator
-    educator_id = maybe_educator.try(:id) # might be nil
-    homeroom.assign_attributes(educator_id: educator_id)
-
-    homeroom
   end
 
   def log(msg)

--- a/app/importers/rows/educator_row.rb
+++ b/app/importers/rows/educator_row.rb
@@ -1,4 +1,4 @@
-class EducatorRow < Struct.new(:row, :homeroom_id, :school_ids_dictionary)
+class EducatorRow < Struct.new(:row, :assigned_homeroom_id, :school_ids_dictionary)
   # Returns a new or existing Educator record matching the row, or nil if it can't
   # understand the row.
   def match_educator_record
@@ -14,7 +14,7 @@ class EducatorRow < Struct.new(:row, :homeroom_id, :school_ids_dictionary)
       staff_type: row[:staff_type],
       admin: is_admin?,
       local_id: row[:local_id],
-      homeroom_id: homeroom_id,
+      assigned_homeroom_id: assigned_homeroom_id,
       school_id: school_rails_id
     })
 

--- a/app/importers/rows/educator_row.rb
+++ b/app/importers/rows/educator_row.rb
@@ -1,4 +1,4 @@
-class EducatorRow < Struct.new(:row, :school_ids_dictionary)
+class EducatorRow < Struct.new(:row, :homeroom_id, :school_ids_dictionary)
   # Returns a new or existing Educator record matching the row, or nil if it can't
   # understand the row.
   def match_educator_record
@@ -14,6 +14,7 @@ class EducatorRow < Struct.new(:row, :school_ids_dictionary)
       staff_type: row[:staff_type],
       admin: is_admin?,
       local_id: row[:local_id],
+      homeroom_id: homeroom_id,
       school_id: school_rails_id
     })
 

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -2,7 +2,8 @@ class Educator < ActiveRecord::Base
   devise :ldap_authenticatable_tiny, :rememberable, :trackable, :timeoutable, authentication_keys: [:login_text]
 
   belongs_to  :school
-  belongs_to  :homeroom, optional: true
+  has_one     :homeroom
+  belongs_to  :assigned_homeroom, optional: true
   has_many    :students, through: :homeroom
   has_many    :educator_section_assignments
   has_many    :sections, through: :educator_section_assignments

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -2,7 +2,7 @@ class Educator < ActiveRecord::Base
   devise :ldap_authenticatable_tiny, :rememberable, :trackable, :timeoutable, authentication_keys: [:login_text]
 
   belongs_to  :school
-  belongs_to  :homeroom
+  belongs_to  :homeroom, optional: true
   has_many    :students, through: :homeroom
   has_many    :educator_section_assignments
   has_many    :sections, through: :educator_section_assignments

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -2,7 +2,7 @@ class Educator < ActiveRecord::Base
   devise :ldap_authenticatable_tiny, :rememberable, :trackable, :timeoutable, authentication_keys: [:login_text]
 
   belongs_to  :school
-  has_one     :homeroom
+  belongs_to  :homeroom
   has_many    :students, through: :homeroom
   has_many    :educator_section_assignments
   has_many    :sections, through: :educator_section_assignments

--- a/db/migrate/20180925121832_educator_homeroom_key.rb
+++ b/db/migrate/20180925121832_educator_homeroom_key.rb
@@ -1,14 +1,14 @@
 class EducatorHomeroomKey < ActiveRecord::Migration[5.2]
   def change
     puts "Add new column to Educator table..."
-    add_reference :educators, :homeroom
-    add_foreign_key :educators, :homerooms
+    add_column :educators, :assigned_homeroom_id, :integer
+    add_foreign_key :educators, :homerooms, column: 'assigned_homeroom_id'
 
-    puts "Copying references from #{Homeroom.all} homeroom records..."
+    puts "Copying references from #{Homeroom.all.size} homeroom records..."
     copied_count = 0
     Homeroom.all.each do |homeroom|
       if homeroom.educator.present?
-        homeroom.educator.update!(homeroom_id: homeroom.id)
+        homeroom.educator.update!(assigned_homeroom_id: homeroom.id)
         copied_count += 1
       end
     end

--- a/db/migrate/20180925121832_educator_homeroom_key.rb
+++ b/db/migrate/20180925121832_educator_homeroom_key.rb
@@ -1,0 +1,6 @@
+class EducatorHomeroomKey < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :educators, :homeroom
+    add_foreign_key :educators, :homerooms
+  end
+end

--- a/db/migrate/20180925121832_educator_homeroom_key.rb
+++ b/db/migrate/20180925121832_educator_homeroom_key.rb
@@ -1,6 +1,18 @@
 class EducatorHomeroomKey < ActiveRecord::Migration[5.2]
   def change
+    puts "Add new column to Educator table..."
     add_reference :educators, :homeroom
     add_foreign_key :educators, :homerooms
+
+    puts "Copying references from #{Homeroom.all} homeroom records..."
+    copied_count = 0
+    Homeroom.all.each do |homeroom|
+      if homeroom.educator.present?
+        homeroom.educator.update!(homeroom_id: homeroom.id)
+        copied_count += 1
+      end
+    end
+    puts "Updated #{copied_count} Educator records."
+    puts "Done."
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_24_200334) do
+ActiveRecord::Schema.define(version: 2018_09_25_121832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -151,7 +151,9 @@ ActiveRecord::Schema.define(version: 2018_09_24_200334) do
     t.boolean "can_set_districtwide_access", default: false, null: false
     t.text "student_searchbar_json"
     t.text "login_name", null: false
+    t.bigint "homeroom_id"
     t.index ["grade_level_access"], name: "index_educators_on_grade_level_access", using: :gin
+    t.index ["homeroom_id"], name: "index_educators_on_homeroom_id"
   end
 
   create_table "event_note_attachments", id: :serial, force: :cascade do |t|
@@ -525,6 +527,7 @@ ActiveRecord::Schema.define(version: 2018_09_24_200334) do
   add_foreign_key "educator_labels", "educators", name: "educator_labels_educator_id_fk"
   add_foreign_key "educator_section_assignments", "educators"
   add_foreign_key "educator_section_assignments", "sections"
+  add_foreign_key "educators", "homerooms"
   add_foreign_key "educators", "schools", name: "educators_school_id_fk"
   add_foreign_key "event_note_attachments", "event_notes", name: "event_note_attachments_event_note_id_fk"
   add_foreign_key "event_note_revisions", "educators", name: "event_note_revisions_educator_id_fk"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -151,9 +151,8 @@ ActiveRecord::Schema.define(version: 2018_09_25_121832) do
     t.boolean "can_set_districtwide_access", default: false, null: false
     t.text "student_searchbar_json"
     t.text "login_name", null: false
-    t.bigint "homeroom_id"
+    t.integer "assigned_homeroom_id"
     t.index ["grade_level_access"], name: "index_educators_on_grade_level_access", using: :gin
-    t.index ["homeroom_id"], name: "index_educators_on_homeroom_id"
   end
 
   create_table "event_note_attachments", id: :serial, force: :cascade do |t|
@@ -527,7 +526,7 @@ ActiveRecord::Schema.define(version: 2018_09_25_121832) do
   add_foreign_key "educator_labels", "educators", name: "educator_labels_educator_id_fk"
   add_foreign_key "educator_section_assignments", "educators"
   add_foreign_key "educator_section_assignments", "sections"
-  add_foreign_key "educators", "homerooms"
+  add_foreign_key "educators", "homerooms", column: "assigned_homeroom_id"
   add_foreign_key "educators", "schools", name: "educators_school_id_fk"
   add_foreign_key "event_note_attachments", "event_notes", name: "event_note_attachments_event_note_id_fk"
   add_foreign_key "event_note_revisions", "educators", name: "event_note_revisions_educator_id_fk"


### PR DESCRIPTION
# Who is this PR for?
educators, developers

# What problem does this PR fix?
Part of https://github.com/studentinsights/studentinsights/issues/1880#issuecomment-416420431.

Multiple educators can be assigned to the same homeroom, but Insights doesn't allow this now.  This results in the importer process thrashing each day over who is assigned to the homeroom, and effectively alternating who will be authorized to view those students.  This isn't user-impacting right now, and it came up from validating the Bedford imports.

The overall idea is to migrate the key to the Educator model, and do this in pieces:
- [ ] add new key, copy values into it
- [ ] run import
- [ ] update read side (feed, homerooms_controller)
- [ ] drop old key
- [ ] migrate column name and read code

Because these are related, once we start we should finish them all to avoid allowing drift during the migration.

# What does this PR do?
This PR aims to do the first two items.

# Checklists
+ [x] Author included specs for new code
