### PR TITLE
Levels: Add support gaps links for NGE/10GE and SST, enable sorting

### DIFF
--- a/app/assets/javascripts/components/EscapeListener.js
+++ b/app/assets/javascripts/components/EscapeListener.js
@@ -7,11 +7,11 @@ import _ from 'lodash';
 export default class EscapeListener extends React.Component {
   constructor(props) {
     super(props);
-    this.onKeyUp = this.onKeyUp.bind(this);
+    this.onKeyDown = this.onKeyDown.bind(this);
     this.onClick = this.onClick.bind(this);
   }
 
-  onKeyUp(e) {
+  onKeyDown(e) {
     const {onEscape} = this.props;
     if (e.which === 27) onEscape();
   }
@@ -28,7 +28,7 @@ export default class EscapeListener extends React.Component {
       <div
         className={classNameString}
         style={style}
-        onKeyUp={this.onKeyUp}
+        onKeyDown={this.onKeyDown}
         onClick={escapeOnUnhandledClick && this.onClick}>{children}</div>
     );
   }

--- a/app/assets/javascripts/components/HelpBubble.js
+++ b/app/assets/javascripts/components/HelpBubble.js
@@ -21,13 +21,15 @@ export default class HelpBubble extends React.Component {
   }
 
   closeModal(e){
-    this.setState({modalIsOpen: false});
     e.preventDefault();
+    e.stopPropagation();
+    this.setState({modalIsOpen: false});
   }
 
   openModal(e){
-    this.setState({modalIsOpen: true});
     e.preventDefault();
+    e.stopPropagation();
+    this.setState({modalIsOpen: true});
   }
 
   render(){

--- a/app/assets/javascripts/helpers/SortHelpers.js
+++ b/app/assets/javascripts/helpers/SortHelpers.js
@@ -71,7 +71,6 @@ export function sortByGrade(gradeA, gradeB) {
 export function rankedByGradeLevel(gradeLevel) {
   return ORDERED_GRADES[gradeLevel];
 }
-
 const ORDERED_SCHOOL_TYPES = {
   'ES': 200,
   'ESMS': 300,
@@ -84,4 +83,23 @@ const ORDERED_SCHOOL_TYPES = {
 
 export function rankedBySchoolType(schoolType) {
   return ORDERED_SCHOOL_TYPES[schoolType];
+}
+
+const ORDERED_LETTER_GRADES = {
+  'A+': 100,
+  'A': 120,
+  'A-': 120,
+  'B+': 130,
+  'B': 150,
+  'B-': 160,
+  'C+': 170,
+  'C': 180,
+  'C-': 190,
+  'D+': 200,
+  'D': 210,
+  'D-': 220,
+  'F': 230
+};
+export function rankedByLetterGrade(letterGrade) {
+  return ORDERED_LETTER_GRADES[letterGrade] || 0;
 }

--- a/app/assets/javascripts/my_students/__snapshots__/FilterStudentsBar.test.js.snap
+++ b/app/assets/javascripts/my_students/__snapshots__/FilterStudentsBar.test.js.snap
@@ -3,7 +3,7 @@
 exports[`snapshots with all options 1`] = `
 <div
   className="FilterStudentsBar EscapeListener"
-  onKeyUp={[Function]}
+  onKeyDown={[Function]}
 >
   <div
     className="FilterBar"
@@ -291,7 +291,7 @@ exports[`snapshots with all options 1`] = `
 exports[`snapshots without options 1`] = `
 <div
   className="FilterStudentsBar EscapeListener"
-  onKeyUp={[Function]}
+  onKeyDown={[Function]}
 >
   <div
     className="FilterBar"

--- a/app/assets/javascripts/school_absences/__snapshots__/SchoolAbsencesDashboard.test.js.snap
+++ b/app/assets/javascripts/school_absences/__snapshots__/SchoolAbsencesDashboard.test.js.snap
@@ -23,7 +23,7 @@ exports[`snapshots works for bedford 1`] = `
   >
     <div
       className="SchoolAbsencesDashboard EscapeListener"
-      onKeyUp={[Function]}
+      onKeyDown={[Function]}
       style={
         Object {
           "display": "flex",
@@ -525,7 +525,7 @@ exports[`snapshots works for bedford 1`] = `
           <div
             className="EscapeListener"
             onClick={[Function]}
-            onKeyUp={[Function]}
+            onKeyDown={[Function]}
             style={
               Object {
                 "display": "flex",
@@ -585,7 +585,7 @@ exports[`snapshots works for demo 1`] = `
   >
     <div
       className="SchoolAbsencesDashboard EscapeListener"
-      onKeyUp={[Function]}
+      onKeyDown={[Function]}
       style={
         Object {
           "display": "flex",
@@ -1167,7 +1167,7 @@ exports[`snapshots works for demo 1`] = `
           <div
             className="EscapeListener"
             onClick={[Function]}
-            onKeyUp={[Function]}
+            onKeyDown={[Function]}
             style={
               Object {
                 "display": "flex",
@@ -1227,7 +1227,7 @@ exports[`snapshots works for new_bedford 1`] = `
   >
     <div
       className="SchoolAbsencesDashboard EscapeListener"
-      onKeyUp={[Function]}
+      onKeyDown={[Function]}
       style={
         Object {
           "display": "flex",
@@ -1562,7 +1562,7 @@ exports[`snapshots works for new_bedford 1`] = `
           <div
             className="EscapeListener"
             onClick={[Function]}
-            onKeyUp={[Function]}
+            onKeyDown={[Function]}
             style={
               Object {
                 "display": "flex",
@@ -1622,7 +1622,7 @@ exports[`snapshots works for somerville 1`] = `
   >
     <div
       className="SchoolAbsencesDashboard EscapeListener"
-      onKeyUp={[Function]}
+      onKeyDown={[Function]}
       style={
         Object {
           "display": "flex",
@@ -2204,7 +2204,7 @@ exports[`snapshots works for somerville 1`] = `
           <div
             className="EscapeListener"
             onClick={[Function]}
-            onKeyUp={[Function]}
+            onKeyDown={[Function]}
             style={
               Object {
                 "display": "flex",

--- a/app/assets/javascripts/tiering/StudentLevelsTable.js
+++ b/app/assets/javascripts/tiering/StudentLevelsTable.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Table, Column, AutoSizer} from 'react-virtualized';
+import _ from 'lodash';
+import moment from 'moment';
+import {Table, Column, AutoSizer, SortDirection} from 'react-virtualized';
 import 'react-select/dist/react-select.css';
 import {toMomentFromTimestamp} from '../helpers/toMoment';
+import {rankedByLetterGrade} from '../helpers/SortHelpers';
 import {prettyProgramOrPlacementText} from '../helpers/specialEducation';
 import {
   firstMatch,
@@ -22,26 +25,92 @@ import {
 export default class StudentLevelsTable extends React.Component {
   constructor(props) {
     super(props);
+
+    this.state = {
+      sortBy: 'level',
+      sortDirection: SortDirection.ASC,
+    };
+    this.onTableSort = this.onTableSort.bind(this);
+  }
+
+  orderedStudents() {
+    const {studentsWithTiering} = this.props;
+    const {sortBy, sortDirection} = this.state;
+
+    // map dataKey to an accessor/sort function
+    const sortFns = {
+      student(student) { return `${student.last_name}, ${student.first_name}`; },
+      level(student) { return student.tier.level; },
+      absence(student) { return student.tier.data.recent_absence_rate; },
+      discipline(student) { return student.tier.data.recent_discipline_actions; },
+      en_or_ell(student) { return sortByGrade(EN_OR_ELL, student); },
+      history(student) { return sortByGrade(HISTORY, student); },
+      math(student) { return sortByGrade(MATH, student); },
+      science(student) { return sortByGrade(SCIENCE, student); },
+      nge(student) { return sortTimestamp(student.notes.last_experience_note.recorded_at); },
+      sst(student) { return sortTimestamp(student.notes.last_sst_note.recorded_at); },
+      study(student) { return sortIfCourse(STUDY_SKILLS, student); },
+      support(student) { return sortIfCourse(ACADEMIC_SUPPORT, student); },
+      redirect(student) { return sortIfCourse(REDIRECT, student); },
+      recovery(student) { return sortIfCourse(CREDIT_RECOVERY, student); },
+      program_assigned(student) { return prettyProgramOrPlacementText(student); },
+      fallback(student) { return student[sortBy]; }
+    };
+
+    // "Natural" sort order, before table sorting
+    const sortFn = sortFns[sortBy] || sortFns.fallback;
+    const sortedRows = _.sortBy(studentsWithTiering, [
+      (s => sortFn(s)),
+      (s => s.tier.level),
+      (s => s.tier.triggers.length),
+      (s => s.tier.triggers.sort()),
+      (s => s.last_name),
+      (s => s.first_name)
+    ]);
+    // sort and respect direction
+    
+    // const sortedRows = _.sortBy(studentsWithTiering, sortFn);
+    return (sortDirection === SortDirection.DESC) 
+      ? sortedRows.reverse()
+      : sortedRows;
+  }
+
+  onTableSort({defaultSortDirection, event, sortBy, sortDirection}) {
+    if (sortBy === this.state.sortBy) {
+      const oppositeSortDirection = (this.state.sortDirection == SortDirection.DESC)
+        ? SortDirection.ASC
+        : SortDirection.DESC;
+      this.setState({ sortDirection: oppositeSortDirection });
+    } else {
+      this.setState({sortBy});
+    }
+
+    this.tableEl.scrollToRow(0);
   }
 
   render() {
-    const {sortedStudentsWithTiering} = this.props;
+    const {sortDirection, sortBy} = this.state;
     const gradeCellWidth = 50;
     const numericCellWidth = 70;
     const supportCellWidth = 70;
 
+    const students = this.orderedStudents();
     return (
       <AutoSizer className="StudentLevelsTable">
         {({height, width}) => (
           <Table
+            ref={el => this.tableEl = el}
             width={width}
             headerHeight={40}
             height={height}
-            rowCount={sortedStudentsWithTiering.length}
-            rowGetter={({index}) => sortedStudentsWithTiering[index]}
+            rowCount={students.length}
+            rowGetter={({index}) => students[index]}
             rowHeight={40}
             rowStyle={{display: 'flex', alignItems: 'center'}}
             headerStyle={styles.tableHeaderStyle}
+            sort={this.onTableSort}
+            sortBy={sortBy}
+            sortDirection={sortDirection}
           >
             <Column
               dataKey="student"
@@ -65,7 +134,7 @@ export default class StudentLevelsTable extends React.Component {
               width={numericCellWidth}
               cellRenderer={this.renderDisciplineIncidents} />
             <Column
-              dataKey="ela"
+              dataKey="en_or_ell"
               label={<span><br />EN/ELL</span>}
               width={gradeCellWidth}
               cellRenderer={this.renderGradeFor.bind(this, EN_OR_ELL)} />
@@ -218,7 +287,7 @@ StudentLevelsTable.contextTypes = {
   nowFn: PropTypes.func.isRequired
 };
 StudentLevelsTable.propTypes = {
-  sortedStudentsWithTiering: PropTypes.array.isRequired
+  studentsWithTiering: PropTypes.array.isRequired
 };
 
 const warningColor = 'rgb(255, 222, 198)';
@@ -263,3 +332,21 @@ const styles = {
     padding: 8
   }
 };
+
+function sortByGrade(patterns, student) {
+  const assignment = firstMatch(student.student_section_assignments, patterns);
+  return (assignment && assignment.grade_letter)
+    ? rankedByLetterGrade(assignment.grade_letter)
+    : Number.POSITIVE_INFINITY;
+}
+
+function sortIfCourse(patterns, student) {
+  const assignment = firstMatch(student.student_section_assignments, patterns);
+  return (assignment) ? 1 : 0;
+}
+
+function sortTimestamp(maybeString) {
+  return (maybeString)
+    ? moment.utc(maybeString).unix()
+    : Number.NEGATIVE_INFINITY;
+}

--- a/app/assets/javascripts/tiering/StudentLevelsTable.test.js
+++ b/app/assets/javascripts/tiering/StudentLevelsTable.test.js
@@ -6,7 +6,7 @@ import tieringShowJson from './tieringShowJson.fixture';
 
 function testProps(props = {}) {
   return {
-    sortedStudentsWithTiering: tieringShowJson.students_with_tiering,
+    studentsWithTiering: tieringShowJson.students_with_tiering,
     ...props
   };
 }

--- a/app/assets/javascripts/tiering/SupportGaps.js
+++ b/app/assets/javascripts/tiering/SupportGaps.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
 import Button from '../components/Button';
 import StudentLevelsTable from './StudentLevelsTable';
 

--- a/app/assets/javascripts/tiering/SupportGaps.js
+++ b/app/assets/javascripts/tiering/SupportGaps.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import Button from '../components/Button';
+import StudentLevelsTable from './StudentLevelsTable';
+
+
+// Focused lists of students who meet triggered but aren't yet being mentioned in support meetings.
+export default class SupportGaps extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isShowingList: false
+    };
+    this.onLinkClicked = this.onLinkClicked.bind(this);
+  }
+
+  onLinkClicked(e) {
+    e.preventDefault();
+    const {isShowingList} = this.state;
+    this.setState({isShowingList: !isShowingList});
+  }
+
+  render() {
+    const {message} = this.props;
+    const {isShowingList} = this.state;
+    return (
+      <div className="SupportGaps" style={styles.root}>
+        <div style={{display: 'flex', flexDirection: 'column', marginBottom: 40}}>
+          <div style={{flex: 1}}>{message}</div>
+          {!isShowingList && <Button style={{marginTop: 20}} onClick={this.onLinkClicked}>show students</Button>}
+        </div>
+        {this.renderStudentsList()}
+      </div>
+    );
+  }
+
+  renderStudentsList(key) {
+    const {isShowingList} = this.state;
+    if (!isShowingList) return null;
+
+    const {uncoveredStudentsWithTiering} = this.props;
+    return (
+      <div style={styles.table}>
+        <StudentLevelsTable studentsWithTiering={uncoveredStudentsWithTiering} />
+      </div>
+    );
+  }
+}
+SupportGaps.contextTypes = {
+  nowFn: PropTypes.func.isRequired
+};
+SupportGaps.propTypes = {
+  message: PropTypes.node.isRequired,
+  uncoveredStudentsWithTiering: PropTypes.array.isRequired
+};
+
+const strengthColor = '#4d884d';
+const styles = {
+  root: {
+    fontSize: 14,
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1
+  },
+  table: {
+    display: 'flex',
+    flex: 1,
+    flexDirection: 'column'
+  },
+  bar: {
+    backgroundColor: strengthColor,
+    borderLeft: '1px solid #aaa',
+    color: 'white'
+  },
+  person: {
+    fontSize: 14,
+    display: 'block'
+  }
+};

--- a/app/assets/javascripts/tiering/TieringView.js
+++ b/app/assets/javascripts/tiering/TieringView.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import Modal from 'react-modal';
 import EscapeListener from '../components/EscapeListener';
 import FilterBar from '../components/FilterBar';
 import SimpleFilterSelect, {ALL} from '../components/SimpleFilterSelect';
@@ -16,6 +15,11 @@ import {
   STUDY_SKILLS
 } from './Courses';
 import StudentLevelsTable from './StudentLevelsTable';
+import SupportGaps from './SupportGaps';
+import HelpBubble, {
+  modalFromRight,
+  dialogFullScreenFlex
+} from '../components/HelpBubble';
 
 
 // Experimental UI for HS tiering prototype
@@ -30,7 +34,6 @@ export default class TieringView extends React.Component {
     this.onTierChanged = this.onTierChanged.bind(this);
     this.onTriggerChanged = this.onTriggerChanged.bind(this);
     this.onSearchChanged = this.onSearchChanged.bind(this);
-    this.onToggleModal = this.onToggleModal.bind(this);
   }
 
   filterStudents() {
@@ -81,32 +84,27 @@ export default class TieringView extends React.Component {
     this.setState({search});
   }
 
-  onToggleModal() {
-    const {isModalOpen} = this.state;
-    this.setState({isModalOpen: !isModalOpen});
-  }
-
   render() {
-    const students = this.filterStudents();
+    const filteredStudents = this.filterStudents();
     return (
       <EscapeListener className="TieringView" style={{...styles.root, ...styles.flexVertical}} onEscape={this.onEscape}>
-        {this.renderSelection(students)}
-        {this.renderTable(students)}
+        {this.renderSelection(filteredStudents)}
+        {this.renderTable(filteredStudents)}
       </EscapeListener>
     );
   }
 
-  renderSelection(studentsWithTiering) {
+  renderSelection(filteredStudents) {
     const {grade, house, tier, trigger, search} = this.state;
 
     const nullOption = [{ value: ALL, label: 'All' }];
     const possibleTiers = ['0', '1', '2', '3', '4'];
     const possibleTriggers = ['academic', 'absence', 'discipline'];
     return (
-      <FilterBar style={styles.filterBar}>
+      <FilterBar style={styles.filterBar} barStyle={{flex: 1}}>
         <input
           style={styles.search}
-          placeholder={`Search ${studentsWithTiering.length} students...`}
+          placeholder={`Search ${filteredStudents.length} students...`}
           value={search}
           onChange={this.onSearchChanged} />
         <SelectGrade
@@ -134,26 +132,83 @@ export default class TieringView extends React.Component {
           options={nullOption.concat(possibleTriggers.map(value => {
             return { value, label: `${value} trigger` };
           }))} />
-        <span style={styles.tieringInfo}>Last 45 days</span>
-        {this.renderSummaryModal(studentsWithTiering)}
+        <div style={styles.textBar}>
+          {this.renderExperienceGaps(filteredStudents)}
+          {this.renderSSTGaps(filteredStudents)}
+          {this.renderStats(filteredStudents)}
+          <span style={styles.tieringInfo}>Last 45 days</span>
+        </div>
       </FilterBar>
     );
   }
 
-  renderSummaryModal(studentsWithTiering) {
-    const {isModalOpen} = this.state;
+  renderExperienceGaps(filteredStudents) {
+    const uncoveredStudents = filteredStudents.filter(student => (student.grade === '9' || student.grade === '10') && hasAcademicTrigger(student) && !student.notes.last_experience_note.event_note_type_id);
+    return (
+      <HelpBubble
+        modalStyle={styles.modalFullScreen}
+        style={{display: 'inline-block', marginLeft: 0}}
+        linkStyle={styles.summary}
+        dialogStyle={dialogFullScreenFlex}
+        withoutSpacer={true}
+        withoutContentWrapper={true}
+        teaser="NGE/110GE"
+        title="Students not yet mentioned in NGE/10GE"
+        content={
+          <SupportGaps
+            message={this.renderSupportGapsMessageWithFilterWarning(
+              <div>There are <b>{uncoveredStudents.length} students</b> with academic triggers recently who haven't been mentioned in NGE or 10GE.</div>
+            )}
+            uncoveredStudentsWithTiering={uncoveredStudents}
+          />
+        }
+      />
+    );
+  }
+  
+  renderSSTGaps(filteredStudents) {
+    const uncoveredStudents = filteredStudents.filter(student => (hasAbsenceTrigger(student) || hasDisciplineTrigger(student)) && !student.notes.last_sst_note.event_note_type_id);
+    return (
+      <HelpBubble
+        modalStyle={styles.modalFullScreen}
+        style={{display: 'inline-block', marginLeft: 0}}
+        linkStyle={styles.summary}
+        dialogStyle={dialogFullScreenFlex}
+        withoutSpacer={true}
+        withoutContentWrapper={true}
+        teaser="SST"
+        title="Students not yet mentioned in SST"
+        content={
+          <SupportGaps
+            message={this.renderSupportGapsMessageWithFilterWarning(
+              <div>There are <b>{uncoveredStudents.length} students</b> with absence or discipline triggers recently who haven't been mentioned in SST.</div>
+            )}
+            uncoveredStudentsWithTiering={uncoveredStudents}
+          />
+        }
+      />
+    );
+  }
+
+  renderSupportGapsMessageWithFilterWarning(message) {
     return (
       <div>
-        <a href="#" style={styles.summary} onClick={this.onToggleModal}>Summary</a>
-        <Modal
-          ariaHideApp={false}
-          isOpen={isModalOpen}
-          onRequestClose={this.onToggleModal}
-          contentLabel="Modal"
-        >
-          {this.renderSummary(studentsWithTiering)}
-        </Modal>
+        <div>{message}</div>
+        {!_.isEqual(initialState(), this.state) && <div style={{color: 'darkorange', fontWeight: 'bold'}}>Filters are applied.</div>}
       </div>
+    );
+  }
+
+  renderStats(filteredStudents) {
+    return (
+      <HelpBubble
+        modalStyle={modalFromRight}
+        style={{display: 'inline-block'}}
+        linkStyle={styles.summary}
+        teaser="Stats"
+        title="Stats"
+        content={this.renderSummary(filteredStudents)}
+      />
     );
   }
 
@@ -238,17 +293,9 @@ export default class TieringView extends React.Component {
   }
 
   renderTable(studentsWithTiering) {
-    const sortedStudentsWithTiering = _.orderBy(studentsWithTiering, [
-      (s => s.tier.level),
-      (s => s.tier.triggers.length),
-      (s => s.tier.triggers.sort()),
-      (s => s.last_name),
-      (s => s.first_name)
-    ]);
-
     return (
       <div style={{...styles.tableContainer, ...styles.flexVertical}}>
-        <StudentLevelsTable sortedStudentsWithTiering={sortedStudentsWithTiering} />
+        <StudentLevelsTable studentsWithTiering={studentsWithTiering} />
       </div>
     );
   }
@@ -296,24 +343,25 @@ const styles = {
     paddingLeft: 10,
     borderRadius: 3,
     border: '1px solid #ddd',
-    marginLeft: 20,
+    marginLeft: 10,
     fontSize: 12,
     width: 150
   },
   select: {
     width: '10em',
-    marginLeft: 20
+    marginLeft: 15
   },
   summaryContainer: {
     display: 'flex',
-    margin: 10
+    margin: 10,
+    fontSize: 14
   },
   summaryColumn: {
     flex: 1,
     margin: 10
   },
   tieringInfo: {
-    marginLeft: 20,
+    marginLeft: 15,
     fontSize: 12,
     color: '#666'
   },
@@ -323,8 +371,24 @@ const styles = {
   },
   summary: {
     padding: 5,
-    marginLeft: 10,
     fontSize: 12
+  },
+  modalFullScreen: {
+    content: {
+      display: 'flex',
+      flexDirection: 'column',
+      top: 40,
+      bottom: 40,
+      left: 40,
+      right: 40
+    }
+  },
+  textBar: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'center'
   }
 };
 
@@ -334,7 +398,19 @@ function initialState() {
     grade: ALL,
     house: ALL,
     tier: ALL,
-    trigger: ALL,
-    isModalOpen: false
+    trigger: ALL
   };
+}
+
+
+function hasAcademicTrigger(student) {
+  return student.tier.triggers.indexOf('academic') !== -1;
+}
+
+function hasDisciplineTrigger(student) {
+  return student.tier.triggers.indexOf('discipline') !== -1;
+}
+
+function hasAbsenceTrigger(student) {
+  return student.tier.triggers.indexOf('absence') !== -1;
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react": "15.4.2",
     "react-beautiful-dnd": "6.0.2",
     "react-dom": "15.4.2",
-    "react-modal": "^3.0.4",
+    "react-modal": "3.1.10",
     "react-router-dom": "^4.2.2",
     "react-select": "^1.2.1",
     "react-test-renderer": "15.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6781,7 +6781,15 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-react-modal@^3.0.4, react-modal@^3.3.2:
+react-modal@3.1.10:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.1.10.tgz#8898b5cc4ebba78adbb8dea4c55a69818aa682cc"
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.5.10"
+    warning "^3.0.0"
+
+react-modal@^3.3.2:
   version "3.4.4"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.4.4.tgz#e9dde25e9e85a59c76831f2a2b468712a546aded"
   dependencies:


### PR DESCRIPTION
# Who is this PR for?
SHS admin team

# What problem does this PR fix?
Enabling a bit more exploring here before doing anything targeted or focused.  No way to sort columns yet, or to seeing global "coverage" for triggers by notes in support structures like NGE/10GE and SST.

# What does this PR do?
Adds sorting by column, and two new links that popup students with triggers that aren't mentioned in the support structures we'd expect.

# Screenshot (if adding a client-side feature)
<img width="936" alt="screen shot 2018-09-25 at 5 22 23 pm" src="https://user-images.githubusercontent.com/1056957/46044129-ecf11100-c0e7-11e8-9452-e33dcca6536d.png">
<img width="940" alt="screen shot 2018-09-25 at 5 22 18 pm" src="https://user-images.githubusercontent.com/1056957/46044130-ecf11100-c0e7-11e8-8d7f-b3b744d38a8b.png">
<img width="1016" alt="screen shot 2018-09-25 at 5 22 05 pm" src="https://user-images.githubusercontent.com/1056957/46044132-ecf11100-c0e7-11e8-83e2-01285c4c41df.png">
<img width="1019" alt="screen shot 2018-09-25 at 5 21 57 pm" src="https://user-images.githubusercontent.com/1056957/46044133-ecf11100-c0e7-11e8-8d7b-08790e8e71ad.png">
