### PR TITLE
Fix bug with only including NGE/10GE students in low grades box, fix level 1 tier bug

### DIFF
--- a/app/lib/experimental_somerville_high_tiers.rb
+++ b/app/lib/experimental_somerville_high_tiers.rb
@@ -118,11 +118,11 @@ class ExperimentalSomervilleHighTiers
     ].compact
     return Tier.new(2, tier_two_triggers, data) if tier_two_triggers.size > 0
 
-    # Level 1: 1 F and 2 Ds
+    # Level 1: 1 F or 2 Ds
     #   OR less than 95% attendance over last 45 days
     #   (no discipline involved)
     tier_one_triggers = [
-      (:academic if data[:course_failures] == 1 and data[:course_ds] >= 2),
+      (:academic if data[:course_failures] == 1 || data[:course_ds] >= 2),
       (:absence if data[:recent_absence_rate] < 0.95)
     ].compact
     return Tier.new(1, tier_one_triggers, data) if tier_one_triggers.size > 0

--- a/app/lib/insight_students_with_low_grades.rb
+++ b/app/lib/insight_students_with_low_grades.rb
@@ -1,6 +1,4 @@
 class InsightStudentsWithLowGrades
-  EXPERIENCE_TEAM_GRADES = ['9', '10']
-
   def initialize(educator, options = {})
     @educator = educator
     @authorizer = Authorizer.new(@educator)
@@ -8,8 +6,8 @@ class InsightStudentsWithLowGrades
   end
 
   # High-school only.  Returns a list of students in the educator's
-  # sections that have low grades, but haven't been commented on in
-  # NGE or 10GE yet.  The intention is that this information is immediately
+  # sections that have low grades, but haven't been commented on anywhere yet.
+  # The intention is that this information is immediately
   # actionable for high school teachers.
   #
   # This method returns hashes that are the shape of what is needed
@@ -29,13 +27,9 @@ class InsightStudentsWithLowGrades
   private
   def assignments(time_now, time_threshold, grade_threshold)
     # This is high-school only, only look at students the educator
-    # has in their own sections.  And only look at students in the
-    # experience team program.
+    # has in their own sections.
     students = @authorizer.authorized { @educator.section_students }
-    nge_or_10ge_students = students.select do |student|
-      included_in_experience_team?(student)
-    end
-    student_ids = nge_or_10ge_students.map(&:id)
+    student_ids = students.map(&:id)
 
     # Query for low grades and uncommented students, then join both
     # This query structure came to be after some optimizations to reduce
@@ -87,15 +81,5 @@ class InsightStudentsWithLowGrades
         }
       }
     })
-  end
-
-  # This is an imprecise heuristic in general but works here.
-  # In reality, it's more nuanced than this in reality; the NGE and
-  # 10GE teams are defined by the teachers who are in it, not the
-  # students.  The more precise way to answer this is to look at that
-  # list of teachers, and then the list of students who are in their
-  # sections and also in NGE and 10GE.
-  def included_in_experience_team?(student)
-    EXPERIENCE_TEAM_GRADES.include?(student.grade)
   end
 end

--- a/spec/controllers/district_controller_spec.rb
+++ b/spec/controllers/district_controller_spec.rb
@@ -23,6 +23,16 @@ describe DistrictController, :type => :controller do
             "slug"=>"hea"
           }
         }, {
+          "enrollment"=>1,
+          "grade"=>"8",
+          "school"=>
+           {"id"=>pals.west.id,
+            "school_type"=>"ESMS",
+            "name"=>"West Somerville Neighborhood",
+            "local_id"=>"WSNS",
+            "slug"=>"wsns"
+          }
+        }, {
           "enrollment"=>2,
           "grade"=>"9",
           "school"=>{
@@ -33,14 +43,13 @@ describe DistrictController, :type => :controller do
             "slug"=>"shs"}
         }, {
           "enrollment"=>1,
-          "grade"=>"8",
-          "school"=>
-           {"id"=>pals.west.id,
-            "school_type"=>"ESMS",
-            "name"=>"West Somerville Neighborhood",
-            "local_id"=>"WSNS",
-            "slug"=>"wsns"
-          }
+          "grade"=>"12",
+          "school"=>{
+            "id"=>pals.shs.id,
+            "school_type"=>"HS",
+            "name"=>"Somerville High",
+            "local_id"=>"SHS",
+            "slug"=>"shs"}
         }
       ])
     end

--- a/spec/controllers/educators_controller_spec.rb
+++ b/spec/controllers/educators_controller_spec.rb
@@ -69,7 +69,8 @@ describe EducatorsController, :type => :controller do
       expect(response).to be_successful
       expect(included_student_ids(response)).to contain_exactly(*[
         pals.shs_freshman_mari.id,
-        pals.shs_freshman_amir.id
+        pals.shs_freshman_amir.id,
+        pals.shs_senior_kylo.id
       ])
     end
 
@@ -82,7 +83,8 @@ describe EducatorsController, :type => :controller do
       expect(included_student_ids(response)).to contain_exactly(*[
         pals.west_eighth_ryan.id,
         pals.shs_freshman_mari.id,
-        pals.shs_freshman_amir.id
+        pals.shs_freshman_amir.id,
+        pals.shs_senior_kylo.id
       ])
     end
 
@@ -94,7 +96,8 @@ describe EducatorsController, :type => :controller do
       expect(response).to be_successful
       expect(included_student_ids(response)).to contain_exactly(*[
         pals.shs_freshman_mari.id,
-        pals.shs_freshman_amir.id
+        pals.shs_freshman_amir.id,
+        pals.shs_senior_kylo.id
       ])
     end
   end

--- a/spec/controllers/service_uploads_controller_spec.rb
+++ b/spec/controllers/service_uploads_controller_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe ServiceUploadsController, type: :controller do
         pals.west_eighth_ryan.local_id,
         pals.shs_freshman_mari.local_id,
         pals.shs_freshman_amir.local_id,
+        pals.shs_senior_kylo.local_id,
         pals.healey_kindergarten_student.local_id
       ])
     end

--- a/spec/controllers/tiering_controller_spec.rb
+++ b/spec/controllers/tiering_controller_spec.rb
@@ -37,7 +37,7 @@ describe TieringController, :type => :controller do
 
         # check shape of data
         expect(json.keys).to eq ['students_with_tiering']
-        expect(json['students_with_tiering'].size).to eq 2
+        expect(json['students_with_tiering'].size).to eq 3
         expect(json['students_with_tiering'].map(&:keys).flatten.uniq).to eq([
           "id",
           "grade",

--- a/spec/controllers/tiering_controller_spec.rb
+++ b/spec/controllers/tiering_controller_spec.rb
@@ -75,6 +75,15 @@ describe TieringController, :type => :controller do
             "recent_absence_rate"=>1.0,
             "recent_discipline_actions"=>0
           }
+        }, {
+          "level"=>1,
+          "triggers"=>['academic'],
+          "data"=>{
+            "course_failures"=>1,
+            "course_ds"=>0,
+            "recent_absence_rate"=>1.0,
+            "recent_discipline_actions"=>0
+          }
         }])
       end
     end

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Authorizer do
   it 'sets up test context correctly' do
     expect(School.all.size).to eq 13
     expect(Homeroom.all.size).to eq 6
-    expect(Student.all.size).to eq 4
+    expect(Student.all.size).to eq 5
     expect(Educator.all.size).to eq 15
     expect(Course.all.size).to eq 3
     expect(Section.all.size).to eq 6
@@ -34,7 +34,8 @@ RSpec.describe Authorizer do
         pals.healey_kindergarten_student,
         pals.west_eighth_ryan,
         pals.shs_freshman_mari,
-        pals.shs_freshman_amir
+        pals.shs_freshman_amir,
+        pals.shs_senior_kylo
       ])
       expect(authorized(pals.healey_vivian_teacher) { students }).to eq [pals.healey_kindergarten_student]
       expect(authorized(pals.shs_bill_nye) { students }).to eq [pals.shs_freshman_mari]
@@ -93,7 +94,8 @@ RSpec.describe Authorizer do
           pals.healey_kindergarten_student,
           pals.west_eighth_ryan,
           pals.shs_freshman_mari,
-          pals.shs_freshman_amir
+          pals.shs_freshman_amir,
+          pals.shs_senior_kylo
         ]
         expect(authorized(pals.healey_vivian_teacher) { Student.all }).to match_array [
           pals.healey_kindergarten_student
@@ -131,7 +133,8 @@ RSpec.describe Authorizer do
           pals.healey_kindergarten_student.id,
           pals.west_eighth_ryan.id,
           pals.shs_freshman_mari.id,
-          pals.shs_freshman_amir.id
+          pals.shs_freshman_amir.id,
+          pals.shs_senior_kylo.id
         ])
         expect((authorized(pals.healey_vivian_teacher) { thin_relation }).map(&:id)).to eq([
           pals.healey_kindergarten_student.id

--- a/spec/lib/experimental_somerville_high_tiers_spec.rb
+++ b/spec/lib/experimental_somerville_high_tiers_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe ExperimentalSomervilleHighTiers do
           "last_experience_note"=>{},
           "last_other_note"=>{}
         }
-      },
-        {
+      }, {
           "id"=>pals.shs_freshman_amir.id,
           "grade"=>"9",
           "first_name"=>"Amir",
@@ -66,6 +65,39 @@ RSpec.describe ExperimentalSomervilleHighTiers do
             "triggers"=>[],
             "data"=>{
               "course_failures"=>0,
+              "course_ds"=>0,
+              "recent_absence_rate"=>1.0,
+              "recent_discipline_actions"=>0
+            }
+          },
+          "notes"=>{
+            "last_sst_note"=>{},
+            "last_experience_note"=>{},
+            "last_other_note"=>{}
+          }
+        }, {
+          "id"=>pals.shs_senior_kylo.id,
+          "grade"=>"12",
+          "first_name"=>"Kylo",
+          "last_name"=>"Ren",
+          "program_assigned"=>nil,
+          "sped_placement"=>nil,
+          "house"=>"Broadway",
+          "student_section_assignments"=>[{
+            "id"=>pals.shs_senior_kylo.student_section_assignments.first.id,
+            "grade_numeric"=>"61.0",
+            "grade_letter"=>"F",
+            "section"=>{
+              "id"=>pals.shs_second_period_ceramics.id,
+              "section_number"=>"ART-302A",
+              "course_description"=>"ART MAJOR FOUNDATIONS"
+            }
+          }],
+          "tier"=>{
+            "level"=>0,
+            "triggers"=>[],
+            "data"=>{
+              "course_failures"=>1,
               "course_ds"=>0,
               "recent_absence_rate"=>1.0,
               "recent_discipline_actions"=>0

--- a/spec/lib/experimental_somerville_high_tiers_spec.rb
+++ b/spec/lib/experimental_somerville_high_tiers_spec.rb
@@ -94,8 +94,8 @@ RSpec.describe ExperimentalSomervilleHighTiers do
             }
           }],
           "tier"=>{
-            "level"=>0,
-            "triggers"=>[],
+            "level"=>1,
+            "triggers"=>['academic'],
             "data"=>{
               "course_failures"=>1,
               "course_ds"=>0,
@@ -110,6 +110,149 @@ RSpec.describe ExperimentalSomervilleHighTiers do
           }
         }
       ])
+    end
+  end
+
+  describe '#decide_tier' do
+    def decide_tier_output(data)
+      tiers = ExperimentalSomervilleHighTiers.new(pals.uri)
+      tier = tiers.send(:decide_tier, data)
+      [tier.level, tier.triggers]
+    end
+
+    it 'Level 0' do
+      expect(decide_tier_output({
+        course_ds: 0,
+        course_failures: 0,
+        recent_discipline_actions: 0,
+        recent_absence_rate: 1.0
+      })).to eq [0, []]
+      expect(decide_tier_output({
+        course_ds: 1,
+        course_failures: 0,
+        recent_discipline_actions: 0,
+        recent_absence_rate: 1.0
+      })).to eq [0, []]
+      expect(decide_tier_output({
+        course_ds: 1,
+        course_failures: 0,
+        recent_discipline_actions: 0,
+        recent_absence_rate: 0.95
+      })).to eq [0, []]
+      expect(decide_tier_output({
+        course_ds: 1,
+        course_failures: 0,
+        recent_discipline_actions: 4,
+        recent_absence_rate: 1.0
+      })).to eq [0, []]
+    end
+
+    it 'Level 1: 1 F or 2 Ds OR less than 95 attendance over last 45 days' do
+      expect(decide_tier_output({
+        course_ds: 0,
+        course_failures: 1,
+        recent_discipline_actions: 0,
+        recent_absence_rate: 1.0
+      })).to eq [1, [:academic]]
+      expect(decide_tier_output({
+        course_ds: 2,
+        course_failures: 0,
+        recent_discipline_actions: 0,
+        recent_absence_rate: 1.0
+      })).to eq [1, [:academic]]
+      expect(decide_tier_output({
+        course_ds: 0,
+        course_failures: 0,
+        recent_discipline_actions: 0,
+        recent_absence_rate: 0.94
+      })).to eq [1, [:absence]]
+      expect(decide_tier_output({
+        course_ds: 2,
+        course_failures: 1,
+        recent_discipline_actions: 0,
+        recent_absence_rate: 0.90
+      })).to eq [1, [:academic, :absence]]
+      expect(decide_tier_output({
+        course_ds: 4,
+        course_failures: 0,
+        recent_discipline_actions: 0,
+        recent_absence_rate: 1.00
+      })).to eq [1, [:academic]]
+    end
+
+    it "Level 2: 2 F's OR less than 90 attendance over last 45" do
+      expect(decide_tier_output({
+        course_ds: 0,
+        course_failures: 2,
+        recent_discipline_actions: 0,
+        recent_absence_rate: 0.90
+      })).to eq [2, [:academic]]
+      expect(decide_tier_output({
+        course_ds: 0,
+        course_failures: 0,
+        recent_discipline_actions: 0,
+        recent_absence_rate: 0.89
+      })).to eq [2, [:absence]]
+      expect(decide_tier_output({
+        course_ds: 0,
+        course_failures: 2,
+        recent_discipline_actions: 0,
+        recent_absence_rate: 0.85
+      })).to eq [2, [:academic, :absence]]
+    end
+
+    it "Level 3: 3 F's OR less than 85 attendance over last 45 OR 5-6 discipline actions over the last 45 school days" do
+      expect(decide_tier_output({
+        course_ds: 0,
+        course_failures: 3,
+        recent_discipline_actions: 0,
+        recent_absence_rate: 1.0
+      })).to eq [3, [:academic]]
+      expect(decide_tier_output({
+        course_ds: 0,
+        course_failures: 0,
+        recent_discipline_actions: 0,
+        recent_absence_rate: 0.84
+      })).to eq [3, [:absence]]
+      expect(decide_tier_output({
+        course_ds: 0,
+        course_failures: 0,
+        recent_discipline_actions: 5,
+        recent_absence_rate: 1.0
+      })).to eq [3, [:discipline]]
+      expect(decide_tier_output({
+        course_ds: 0,
+        course_failures: 3,
+        recent_discipline_actions: 5,
+        recent_absence_rate: 0.80
+      })).to eq [3, [:academic, :absence, :discipline]]
+    end
+
+    it "Level 4: At least 4 F's OR less than 80% attendance over last 45 school days OR 7 or more discipline actions over the last 45 school days" do
+      expect(decide_tier_output({
+        course_ds: 0,
+        course_failures: 4,
+        recent_discipline_actions: 0,
+        recent_absence_rate: 1.0
+      })).to eq [4, [:academic]]
+      expect(decide_tier_output({
+        course_ds: 0,
+        course_failures: 0,
+        recent_discipline_actions: 0,
+        recent_absence_rate: 0.79
+      })).to eq [4, [:absence]]
+      expect(decide_tier_output({
+        course_ds: 0,
+        course_failures: 0,
+        recent_discipline_actions: 7,
+        recent_absence_rate: 1.0
+      })).to eq [4, [:discipline]]
+      expect(decide_tier_output({
+        course_ds: 0,
+        course_failures: 4,
+        recent_discipline_actions: 7,
+        recent_absence_rate: 0.79
+      })).to eq [4, [:academic, :absence, :discipline]]
     end
   end
 end

--- a/spec/lib/feed_filter_spec.rb
+++ b/spec/lib/feed_filter_spec.rb
@@ -36,10 +36,12 @@ RSpec.describe FeedFilter do
         unfiltered_students = Authorizer.new(pals.shs_harry_housemaster).authorized { Student.active.to_a }
         expect(unfiltered_students).to contain_exactly(
           pals.shs_freshman_mari,
-          pals.shs_freshman_amir
+          pals.shs_freshman_amir,
+          pals.shs_senior_kylo
         )
         expect(FeedFilter.new(pals.shs_harry_housemaster).filter_for_educator(unfiltered_students)).to contain_exactly(*[
-          pals.shs_freshman_amir
+          pals.shs_freshman_amir,
+          pals.shs_senior_kylo
         ])
       end
     end
@@ -77,7 +79,8 @@ RSpec.describe FeedFilter do
         unfiltered_students = Authorizer.new(pals.shs_sofia_counselor).authorized { Student.active.to_a }
         expect(unfiltered_students).to contain_exactly(
           pals.shs_freshman_mari,
-          pals.shs_freshman_amir
+          pals.shs_freshman_amir,
+          pals.shs_senior_kylo
         )
         expect(FeedFilter.new(pals.shs_sofia_counselor).filter_for_educator(unfiltered_students)).to contain_exactly(*[
           pals.shs_freshman_mari

--- a/spec/lib/feed_spec.rb
+++ b/spec/lib/feed_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe Feed do
       students = Feed.students_for_feed(pals.shs_sofia_counselor)
       expect(students.map(&:id)).to contain_exactly(*[
         pals.shs_freshman_mari.id,
-        pals.shs_freshman_amir.id
+        pals.shs_freshman_amir.id,
+        pals.shs_senior_kylo.id
       ])
     end
   end

--- a/spec/lib/insight_students_with_low_grades_spec.rb
+++ b/spec/lib/insight_students_with_low_grades_spec.rb
@@ -43,6 +43,37 @@ RSpec.describe InsightStudentsWithLowGrades do
         }]
       }]
     end
+
+    it 'finds students in any course, not just NGE or 10GE' do
+      time_threshold = time_now - 45.days
+      grade_threshold = 69
+      insight = InsightStudentsWithLowGrades.new(pals.shs_hugo_art_teacher)
+      students_with_low_grades = insight.students_with_low_grades_json(time_now, time_threshold, grade_threshold)
+      expect(students_with_low_grades).to eq [{
+        "student"=>{
+          "id"=>pals.shs_senior_kylo.id,
+          "first_name"=>'Kylo',
+          "last_name"=>'Ren',
+          "grade"=>'12',
+          "house"=>'Broadway'
+        },
+        "assignments"=>[{
+          "id"=>pals.shs_senior_kylo.student_section_assignments.first.id,
+          "grade_numeric"=>'61.0',
+          "grade_letter"=>"F",
+          "section"=>{
+            "id"=>pals.shs_second_period_ceramics.id,
+            "section_number"=>"ART-302A",
+            "course_description"=>'ART MAJOR FOUNDATIONS',
+            "educators"=>[{
+              "id"=>pals.shs_hugo_art_teacher.id,
+              "email"=>"hugo@demo.studentinsights.org",
+              "full_name"=>"Teacher, Hugo"
+            }]
+          }
+        }]
+      }]
+    end
   end
 
   describe '#assignments_below_threshold' do
@@ -114,14 +145,6 @@ RSpec.describe InsightStudentsWithLowGrades do
       expect(json.keys).to eq(['id', 'grade_numeric', 'grade_letter', 'section'])
       expect(json['section'].keys).to eq(['id', 'section_number', 'course_description', 'educators'])
       expect(json['section']['educators'].first.keys).to eq(['id', 'email', 'full_name'])
-    end
-  end
-
-  describe '#included_in_experience_team?' do
-    let!(:insight) { InsightStudentsWithLowGrades.new(pals.shs_bill_nye) }
-    it 'filters out students by grade' do
-      expect(insight.send(:included_in_experience_team?, pals.shs_freshman_mari)).to eq true
-      expect(insight.send(:included_in_experience_team?, pals.healey_kindergarten_student)).to eq false
     end
   end
 end

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -28,6 +28,7 @@ class TestPals
   attr_reader :west_eighth_ryan
   attr_reader :shs_freshman_mari
   attr_reader :shs_freshman_amir
+  attr_reader :shs_senior_kylo
 
   # educators
   attr_reader :uri
@@ -414,6 +415,25 @@ class TestPals
       section: @shs_third_period_physics,
       grade_numeric: 84,
       grade_letter: 'B'
+    )
+    @shs_senior_kylo = Student.create!(
+      first_name: 'Kylo',
+      last_name: 'Ren',
+      school: @shs,
+      homeroom: nil,
+      house: 'Broadway',
+      counselor: 'FISHMAN',
+      grade: '12',
+      date_of_birth: '2001-02-07',
+      local_id: '2225555555',
+      state_id: '9925555555',
+      enrollment_status: 'Active'
+    )
+    StudentSectionAssignment.create!(
+      student: @shs_senior_kylo,
+      section: @shs_second_period_ceramics,
+      grade_numeric: 61,
+      grade_letter: 'F'
     )
 
     reindex!


### PR DESCRIPTION
# Who is this PR for?
HS teachers

# What problem does this PR fix?
Fixes a bug with https://github.com/studentinsights/studentinsights/pull/2057, which intended to release the "low grades" box to all HS teachers, but didn't update a filter that filtered students down to only 9th and 10th grade.

# What does this PR do?
Removes that filter and adds a test.

# Checklists
+ [x] Author included specs for new code
