### PR TITLE
Levels: Update copy on levels page, add link to SHS doc

### DIFF
--- a/app/assets/javascripts/tiering/StudentLevelsTable.js
+++ b/app/assets/javascripts/tiering/StudentLevelsTable.js
@@ -125,7 +125,7 @@ export default class StudentLevelsTable extends React.Component {
               cellRenderer={this.renderLevel} />
             <Column
               dataKey="absence"
-              label={<span>Absence<br/>Rate</span>}
+              label={<span>Attendance<br/>Rate</span>}
               width={numericCellWidth}
               cellRenderer={this.renderAbsenceRate} />
             <Column

--- a/app/assets/javascripts/tiering/SupportGaps.js
+++ b/app/assets/javascripts/tiering/SupportGaps.js
@@ -22,12 +22,13 @@ export default class SupportGaps extends React.Component {
   }
 
   render() {
-    const {message} = this.props;
+    const {message, systemsAndSupports} = this.props;
     const {isShowingList} = this.state;
     return (
       <div className="SupportGaps" style={styles.root}>
         <div style={{display: 'flex', flexDirection: 'column', marginBottom: 40}}>
           <div style={{flex: 1}}>{message}</div>
+          <div>{systemsAndSupports}</div>
           {!isShowingList && <Button style={{marginTop: 20}} onClick={this.onLinkClicked}>show students</Button>}
         </div>
         {this.renderStudentsList()}
@@ -52,6 +53,7 @@ SupportGaps.contextTypes = {
 };
 SupportGaps.propTypes = {
   message: PropTypes.node.isRequired,
+  systemsAndSupports: PropTypes.node.isRequired,
   uncoveredStudentsWithTiering: PropTypes.array.isRequired
 };
 

--- a/app/assets/javascripts/tiering/TieringPage.js
+++ b/app/assets/javascripts/tiering/TieringPage.js
@@ -12,6 +12,7 @@ import TieringView from './TieringView';
 
 
 // Experimental page for looking at HS support tiers (Somerville only)
+export const SYSTEMS_AND_SUPPORTS_URL = 'https://docs.google.com/document/d/10Rm-FMeQsj_ArxqVWefa6bz8-cs2zsCEubaP3iR24KA/edit';
 export default class TieringPage extends React.Component {
   constructor(props) {
     super(props);
@@ -35,7 +36,10 @@ export default class TieringPage extends React.Component {
       <div className="TieringPage" style={styles.flexVertical}>
         <ExperimentalBanner />
         <div style={{margin: 10}}>
-          <SectionHeading>HS Levels: v1 prototype</SectionHeading>
+          <SectionHeading titleStyle={styles.title}>
+            <div>HS Levels: v1 prototype</div>
+            <a style={{fontSize: 12}} href={SYSTEMS_AND_SUPPORTS_URL} target="_blank">Open SHS Systems and Supports doc</a>
+          </SectionHeading>
         </div>
         <GenericLoader
           promiseFn={this.fetchTiering}
@@ -46,7 +50,12 @@ export default class TieringPage extends React.Component {
   }
 
   renderTiering(studentsWithTiering) {
-    return <TieringView studentsWithTiering={studentsWithTiering} />;
+    return (
+      <TieringView
+        systemsAndSupportsUrl={SYSTEMS_AND_SUPPORTS_URL}
+        studentsWithTiering={studentsWithTiering}
+      />
+    );
   }
 }
 TieringPage.propTypes = {
@@ -59,5 +68,11 @@ const styles = {
     display: 'flex',
     flex: 1,
     flexDirection: 'column'
+  },
+  title: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center'
   }
 };

--- a/app/assets/javascripts/tiering/TieringView.js
+++ b/app/assets/javascripts/tiering/TieringView.js
@@ -142,6 +142,11 @@ export default class TieringView extends React.Component {
     );
   }
 
+  renderSystemsAndSupportsLink() {
+    const {systemsAndSupportsUrl} = this.props;
+    return <a href={systemsAndSupportsUrl} target="_blank">Open SHS Systems and Supports doc</a>;
+  }
+
   renderExperienceGaps(filteredStudents) {
     const uncoveredStudents = filteredStudents.filter(student => (student.grade === '9' || student.grade === '10') && hasAcademicTrigger(student) && !student.notes.last_experience_note.event_note_type_id);
     return (
@@ -159,6 +164,7 @@ export default class TieringView extends React.Component {
             message={this.renderSupportGapsMessageWithFilterWarning(
               <div>There are <b>{uncoveredStudents.length} students</b> with academic triggers recently who haven't been mentioned in NGE or 10GE.</div>
             )}
+            systemsAndSupports={this.renderSystemsAndSupportsLink()}
             uncoveredStudentsWithTiering={uncoveredStudents}
           />
         }
@@ -183,6 +189,7 @@ export default class TieringView extends React.Component {
             message={this.renderSupportGapsMessageWithFilterWarning(
               <div>There are <b>{uncoveredStudents.length} students</b> with absence or discipline triggers recently who haven't been mentioned in SST.</div>
             )}
+            systemsAndSupports={this.renderSystemsAndSupportsLink()}
             uncoveredStudentsWithTiering={uncoveredStudents}
           />
         }
@@ -214,25 +221,28 @@ export default class TieringView extends React.Component {
 
   renderSummary(studentsWithTiering) {
     return (
-      <div style={styles.summaryContainer}>
-        <div style={styles.summaryColumn}>
-          <h4 style={{marginBottom: 10}}>by levels</h4>
-          {this.renderTierCount(studentsWithTiering, 0)}
-          {this.renderTierCount(studentsWithTiering, 1)}
-          {this.renderTierCount(studentsWithTiering, 2)}
-          {this.renderTierCount(studentsWithTiering, 3)}
-          {this.renderTierCount(studentsWithTiering, 4)}
-        </div>
-        <div style={styles.summaryColumn}>
-          <h4 style={{marginBottom: 10}}>by triggers</h4>
-          {this.renderTriggerCount(studentsWithTiering)}
-        </div>
-        <div style={styles.summaryColumn}>
-          <h4 style={{marginBottom: 10}}>by supports</h4>
-          {this.renderServiceCount(studentsWithTiering, 'Credit recovery', CREDIT_RECOVERY)}
-          {this.renderServiceCount(studentsWithTiering, 'Academic support', ACADEMIC_SUPPORT)}
-          {this.renderServiceCount(studentsWithTiering, 'Redirect', REDIRECT)}
-          {this.renderServiceCount(studentsWithTiering, 'Study skills', STUDY_SKILLS)}
+      <div>
+        {this.renderSystemsAndSupportsLink()}
+        <div style={styles.summaryContainer}>
+          <div style={styles.summaryColumn}>
+            <h4 style={{marginBottom: 10}}>by levels</h4>
+            {this.renderTierCount(studentsWithTiering, 0)}
+            {this.renderTierCount(studentsWithTiering, 1)}
+            {this.renderTierCount(studentsWithTiering, 2)}
+            {this.renderTierCount(studentsWithTiering, 3)}
+            {this.renderTierCount(studentsWithTiering, 4)}
+          </div>
+          <div style={styles.summaryColumn}>
+            <h4 style={{marginBottom: 10}}>by triggers</h4>
+            {this.renderTriggerCount(studentsWithTiering)}
+          </div>
+          <div style={styles.summaryColumn}>
+            <h4 style={{marginBottom: 10}}>by supports</h4>
+            {this.renderServiceCount(studentsWithTiering, 'Credit recovery', CREDIT_RECOVERY)}
+            {this.renderServiceCount(studentsWithTiering, 'Academic support', ACADEMIC_SUPPORT)}
+            {this.renderServiceCount(studentsWithTiering, 'Redirect', REDIRECT)}
+            {this.renderServiceCount(studentsWithTiering, 'Study skills', STUDY_SKILLS)}
+          </div>
         </div>
       </div>
     );
@@ -301,6 +311,7 @@ export default class TieringView extends React.Component {
   }
 }
 TieringView.propTypes = {
+  systemsAndSupportsUrl: PropTypes.string.isRequired,
   studentsWithTiering: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.number.isRequired,
     first_name: PropTypes.string.isRequired,

--- a/app/assets/javascripts/tiering/TieringView.test.js
+++ b/app/assets/javascripts/tiering/TieringView.test.js
@@ -6,6 +6,7 @@ import tieringShowJson from './tieringShowJson.fixture';
 
 function testProps(props = {}) {
   return {
+    systemsAndSupportsUrl: 'https://example.com/foo',
     studentsWithTiering: tieringShowJson.students_with_tiering,
     ...props
   };


### PR DESCRIPTION
# Who is this PR for?
SHS admin team

# What problem does this PR fix?
"Absence" rate should be "attendance" rate.  No definitions of levels or triggers anywhere.

# What does this PR do?
Adding a link to the systems and supports doc, which has definitions and supports.

# Screenshot (if adding a client-side feature)
<img width="939" alt="screen shot 2018-09-27 at 10 47 36 am" src="https://user-images.githubusercontent.com/1056957/46155190-bd0b5000-c244-11e8-9e65-8528d88a32a0.png">
<img width="1022" alt="screen shot 2018-09-27 at 10 47 31 am" src="https://user-images.githubusercontent.com/1056957/46155192-bd0b5000-c244-11e8-9e2c-482b27151691.png">
