### PR TITLE
IEP import: Add validations and add migrations for new fields

### DIFF
--- a/app/models/iep_document.rb
+++ b/app/models/iep_document.rb
@@ -1,4 +1,30 @@
 class IepDocument < ActiveRecord::Base
   belongs_to :student
   validates :file_name, presence: true, uniqueness: true
+  validate :validate_file_name
+
+  def self.parse_local_id(file_name)
+    self.parse_file_name(file_name).try(:[], :local_id)
+  end
+
+  def self.parse_file_name(file_name)
+    basename = file_name.split('.pdf')[0]
+    return nil if basename.nil?
+    local_id, iep_at_a_glance, *names = basename.split('_')
+    return nil if iep_at_a_glance != 'IEPAtAGlance'
+    {
+      local_id: local_id,
+      names: names
+    }
+  end
+
+  private
+  def validate_file_name
+    local_id_from_file_name = IepDocument.parse_local_id(self.file_name)
+    if local_id_from_file_name.nil?
+      errors.add(:file_name, 'could not be parsed')
+    elsif local_id_from_file_name != self.student.local_id
+      errors.add(:student_id, 'reference does not match local_id in filename')
+    end
+  end
 end

--- a/db/migrate/20180928130000_add_iep_document_file_fields.rb
+++ b/db/migrate/20180928130000_add_iep_document_file_fields.rb
@@ -1,0 +1,7 @@
+class AddIepDocumentFileFields < ActiveRecord::Migration[5.2]
+  def change
+    add_column :iep_documents, :file_digest, :string
+    add_column :iep_documents, :file_size, :integer
+    add_column :iep_documents, :s3_filename, :string
+  end
+end

--- a/db/migrate/20180928130451_add_non_null_photos.rb
+++ b/db/migrate/20180928130451_add_non_null_photos.rb
@@ -1,0 +1,7 @@
+class AddNonNullPhotos < ActiveRecord::Migration[5.2]
+  def change
+    change_column :student_photos, :file_digest, :string, null: false
+    change_column :student_photos, :file_size, :integer, null: false
+    change_column :student_photos, :s3_filename, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_24_200334) do
+ActiveRecord::Schema.define(version: 2018_09_28_130451) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -151,6 +151,7 @@ ActiveRecord::Schema.define(version: 2018_09_24_200334) do
     t.boolean "can_set_districtwide_access", default: false, null: false
     t.text "student_searchbar_json"
     t.text "login_name", null: false
+    t.integer "assigned_homeroom_id"
     t.index ["grade_level_access"], name: "index_educators_on_grade_level_access", using: :gin
   end
 
@@ -239,6 +240,9 @@ ActiveRecord::Schema.define(version: 2018_09_24_200334) do
     t.integer "student_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "file_digest"
+    t.integer "file_size"
+    t.string "s3_filename"
     t.index ["student_id"], name: "index_iep_documents_on_student_id"
   end
 
@@ -399,9 +403,9 @@ ActiveRecord::Schema.define(version: 2018_09_24_200334) do
 
   create_table "student_photos", force: :cascade do |t|
     t.bigint "student_id"
-    t.string "file_digest"
-    t.integer "file_size"
-    t.string "s3_filename"
+    t.string "file_digest", null: false
+    t.integer "file_size", null: false
+    t.string "s3_filename", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["student_id"], name: "index_student_photos_on_student_id"
@@ -525,6 +529,7 @@ ActiveRecord::Schema.define(version: 2018_09_24_200334) do
   add_foreign_key "educator_labels", "educators", name: "educator_labels_educator_id_fk"
   add_foreign_key "educator_section_assignments", "educators"
   add_foreign_key "educator_section_assignments", "sections"
+  add_foreign_key "educators", "homerooms", column: "assigned_homeroom_id"
   add_foreign_key "educators", "schools", name: "educators_school_id_fk"
   add_foreign_key "event_note_attachments", "event_notes", name: "event_note_attachments_event_note_id_fk"
   add_foreign_key "event_note_revisions", "educators", name: "event_note_revisions_educator_id_fk"

--- a/spec/controllers/iep_documents_controller_spec.rb
+++ b/spec/controllers/iep_documents_controller_spec.rb
@@ -23,11 +23,17 @@ RSpec.describe IepDocumentsController, type: :controller do
       ).and_return FakeAwsResponse.new
     end
 
-    let(:student) { FactoryBot.create(:student) }
+    let(:student) do
+      FactoryBot.create(:student, {
+        first_name: 'Alexander',
+        last_name: 'Hamilton',
+        local_id: '124046632'
+      })
+    end
 
     subject {
       IepDocument.create(
-        file_name: 'IEP Document',
+        file_name: '124046632_IEPAtAGlance_Alexander_Hamilton.pdf',
         student: student,
       )
     }

--- a/spec/models/iep_document_spec.rb
+++ b/spec/models/iep_document_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe IepDocument do
+  def create_test_student
+    FactoryBot.create(:student, {
+      first_name: 'Alexander',
+      last_name: 'Hamilton',
+      local_id: '124046632'
+    })
+  end
+
+  it 'can create with expected file_name format' do
+    expect(IepDocument.create({
+      student: create_test_student,
+      file_name: '124046632_IEPAtAGlance_Alexander_Hamilton.pdf'
+    }).errors.details).to eq({})
+  end
+
+  it 'validates that local_id in filename matches referenced student' do
+    expect(IepDocument.create({
+      student: create_test_student,
+      file_name: '99999999_IEPAtAGlance_Alexander_Hamilton.pdf'
+    }).errors.details).to eq({
+      student_id: [{error: 'reference does not match local_id in filename'}]
+    })
+  end
+
+  it 'validates that file_name can be parsed' do
+    expect(IepDocument.create({
+      student: create_test_student,
+      file_name: '124046632_Alexander_Hamilton.pdf'
+    }).errors.details).to eq({
+      file_name: [{error: 'could not be parsed'}]
+    })
+  end
+end

--- a/spec/models/iep_storer_spec.rb
+++ b/spec/models/iep_storer_spec.rb
@@ -13,28 +13,31 @@ RSpec.describe IepStorer, type: :model do
     def self.info(message); end
   end
 
+  def create_test_student
+    FactoryBot.create(:student, {
+      first_name: 'Alexander',
+      last_name: 'Hamilton',
+      local_id: '124046632'
+    })
+  end
+
   before do
     allow(File).to receive(:open).and_call_original # ActiveSupport calls this for i8n translations
-    allow(File).to receive(:open).with('/path/to/file').and_return 'eeee'
+    allow(File).to receive(:open).with('/tmp/path/124046632_IEPAtAGlance_Alexander_Hamilton.pdf').and_return 'eeee'
   end
 
   subject {
     IepStorer.new(
-      file_name: 'IEP Document',
-      path_to_file: '/path/to/file',
-      local_id: 'abc_student_local_id',
+      file_name: '124046632_IEPAtAGlance_Alexander_Hamilton.pdf',
+      path_to_file: '/tmp/path/124046632_IEPAtAGlance_Alexander_Hamilton.pdf',
+      local_id: '124046632',
       client: FakeAwsClient,
       logger: QuietLogger
     )
   }
 
   context 'local id matches to student' do
-    let!(:student) {
-      FactoryBot.create(:student, {
-        local_id: 'abc_student_local_id',
-        grade: 'KF'
-      })
-    }
+    let!(:student) { create_test_student }
 
     context 'no other document for that student' do
       it 'stores an object to the db' do
@@ -44,7 +47,7 @@ RSpec.describe IepStorer, type: :model do
 
     context 'other document exists for that student' do
       let!(:other_iep) {
-        IepDocument.create!(student: student, file_name: 'xyz')
+        IepDocument.create!(student: student, file_name: '124046632_IEPAtAGlance_Alexander_MIDDLENAME_Hamilton.pdf')
       }
 
       it 'stores an object to the db' do
@@ -54,7 +57,7 @@ RSpec.describe IepStorer, type: :model do
       it 'updates the filename' do
         subject.store
         student.reload
-        expect(student.iep_document.file_name).to eq 'IEP Document'
+        expect(student.iep_document.file_name).to eq '124046632_IEPAtAGlance_Alexander_Hamilton.pdf'
       end
     end
   end


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
There's no validations that the IEP document filename and student references are consistent.  We don't store multiple documents now and so folks can't look back and we can't notify on changes, etc.

# What does this PR do?
Adds validations to the document to sanity-check the filename, and adds new fields for tracking more information about the file, allowing us to detect changes, only store new documents, and change the association to store historical documents.

After this will come:
- [ ] update association and read path
- [ ] run new import
- [ ] run backfill with all files
- [ ] add non-null constraints on new fields

Then we'll have data on how this changes over time, enabling folks to look back, us to highlights changes, etc.