### PR TITLE
Add database constraints for new IepDocument fields, update demo data

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -17,7 +17,7 @@ class ProfileController < ApplicationController
       educators_index: Educator.to_index,
       access: student.access,
       profile_insights: ProfileInsights.new(student).as_json,
-      latest_iep_document: student.latest_iep_document,
+      latest_iep_document: student.latest_iep_document.as_json(only: [:id]),
       sections: serialize_student_sections_for_profile(student),
       current_educator_allowed_sections: current_educator.allowed_sections.map(&:id),
       attendance_data: {

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -24,7 +24,7 @@ class StudentsController < ApplicationController
       access: student.latest_access_results,
       transition_notes: student.transition_notes.as_json(dangerously_include_restricted_note_text: can_access_restricted_transition_notes),
       profile_insights: [], # not supported
-      iep_document: student.latest_iep_document,
+      iep_document: student.latest_iep_document.as_json(only: [:id]),
       sections: serialize_student_sections_for_profile(student),
       current_educator_allowed_sections: current_educator.allowed_sections.map(&:id),
       attendance_data: {

--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -343,9 +343,14 @@ class FakeStudent
 
   def add_ieps
     15.in(100) do
-      IepDocument.create(
-        file_name: "IEP_Document_for_#{@student.last_name}_#{@student.first_name}.pdf",
-        student: @student
+      file_name = "#{@student.local_id}_IEPAtAGlance_{@student.first_name}_#{@student.last_name}.pdf"
+      file_digest = SecureRandom.hex
+      IepDocument.create!(
+        student: @student,
+        file_name: file_name,
+        file_digest: file_digest,
+        file_size: 1000 + SecureRandom.random_number(100000),
+        s3_filename: "#{SecureRandom.hex}/#{Time.now.strftime('%Y-%m-%d')}/#{file_digest}"
       )
     end
     nil

--- a/app/importers/iep_import/iep_storer.rb
+++ b/app/importers/iep_import/iep_storer.rb
@@ -9,8 +9,7 @@ class IepStorer
       return File.read("#{Rails.root}/public/demo-blank-iep.pdf")
     end
 
-    # Read the new location, falling back to the old if it isn't set
-    s3_filename = iep_document.s3_filename || iep_document.file_name
+    s3_filename = iep_document.s3_filename
     object = s3_client.get_object({
       key: s3_filename,
       bucket: IepStorer.bucket_name

--- a/db/migrate/20181001203131_add_iep_document_constraints.rb
+++ b/db/migrate/20181001203131_add_iep_document_constraints.rb
@@ -1,0 +1,8 @@
+class AddIepDocumentConstraints < ActiveRecord::Migration[5.2]
+  def change
+    change_column :iep_documents, :file_size, :integer, null: false
+    change_column :iep_documents, :file_name, :string, null: false
+    change_column :iep_documents, :file_digest, :string, null: false
+    change_column :iep_documents, :s3_filename, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_28_130451) do
+ActiveRecord::Schema.define(version: 2018_10_01_203131) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -151,7 +151,6 @@ ActiveRecord::Schema.define(version: 2018_09_28_130451) do
     t.boolean "can_set_districtwide_access", default: false, null: false
     t.text "student_searchbar_json"
     t.text "login_name", null: false
-    t.integer "assigned_homeroom_id"
     t.index ["grade_level_access"], name: "index_educators_on_grade_level_access", using: :gin
   end
 
@@ -236,13 +235,13 @@ ActiveRecord::Schema.define(version: 2018_09_28_130451) do
   end
 
   create_table "iep_documents", id: :serial, force: :cascade do |t|
-    t.string "file_name"
+    t.string "file_name", null: false
     t.integer "student_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "file_digest"
-    t.integer "file_size"
-    t.string "s3_filename"
+    t.string "file_digest", null: false
+    t.integer "file_size", null: false
+    t.string "s3_filename", null: false
     t.index ["student_id"], name: "index_iep_documents_on_student_id"
   end
 
@@ -529,7 +528,6 @@ ActiveRecord::Schema.define(version: 2018_09_28_130451) do
   add_foreign_key "educator_labels", "educators", name: "educator_labels_educator_id_fk"
   add_foreign_key "educator_section_assignments", "educators"
   add_foreign_key "educator_section_assignments", "sections"
-  add_foreign_key "educators", "homerooms", column: "assigned_homeroom_id"
   add_foreign_key "educators", "schools", name: "educators_school_id_fk"
   add_foreign_key "event_note_attachments", "event_notes", name: "event_note_attachments_event_note_id_fk"
   add_foreign_key "event_note_revisions", "educators", name: "event_note_revisions_educator_id_fk"

--- a/spec/factories/iep_document.rb
+++ b/spec/factories/iep_document.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :iep_document do
+    association :student
+
+    created_at { Time.now }
+    file_name { "#{student.local_id}_IEPAtAGlance_#{student.first_name}_#{student.last_name}.pdf" }
+    file_digest { SecureRandom.hex }
+    file_size { 1000 + SecureRandom.random_number(100000) }
+    s3_filename { "iep_pdfs/#{Digest::SHA256.hexdigest(student.local_id)}/#{created_at.strftime('%Y-%m-%d')}/#{file_digest}" }
+  end
+end

--- a/spec/importers/iep_import/iep_storer_spec.rb
+++ b/spec/importers/iep_import/iep_storer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe IepStorer, type: :model do
   context 'other document exists for that student' do
     it 'stores a new object to s3 and the db' do
       student = create_test_student
-      existing_iep_document = IepDocument.create!({
+      existing_iep_document = FactoryBot.create(:iep_document, {
         student: student,
         file_name: '124046632_IEPAtAGlance_Alexander_MIDDLENAME_Hamilton.pdf'
       })

--- a/spec/models/iep_document_spec.rb
+++ b/spec/models/iep_document_spec.rb
@@ -3,48 +3,46 @@ require 'spec_helper'
 RSpec.describe IepDocument do
   def create_test_student(attrs = {})
     FactoryBot.create(:student, {
-
       first_name: 'Alexander',
       last_name: 'Hamilton',
       local_id: '124046632'
     }.merge(attrs))
   end
 
+  def create_iep_document(student, attrs = {})
+    created_at = attrs.fetch(:created_at, Time.now)
+    FactoryBot.create(:iep_document, {
+      student: student,
+      created_at: created_at
+    }.merge(attrs))
+  end
+
   describe '#pretty_filename_for_download' do
     it 'works' do
       student = create_test_student(id: 978)
-      iep_document = IepDocument.create({
+      iep_document = create_iep_document(student, {
         id: 9003,
-        created_at: '2017-04-03',
-        student: student,
-        file_name: '124046632_IEPAtAGlance_Alexander_Hamilton.pdf'
+        created_at: Time.parse('2017-04-03')
       })
       expect(iep_document.pretty_filename_for_download).to eq 'IEP_HamiltonAlexander_20170403_978_9003.pdf'
     end
   end
 
   it 'can create with expected file_name format' do
-    expect(IepDocument.create({
-      student: create_test_student,
+    expect(create_iep_document(create_test_student, {
       file_name: '124046632_IEPAtAGlance_Alexander_Hamilton.pdf'
     }).errors.details).to eq({})
   end
 
   it 'validates that local_id in filename matches referenced student' do
-    expect(IepDocument.create({
-      student: create_test_student,
-      file_name: '99999999_IEPAtAGlance_Alexander_Hamilton.pdf'
-    }).errors.details).to eq({
-      student_id: [{error: 'reference does not match local_id in filename'}]
-    })
+    expect {
+      create_iep_document(create_test_student, file_name: '99999999_IEPAtAGlance_Alexander_Hamilton.pdf')
+    }.to raise_error(ActiveRecord::RecordInvalid)
   end
 
   it 'validates that file_name can be parsed' do
-    expect(IepDocument.create({
-      student: create_test_student,
-      file_name: '124046632_Alexander_Hamilton.pdf'
-    }).errors.details).to eq({
-      file_name: [{error: 'could not be parsed'}]
-    })
+    expect {
+      create_iep_document(create_test_student, file_name: '124046632_Alexander_Hamilton.pdf')
+    }.to raise_error(ActiveRecord::RecordInvalid)
   end
 end


### PR DESCRIPTION
Part of https://github.com/studentinsights/studentinsights/pull/2136.

# Who is this PR for?
developers

# What problem does this PR fix?
There aren't constraints for new fields on `IepDocument`, since we needed to migrate first.

# What does this PR do?
The migration is done; adds in database constraints and updates demo data to be consistent with them.  Verified this is good to deploy to Somerville; the migration will fail on the demo site and we can rebuild the database.

Separately, limits serialization of this data in the profile page; no need to send anything other than "there is a document," so this just sends down an id if there is one and null if not.
