### PR TITLE
Add whitelist feature to EducatorsImporter

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -140,6 +140,12 @@ class PerDistrict
     end
   end
 
+  # Sometimes we want to be able to import specific educators, even
+  # if they aren't in the specific set of schools we import.
+  def educators_importer_login_name_whitelist
+    ENV.fetch('EDUCATORS_IMPORTER_LOGIN_NAME_WHITELIST', '').split(',')
+  end
+
   # Users in Bedford type in just their login, others
   # use full email addresses.
   def find_educator_by_login_text(login_text)

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -22,6 +22,7 @@ class EducatorsImporter
     end
 
     log('Done loop.')
+    log("@included_because_in_whitelist_count: #{@included_because_in_whitelist_count}")
     log("@skipped_from_school_filter: #{@skipped_from_school_filter}")
     log("@ignored_special_nil_homeroom_count: #{@ignored_special_nil_homeroom_count}")
     log("@ignored_no_homeroom_count: #{@ignored_no_homeroom_count}")
@@ -41,6 +42,7 @@ class EducatorsImporter
 
   private
   def reset_counters!
+    @included_because_in_whitelist_count = 0
     @skipped_from_school_filter = 0
     @ignored_special_nil_homeroom_count = 0
     @ignored_no_homeroom_count = 0
@@ -71,7 +73,10 @@ class EducatorsImporter
   end
 
   def import_row(row)
-    if !filter.include?(row[:school_local_id])
+    # Include login_names on whitelist, or filter out based on school
+    if is_included_in_whitelist?(row)
+      @included_because_in_whitelist_count += 1
+    elsif !filter.include?(row[:school_local_id]) && !
       @skipped_from_school_filter += 1
       return
     end
@@ -84,6 +89,11 @@ class EducatorsImporter
     # sync the `educator_id` field.
     maybe_homeroom = match_homeroom(row, maybe_educator)
     @homeroom_syncer.validate_mark_and_sync!(maybe_homeroom)
+  end
+
+  def is_included_in_whitelist?(row)
+    whitelist = PerDistrict.new.educators_importer_login_name_whitelist
+    whitelist.include?(row[:login_name])
   end
 
   # Match existing Homeroom and update reference to Educator.

--- a/spec/importers/file_importers/educators_importer_spec.rb
+++ b/spec/importers/file_importers/educators_importer_spec.rb
@@ -88,6 +88,15 @@ RSpec.describe EducatorsImporter do
       expect(importer.instance_variable_get(:@educator_syncer).stats[:unchanged_rows_count]).to eq 1
       expect(importer.instance_variable_get(:@homeroom_syncer).stats[:unchanged_rows_count]).to eq 1
     end
+
+    it 'includes rows if login_name is on whitelist, even if school is not in scope' do
+      allow(ENV).to receive(:fetch).with('EDUCATORS_IMPORTER_LOGIN_NAME_WHITELIST', anything()).and_return('ntufts')
+      importer = make_educators_importer(school_scope: ['SHS'])
+      allow(importer).to receive(:download_csv).and_return([make_test_row])
+      importer.import
+      expect(log.output).to include('@skipped_from_school_filter: 0')
+      expect(log.output).to include('@included_because_in_whitelist_count: 1')
+    end
   end
 
   describe 'works for login_name and email across districts' do


### PR DESCRIPTION
# Who is this PR for?
Bedford educators

# What problem does this PR fix?
Generally we want to limit access, and scope this by school.  Sometimes pilot folks are in central office positions or other kinds of positions, and we want to whitelist them for access.  Previously we've done that with patching the database manually.

# What does this PR do?
Brings this under config.

# Checklists
+ [x] Author included specs for new code
