### PR TITLE
Add notes about Educator school optional value"

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -1,7 +1,7 @@
 class Educator < ActiveRecord::Base
   devise :ldap_authenticatable_tiny, :rememberable, :trackable, :timeoutable, authentication_keys: [:login_text]
 
-  belongs_to  :school
+  belongs_to  :school, optional: true # districtwide admin often don't have schools assigned
   has_one     :homeroom
   has_many    :students, through: :homeroom
   has_many    :educator_section_assignments
@@ -16,8 +16,7 @@ class Educator < ActiveRecord::Base
   validates :email, presence: true, uniqueness: true, case_sensitive: false
   validates :login_name, presence: true, uniqueness: true, case_sensitive: false
 
-  validate :validate_has_school_unless_districtwide,
-           :validate_admin_gets_access_to_all_students,
+  validate :validate_admin_gets_access_to_all_students,
            :validate_grade_level_access_is_array_of_strings,
            :validate_grade_level_strings_are_valid,
            :validate_grade_level_strings_are_uniq,
@@ -107,12 +106,6 @@ class Educator < ActiveRecord::Base
   end
 
   private
-  def validate_has_school_unless_districtwide
-    if school.blank?
-      errors.add(:school_id, 'must be assigned a school unless districtwide') unless districtwide_access?
-    end
-  end
-
   def validate_admin_gets_access_to_all_students
     has_access_to_all_students = (
       restricted_to_sped_students == false &&

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -24,26 +24,9 @@ RSpec.describe Educator do
       expect(educator.as_json.has_key?('student_searchbar_json')).to be false
     end
   end
-  describe '#has_school_unless_districtwide' do
-    context 'no school assigned' do
-      context 'has districtwide_access' do
-        let(:educator) {
-          FactoryBot.build(:educator, school: nil, districtwide_access: true)
-        }
-        it 'is valid' do
-          expect(educator).to be_valid
-        end
-      end
 
-      context 'does not have districtwide_access' do
-        let(:educator) {
-          FactoryBot.build(:educator, school: nil, districtwide_access: false)
-        }
-        it 'is not valid' do
-          expect(educator).to be_invalid
-        end
-      end
-    end
+  it 'allows creating Educator without a school, so we can whitelist import admin users outside pilot schools' do
+    expect(FactoryBot.build(:educator, school: nil)).to be_valid
   end
 
   describe '#admin_gets_access_to_all_students' do


### PR DESCRIPTION
Follow-on to https://github.com/studentinsights/studentinsights/pull/2151.  The current validations will prevent us from importing educators outside pilot schools (eg, central admin project leads).  Relax this to let us keep this all in code and config rather than just modifying the db.