### PR TITLE
Fix bug with homeroom label sort order on Absence page

### DIFF
--- a/app/assets/javascripts/school_absences/SchoolAbsencesDashboard.js
+++ b/app/assets/javascripts/school_absences/SchoolAbsencesDashboard.js
@@ -130,8 +130,8 @@ export default class SchoolAbsencesDashboard extends React.Component {
       // Partition by homeroom and compute each group
       const filteredStudents = this.filteredStudents({includeAllHomerooms: true});
       const studentsByHomeroom = _.groupBy(filteredStudents, 'homeroom_label');
-      const homeroomLabels = _.compact(Object.keys(studentsByHomeroom));
-      const unsortedHomeroomSeries = homeroomLabels.map(homeroomLabel => {
+      const unsortedHomeroomLabels = _.compact(Object.keys(studentsByHomeroom));
+      const unsortedHomeroomSeries = unsortedHomeroomLabels.map(homeroomLabel => {
         const students = studentsByHomeroom[homeroomLabel];
         const attendanceData = this.attendanceDataForStudents(students, endMoment);
         return {
@@ -142,6 +142,7 @@ export default class SchoolAbsencesDashboard extends React.Component {
         };
       });
       const homeroomSeries = _.sortBy(unsortedHomeroomSeries, 'attendanceRate');
+      const homeroomLabels = homeroomSeries.map(dataPoint => dataPoint.homeroomLabel);
 
       return {homeroomLabels, homeroomSeries};
     });


### PR DESCRIPTION
# Who is this PR for?
admin educators

# What problem does this PR fix?
The sort order on the absences by homeroom doesn't match the series data.

# What does this PR do?
Fixes that.
