### PR TITLE
Fix bug with findings homeroom by slug or id

### DIFF
--- a/app/controllers/homerooms_controller.rb
+++ b/app/controllers/homerooms_controller.rb
@@ -55,13 +55,22 @@ class HomeroomsController < ApplicationController
 
   # Calling `Homeroom.friendly.find` with a string version of an id will first
   # not match on id, and will match on the name for another homeroom with that
-  # same value.  Be explicit here that we match first on id (with type coercion) and
-  # then if not we look to match on the slug (with type coercion).
+  # same value.  Be explicit here that we match first on id and
+  # then if not we look to match on the slug.
+  #
+  # But type coercion can lead to bugs here too, like:
+  # > Homeroom.find_by_id('7-263') => #<Homeroom id: 7, name: "H-001", ... >
+  # So ensure that this any id lookup is really an integer and manually convert these
+  # types.
   def find_homeroom_by_id_or_slug(homeroom_id_or_slug)
-    homeroom_by_id = Homeroom.find_by_id(homeroom_id_or_slug)
-    return homeroom_by_id unless homeroom_by_id.nil?
+    if homeroom_id_or_slug.to_i.to_s == homeroom_id_or_slug.to_s
+      homeroom_id = homeroom_id_or_slug.to_i
+      homeroom_by_id = Homeroom.find_by_id(homeroom_id)
+      return homeroom_by_id unless homeroom_by_id.nil?
+    end
 
-    homeroom_by_slug = Homeroom.find_by_slug(homeroom_id_or_slug)
+    homeroom_slug = homeroom_id_or_slug.to_s
+    homeroom_by_slug = Homeroom.find_by_slug(homeroom_slug)
     return homeroom_by_slug unless homeroom_by_slug.nil?
 
     raise ActiveRecord::RecordNotFound

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -246,4 +246,18 @@ describe HomeroomsController, :type => :controller do
     end
 
   end
+
+  describe '#find_homeroom_by_id_or_slug' do
+    it 'works with different input types' do
+      homeroom_one = FactoryBot.create(:homeroom, id: 1, name: '7-263')
+      homeroom_two = FactoryBot.create(:homeroom, id: 7, name: '1')
+
+      expect(controller.send(:find_homeroom_by_id_or_slug, '7-263')).to eq homeroom_one
+      expect(controller.send(:find_homeroom_by_id_or_slug, '1')).to eq homeroom_one
+      expect(controller.send(:find_homeroom_by_id_or_slug, 1)).to eq homeroom_one
+      expect(controller.send(:find_homeroom_by_id_or_slug, '7')).to eq homeroom_two
+      expect(controller.send(:find_homeroom_by_id_or_slug, 7)).to eq homeroom_two
+      expect { controller.send(:find_homeroom_by_id_or_slug, 'xyz') }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
 end


### PR DESCRIPTION
# Who is this PR for?
K8 educators

# What problem does this PR fix?
`homerooms_controller` uses the `friendly_id` gem to patch different Rails methods and allow querying by user-friendly slug or by id.  https://github.com/studentinsights/studentinsights/pull/2022 tried to fix this but didn't fix it all the way since normal Rails type coercion is still in place and can lead to bugs like this:

```
irb> Homeroom.find_by_id('7-263')
=> #<Homeroom id: 7, name: "H-001", ... >
```

# What does this PR do?
This PR does explicit type checking and conversions to avoid this kind of bug.  Longer term, we should just remove this gem and only accept one type of param - there's no real value in the URL format here that's worth any complexity.

# Checklists
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code
