### PR TITLE
Profile: Only allow revising your own notes, limit scope of change for revising

### DIFF
--- a/app/assets/javascripts/components/EditableNoteText.js
+++ b/app/assets/javascripts/components/EditableNoteText.js
@@ -2,26 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import EditableTextComponent from './EditableTextComponent';
 import {exportedNoteText} from './NoteText';
-
-const styles = {
-  revisionsText: {
-    color: '#aaa',
-    fontSize: 13,
-    marginTop: 13
-  }
-};
-
-// Render 
-function renderNumberOfRevisions(numberOfRevisions) {
-  if (numberOfRevisions === undefined) return null;
-  return (
-    <div style={styles.revisionsText}>
-      {(numberOfRevisions === 1)
-          ? 'Revised 1 time'
-          : 'Revised ' + numberOfRevisions + ' times'}
-    </div>
-  );
-}
+import NoteRevisionMessage from './NoteRevisionMessage';
 
 
 // A visual component for rendering note text that also handles UX and styling
@@ -39,7 +20,7 @@ function EditableNoteText(props) {
         className="EditableTextComponent EditableNoteText-with-hover"
         text={text}
         onBlurText={onBlurText} />
-      {renderNumberOfRevisions(numberOfRevisions)}
+      <NoteRevisionMessage numberOfRevisions={numberOfRevisions} />
     </div>
   );
 }

--- a/app/assets/javascripts/components/NoteRevisionMessage.js
+++ b/app/assets/javascripts/components/NoteRevisionMessage.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Show how many times a note has been revised
+export default function NoteRevisionMessage({numberOfRevisions}) {
+  if (numberOfRevisions === undefined) return null;
+  return (
+    <div style={styles.revisionsText}>
+      {(numberOfRevisions === 1)
+          ? 'Revised 1 time'
+          : 'Revised ' + numberOfRevisions + ' times'}
+    </div>
+  );
+}
+NoteRevisionMessage.propTypes = {
+  numberOfRevisions: PropTypes.number.isRequired
+};
+
+
+const styles = {
+  revisionsText: {
+    color: '#aaa',
+    fontSize: 13,
+    marginTop: 13
+  }
+};

--- a/app/assets/javascripts/components/NoteText.js
+++ b/app/assets/javascripts/components/NoteText.js
@@ -24,7 +24,7 @@ export const exportedNoteText = {
 function NoteText(props) {
   const {text, style} = props;
   return (
-    <div style={{...exportedNoteText, ...style}}>
+    <div className="NoteText" style={{...exportedNoteText, ...style}}>
       {text}
     </div>
   );

--- a/app/assets/javascripts/feed/__snapshots__/EventNoteCard.test.js.snap
+++ b/app/assets/javascripts/feed/__snapshots__/EventNoteCard.test.js.snap
@@ -131,6 +131,7 @@ exports[`matches snapshot 1`] = `
       }
     >
       <div
+        className="NoteText"
         style={
           Object {
             "border": "1px solid transparent",

--- a/app/assets/javascripts/feed/__snapshots__/FeedView.test.js.snap
+++ b/app/assets/javascripts/feed/__snapshots__/FeedView.test.js.snap
@@ -169,6 +169,7 @@ exports[`FeedView pure component matches snapshot 1`] = `
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -333,6 +334,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -509,6 +511,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -698,6 +701,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -860,6 +864,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -1036,6 +1041,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -1225,6 +1231,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -1414,6 +1421,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -1589,6 +1597,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -1751,6 +1760,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -1940,6 +1950,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -2129,6 +2140,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -2318,6 +2330,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -2480,6 +2493,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -2656,6 +2670,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -2832,6 +2847,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -3008,6 +3024,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -3197,6 +3214,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",
@@ -3359,6 +3377,7 @@ Philis is meeting with parent next week and will present an attendance contract.
         }
       >
         <div
+          className="NoteText"
           style={
             Object {
               "border": "1px solid transparent",

--- a/app/assets/javascripts/notes_feed/NotesFeedPage.js
+++ b/app/assets/javascripts/notes_feed/NotesFeedPage.js
@@ -5,7 +5,7 @@ import NotesList from '../student_profile/NotesList';
 
 export default class NotesFeedPage extends React.Component {
   render() {
-    const {eventNotes, educatorsIndex, canUserAccessRestrictedNotes} = this.props;
+    const {currentEducatorId, eventNotes, educatorsIndex, canUserAccessRestrictedNotes} = this.props;
     const feed = {
       event_notes: eventNotes,
       deprecated: {
@@ -28,6 +28,7 @@ export default class NotesFeedPage extends React.Component {
         <div className="feed" style={styles.feed}>
           <div className="notes-list">
             <NotesList
+              currentEducatorId={currentEducatorId}
               includeStudentPanel={true}
               forceShowingAllNotes={true}
               canUserAccessRestrictedNotes={canUserAccessRestrictedNotes}
@@ -56,6 +57,7 @@ export default class NotesFeedPage extends React.Component {
   }
 }
 NotesFeedPage.propTypes = {
+  currentEducatorId: PropTypes.number.isRequired,
   educatorsIndex: PropTypes.object.isRequired,
   eventNotes: PropTypes.arrayOf(PropTypes.object).isRequired,
   onClickLoadMoreNotes: PropTypes.func.isRequired,

--- a/app/assets/javascripts/notes_feed/NotesFeedPage.test.js
+++ b/app/assets/javascripts/notes_feed/NotesFeedPage.test.js
@@ -8,6 +8,7 @@ import {serializedData} from './NotesFeedPage.fixture';
 export function testProps(props = {}) {
   const {educatorsIndex, notes, totalNotesCount} = serializedData;
   return {
+    currentEducatorId: 999999,
     educatorsIndex,
     totalNotesCount,
     eventNotes: notes,

--- a/app/assets/javascripts/notes_feed/PageContainer.js
+++ b/app/assets/javascripts/notes_feed/PageContainer.js
@@ -44,6 +44,7 @@ class PageContainer extends React.Component {
     const {currentEducator} = this.props;
     return(
       <NotesFeedPage
+        currentEducatorId={currentEducator.id}
         canUserAccessRestrictedNotes={currentEducator.can_view_restricted_notes}
         educatorsIndex={this.state.educatorsIndex}
         eventNotes={this.state.eventNotes}
@@ -56,6 +57,7 @@ class PageContainer extends React.Component {
 
 PageContainer.propTypes = {
   currentEducator: PropTypes.shape({
+    id: PropTypes.number.iRequired,
     can_view_restricted_notes: PropTypes.bool.isRequired
   }).isRequired,
   educatorsIndex: PropTypes.object.isRequired,

--- a/app/assets/javascripts/notes_feed/__snapshots__/NotesFeedPage.test.js.snap
+++ b/app/assets/javascripts/notes_feed/__snapshots__/NotesFeedPage.test.js.snap
@@ -176,6 +176,7 @@ exports[`snapshots view 1`] = `
             >
               <div>
                 <div
+                  className="NoteText"
                   style={
                     Object {
                       "border": "1px solid transparent",
@@ -316,6 +317,7 @@ exports[`snapshots view 1`] = `
             >
               <div>
                 <div
+                  className="NoteText"
                   style={
                     Object {
                       "border": "1px solid transparent",
@@ -456,6 +458,7 @@ exports[`snapshots view 1`] = `
             >
               <div>
                 <div
+                  className="NoteText"
                   style={
                     Object {
                       "border": "1px solid transparent",
@@ -600,6 +603,7 @@ exports[`snapshots view 1`] = `
             >
               <div>
                 <div
+                  className="NoteText"
                   style={
                     Object {
                       "border": "1px solid transparent",
@@ -740,6 +744,7 @@ exports[`snapshots view 1`] = `
               </span>
             </div>
             <div
+              className="NoteText"
               style={
                 Object {
                   "border": "1px solid transparent",

--- a/app/assets/javascripts/student_profile/LightNotesDetails.js
+++ b/app/assets/javascripts/student_profile/LightNotesDetails.js
@@ -65,6 +65,7 @@ export default class LightNotesDetails extends React.Component {
         <div>
           {this.isTakingNotes() && this.renderTakeNotesDialog()}
           <NotesList
+            currentEducatorId={currentEducator.id}
             feed={this.props.feed}
             canUserAccessRestrictedNotes={currentEducator.can_view_restricted_notes}
             educatorsIndex={this.props.educatorsIndex}

--- a/app/assets/javascripts/student_profile/NotesDetails.js
+++ b/app/assets/javascripts/student_profile/NotesDetails.js
@@ -54,6 +54,7 @@ class NotesDetails extends React.Component {
 
   render() {
     const {
+      currentEducator,
       student,
       title,
       feed,
@@ -75,6 +76,7 @@ class NotesDetails extends React.Component {
         </SectionHeading>
         {this.renderTakeNotesSection()}
         <NotesList
+          currentEducatorId={currentEducator.id}
           feed={feed}
           educatorsIndex={educatorsIndex}
           showRestrictedNoteContent={showRestrictedNoteContent}

--- a/app/assets/javascripts/student_profile/NotesDetails.test.js
+++ b/app/assets/javascripts/student_profile/NotesDetails.test.js
@@ -8,6 +8,7 @@ import PerDistrictContainer from '../components/PerDistrictContainer';
 
 function testRenderWithEl(districtKey, props) {
   const mergedProps = {
+    currentEducator: null, // caller should set
     educatorsIndex: {},
     noteInProgressText: '',
     noteInProgressType: null,
@@ -50,7 +51,7 @@ describe('educator can view restricted notes', () => {
   it('renders restricted notes button with zero notes', () => {
     const {el} = testRenderWithEl(SOMERVILLE, {
       showRestrictedNotesButton: true,
-      currentEducator: { can_view_restricted_notes: true },
+      currentEducator: { id: 42, can_view_restricted_notes: true },
       student: { restricted_notes_count: 0 },
     });
     expect(el.innerHTML).toContain('Restricted (0)');
@@ -59,7 +60,7 @@ describe('educator can view restricted notes', () => {
   it('renders restricted notes button with 7 notes', () => {
     const {el} = testRenderWithEl(SOMERVILLE, {
       showRestrictedNotesButton: true,
-      currentEducator: { can_view_restricted_notes: true },
+      currentEducator: { id: 42, can_view_restricted_notes: true },
       student: { restricted_notes_count: 7 },
     });
     expect(el.innerHTML).toContain('Restricted (7)');
@@ -70,7 +71,7 @@ describe('educator can not view restricted notes', () => {
   it('does not render restricted notes button', () => {
     const {el} = testRenderWithEl(SOMERVILLE, {
       showRestrictedNotesButton: true,
-      currentEducator: { can_view_restricted_notes: false },
+      currentEducator: { id: 42, can_view_restricted_notes: false },
       student: { restricted_notes_count: 0 },
     });
     expect(el.innerHTML).not.toContain('Restricted (0)');
@@ -79,7 +80,7 @@ describe('educator can not view restricted notes', () => {
 
 it('defaults to showRestrictedNotesButton:false', () => {
   const {el} = testRenderWithEl(SOMERVILLE, {
-    currentEducator: { can_view_restricted_notes: true },
+    currentEducator: { id: 42, can_view_restricted_notes: true },
     student: { restricted_notes_count: 0 },
   });
   expect(el.innerHTML).not.toContain('Restricted (0)');

--- a/app/assets/javascripts/student_profile/NotesList.js
+++ b/app/assets/javascripts/student_profile/NotesList.js
@@ -81,12 +81,14 @@ export default class NotesList extends React.Component {
       onEventNoteAttachmentDeleted,
       showRestrictedNoteContent,
       allowDirectEditingOfRestrictedNoteText,
-      canUserAccessRestrictedNotes
+      canUserAccessRestrictedNotes,
+      currentEducatorId
     } = this.props;
     const isRedacted = eventNote.is_restricted && !showRestrictedNoteContent;
     const isReadonly = (
       !onSaveNote ||
       !onEventNoteAttachmentDeleted ||
+      (currentEducatorId !== eventNote.educator_id) ||
       isRedacted ||
       (eventNote.is_restricted && !allowDirectEditingOfRestrictedNoteText)
     );
@@ -167,6 +169,7 @@ export default class NotesList extends React.Component {
   }
 }
 NotesList.propTypes = {
+  currentEducatorId: PropTypes.number.isRequired,
   feed: InsightsPropTypes.feed.isRequired,
   educatorsIndex: PropTypes.object.isRequired,
   includeStudentPanel: PropTypes.bool,

--- a/app/assets/javascripts/student_profile/NotesList.test.js
+++ b/app/assets/javascripts/student_profile/NotesList.test.js
@@ -10,6 +10,7 @@ import NotesList from './NotesList';
 
 function testProps(props = {}) {
   return {
+    currentEducatorId: 1,
     feed: feedForTestingNotes,
     educatorsIndex: studentProfile.educatorsIndex,
     onSaveNote: jest.fn(),
@@ -18,34 +19,38 @@ function testProps(props = {}) {
   };
 }
 
+function feedWithEventNotesJson(eventNotesJson) {
+  return {
+    transition_notes: [],
+    services: {
+      active: [],
+      discontinued: []
+    },
+    deprecated: {
+      interventions: []
+    },
+    event_notes: eventNotesJson
+  };
+}
+
 function testPropsForRestrictedNote(props = {}) {
   return testProps({
-    feed: {
-      transition_notes: [],
-      services: {
-        active: [],
-        discontinued: []
-      },
-      deprecated: {
-        interventions: []
-      },
-      event_notes: [{
-        "id": 3,
-        "student_id": 5,
-        "educator_id": 1,
-        "event_note_type_id": 301,
-        "text": "RESTRICTED-this-is-the-note-text",
-        "recorded_at": "2018-02-26T22:20:55.398Z",
-        "created_at": "2018-02-26T22:20:55.416Z",
-        "updated_at": "2018-02-26T22:20:55.416Z",
-        "is_restricted": true,
-        "event_note_revisions_count": 0,
-        "attachments": [
-          { id: 42, url: "https://www.example.com/studentwork" },
-          { id: 47, url: "https://www.example.com/morestudentwork" }
-        ]
-      }]
-    },
+    feed: feedWithEventNotesJson([{
+      "id": 3,
+      "student_id": 5,
+      "educator_id": 1,
+      "event_note_type_id": 301,
+      "text": "RESTRICTED-this-is-the-note-text",
+      "recorded_at": "2018-02-26T22:20:55.398Z",
+      "created_at": "2018-02-26T22:20:55.416Z",
+      "updated_at": "2018-02-26T22:20:55.416Z",
+      "is_restricted": true,
+      "event_note_revisions_count": 0,
+      "attachments": [
+        { id: 42, url: "https://www.example.com/studentwork" },
+        { id: 47, url: "https://www.example.com/morestudentwork" }
+      ]
+    }]),
     ...props
   });
 }
@@ -98,6 +103,48 @@ it('allows anyone to click and see older notes', () => {
   expect($(el).find('.NoteCard').length).toEqual(1);
   ReactTestUtils.Simulate.click($(el).find('.CleanSlateMessage a').get(0));
   expect($(el).find('.NoteCard').length).toEqual(5);
+});
+
+it('allows editing a note you wrote', () => {
+  const el = testRender(testProps({
+    currentEducatorId: 1,
+    feed: feedWithEventNotesJson([{
+      "id": 3,
+      "student_id": 5,
+      "educator_id": 1,
+      "event_note_type_id": 301,
+      "text": "hello-text",
+      "recorded_at": "2018-02-26T22:20:55.398Z",
+      "created_at": "2018-02-26T22:20:55.416Z",
+      "updated_at": "2018-02-26T22:20:55.416Z",
+      "is_restricted": false,
+      "event_note_revisions_count": 0,
+      "attachments": []
+    }]
+  )}));
+  expect($(el).find('.NoteText').length).toEqual(0);
+  expect($(el).find('.EditableNoteText').length).toEqual(1);
+});
+
+it('does not allow editing notes written by someone else', () => {
+  const el = testRender(testProps({
+    currentEducatorId: 999,
+    feed: feedWithEventNotesJson([{
+      "id": 3,
+      "student_id": 5,
+      "educator_id": 1,
+      "event_note_type_id": 301,
+      "text": "hello-text",
+      "recorded_at": "2018-02-26T22:20:55.398Z",
+      "created_at": "2018-02-26T22:20:55.416Z",
+      "updated_at": "2018-02-26T22:20:55.416Z",
+      "is_restricted": false,
+      "event_note_revisions_count": 0,
+      "attachments": []
+    }]
+  )}));
+  expect($(el).find('.NoteText').length).toEqual(1);
+  expect($(el).find('.EditableNoteText').length).toEqual(0);
 });
 
 describe('props impacting restricted notes', () => {

--- a/app/assets/javascripts/student_profile/__snapshots__/RestrictedNotePresence.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/RestrictedNotePresence.test.js.snap
@@ -6,6 +6,7 @@ exports[`snapshots 1`] = `
 >
   <div>
     <div
+      className="NoteText"
       style={
         Object {
           "border": "1px solid transparent",

--- a/app/controllers/event_notes_controller.rb
+++ b/app/controllers/event_notes_controller.rb
@@ -55,11 +55,13 @@ class EventNotesController < ApplicationController
       return render json: { errors: event_note_revision.errors.full_messages }, status: 422
     end
 
-    # Update the EventNote
+    # Update the EventNote, but don't update `recorded_at` - keep that at the original
+    # recording time.  The assumption is that these "updates" are from from the user continually
+    # editing during a meeting (the "start time" is fine) or from typo fixes (we don't care about
+    # those).
     safe_params[:event_note]
     if event_note.update({
-      text: safe_params[:event_note][:text],
-      recorded_at: Time.now
+      text: safe_params[:event_note][:text]
     })
       serializer = EventNoteSerializer.dangerously_include_restricted_note_text(event_note)
       render json: serializer.serialize_event_note

--- a/app/controllers/event_notes_controller.rb
+++ b/app/controllers/event_notes_controller.rb
@@ -47,6 +47,7 @@ class EventNotesController < ApplicationController
   def update
     safe_params = params.permit(:id, :student_id, event_note: [:text])
     event_note = authorized_or_raise! { EventNote.find(safe_params[:id]) }
+    raise Exceptions::EducatorNotAuthorized unless event_note.educator_id == current_educator.id
 
     # First store the current state of the existing event note
     event_note_revision = create_event_note_revision(event_note)
@@ -74,6 +75,8 @@ class EventNotesController < ApplicationController
     event_note = authorized_or_raise! do
       EventNoteAttachment.find(id).try(:event_note)
     end
+    raise Exceptions::EducatorNotAuthorized unless event_note.educator_id == current_educator.id
+
     event_note_attachment = event_note.event_note_attachments.find(id)
     if event_note_attachment.destroy
       render json: {}

--- a/spec/controllers/event_notes_controller_spec.rb
+++ b/spec/controllers/event_notes_controller_spec.rb
@@ -192,7 +192,8 @@ describe EventNotesController, :type => :controller do
         FactoryBot.create(:event_note, {
           text: 'original-text',
           student_id: student.id,
-          educator_id: educator.id
+          educator_id: educator.id,
+          recorded_at: Time.parse('2017-03-11T11:11:11.000Z')
         })
       end
       before { sign_in(educator) }
@@ -201,14 +202,16 @@ describe EventNotesController, :type => :controller do
         expect { make_update_request(student, event_note.id) }.to change(EventNote, :count).by 0
       end
 
-      it 'updates an existing event note' do
-        time_now = Time.parse('2017-03-16 11:12:00')
+      it 'updates an existing event note, but does not update `recorded_at`' do
+        previous_event_note_recorded_at = event_note.recorded_at
+        time_now = Time.parse('2017-03-16T11:12:00.000Z')
         Timecop.freeze(time_now) do
           make_update_request(student, event_note.id, text: 'updated-text!')
         end
         expect(response.status).to eq 200
         event_note.reload
-        expect(event_note.recorded_at).to eq time_now
+        expect(event_note.recorded_at).not_to eq time_now
+        expect(event_note.recorded_at).to eq previous_event_note_recorded_at
         expect(event_note.text).to eq 'updated-text!'
       end
 
@@ -263,7 +266,7 @@ describe EventNotesController, :type => :controller do
           "is_restricted" => false,
           "student_id" => student.id,
           "text" => "updated-text!",
-          "recorded_at" => "2018-08-23T23:38:13.956Z"
+          "recorded_at" => '2017-03-11T11:11:11.000Z'
         })
       end
     end

--- a/spec/controllers/event_notes_controller_spec.rb
+++ b/spec/controllers/event_notes_controller_spec.rb
@@ -191,7 +191,8 @@ describe EventNotesController, :type => :controller do
       let!(:event_note) do
         FactoryBot.create(:event_note, {
           text: 'original-text',
-          student_id: student.id
+          student_id: student.id,
+          educator_id: educator.id
         })
       end
       before { sign_in(educator) }
@@ -267,76 +268,88 @@ describe EventNotesController, :type => :controller do
       end
     end
 
-    context 'authorization checks' do
+    context 'authorization checks for notes' do
       let!(:student) { pals.shs_freshman_mari }
-      let!(:event_note) do
+      let!(:note_from_jodi) do
         FactoryBot.create(:event_note, {
           student_id: student.id,
-          text: 'original-text'
-        })
-      end
-      let!(:restricted_event_note) do
-        FactoryBot.create(:event_note, {
-          is_restricted: true,
-          student_id: student.id,
-          text: 'RESTRICTED-original-sensitive-text'
+          text: 'original-text',
+          educator_id: pals.shs_jodi.id
         })
       end
 
       it 'guards when not signed in' do
-        make_update_request(student, event_note.id, text: 'whatever')
+        make_update_request(student, note_from_jodi.id, text: 'whatever')
         expect(response.status).to eq 401
       end
 
       it 'guards from updating text for an unauthorized student' do
         sign_in(pals.healey_laura_principal)
-        make_update_request(student, event_note.id, text: 'whatever')
+        make_update_request(student, note_from_jodi.id, text: 'whatever')
         expect(response.status).to eq 403
       end
 
       it 'only allows updating text, not other fields' do
-        sign_in(pals.uri)
-        make_update_request(student, event_note.id, event_note_type_id: 99, text: 'new-value')
+        sign_in(pals.shs_jodi)
+        make_update_request(student, note_from_jodi.id, event_note_type_id: 99, text: 'new-value')
 
-        event_note.reload
-        expect(event_note.text).to eq 'new-value'
-        expect(event_note.event_note_type_id).not_to eq 99
+        note_from_jodi.reload
+        expect(note_from_jodi.text).to eq 'new-value'
+        expect(note_from_jodi.event_note_type_id).not_to eq 99
         expect(response.status).to eq 200
         json = JSON.parse(response.body)
         expect(json['text']).to eq 'new-value'
         expect(json['event_note_type_id']).not_to eq 99
       end
 
-      it 'guards from updating text for restricted note when access but not can_view_restricted_notes' do
-        sign_in(pals.shs_jodi)
-        make_update_request(student, restricted_event_note.id, text: 'changed')
+      it 'does not allow updating notes from other educators' do
+        sign_in(pals.uri)
+        make_update_request(student, note_from_jodi.id, text: 'new-value-from-uri')
+        expect(response.status).to eq 403
+      end
+    end
 
-        restricted_event_note.reload
-        expect(restricted_event_note.text).not_to eq 'changed'
+    context 'authorization checks for restricted notes' do
+      let!(:student) { pals.shs_freshman_mari }
+      let!(:harry_restricted_event_note) do
+        FactoryBot.create(:event_note, {
+          is_restricted: true,
+          student_id: student.id,
+          educator_id: pals.shs_harry_housemaster.id,
+          text: 'RESTRICTED-original-sensitive-text'
+        })
+      end
+
+      it 'guards from updating text for restricted note when student access but not can_view_restricted_notes' do
+        sign_in(pals.shs_jodi)
+        make_update_request(student, harry_restricted_event_note.id, text: 'changed')
+
+        harry_restricted_event_note.reload
+        expect(harry_restricted_event_note.text).not_to eq 'changed'
         expect(response.status).to eq 403
       end
 
       it 'permits updating text for restricted note when can_view_restricted_notes' do
-        sign_in(pals.rich_districtwide)
-        make_update_request(student, restricted_event_note.id, text: 'RESTRICTED-updated')
+        sign_in(pals.shs_harry_housemaster)
+        make_update_request(student, harry_restricted_event_note.id, text: 'RESTRICTED-updated')
 
-        restricted_event_note.reload
-        expect(restricted_event_note.text).to eq 'RESTRICTED-updated'
+        harry_restricted_event_note.reload
+        expect(harry_restricted_event_note.text).to eq 'RESTRICTED-updated'
         expect(response.status).to eq 200
         json = JSON.parse(response.body)
         expect(json['text']).to eq 'RESTRICTED-updated'
       end
 
       it 'does not allow anyone to change `is_restricted`' do
-        sign_in(pals.uri)
-        make_update_request(student, restricted_event_note.id, {
+        sign_in(pals.shs_harry_housemaster)
+        make_update_request(student, harry_restricted_event_note.id, {
           text: 'RESTRICTED-beta',
           is_restricted: false
         })
 
-        restricted_event_note.reload
-        expect(restricted_event_note.is_restricted).to eq true
-        expect(restricted_event_note.text).to eq 'RESTRICTED-beta'
+        harry_restricted_event_note.reload
+        expect(harry_restricted_event_note.is_restricted).to eq true
+        expect(harry_restricted_event_note.text).to eq 'RESTRICTED-beta'
         json = JSON.parse(response.body)
         expect(json['is_restricted']).to eq true
         expect(json['text']).to eq 'RESTRICTED-beta'
@@ -353,35 +366,55 @@ describe EventNotesController, :type => :controller do
       }
     end
 
-    let(:educator) { FactoryBot.create(:educator, districtwide_access: true) }
-    before { sign_in(educator) }
-    let(:event_note) { FactoryBot.create(:event_note) }
-    let!(:event_note_attachment) {
-      EventNoteAttachment.create(url: 'www.goodurl.com', event_note: event_note)
-    }
-
-    context 'no error!' do
-      it 'destroys the object and returns empty object' do
-        destroy_attachment(event_note_attachment.id)
-        expect(response.body).to eq '{}'
-        expect(event_note.reload.event_note_attachments.size).to eq 0
-      end
+    def create_note_from_jodi
+      note_from_jodi = FactoryBot.create(:event_note, {
+        student_id: pals.shs_freshman_mari.id,
+        educator_id: pals.shs_jodi.id,
+        text: 'original-text-from-jodi',
+      })
+      EventNoteAttachment.create!({
+        url: 'www.goodurl.com',
+        event_note: note_from_jodi
+      })
+      note_from_jodi
     end
 
-    context 'unauthorized educator' do
-      let(:educator) { FactoryBot.create(:educator) }
+    it 'works and destroys the object and returns empty object' do
+      note_from_jodi = create_note_from_jodi
+      sign_in(pals.shs_jodi)
+      destroy_attachment(note_from_jodi.event_note_attachments.first.id)
+      expect(response.body).to eq '{}'
+      expect(note_from_jodi.reload.event_note_attachments.size).to eq 0
+    end
 
-      it 'fails authorization' do
-        destroy_attachment(event_note_attachment.id)
+    it '404s on non-existent id' do
+      sign_in(pals.uri)
+      destroy_attachment(12345) # non-existent
+      expect(response.status).to eq 404
+    end
+
+    context 'authorization checks' do
+      it 'does not allow deleting attachments for notes created by other educators' do
+        note_from_jodi = create_note_from_jodi
+        sign_in(pals.uri)
+        destroy_attachment(note_from_jodi.event_note_attachments.first.id)
         expect(response.status).to eq 403
-        expect(event_note.reload.event_note_attachments.size).to eq 1
+        expect(note_from_jodi.reload.event_note_attachments.size).to eq 1
       end
-    end
 
-    context 'on bad id' do
-      it 'fails' do
-        destroy_attachment(12345) # non-existent
-        expect(response.status).to eq 404
+      it 'does not allow deleting attachments if not authorized for student' do
+        note_from_jodi = create_note_from_jodi
+        sign_in(pals.healey_laura_principal)
+        destroy_attachment(note_from_jodi.event_note_attachments.first.id)
+        expect(response.status).to eq 403
+        expect(note_from_jodi.reload.event_note_attachments.size).to eq 1
+      end
+
+      it 'does not allow users not signed in' do
+        note_from_jodi = create_note_from_jodi
+        destroy_attachment(note_from_jodi.event_note_attachments.first.id)
+        expect(response.status).to eq 401
+        expect(note_from_jodi.reload.event_note_attachments.size).to eq 1
       end
     end
   end


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
Folks are concerned about revising notes, and want to limit how much this is possible.  Also, currently if a user edits a note it updates the `recorded_at` and bumps it up in the feed and profile in a way that is unexpected.

# What does this PR do?
Prevents users from editing notes someone else wrote, in the UI and in the controller.

# Checklists
+ [x] Author checked latest in IE - Student Profile
+ [x] Author checked latest in IE - Home page feed
+ [x] Author checked latest in IE - My notes
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code
