### PR TITLE
Rake task for manually running validations across all models and records

### DIFF
--- a/lib/tasks/validations.rake
+++ b/lib/tasks/validations.rake
@@ -30,6 +30,11 @@ namespace :validations do
 
       invalid_count_by_class = invalids.group_by(&:class).map {|key, values| [key, values.size] }
       puts "Invalids by model class: #{invalid_count_by_class.inspect}"
+      puts "Invalid record ids by class..."
+      invalids.group_by(&:class).each do |key, values|
+        puts "  invalids: #{key}.where(id: #{values.map(&:id)})"
+      end
+      puts "Done."
       nil
     end
 

--- a/lib/tasks/validations.rake
+++ b/lib/tasks/validations.rake
@@ -1,0 +1,38 @@
+namespace :validations do
+  desc 'Check all validations manually across all models and records in the database'
+  task run_all_manually: :environment do
+    def invalid_records(model_classes)
+      invalids = []
+      counter = 0
+      model_classes.each do |model_class|
+        model_class.all.each do |record|
+          invalids << record if !record.valid?
+
+          counter += 1
+          puts "  checked: #{counter}" if counter > 0 && counter % 1000 == 0
+        end
+      end
+      invalids
+    end
+
+    def print_invalid_records_by_model!
+      puts "Eager loading models..."
+      Rails.application.eager_load!
+      model_classes = ApplicationRecord.descendants
+      puts "Total classes: #{ApplicationRecord.descendants.size}"
+
+      count = model_classes.map {|model_class| model_class.all.size }.sum
+      puts "Total records: #{count}"
+
+      puts "Checking each model..."
+      invalids = invalid_records(model_classes)
+      puts "Total invalids: #{invalids.size}"
+
+      invalid_count_by_class = invalids.group_by(&:class).map {|key, values| [key, values.size] }
+      puts "Invalids by model class: #{invalid_count_by_class.inspect}"
+      nil
+    end
+
+    print_invalid_records_by_model!
+  end
+end


### PR DESCRIPTION
In the work for https://github.com/studentinsights/studentinsights/pull/2156, it came up that there are models in the database that violation validations.  This can happen when we add a validation, ship it, and then don't load that model into memory.  This is one reason why database constraints are stronger than validations (if violated, they'll raise when adding the constraint).

Work in https://github.com/studentinsights/studentinsights/pull/2160 should help with adding more constraints, but this adds a one-off task for running all validations on all models and records.  I'll run this now to verify there are no other gaps, and potentially schedule it to run and raise weekly if anything gets through.  This task will probably be quite slow (Rails presence validations for associations trigger queries to verify that the record is present, even if a database foreign key constraint is present).  We could speed this up by ensuring we have foreign key constraints (which `immigrant` enforces) and changing Rails presence validations on the association to just be presence validations on the key column, but let's see how long this takes first and if we can just run it weekly.