### PR TITLE
Remove validation and constraint on Student state_id

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -36,7 +36,6 @@ class Student < ActiveRecord::Base
   validates :local_id, presence: true, uniqueness: true
   validates :first_name, presence: true
   validates :last_name, presence: true
-  validates :state_id, presence: true
   validates :school, presence: true
   validates :grade, inclusion: { in: GradeLevels::ORDERED_GRADE_LEVELS }
   validates :plan_504, inclusion: { in: PerDistrict.new.valid_plan_504_values }

--- a/db/migrate/20181009111501_add_key_constraints.rb
+++ b/db/migrate/20181009111501_add_key_constraints.rb
@@ -42,7 +42,6 @@ class AddKeyConstraints < ActiveRecord::Migration[5.2]
     change_column :student_assessments, :assessment_id, :integer, null: false
 
     change_column :students, :local_id, :string, null: false
-    change_column :students, :state_id, :string, null: false    
     change_column :students, :school_id, :integer, null: false
     change_column :students, :created_at, :datetime, null: false
     change_column :students, :updated_at, :datetime, null: false

--- a/db/migrate/20181009124708_remove_student_state_id_constraint.rb
+++ b/db/migrate/20181009124708_remove_student_state_id_constraint.rb
@@ -1,0 +1,5 @@
+class RemoveStudentStateIdConstraint < ActiveRecord::Migration[5.2]
+  def change
+    change_column :students, :state_id, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_09_111501) do
+ActiveRecord::Schema.define(version: 2018_10_09_124708) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -457,7 +457,7 @@ ActiveRecord::Schema.define(version: 2018_10_09_111501) do
     t.integer "homeroom_id"
     t.string "first_name", null: false
     t.string "last_name", null: false
-    t.string "state_id", null: false
+    t.string "state_id"
     t.string "home_language"
     t.integer "school_id", null: false
     t.string "student_address"


### PR DESCRIPTION
We don't use this anywhere, and student records can be missing this in Somerville when they're first added.  This came up with deploying https://github.com/studentinsights/studentinsights/pull/2160