### PR TITLE
Add counts for validation failures by field in RecordSyncer stats output

### DIFF
--- a/app/importers/helpers/record_syncer.rb
+++ b/app/importers/helpers/record_syncer.rb
@@ -15,6 +15,8 @@ class RecordSyncer
     @created_rows_count = 0
     @destroyed_records_count = 0
 
+    @validation_failure_counts_by_field = {}
+
     @marked_ids = []
   end
 
@@ -35,6 +37,10 @@ class RecordSyncer
     # invalid records like this will get purged by `delete_unmarked_records!`
     if !insights_record.valid?
       @invalid_rows_count += 1
+      insights_record.errors.messages.keys.each do |validation_key|
+        @validation_failure_counts_by_field[validation_key] = 0 unless @validation_failure_counts_by_field.has_key?(validation_key)
+        @validation_failure_counts_by_field[validation_key] += 1
+      end
       return :invalid
     end
 
@@ -111,6 +117,7 @@ class RecordSyncer
       created_rows_count: @created_rows_count,
       marked_ids_count: @marked_ids.size,
       destroyed_records_count: @destroyed_records_count,
+      validation_failure_counts_by_field: @validation_failure_counts_by_field
     }
   end
 

--- a/spec/importers/helpers/record_syncer_spec.rb
+++ b/spec/importers/helpers/record_syncer_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 1,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
@@ -44,6 +45,10 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 1,
+        validation_failure_counts_by_field: {
+          student_id: 1,
+          occurred_at: 1
+        },
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
@@ -60,6 +65,9 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 1,
+        validation_failure_counts_by_field: {
+          student_id: 1
+        },
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
@@ -75,6 +83,7 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 1,
         updated_rows_count: 0,
         created_rows_count: 0,
@@ -91,6 +100,7 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 0,
         updated_rows_count: 1,
         created_rows_count: 0,
@@ -106,6 +116,7 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 1,
@@ -154,11 +165,12 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
         marked_ids_count: 0,
-        destroyed_records_count: 0,
+        destroyed_records_count: 0
       })
     end
 
@@ -191,11 +203,12 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 2,
         updated_rows_count: 0,
         created_rows_count: 0,
         marked_ids_count: 2,
-        destroyed_records_count: 1,
+        destroyed_records_count: 1
       })
     end
 
@@ -211,11 +224,12 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
         marked_ids_count: 0,
-        destroyed_records_count: 5,
+        destroyed_records_count: 5
       })
     end
 
@@ -230,11 +244,12 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 1,
         marked_ids_count: 1,
-        destroyed_records_count: 0,
+        destroyed_records_count: 0
       })
     end
 
@@ -251,11 +266,14 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 1,
+        validation_failure_counts_by_field: {
+          student_id: 1
+        },
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
         marked_ids_count: 0,
-        destroyed_records_count: 1,
+        destroyed_records_count: 1
       })
     end
   end


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
When there are validation failures on import, we see counts, but it's hard to tell what's normal and  expected and then to do the next step of updating importer to expect this or fixing the underlying issue.

# What does this PR do?
Adds info about which fields failed validation in the output of `RecordSyncer` so this is visible in logs.
