### PR TITLE
Add overlay if student is inactive or missing from export 

### DIFF
--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -204,3 +204,13 @@ export function studentTableEventNoteTypeIds(districtKey, schoolType) {
   throw new Error(`unsupported districtKey: ${districtKey}`);
 }
 
+
+// See PerDistrict.rb#does_students_export_include_rows_for_inactive_students?
+export function isStudentActive(districtKey, student) {
+  if (districtKey === BEDFORD) return !student.missing_from_last_export;
+  if (districtKey === NEW_BEDFORD) return !student.missing_from_last_export;
+  if (districtKey === SOMERVILLE) return student.enrollment_status === 'Active';
+
+  // Check both as fallback
+  return student.enrollment_status === 'Active' && !student.missing_from_last_export;
+}

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -44,9 +44,11 @@ export default class LightProfilePage extends React.Component {
   render() {
     const {student, districtKey} = this.props;
     const isHighSchool = (student.school_type === 'HS');
+    
     return (
       <PerDistrictContainer districtKey={districtKey}>
         <div className="LightProfilePage" style={styles.root}>
+          {this.renderInactiveOverlay()}
           {this.renderHeader()}
           <div style={styles.tabsContainer}>
             <div style={styles.tabLayout}>{this.renderNotesColumn()}</div>
@@ -62,6 +64,20 @@ export default class LightProfilePage extends React.Component {
           </div>
         </div>
       </PerDistrictContainer>
+    );
+  }
+
+  renderInactiveOverlay() {
+    const {student} = this.props;
+    const isInactive = (student.missing_from_last_export || student.enrollment_status !== 'Active');
+    if (!isInactive) return null;
+
+    return (
+      <div className="LightProfilePage-inactive-overlay" style={styles.inactiveOverlay}>
+        <div style={styles.inactiveOverlayMessage}>
+          {student.first_name} is no longer actively enrolled
+        </div>
+      </div>
     );
   }
 
@@ -460,6 +476,25 @@ LightProfilePage.propTypes = {
 const styles = {
   root: {
     fontSize: 14
+  },
+  inactiveOverlay: {
+    position: 'fixed',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    background: '#6669',
+    zIndex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  inactiveOverlayMessage: {
+    background: 'white',
+    padding: 50,
+    fontWeight: 'bold',
+    fontSize: 20,
+    color: 'black'
   },
   tabsContainer: {
     display: 'flex',

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -6,6 +6,7 @@ import {updateGlobalStylesToRemoveHorizontalScrollbars, alwaysShowVerticalScroll
 import * as InsightsPropTypes from '../helpers/InsightsPropTypes';
 import {toMomentFromTimestamp} from '../helpers/toMoment';
 import * as FeedHelpers from '../helpers/FeedHelpers';
+import {isStudentActive} from '../helpers/PerDistrict';
 import PerDistrictContainer from '../components/PerDistrictContainer';
 import LightProfileHeader from './LightProfileHeader';
 import LightProfileTab, {LightShoutNumber} from './LightProfileTab';
@@ -68,9 +69,9 @@ export default class LightProfilePage extends React.Component {
   }
 
   renderInactiveOverlay() {
-    const {student} = this.props;
-    const isInactive = (student.missing_from_last_export || student.enrollment_status !== 'Active');
-    if (!isInactive) return null;
+    const {student, districtKey} = this.props;
+    const isActive = isStudentActive(districtKey, student);
+    if (isActive) return null;
 
     return (
       <div className="LightProfilePage-inactive-overlay" style={styles.inactiveOverlay}>

--- a/app/assets/javascripts/student_profile/LightProfilePage.test.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.test.js
@@ -135,6 +135,7 @@ describe('inactive overlay', () => {
     const defaultProps = testPropsForOlafWhite();
     const el = testRender({
       ...defaultProps,
+      districtKey: 'somerville',
       student: {
         ...defaultProps.student,
         enrollment_status: 'Withdrawn'
@@ -148,6 +149,7 @@ describe('inactive overlay', () => {
     const defaultProps = testPropsForOlafWhite();
     const el = testRender({
       ...defaultProps,
+      districtKey: 'new-bedford',
       student: {
         ...defaultProps.student,
         missing_from_last_export: true

--- a/app/assets/javascripts/student_profile/LightProfilePage.test.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.test.js
@@ -131,7 +131,7 @@ it('#countEventsSince works', () => {
 });
 
 describe('inactive overlay', () => {
-  it('is shown for inactive students', () => {
+  it('is shown for inactive students in Somerville', () => {
     const defaultProps = testPropsForOlafWhite();
     const el = testRender({
       ...defaultProps,
@@ -145,11 +145,25 @@ describe('inactive overlay', () => {
     expect($(el).text()).toContain('no longer actively enrolled');
   });
 
-  it('is shown for students missing from export', () => {
+  it('is shown for students missing from export in New Bedford', () => {
     const defaultProps = testPropsForOlafWhite();
     const el = testRender({
       ...defaultProps,
       districtKey: 'new-bedford',
+      student: {
+        ...defaultProps.student,
+        missing_from_last_export: true
+      }
+    });
+    expect($(el).find('.LightProfilePage-inactive-overlay').length).toEqual(1);
+    expect($(el).text()).toContain('no longer actively enrolled');
+  });
+
+  it('is shown for students missing from export in Bedford', () => {
+    const defaultProps = testPropsForOlafWhite();
+    const el = testRender({
+      ...defaultProps,
+      districtKey: 'bedford',
       student: {
         ...defaultProps.student,
         missing_from_last_export: true

--- a/app/assets/javascripts/student_profile/LightProfilePage.test.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.test.js
@@ -129,3 +129,31 @@ it('#countEventsSince works', () => {
   ];
   expect(countEventsSince(toMoment('8/28/2018'), absences, 45)).toEqual(1);
 });
+
+describe('inactive overlay', () => {
+  it('is shown for inactive students', () => {
+    const defaultProps = testPropsForOlafWhite();
+    const el = testRender({
+      ...defaultProps,
+      student: {
+        ...defaultProps.student,
+        enrollment_status: 'Withdrawn'
+      }
+    });
+    expect($(el).find('.LightProfilePage-inactive-overlay').length).toEqual(1);
+    expect($(el).text()).toContain('no longer actively enrolled');
+  });
+
+  it('is shown for students missing from export', () => {
+    const defaultProps = testPropsForOlafWhite();
+    const el = testRender({
+      ...defaultProps,
+      student: {
+        ...defaultProps.student,
+        missing_from_last_export: true
+      }
+    });
+    expect($(el).find('.LightProfilePage-inactive-overlay').length).toEqual(1);
+    expect($(el).text()).toContain('no longer actively enrolled');
+  });
+});

--- a/app/importers/helpers/record_syncer.rb
+++ b/app/importers/helpers/record_syncer.rb
@@ -15,6 +15,8 @@ class RecordSyncer
     @created_rows_count = 0
     @destroyed_records_count = 0
 
+    @validation_failure_counts_by_field = {}
+
     @marked_ids = []
   end
 
@@ -35,6 +37,10 @@ class RecordSyncer
     # invalid records like this will get purged by `delete_unmarked_records!`
     if !insights_record.valid?
       @invalid_rows_count += 1
+      insights_record.errors.messages.keys.each do |validation_key|
+        @validation_failure_counts_by_field[validation_key] = 0 unless @validation_failure_counts_by_field.has_key?(validation_key)
+        @validation_failure_counts_by_field[validation_key] += 1
+      end
       return :invalid
     end
 
@@ -111,6 +117,7 @@ class RecordSyncer
       created_rows_count: @created_rows_count,
       marked_ids_count: @marked_ids.size,
       destroyed_records_count: @destroyed_records_count,
+      validation_failure_counts_by_field: @validation_failure_counts_by_field
     }
   end
 

--- a/spec/importers/helpers/record_syncer_spec.rb
+++ b/spec/importers/helpers/record_syncer_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 1,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
@@ -44,6 +45,10 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 1,
+        validation_failure_counts_by_field: {
+          student_id: 1,
+          occurred_at: 1
+        },
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
@@ -60,6 +65,9 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 1,
+        validation_failure_counts_by_field: {
+          student_id: 1
+        },
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
@@ -75,6 +83,7 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 1,
         updated_rows_count: 0,
         created_rows_count: 0,
@@ -91,6 +100,7 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 0,
         updated_rows_count: 1,
         created_rows_count: 0,
@@ -106,6 +116,7 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 1,
@@ -154,11 +165,12 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
         marked_ids_count: 0,
-        destroyed_records_count: 0,
+        destroyed_records_count: 0
       })
     end
 
@@ -191,11 +203,12 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 2,
         updated_rows_count: 0,
         created_rows_count: 0,
         marked_ids_count: 2,
-        destroyed_records_count: 1,
+        destroyed_records_count: 1
       })
     end
 
@@ -211,11 +224,12 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
         marked_ids_count: 0,
-        destroyed_records_count: 5,
+        destroyed_records_count: 5
       })
     end
 
@@ -230,11 +244,12 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
+        validation_failure_counts_by_field: {},
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 1,
         marked_ids_count: 1,
-        destroyed_records_count: 0,
+        destroyed_records_count: 0
       })
     end
 
@@ -251,11 +266,14 @@ RSpec.describe RecordSyncer do
       expect(syncer.stats).to eq({
         passed_nil_record_count: 0,
         invalid_rows_count: 1,
+        validation_failure_counts_by_field: {
+          student_id: 1
+        },
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
         marked_ids_count: 0,
-        destroyed_records_count: 1,
+        destroyed_records_count: 1
       })
     end
   end


### PR DESCRIPTION
# Who is this PR for?
educators, developers

# What problem does this PR fix?
Student Insights contains records for students that are no longer actively enrolled.  These records aren't reachable from other UI elements, but the profile page still is.  So when debugging, if we visit this page (which can be useful) it's not obvious the student is active.

# What does this PR do?
Adds an overlay to the profile page if the student is inactive.

# Screenshot (if adding a client-side feature)
<img width="1230" alt="screen shot 2018-10-09 at 9 35 12 am" src="https://user-images.githubusercontent.com/1056957/46673060-ee6e0f00-cba6-11e8-818f-19a280af7380.png">

# Checklists
+ [x] Author checked latest in IE - Student Profile
+ [x] Author included specs for new code
