### PR TITLE
EducatorsImporter: Explictly filter out educator rows with missing emails

### DIFF
--- a/app/importers/rows/educator_row.rb
+++ b/app/importers/rows/educator_row.rb
@@ -2,13 +2,16 @@ class EducatorRow < Struct.new(:row, :school_ids_dictionary)
   # Returns a new or existing Educator record matching the row, or nil if it can't
   # understand the row.
   def match_educator_record
+    # login_name is the primary key, but we also always require email
     login_name = row[:login_name]
+    email = email_from_row(row)
     return nil if login_name.nil? || login_name == ''
+    return nil if email.nil? || email == ''
 
     # login_name is the primary key, and email is always secondary
     educator = Educator.find_or_initialize_by(login_name: login_name)
     educator.assign_attributes({
-      email: email_from_row,
+      email: email,
       state_id: row[:state_id],
       full_name: row[:full_name],
       staff_type: row[:staff_type],
@@ -32,7 +35,7 @@ class EducatorRow < Struct.new(:row, :school_ids_dictionary)
 
   private
 
-  def email_from_row
+  def email_from_row(row)
     PerDistrict.new.email_from_educator_import_row(row)
   end
 


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Bedford sends some rows without email addresses; these fail validations when we try to sync.  We could relax the validations or filter these explicitly.

# What does this PR do?
Filters these out explicitly, requiring both `login_name` and `email` to be imported.
