### PR TITLE
HS Levels: Add EducatorLabel for section-based feed, enabling schoolwide access for data coordinators

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -131,7 +131,6 @@ class PerDistrict
     end
   end
 
-
   # In the import process, we typically only get usernames
   # as the `login_name`, and emails are the same but with a domain
   # suffix.  But for Bedford, emails are distinct and imported separately

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -122,6 +122,16 @@ class PerDistrict
     end
   end
 
+  # For filtering the feed by students in sections
+  def enable_section_based_feed?
+    if @district_key == SOMERVILLE || @district_key == DEMO
+      EnvironmentVariable.is_true('ENABLE_SECTION_BASED_FEED')
+    else
+      false
+    end
+  end
+
+
   # In the import process, we typically only get usernames
   # as the `login_name`, and emails are the same but with a domain
   # suffix.  But for Bedford, emails are distinct and imported separately

--- a/app/lib/env.rb
+++ b/app/lib/env.rb
@@ -21,6 +21,7 @@ class Env
     # feature switches
     default_env['ENABLE_COUNSELOR_BASED_FEED'] = 'true'
     default_env['ENABLE_HOUSEMASTER_BASED_FEED'] = 'true'
+    default_env['ENABLE_SECTION_BASED_FEED'] = 'true'
     default_env['HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8'] = 'false'
     default_env['ENABLE_MASQUERADING'] = 'true'
     default_env['ENABLE_STUDENT_VOICE_SURVEYS_UPLOADS'] = 'true'

--- a/app/lib/experimental_somerville_high_tiers.rb
+++ b/app/lib/experimental_somerville_high_tiers.rb
@@ -12,7 +12,6 @@ class ExperimentalSomervilleHighTiers
 
   def initialize(educator, options = {})
     @educator = educator
-    @authorizer = Authorizer.new(@educator)
     @time_interval = options.fetch(:time_interval, 45.days)
 
     if !PerDistrict.new.enabled_high_school_tiering?
@@ -24,11 +23,7 @@ class ExperimentalSomervilleHighTiers
     cutoff_time = time_now - @time_interval
 
     # query for students, enforce authorization
-    students = @authorizer.authorized do
-      Student.active
-        .where(school_id: school_ids)
-        .to_a # because of AuthorizedDispatcher#filter_relation
-    end
+    students = authorized_students
     student_ids = students.map(&:id)
 
     # query for absences and discipline events in batch
@@ -149,6 +144,17 @@ class ExperimentalSomervilleHighTiers
   end
 
   private
+  # Some educators at the HS have "data coordinator" roles as well, and they
+  # help facilitate different analyses etc, so they 
+  def authorized_students
+    relevant_students = Student.active.where(school_id: school_ids).to_a
+    if @educator.labels.include?('skip_authorization_and_allow_access_to_all_students_in_levels_page')
+      relevant_students
+    else
+      Authorizer.new(@educator).authorized { relevant_students}
+    end
+  end
+
   # query_map is {:result_key => [event_note_type_id]}
   def most_recent_event_notes_by_student_id(student_ids, cutoff_time, query_map)
     notes_by_student_id = {}

--- a/app/lib/feed_filter.rb
+++ b/app/lib/feed_filter.rb
@@ -7,7 +7,8 @@ class FeedFilter
   def filter_for_educator(students)
     filters = [
       CounselorFilter.new(@educator),
-      HouseFilter.new(@educator)
+      HouseFilter.new(@educator),
+      SectionsFilter.new(@educator)
     ]
 
     filtered_students = students
@@ -20,6 +21,30 @@ class FeedFilter
   end
 
   private
+  # Filters by students in sections that a teacher is currently teaching.
+  # For HS teachers who need schoolwide access for admin parts of their role (eg, data coordinator, 
+  # department head), but who also serve as classroom teachers and really want to just focus on those
+  # students for most uses cases (eg, the feed, notifications).
+  class SectionsFilter
+    def initialize(educator)
+      @educator = educator
+    end
+
+    def should_use?
+      return false unless PerDistrict.new.enable_section_based_feed?
+      EducatorLabel.has_static_label?(@educator.id, 'use_section_based_feed')
+    end
+
+    def keep?(student)
+      student.in?(section_students)
+    end
+
+    private
+    def section_students
+      @section_students ||= @educator.section_students.to_a
+    end
+  end
+
   # For filtering base on the student's counselor field.
   class CounselorFilter
     def initialize(educator)

--- a/app/lib/feed_filter.rb
+++ b/app/lib/feed_filter.rb
@@ -22,7 +22,7 @@ class FeedFilter
 
   private
   # Filters by students in sections that a teacher is currently teaching.
-  # For HS teachers who need schoolwide access for admin parts of their role (eg, data coordinator, 
+  # For HS teachers who need schoolwide access for admin parts of their role (eg, data coordinator,
   # department head), but who also serve as classroom teachers and really want to just focus on those
   # students for most uses cases (eg, the feed, notifications).
   class SectionsFilter

--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -14,9 +14,9 @@ class EducatorLabel < ApplicationRecord
         'class_list_maker_finalizer_principal',
         'use_counselor_based_feed',
         'use_housemaster_based_feed',
+        'use_section_based_feed',
         'enable_class_lists_override',
-        'can_upload_student_voice_surveys',
-        'skip_authorization_and_allow_access_to_all_students_in_levels_page'
+        'can_upload_student_voice_surveys'
       ]
     }
   }

--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -15,7 +15,8 @@ class EducatorLabel < ApplicationRecord
         'use_counselor_based_feed',
         'use_housemaster_based_feed',
         'enable_class_lists_override',
-        'can_upload_student_voice_surveys'
+        'can_upload_student_voice_surveys',
+        'skip_authorization_and_allow_access_to_all_students_in_levels_page'
       ]
     }
   }

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -107,6 +107,16 @@ RSpec.describe Authorizer do
         expect(authorized(pals.shs_bill_nye) { Student.all }).to match_array [
           pals.shs_freshman_mari
         ]
+        expect(authorized(pals.shs_fatima_science_teacher) { Student.all }).to match_array [
+          pals.shs_freshman_mari,
+          pals.shs_freshman_amir,
+          pals.shs_senior_kylo
+        ]
+        expect(authorized(pals.shs_harry_housemaster) { Student.all }).to match_array [
+          pals.shs_freshman_mari,
+          pals.shs_freshman_amir,
+          pals.shs_senior_kylo
+        ]
       end
 
       it 'limits access for Student.find' do

--- a/spec/lib/feed_filter_spec.rb
+++ b/spec/lib/feed_filter_spec.rb
@@ -5,87 +5,114 @@ RSpec.describe FeedFilter do
   let!(:time_now) { pals.time_now }
 
   describe 'housemaster-based feed only' do
-    before { @enable_counselor_based_feed = ENV['ENABLE_COUNSELOR_BASED_FEED'] }
-    before { ENV['ENABLE_COUNSELOR_BASED_FEED'] = nil }
-    after { ENV['ENABLE_COUNSELOR_BASED_FEED'] = @enable_counselor_based_feed }
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('ENABLE_COUNSELOR_BASED_FEED').and_return(nil)
+      allow(ENV).to receive(:[]).with('ENABLE_SECTION_BASED_FEED').and_return(nil)
+    end
 
-    context 'when disabled globally' do
-      before { @enable_housemaster_based_feed = ENV['ENABLE_HOUSEMASTER_BASED_FEED'] }
-      before { ENV['ENABLE_HOUSEMASTER_BASED_FEED'] = nil }
-      after { ENV['ENABLE_HOUSEMASTER_BASED_FEED'] = @enable_housemaster_based_feed }
-
-      it 'does not filter for anyone' do
-        Educator.all.each do |educator|
-          unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
-          expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
-        end
+    it 'does not filter for anyone when disabled globally' do
+      allow(ENV).to receive(:[]).with('ENABLE_HOUSEMASTER_BASED_FEED').and_return(nil)
+      Educator.all.each do |educator|
+        unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
+        expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
       end
     end
 
-    context 'without mapping for educator' do
-      it 'does not filter' do
-        (Educator.all - [pals.shs_harry_housemaster]).each do |educator|
-          unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
-          expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
-        end
+    it 'does not filter without mapping for educator' do
+      allow(ENV).to receive(:[]).with('ENABLE_HOUSEMASTER_BASED_FEED').and_return('true')
+      (Educator.all - [pals.shs_harry_housemaster]).each do |educator|
+        unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
+        expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
       end
     end
 
-    context 'when enabled globally and there is a mapping for educator' do
-      it 'does filter' do
-        unfiltered_students = Authorizer.new(pals.shs_harry_housemaster).authorized { Student.active.to_a }
-        expect(unfiltered_students).to contain_exactly(
-          pals.shs_freshman_mari,
-          pals.shs_freshman_amir,
-          pals.shs_senior_kylo
-        )
-        expect(FeedFilter.new(pals.shs_harry_housemaster).filter_for_educator(unfiltered_students)).to contain_exactly(*[
-          pals.shs_freshman_amir,
-          pals.shs_senior_kylo
-        ])
-      end
+    it 'does filter when enabled globally and there is a mapping for educator' do
+      allow(ENV).to receive(:[]).with('ENABLE_HOUSEMASTER_BASED_FEED').and_return('true')
+      unfiltered_students = Authorizer.new(pals.shs_harry_housemaster).authorized { Student.active.to_a }
+      expect(unfiltered_students).to contain_exactly(
+        pals.shs_freshman_mari,
+        pals.shs_freshman_amir,
+        pals.shs_senior_kylo
+      )
+      expect(FeedFilter.new(pals.shs_harry_housemaster).filter_for_educator(unfiltered_students)).to contain_exactly(*[
+        pals.shs_freshman_amir,
+        pals.shs_senior_kylo
+      ])
     end
   end
 
   describe 'counselor-based feed only' do
-    before { @enable_housemaster_based_feed = ENV['ENABLE_HOUSEMASTER_BASED_FEED'] }
-    before { ENV['ENABLE_HOUSEMASTER_BASED_FEED'] = nil }
-    after { ENV['ENABLE_HOUSEMASTER_BASED_FEED'] = @enable_housemaster_based_feed }
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('ENABLE_HOUSEMASTER_BASED_FEED').and_return(nil)
+      allow(ENV).to receive(:[]).with('ENABLE_SECTION_BASED_FEED').and_return(nil)
+    end
 
-    context 'when disabled globally' do
-      before { @enabled_counselor_based_feed = ENV['ENABLE_COUNSELOR_BASED_FEED'] }
-      before { ENV['ENABLE_COUNSELOR_BASED_FEED'] = nil }
-      after { ENV['ENABLE_COUNSELOR_BASED_FEED'] = @enabled_counselor_based_feed }
-
-      it 'does not filter for anyone' do
-        Educator.all.each do |educator|
-          unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
-          expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
-        end
+    it 'does not filter for anyone when disabled globally' do
+      allow(ENV).to receive(:[]).with('ENABLE_COUNSELOR_BASED_FEED').and_return(nil)
+      Educator.all.each do |educator|
+        unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
+        expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
       end
     end
 
-    context 'without mapping for educator' do
-      it 'does not filter' do
-        (Educator.all - [pals.shs_sofia_counselor]).each do |educator|
-          unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
-          expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
-        end
+    it 'does not filter without mapping for educator' do
+      allow(ENV).to receive(:[]).with('ENABLE_COUNSELOR_BASED_FEED').and_return('true')
+      (Educator.all - [pals.shs_sofia_counselor]).each do |educator|
+        unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
+        expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
       end
     end
 
-    context 'when enabled globally and there is a mapping for educator' do
-      it 'does filter' do
-        unfiltered_students = Authorizer.new(pals.shs_sofia_counselor).authorized { Student.active.to_a }
-        expect(unfiltered_students).to contain_exactly(
-          pals.shs_freshman_mari,
-          pals.shs_freshman_amir,
-          pals.shs_senior_kylo
-        )
-        expect(FeedFilter.new(pals.shs_sofia_counselor).filter_for_educator(unfiltered_students)).to contain_exactly(*[
-          pals.shs_freshman_mari
-        ])
+    it 'does filter when enabled globally and there is a mapping for educator' do
+      allow(ENV).to receive(:[]).with('ENABLE_COUNSELOR_BASED_FEED').and_return('true')
+      unfiltered_students = Authorizer.new(pals.shs_sofia_counselor).authorized { Student.active.to_a }
+      expect(unfiltered_students).to contain_exactly(
+        pals.shs_freshman_mari,
+        pals.shs_freshman_amir,
+        pals.shs_senior_kylo
+      )
+      expect(FeedFilter.new(pals.shs_sofia_counselor).filter_for_educator(unfiltered_students)).to contain_exactly(*[
+        pals.shs_freshman_mari
+      ])
+    end
+  end
+
+  describe 'section-based feed only' do
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('ENABLE_COUNSELOR_BASED_FEED').and_return(nil)
+      allow(ENV).to receive(:[]).with('ENABLE_HOUSEMASTER_BASED_FEED').and_return(nil)
+    end
+
+    it 'when disabled globally, does not filter for anyone' do
+      allow(ENV).to receive(:[]).with('ENABLE_SECTION_BASED_FEED').and_return(nil)
+      Educator.all.each do |educator|
+        unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
+        expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
       end
+    end
+
+    it 'does not filter without mapping for educator' do
+      allow(ENV).to receive(:[]).with('ENABLE_SECTION_BASED_FEED').and_return('true')
+      (Educator.all - [pals.shs_fatima_science_teacher]).each do |educator|
+        unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
+        expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
+      end
+    end
+
+    it 'filters to only students in sections when enabled globally' do
+      allow(ENV).to receive(:[]).with('ENABLE_SECTION_BASED_FEED').and_return('true')
+      unfiltered_students = Authorizer.new(pals.shs_fatima_science_teacher).authorized { Student.active.to_a }
+      expect(unfiltered_students).to contain_exactly(
+        pals.shs_freshman_mari,
+        pals.shs_freshman_amir,
+        pals.shs_senior_kylo
+      )
+      expect(FeedFilter.new(pals.shs_fatima_science_teacher).filter_for_educator(unfiltered_students)).to contain_exactly(*[
+        pals.shs_freshman_amir
+      ])
     end
   end
 end

--- a/spec/lib/paths_for_educator_spec.rb
+++ b/spec/lib/paths_for_educator_spec.rb
@@ -70,7 +70,10 @@ RSpec.describe PathsForEducator do
           section: '/educators/my_sections'
         })
         expect(navbar_links(pals.shs_fatima_science_teacher)).to eq({
-          section: '/educators/my_sections'
+          absences: '/schools/shs/absences',
+          school: '/schools/shs',
+          section: '/educators/my_sections',
+          tardies: '/schools/shs/tardies'
         })
       end
     end

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -353,12 +353,20 @@ class TestPals
     ])
 
     # Fatima teaches two sections of physics at the high school.
+    # She's a data coordinator, so has schoolwide access also, but
+    # wants her feed and other views to be focused on students in her
+    # courses.
     @shs_fatima_science_teacher = Educator.create!(
       login_name: 'fatima',
       email: "fatima@#{email_domain}",
       full_name: 'Teacher, Fatima',
+      schoolwide_access: true,
       local_id: '750',
       school: @shs
+    )
+    EducatorLabel.create!(
+      educator: @shs_fatima_science_teacher,
+      label_key: 'use_section_based_feed'
     )
     @shs_physics_course = Course.create!({
       school: @shs,


### PR DESCRIPTION
# Who is this PR for?
HS data coordinators, dept. heads potentially

# What problem does this PR fix?
Data coordinators work as teachers, but also have other responsibilities where they have access to other student data.  Right now there's no way to have both concepts.

# What does this PR do?
Adds a new `FeedFilter` based on sections.  This way HS teachers can use this for normal product features, while also having `schoolwide_access` for authorization and particular admin functions.

# Checklists
+ [x] Author improved specs for code in need of better test coverage
+ [x] Author included specs for new code
