### PR TITLE
Levels: Fix bug with matching on multiple courses in department, clarify matching, add link to source

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -5,7 +5,7 @@
   "alwaysNotifyForPaths": [
     {
       "name": "kevinrobinson",
-      "files": ["config/**/*.rb", "Procfile", ".eslintrc"],
+      "files": ["config/**/*.rb", "Procfile", ".eslintrc", "app/lib/shs_tiers.rb"],
       "skipTeamPrs": false
     }
   ],

--- a/app/assets/javascripts/helpers/SortHelpers.js
+++ b/app/assets/javascripts/helpers/SortHelpers.js
@@ -101,5 +101,9 @@ const ORDERED_LETTER_GRADES = {
   'F': 230
 };
 export function rankedByLetterGrade(letterGrade) {
-  return ORDERED_LETTER_GRADES[letterGrade] || 0;
+  return hasLetterGrade(letterGrade) ? 0 : ORDERED_LETTER_GRADES[letterGrade];
+}
+
+export function hasLetterGrade(letterGrade) {
+  return (ORDERED_LETTER_GRADES[letterGrade] !== undefined);
 }

--- a/app/assets/javascripts/tiering/Courses.js
+++ b/app/assets/javascripts/tiering/Courses.js
@@ -1,46 +1,26 @@
 import _ from 'lodash';
+import {rankedByLetterGrade, hasLetterGrade} from '../helpers/SortHelpers';
 
 // eg see http://www.somerville.k12.ma.us/sites/default/files/SHS_2018-2019%20Program%20of%20Studies%20Final%20-%20Jan%2010%202018.pdf
 
-function matches(text, patterns) {
-  return _.some(patterns, pattern => text.indexOf(pattern) !== -1);
-}
-
-export function labelAssignment(assignment) {
-  const text = assignment.section.course_description;
-  if (matches(text, ELA)) return 'ela';
-  if (matches(text, HISTORY)) return 'history';
-  if (matches(text, MATH)) return 'math';
-  if (matches(text, SCIENCE)) return 'science';
-  if (matches(text, LANGUAGE)) return 'language';
-  if (matches(text, HEALTH)) return 'health';
-
-  if (matches(text, MUSIC)) return 'elective';
-  if (matches(text, ART)) return 'elective';
-  if (matches(text, ENGINEERING)) return 'elective';
-  if (matches(text, BUSINESS)) return 'elective';
-  
-  if (matches(text, REDIRECT)) return 'support';
-  if (matches(text, CREDIT_RECOVERY)) return 'support';
-  if (matches(text, ACADEMIC_SUPPORT)) return 'support';
-  if (matches(text, ADVISORY)) return 'support';
-  if (matches(text, ENROOT)) return 'support';
-  if (matches(text, OTHER_SUPPORT)) return 'support';
-  if (matches(text, PATH_PROGRAM)) return 'support';
-
-  if (matches(text, ELL)) return 'ell';
-  if (matches(text, LIFE_SKILLS)) return 'life';
-
-  if (matches(text, OTHER)) return 'elective';
-  return 'unknown';
-}
-
 // This doesn't work exactly, since multiple sections may match
+// (eg, multiple course enrollments in math, and only one has a grade).
+//
+// So as a heuristic, match courses first, then look at those with grades,
+// and then take the lowest grade (since the idea here is to help educators
+// find where students would benefit from more supports).
 export function firstMatch(assignments, patterns) {
-  return _.head(assignments.filter(assignment => {
+  const matchingAssignments = assignments.filter(assignment => {
     const text = assignment.section.course_description;
     return _.some(patterns, pattern => text.indexOf(pattern) !== -1);
-  }));
+  });
+  const matchingAssignmentsWithGrades = matchingAssignments.filter(assignment => {
+    return hasLetterGrade(assignment.grade_letter);
+  });
+  const sortedMatchingAssignments = _.sortBy(matchingAssignmentsWithGrades, assignment => {
+    return rankedByLetterGrade(assignment.grade_letter);
+  });
+  return _.last(sortedMatchingAssignments);
 }
 
 export const REDIRECT = [
@@ -64,44 +44,28 @@ export const STUDY_SKILLS = [
   'STUDY SKILLS'
 ];
 
-const BUSINESS = [
-  'ACCOUNTING',
-  'ENTREPRENEURSHIP',
-  'MARKETING',
-  'PRACTICAL LAW',
-  'FINANCE',
-];
 
 
-const OTHER = [
-  'JOURNALISM',
-  'TV/MEDIA PROD',
-  'Extended Learning Program',
-  'CHILD DEVELOPMENT',
-  'INTERNSHIP',
-  'VOC',
-  'DENTAL',
-  'CARPENTRY',
-  'COSMETOLOGY',
-  'COMPUTER PRIN/REP'
-];
-
-export const ELL = [
-  'ALCS - GENERAL SUPPORT',
-  'ESL', // core ELL classes are considered part of the English dept.
-  'GOAL PROGRAM DAILY SEMINAR',
-  'ACADEMIC LITERACY'
-];
-
-export const ELA = [
+const ENGLISH = [
   'ENGLISH',
   'READING FOUNDATIONS',
   'CREATIVE WRITING'
 ];
 
-export const EN_OR_ELL = ELL.concat(ELA);
+const CORE_ELL_IN_PLACE_OF_ENGLISH = [
+  'ESL'
+];
 
-export const HISTORY = [
+const ELL = CORE_ELL_IN_PLACE_OF_ENGLISH.concat([
+  'ALCS - GENERAL SUPPORT',
+  'GOAL PROGRAM DAILY SEMINAR',
+  'ACADEMIC LITERACY'
+]);
+
+ // core ELL classes are considered part of the English dept. in the levels UI
+export const ENGLISH_OR_CORE_ELL = CORE_ELL_IN_PLACE_OF_ENGLISH.concat(ENGLISH);
+
+export const SOCIAL_STUDIES = [
   'HISTORY',
   'GOVT and POLITICS AP',
   'AMERICAN IDENTITIES HONORS',
@@ -133,33 +97,23 @@ export const SCIENCE = [
   'ASTRONOMY'
 ];
 
-export const LANGUAGE = [
+
+const BUSINESS = [
+  'ACCOUNTING',
+  'ENTREPRENEURSHIP',
+  'MARKETING',
+  'PRACTICAL LAW',
+  'FINANCE',
+];
+
+const WORLD_LANGUAGES = [
   'FRENCH',
   'PORTUGUESE',
   'SPANISH',
   'ITALIAN'
 ];
 
-export const ENGINEERING = [
-  'COMPUTER SCIENCE',
-  'ELECTRICAL',
-  'ENGINEERING',
-  'MACHINE TECH',
-  'AUTO TECHNOLOGY',
-  'METAL FABRICATION',
-  'COMPUTER ASST DRAFTING'
-];
-
-export const LIFE_SKILLS = [
-  'ADAPTIVE LIFE SKILLS',
-  'LIFE SKILLS PRE-WORK',
-  'LIFE SKILLS SOCIAL SCIENCE',
-  'LIFE SKILLS READING',
-  'LIFE SKILLS - semester'
-];
-
-
-export const HEALTH = [
+const HEALTH = [
   'HEALTH',
   'FITNESS EDUCATION',
   'TEAM ACTIVITIES PE',
@@ -194,18 +148,89 @@ const ART = [
   'ARCHITECTURAL DRAWING'
 ];
 
+const CTE = [];
+const LIBRARY = [];
+const PHYSICAL_EDUCATION = [];
 
-const ENROOT = [
-  'ENROOT'
-];
+// const ENROOT = [
+//   'ENROOT'
+// ];
 
-const PATH_PROGRAM = [
-  'PATH PROGRAM ROSTER',
-  'PATH PROGRAM SUPPORT'
-];
+// const PATH_PROGRAM = [
+//   'PATH PROGRAM ROSTER',
+//   'PATH PROGRAM SUPPORT'
+// ];
 
-const OTHER_SUPPORT = [
-  'STUDENT MENTOR',
-  'TRANSITION SKILLS',
-  'GRADUATION PLAN'
-];
+// const OTHER_SUPPORT = [
+//   'STUDENT MENTOR',
+//   'TRANSITION SKILLS',
+//   'GRADUATION PLAN'
+// ];
+
+// const ENGINEERING = [
+//   'COMPUTER SCIENCE',
+//   'ELECTRICAL',
+//   'ENGINEERING',
+//   'MACHINE TECH',
+//   'AUTO TECHNOLOGY',
+//   'METAL FABRICATION',
+//   'COMPUTER ASST DRAFTING'
+// ];
+
+// const LIFE_SKILLS = [
+//   'ADAPTIVE LIFE SKILLS',
+//   'LIFE SKILLS PRE-WORK',
+//   'LIFE SKILLS SOCIAL SCIENCE',
+//   'LIFE SKILLS READING',
+//   'LIFE SKILLS - semester'
+// ];
+
+// const OTHER = [
+//   'JOURNALISM',
+//   'TV/MEDIA PROD',
+//   'Extended Learning Program',
+//   'CHILD DEVELOPMENT',
+//   'INTERNSHIP',
+//   'VOC',
+//   'DENTAL',
+//   'CARPENTRY',
+//   'COSMETOLOGY',
+//   'COMPUTER PRIN/REP'
+// ];
+
+const SPECIAL_PROGRAMS = []
+  .concat(REDIRECT)
+  .concat(ADVISORY)
+  .concat(ACADEMIC_SUPPORT)
+  .concat(CREDIT_RECOVERY);
+
+const SPECIAL_EDUCATION = []
+  .concat(STUDY_SKILLS);
+
+export function labelDepartmentKey(assignment) {
+  const text = assignment.section.course_description;
+
+  if (matches(text, ENGLISH)) return 'english';
+  if (matches(text, MATH)) return 'math';
+  if (matches(text, SCIENCE)) return 'science';
+  if (matches(text, SOCIAL_STUDIES)) return 'social_studies';
+
+  if (matches(text, ART)) return 'art';
+  if (matches(text, BUSINESS)) return 'business';
+  if (matches(text, CTE)) return 'cte';
+  if (matches(text, ELL)) return 'ell';
+  if (matches(text, HEALTH)) return 'health';
+  if (matches(text, LIBRARY)) return 'library';  
+  if (matches(text, MUSIC)) return 'music';
+  if (matches(text, HEALTH)) return 'health';
+  if (matches(text, PHYSICAL_EDUCATION)) return 'physical_education';
+  if (matches(text, SPECIAL_EDUCATION)) return 'special_education';
+  if (matches(text, WORLD_LANGUAGES)) return 'world_languages';
+  if (matches(text, SPECIAL_PROGRAMS)) return 'special_programs';
+
+  return 'unknown';
+}
+
+function matches(text, patterns) {
+  return _.some(patterns, pattern => text.indexOf(pattern) !== -1);
+}

--- a/app/assets/javascripts/tiering/Courses.js
+++ b/app/assets/javascripts/tiering/Courses.js
@@ -56,6 +56,10 @@ const CORE_ELL_IN_PLACE_OF_ENGLISH = [
   'ESL'
 ];
 
+// Depending on the persective, courses might be considered ELL or
+// within another department (eg, "ESL - Semester SS" would be ESL if asking
+// which department "owns" the course, or would be Social Studies if asking
+// for a student's grade in a particular type of subject).
 const ELL = CORE_ELL_IN_PLACE_OF_ENGLISH.concat([
   'ALCS - GENERAL SUPPORT',
   'GOAL PROGRAM DAILY SEMINAR',

--- a/app/assets/javascripts/tiering/StudentLevelsTable.js
+++ b/app/assets/javascripts/tiering/StudentLevelsTable.js
@@ -12,9 +12,9 @@ import DownloadCsvLink from '../components/DownloadCsvLink';
 import ReactModal from 'react-modal';
 import {
   firstMatch,
-  EN_OR_ELL,
+  ENGLISH_OR_CORE_ELL,
   MATH,
-  HISTORY,
+  SOCIAL_STUDIES,
   SCIENCE,
   CREDIT_RECOVERY,
   ACADEMIC_SUPPORT,
@@ -72,15 +72,15 @@ export default class StudentLevelsTable extends React.Component {
       width: numericCellWidth,
       cellRenderer: this.renderDisciplineIncidents
     }, {
-      dataKey: 'en_or_ell',
+      dataKey: 'english_or_core_ell',
       label: <span><br />EN/ELL</span>,
       width: gradeCellWidth,
-      cellRenderer: this.renderGradeFor.bind(this, EN_OR_ELL)
+      cellRenderer: this.renderGradeFor.bind(this, ENGLISH_OR_CORE_ELL)
     }, {
-      dataKey: 'history',
+      dataKey: 'social_studies',
       label: <span>Social<br/>Studies</span>,
       width: gradeCellWidth,
-      cellRenderer: this.renderGradeFor.bind(this, HISTORY)
+      cellRenderer: this.renderGradeFor.bind(this, SOCIAL_STUDIES)
     }, {
       dataKey: 'math',
       label: <span><br />Math</span>,
@@ -139,8 +139,8 @@ export default class StudentLevelsTable extends React.Component {
       level(student) { return student.tier.level; },
       absence(student) { return student.tier.data.recent_absence_rate; },
       discipline(student) { return student.tier.data.recent_discipline_actions; },
-      en_or_ell(student) { return sortByGrade(EN_OR_ELL, student); },
-      history(student) { return sortByGrade(HISTORY, student); },
+      english_or_core_ell(student) { return sortByGrade(ENGLISH_OR_CORE_ELL, student); },
+      social_studies(student) { return sortByGrade(SOCIAL_STUDIES, student); },
       math(student) { return sortByGrade(MATH, student); },
       science(student) { return sortByGrade(SCIENCE, student); },
       nge(student) { return sortTimestamp(student.notes.last_experience_note.recorded_at); },

--- a/app/assets/javascripts/tiering/TieringPage.js
+++ b/app/assets/javascripts/tiering/TieringPage.js
@@ -13,6 +13,7 @@ import TieringView from './TieringView';
 
 // Experimental page for looking at HS support tiers (Somerville only)
 export const SYSTEMS_AND_SUPPORTS_URL = 'https://docs.google.com/document/d/10Rm-FMeQsj_ArxqVWefa6bz8-cs2zsCEubaP3iR24KA/edit';
+export const SOURCE_CODE_URL = 'https://github.com/studentinsights/studentinsights/blob/master/app/lib/shs_tiers.rb';
 export default class TieringPage extends React.Component {
   constructor(props) {
     super(props);
@@ -38,7 +39,10 @@ export default class TieringPage extends React.Component {
         <div style={{margin: 10}}>
           <SectionHeading titleStyle={styles.title}>
             <div>HS Levels: v1 prototype</div>
-            <a style={{fontSize: 12}} href={SYSTEMS_AND_SUPPORTS_URL} target="_blank">Open SHS Systems and Supports doc</a>
+            <div style={styles.headerLinkContainer}>
+              <a style={styles.headerLink} href={SYSTEMS_AND_SUPPORTS_URL} target="_blank">SHS Systems and Supports doc</a>
+              <a style={styles.headerLink} href={SOURCE_CODE_URL} target="_blank">Source code</a>
+            </div>
           </SectionHeading>
         </div>
         <GenericLoader
@@ -53,6 +57,7 @@ export default class TieringPage extends React.Component {
     return (
       <TieringView
         systemsAndSupportsUrl={SYSTEMS_AND_SUPPORTS_URL}
+        sourceCodeUrl={SOURCE_CODE_URL}
         studentsWithTiering={studentsWithTiering}
       />
     );
@@ -74,5 +79,13 @@ const styles = {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center'
+  },
+  headerLinkContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-end'
+  },
+  headerLink: {
+    fontSize: 12
   }
 };

--- a/app/assets/javascripts/tiering/TieringView.js
+++ b/app/assets/javascripts/tiering/TieringView.js
@@ -158,8 +158,13 @@ export default class TieringView extends React.Component {
   }
 
   renderSystemsAndSupportsLink() {
-    const {systemsAndSupportsUrl} = this.props;
-    return <a href={systemsAndSupportsUrl} target="_blank">Open SHS Systems and Supports doc</a>;
+    const {systemsAndSupportsUrl, sourceCodeUrl} = this.props;
+    return (
+      <div>
+        <a style={{display: 'block'}} href={systemsAndSupportsUrl} target="_blank">Open SHS Systems and Supports doc</a>
+        <a style={{display: 'block'}} href={sourceCodeUrl} target="_blank">Open source code</a>
+      </div>
+    );
   }
 
   renderExperienceGaps(filteredStudents) {
@@ -324,6 +329,7 @@ export default class TieringView extends React.Component {
 }
 TieringView.propTypes = {
   systemsAndSupportsUrl: PropTypes.string.isRequired,
+  sourceCodeUrl: PropTypes.string.isRequired,
   studentsWithTiering: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.number.isRequired,
     first_name: PropTypes.string.isRequired,

--- a/app/assets/javascripts/tiering/TieringView.js
+++ b/app/assets/javascripts/tiering/TieringView.js
@@ -8,7 +8,7 @@ import SelectGrade from '../components/SelectGrade';
 import SelectHouse from '../components/SelectHouse';
 import SelectEnglishProficiency from '../components/SelectEnglishProficiency';
 import {
-  labelAssignment,
+  labelDepartmentKey,
   firstMatch,
   CREDIT_RECOVERY,
   ACADEMIC_SUPPORT,
@@ -229,12 +229,12 @@ export default class TieringView extends React.Component {
         linkStyle={{...styles.summary, padding: 0}}
         teaser="Breakdown"
         title="Breakdown"
-        content={this.renderSummary(filteredStudents)}
+        content={this.renderBreakdown(filteredStudents)}
       />
     );
   }
 
-  renderSummary(studentsWithTiering) {
+  renderBreakdown(studentsWithTiering) {
     return (
       <div>
         {this.renderSystemsAndSupportsLink()}
@@ -263,24 +263,21 @@ export default class TieringView extends React.Component {
     );
   }
 
+  // Unused, but for internal debugging
   renderUnlabeledCourses(studentsWithTiering) {
     const assignments = _.flatten(studentsWithTiering.map(s => s.student_section_assignments_right_now));
     const labeledAssignments = assignments.map(assignment => {
       return {
         ...assignment,
-        label: labelAssignment(assignment)
+        departmentKey: labelDepartmentKey(assignment)
       };
     });
 
-    const missing = _.uniq(labeledAssignments
-      .filter(a => a.label === 'unknown')
-      .map(a => a.section.course_description))
-      .slice(0, 10);
+    const unlabeledCourses = _.uniq(labeledAssignments
+      .filter(a => a.departmentKey === 'unknown')
+      .map(a => a.section.course_description));
 
-    return <div>
-      <pre>{JSON.stringify(_.countBy(labeledAssignments, 'label'), null, 2)}</pre>
-      <pre>{JSON.stringify(missing, null, 2)}</pre>
-    </div>;
+    return <pre>{JSON.stringify(unlabeledCourses(studentsWithTiering), null, 2)}</pre>;
   }
 
   renderTierCount(studentsWithTiering, n) {
@@ -308,10 +305,10 @@ export default class TieringView extends React.Component {
     return this.renderSummaryBit(text, count, percentage);
   }
 
-  renderSummaryBit(label, count, percentage) {
+  renderSummaryBit(labelText, count, percentage) {
     return (
-      <div key={label}>
-        <div><b>{label}</b>:</div>
+      <div key={labelText}>
+        <div><b>{labelText}</b>:</div>
         <div style={{marginLeft: 10, marginBottom: 5}}>{percentage}% ({count} students)</div>
       </div>
     );

--- a/app/assets/javascripts/tiering/TieringView.test.js
+++ b/app/assets/javascripts/tiering/TieringView.test.js
@@ -8,6 +8,7 @@ import tieringShowJson from './tieringShowJson.fixture';
 function testProps(props = {}) {
   return {
     systemsAndSupportsUrl: 'https://example.com/foo',
+    sourceCodeUrl: 'https://example.com/source',
     studentsWithTiering: tieringShowJson.students_with_tiering,
     ...props
   };


### PR DESCRIPTION
# Who is this PR for?
HS educators

# What problem does this PR fix?
When students are in multiple courses within a department, they might have a grade in one course that would meet an academic trigger to provide more support.  Yet when the Insights UI does this match, it just takes the first course that matches in the department, and so that grade doesn't appear in the table for that department.

# What does this PR do?
This PR updates the table UI to match on courses in the department, then courses with grades, and take the lowest (since the intent is to find places where students could benefit from more supports).

It also adds a link to the source code to the levels calculation, factored out in https://github.com/studentinsights/studentinsights/pull/2181 to make that clearer.

# Screenshot (if adding a client-side feature)
Showing link to source code:
<img width="1044" alt="screen shot 2018-10-15 at 12 21 12 pm" src="https://user-images.githubusercontent.com/1056957/46964104-532cdc00-d075-11e8-967d-c3ebfca439a6.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Levels

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here