### PR TITLE
Levels: Try overflow hidden for Chromebook IE wiggle bug

### DIFF
--- a/app/assets/javascripts/tiering/StudentLevelsTable.js
+++ b/app/assets/javascripts/tiering/StudentLevelsTable.js
@@ -195,7 +195,7 @@ export default class StudentLevelsTable extends React.Component {
     const students = this.orderedStudents();
     
     return (
-      <div className="StudentLevelsTable" style={{flex: 1, display: 'block', flexDirection: 'column'}}>
+      <div className="StudentLevelsTable" style={styles.root}>
         {this.renderDownloadLink(columns, students)}
         <AutoSizer>
           {({height, width}) => (
@@ -360,6 +360,15 @@ StudentLevelsTable.propTypes = {
 const warningColor = 'rgb(255, 222, 198)';
 const strengthColor = '#4d884d';
 const styles = {
+  root: {
+    flex: 1,
+    display: 'block',
+    flexDirection: 'column',
+    // works around bug with the way `react-virtualized` resizes that impacts
+    // Windows 10 Chromebooks in particular, and I haven't been able to reproduce
+    // in a VM
+    overflow: 'hidden'
+  },
   tableHeaderStyle: {
     display: 'flex',
     fontSize: 12,


### PR DESCRIPTION
# Who is this PR for?
HS educators on Chromebooks

# What problem does this PR fix?
There's a bug where the layout constantly resizes and the page jumps continually.  This is from `react-virtualized` resizing, and I suspect is an interaction between the browser scrollbars and the `AutoSizer`.

# What does this PR do?
Adds in `overflow: hidden` to the container, which in Web Inspector on an impacting Chromebook resolves the issue (I haven't been able to reproduce on a VM).
