### PR TITLE
Feed: don't show homeroom for HS students, fix minor text alignment bug

### DIFF
--- a/app/assets/javascripts/class_lists/fixtures/profile_json.js
+++ b/app/assets/javascripts/class_lists/fixtures/profile_json.js
@@ -1,1 +1,274 @@
-export default {"feed_cards":[{"type":"event_note_card","timestamp":"2011-11-12T00:00:00.000Z","json":{"id":443,"event_note_type_id":305,"text":"Elsa will go through the special ed process for placement","recorded_at":"2011-11-12T00:00:00.000Z","educator":{"id":1,"email":"rich@demo.studentinsights.org","full_name":"Districtwide, Rich"},"student":{"id":96,"grade":"2","first_name":"Elsa","last_name":"Disney","house":null,"homeroom":{"id":11,"name":"HEA 200"}}}},{"type":"event_note_card","timestamp":"2011-10-12T00:00:00.000Z","json":{"id":442,"event_note_type_id":305,"text":"Meredith is setting up a family meeting to discuss absences and tardies, and to follow up on concerns about supporting morning routines at home.","recorded_at":"2011-10-12T00:00:00.000Z","educator":{"id":1,"email":"rich@demo.studentinsights.org","full_name":"Districtwide, Rich"},"student":{"id":96,"grade":"2","first_name":"Elsa","last_name":"Disney","house":null,"homeroom":{"id":11,"name":"HEA 200"}}}},{"type":"event_note_card","timestamp":"2011-08-20T00:00:00.000Z","json":{"id":441,"event_note_type_id":304,"text":"Elsa will go through the special ed process for placement","recorded_at":"2011-08-20T00:00:00.000Z","educator":{"id":1,"email":"rich@demo.studentinsights.org","full_name":"Districtwide, Rich"},"student":{"id":96,"grade":"2","first_name":"Elsa","last_name":"Disney","house":null,"homeroom":{"id":11,"name":"HEA 200"}}}},{"type":"event_note_card","timestamp":"2011-07-13T00:00:00.000Z","json":{"id":440,"event_note_type_id":301,"text":"Not engaged in academic work and misbehaving in class.  There have been meetings between the teacher and support staff, and Sam has talked with Elsa twice this week.  Philis following up with outside providers as well.","recorded_at":"2011-07-13T00:00:00.000Z","educator":{"id":1,"email":"rich@demo.studentinsights.org","full_name":"Districtwide, Rich"},"student":{"id":96,"grade":"2","first_name":"Elsa","last_name":"Disney","house":null,"homeroom":{"id":11,"name":"HEA 200"}}}},{"type":"event_note_card","timestamp":"2011-05-23T00:00:00.000Z","json":{"id":439,"event_note_type_id":300,"text":"Elsa will go through the special ed process for placement","recorded_at":"2011-05-23T00:00:00.000Z","educator":{"id":1,"email":"rich@demo.studentinsights.org","full_name":"Districtwide, Rich"},"student":{"id":96,"grade":"2","first_name":"Elsa","last_name":"Disney","house":null,"homeroom":{"id":11,"name":"HEA 200"}}}},{"type":"event_note_card","timestamp":"2011-03-29T00:00:00.000Z","json":{"id":438,"event_note_type_id":302,"text":"Meredith is setting up a family meeting to discuss absences and tardies, and to follow up on concerns about supporting morning routines at home.","recorded_at":"2011-03-29T00:00:00.000Z","educator":{"id":1,"email":"rich@demo.studentinsights.org","full_name":"Districtwide, Rich"},"student":{"id":96,"grade":"2","first_name":"Elsa","last_name":"Disney","house":null,"homeroom":{"id":11,"name":"HEA 200"}}}},{"type":"event_note_card","timestamp":"2011-02-21T00:00:00.000Z","json":{"id":437,"event_note_type_id":304,"text":"Philis is meeting with parent next week and will present an attendance contract.","recorded_at":"2011-02-21T00:00:00.000Z","educator":{"id":1,"email":"rich@demo.studentinsights.org","full_name":"Districtwide, Rich"},"student":{"id":96,"grade":"2","first_name":"Elsa","last_name":"Disney","house":null,"homeroom":{"id":11,"name":"HEA 200"}}}},{"type":"event_note_card","timestamp":"2010-12-27T00:00:00.000Z","json":{"id":436,"event_note_type_id":301,"text":"Elsa will go through the special ed process for placement","recorded_at":"2010-12-27T00:00:00.000Z","educator":{"id":1,"email":"rich@demo.studentinsights.org","full_name":"Districtwide, Rich"},"student":{"id":96,"grade":"2","first_name":"Elsa","last_name":"Disney","house":null,"homeroom":{"id":11,"name":"HEA 200"}}}},{"type":"event_note_card","timestamp":"2010-10-29T00:00:00.000Z","json":{"id":435,"event_note_type_id":304,"text":"Philis is meeting with parent next week and will present an attendance contract.","recorded_at":"2010-10-29T00:00:00.000Z","educator":{"id":1,"email":"rich@demo.studentinsights.org","full_name":"Districtwide, Rich"},"student":{"id":96,"grade":"2","first_name":"Elsa","last_name":"Disney","house":null,"homeroom":{"id":11,"name":"HEA 200"}}}}]};
+export default {
+  "feed_cards": [
+    {
+      "type": "event_note_card",
+      "timestamp": "2011-11-12T00:00:00.000Z",
+      "json": {
+        "id": 443,
+        "event_note_type_id": 305,
+        "text": "Elsa will go through the special ed process for placement",
+        "recorded_at": "2011-11-12T00:00:00.000Z",
+        "educator": {
+          "id": 1,
+          "email": "rich@demo.studentinsights.org",
+          "full_name": "Districtwide, Rich"
+        },
+        "student": {
+          "id": 96,
+          "grade": "2",
+          "first_name": "Elsa",
+          "last_name": "Disney",
+          "house": null,
+          "school": {
+            "local_id": "HEA",
+            "school_type": "ESMS"
+          },
+          "homeroom": {
+            "id": 11,
+            "name": "HEA 200"
+          }
+        }
+      }
+    },
+    {
+      "type": "event_note_card",
+      "timestamp": "2011-10-12T00:00:00.000Z",
+      "json": {
+        "id": 442,
+        "event_note_type_id": 305,
+        "text": "Meredith is setting up a family meeting to discuss absences and tardies, and to follow up on concerns about supporting morning routines at home.",
+        "recorded_at": "2011-10-12T00:00:00.000Z",
+        "educator": {
+          "id": 1,
+          "email": "rich@demo.studentinsights.org",
+          "full_name": "Districtwide, Rich"
+        },
+        "student": {
+          "id": 96,
+          "grade": "2",
+          "first_name": "Elsa",
+          "last_name": "Disney",
+          "house": null,
+          "school": {
+            "local_id": "HEA",
+            "school_type": "ESMS"
+          },
+          "homeroom": {
+            "id": 11,
+            "name": "HEA 200"
+          }
+        }
+      }
+    },
+    {
+      "type": "event_note_card",
+      "timestamp": "2011-08-20T00:00:00.000Z",
+      "json": {
+        "id": 441,
+        "event_note_type_id": 304,
+        "text": "Elsa will go through the special ed process for placement",
+        "recorded_at": "2011-08-20T00:00:00.000Z",
+        "educator": {
+          "id": 1,
+          "email": "rich@demo.studentinsights.org",
+          "full_name": "Districtwide, Rich"
+        },
+        "student": {
+          "id": 96,
+          "grade": "2",
+          "first_name": "Elsa",
+          "last_name": "Disney",
+          "house": null,
+          "school": {
+            "local_id": "HEA",
+            "school_type": "ESMS"
+          },
+          "homeroom": {
+            "id": 11,
+            "name": "HEA 200"
+          }
+        }
+      }
+    },
+    {
+      "type": "event_note_card",
+      "timestamp": "2011-07-13T00:00:00.000Z",
+      "json": {
+        "id": 440,
+        "event_note_type_id": 301,
+        "text": "Not engaged in academic work and misbehaving in class.  There have been meetings between the teacher and support staff, and Sam has talked with Elsa twice this week.  Philis following up with outside providers as well.",
+        "recorded_at": "2011-07-13T00:00:00.000Z",
+        "educator": {
+          "id": 1,
+          "email": "rich@demo.studentinsights.org",
+          "full_name": "Districtwide, Rich"
+        },
+        "student": {
+          "id": 96,
+          "grade": "2",
+          "first_name": "Elsa",
+          "last_name": "Disney",
+          "house": null,
+          "school": {
+            "local_id": "HEA",
+            "school_type": "ESMS"
+          },
+          "homeroom": {
+            "id": 11,
+            "name": "HEA 200"
+          }
+        }
+      }
+    },
+    {
+      "type": "event_note_card",
+      "timestamp": "2011-05-23T00:00:00.000Z",
+      "json": {
+        "id": 439,
+        "event_note_type_id": 300,
+        "text": "Elsa will go through the special ed process for placement",
+        "recorded_at": "2011-05-23T00:00:00.000Z",
+        "educator": {
+          "id": 1,
+          "email": "rich@demo.studentinsights.org",
+          "full_name": "Districtwide, Rich"
+        },
+        "student": {
+          "id": 96,
+          "grade": "2",
+          "first_name": "Elsa",
+          "last_name": "Disney",
+          "house": null,
+          "school": {
+            "local_id": "HEA",
+            "school_type": "ESMS"
+          },
+          "homeroom": {
+            "id": 11,
+            "name": "HEA 200"
+          }
+        }
+      }
+    },
+    {
+      "type": "event_note_card",
+      "timestamp": "2011-03-29T00:00:00.000Z",
+      "json": {
+        "id": 438,
+        "event_note_type_id": 302,
+        "text": "Meredith is setting up a family meeting to discuss absences and tardies, and to follow up on concerns about supporting morning routines at home.",
+        "recorded_at": "2011-03-29T00:00:00.000Z",
+        "educator": {
+          "id": 1,
+          "email": "rich@demo.studentinsights.org",
+          "full_name": "Districtwide, Rich"
+        },
+        "student": {
+          "id": 96,
+          "grade": "2",
+          "first_name": "Elsa",
+          "last_name": "Disney",
+          "house": null,
+          "school": {
+            "local_id": "HEA",
+            "school_type": "ESMS"
+          },
+          "homeroom": {
+            "id": 11,
+            "name": "HEA 200"
+          }
+        }
+      }
+    },
+    {
+      "type": "event_note_card",
+      "timestamp": "2011-02-21T00:00:00.000Z",
+      "json": {
+        "id": 437,
+        "event_note_type_id": 304,
+        "text": "Philis is meeting with parent next week and will present an attendance contract.",
+        "recorded_at": "2011-02-21T00:00:00.000Z",
+        "educator": {
+          "id": 1,
+          "email": "rich@demo.studentinsights.org",
+          "full_name": "Districtwide, Rich"
+        },
+        "student": {
+          "id": 96,
+          "grade": "2",
+          "first_name": "Elsa",
+          "last_name": "Disney",
+          "house": null,
+          "school": {
+            "local_id": "HEA",
+            "school_type": "ESMS"
+          },
+          "homeroom": {
+            "id": 11,
+            "name": "HEA 200"
+          }
+        }
+      }
+    },
+    {
+      "type": "event_note_card",
+      "timestamp": "2010-12-27T00:00:00.000Z",
+      "json": {
+        "id": 436,
+        "event_note_type_id": 301,
+        "text": "Elsa will go through the special ed process for placement",
+        "recorded_at": "2010-12-27T00:00:00.000Z",
+        "educator": {
+          "id": 1,
+          "email": "rich@demo.studentinsights.org",
+          "full_name": "Districtwide, Rich"
+        },
+        "student": {
+          "id": 96,
+          "grade": "2",
+          "first_name": "Elsa",
+          "last_name": "Disney",
+          "house": null,
+          "school": {
+            "local_id": "HEA",
+            "school_type": "ESMS"
+          },
+          "homeroom": {
+            "id": 11,
+            "name": "HEA 200"
+          }
+        }
+      }
+    },
+    {
+      "type": "event_note_card",
+      "timestamp": "2010-10-29T00:00:00.000Z",
+      "json": {
+        "id": 435,
+        "event_note_type_id": 304,
+        "text": "Philis is meeting with parent next week and will present an attendance contract.",
+        "recorded_at": "2010-10-29T00:00:00.000Z",
+        "educator": {
+          "id": 1,
+          "email": "rich@demo.studentinsights.org",
+          "full_name": "Districtwide, Rich"
+        },
+        "student": {
+          "id": 96,
+          "grade": "2",
+          "first_name": "Elsa",
+          "last_name": "Disney",
+          "house": null,
+          "school": {
+            "local_id": "HEA",
+            "school_type": "ESMS"
+          },
+          "homeroom": {
+            "id": 11,
+            "name": "HEA 200"
+          }
+        }
+      }
+    }
+  ]
+};

--- a/app/assets/javascripts/feed/EventNoteCard.js
+++ b/app/assets/javascripts/feed/EventNoteCard.js
@@ -53,6 +53,10 @@ EventNoteCard.propTypes = {
       last_name: PropTypes.string.isRequired,
       grade: PropTypes.string.isRequired,
       house: PropTypes.string,
+      school: PropTypes.shape({
+        local_id: PropTypes.string.isRequired,
+        school_type: PropTypes.string.isRequired
+      }),
       homeroom: PropTypes.shape({
         id: PropTypes.number.isRequired,
         name: PropTypes.string.isRequired,

--- a/app/assets/javascripts/feed/EventNoteCard.test.js
+++ b/app/assets/javascripts/feed/EventNoteCard.test.js
@@ -22,6 +22,10 @@ function testProps(props = {}) {
         last_name: 'Skywalker',
         grade: '9',
         house: 'Beacon',
+        school: {
+          local_id: 'SHS',
+          school_type: 'HS'
+        },
         homeroom: {
           id: 13,
           name: 'SHS-052',

--- a/app/assets/javascripts/feed/FeedCardFrame.js
+++ b/app/assets/javascripts/feed/FeedCardFrame.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Card from '../components/Card';
+import {isHomeroomMeaningful} from '../helpers/PerDistrict';
 import Homeroom from '../components/Homeroom';
 import {gradeText} from '../helpers/gradeText';
 
@@ -9,23 +10,21 @@ import {gradeText} from '../helpers/gradeText';
 class FeedCardFrame extends React.Component {
   render() {
     const {style, student, byEl, whereEl, whenEl, children, badgesEl} = this.props;
-    const {homeroom} = student;
-    
+    const {homeroom, school} = student;
+    const shouldShowHomeroom = homeroom && isHomeroomMeaningful(school.school_type);
     return (
       <Card className="FeedCardFrame" style={style}>
         <div style={styles.header}>
           <div style={styles.studentHeader}>
             <div>
-              <div>
-                <a style={styles.person} href={`/students/${student.id}`}>{student.first_name} {student.last_name}</a>
-              </div>
-              <div>{gradeText(student.grade)}</div>
-              <div>
-                {homeroom && <Homeroom
-                  id={homeroom.id}
-                  name={homeroom.name}
-                  educator={homeroom.educator} />}
-              </div>
+              <a style={styles.person} href={`/students/${student.id}`}>{student.first_name} {student.last_name}</a>
+            </div>
+            <div>{gradeText(student.grade)}</div>
+            <div>
+              {shouldShowHomeroom && <Homeroom
+                id={homeroom.id}
+                name={homeroom.name}
+                educator={homeroom.educator} />}
             </div>
           </div>
           <div style={styles.by}>
@@ -54,6 +53,10 @@ FeedCardFrame.propTypes = {
     last_name: PropTypes.string.isRequired,
     grade: PropTypes.string.isRequired,
     house: PropTypes.string,
+    school: PropTypes.shape({
+      local_id: PropTypes.string.isRequired,
+      school_type: PropTypes.string.isRequired
+    }),
     homeroom: PropTypes.shape({
       id: PropTypes.number.isRequired,
       name: PropTypes.string.isRequired,
@@ -74,11 +77,13 @@ const styles = {
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-between',
-    alignItems: 'center'
+    alignItems: 'flex-start'
   },
   studentHeader: {
     display: 'flex',
-    alignItems: 'center'
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start'
   },
   body: {
     marginBottom: 20,

--- a/app/assets/javascripts/feed/FeedCardFrame.test.js
+++ b/app/assets/javascripts/feed/FeedCardFrame.test.js
@@ -10,6 +10,10 @@ function testStudent() {
     last_name: 'Skywalker',
     grade: '9',
     house: 'Beacon',
+    school: {
+      local_id: 'SHS',
+      school_type: 'HS'
+    },
     homeroom: {
       id: 13,
       name: 'SHS-052',
@@ -22,25 +26,61 @@ function testStudent() {
   };
 }
 
-it('renders without crashing', () => {
+function testStudentElementary() {
+  return {
+    id: 32,
+    first_name: 'Pluto',
+    last_name: 'Skywalker',
+    grade: '3',
+    house: null,
+    school: {
+      local_id: 'HEA',
+      school_type: 'ESMS'
+    },
+    homeroom: {
+      id: 32,
+      name: 'HEA-011',
+      educator: {
+        id: 3,
+        email: 'alex@demo.studentinsights.org',
+        full_name: 'Teacher, Alex',
+      }
+    }
+  };
+}
+
+function testProps(student) {
+  return {
+    byEl: <div>by</div>,
+    whereEl: <div>where</div>,
+    whenEl: <div>when</div>,
+    badgesEl: <div>badges</div>,
+    children: 'kids',
+    student
+  };
+}
+
+function testRender(props) {
   const el = document.createElement('div');
-  ReactDOM.render(withDefaultNowContext(
-    <FeedCardFrame
-      student={testStudent()}
-      byEl={<div>by</div>}
-      whereEl={<div>where</div>}
-      whenEl={<div>when</div>}
-      badgesEl={<div>badges</div>}>
-      kids
-    </FeedCardFrame>
-  ), el);
+  ReactDOM.render(withDefaultNowContext(<FeedCardFrame {...props} />), el);
+  return el;
+}
+
+it('renders for HS without crashing', () => {
+  const el = testRender(testProps(testStudent()));
   expect($(el).text()).toContain('Mari Skywalker');
   expect($(el).text()).toContain('9th grade');
-  expect($(el).text()).toContain('SHS-052');
-  expect($(el).text()).toContain('with Lois Teacher');
+  expect($(el).text()).not.toContain('SHS-052');
+  expect($(el).text()).not.toContain('with Lois Teacher');
   expect($(el).text()).toContain('by');
   expect($(el).text()).toContain('where');
   expect($(el).text()).toContain('when');
   expect($(el).text()).toContain('badges');
   expect($(el).text()).toContain('kids');
+});
+
+it('renders homeroom for ESMS', () => {
+  const el = testRender(testProps(testStudentElementary()));
+  expect($(el).text()).toContain('HEA-011');
+  expect($(el).text()).toContain('with Alex Teacher');
 });

--- a/app/assets/javascripts/feed/IncidentCard.test.js
+++ b/app/assets/javascripts/feed/IncidentCard.test.js
@@ -20,6 +20,10 @@ export function testProps(props = {}) {
         "first_name": "Mowgli",
         "last_name": "Pan",
         "house": "Beacon",
+        "school": {
+          "local_id": "SHS",
+          "school_type": "HS"
+        },
         "homeroom": {
           "id": 4,
           "name": "SHS ALL"
@@ -34,6 +38,13 @@ it('renders without crashing', () => {
   const props = testProps();
   const el = document.createElement('div');
   ReactDOM.render(withDefaultNowContext(<IncidentCard {...props} />), el);
+});
+
+it('does not render homeroom for HS since it is not meaningful', () => {
+  const props = testProps();
+  const el = document.createElement('div');
+  ReactDOM.render(withDefaultNowContext(<IncidentCard {...props} />), el);
+  expect($(el).text()).not.toContain('SHS ALL');
 });
 
 it('matches snapshot', () => {

--- a/app/assets/javascripts/feed/__snapshots__/EventNoteCard.test.js.snap
+++ b/app/assets/javascripts/feed/__snapshots__/EventNoteCard.test.js.snap
@@ -17,7 +17,7 @@ exports[`matches snapshot 1`] = `
     <div
       style={
         Object {
-          "alignItems": "center",
+          "alignItems": "flex-start",
           "display": "flex",
           "flexDirection": "row",
           "justifyContent": "space-between",
@@ -27,55 +27,31 @@ exports[`matches snapshot 1`] = `
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
+            "flexDirection": "column",
+            "justifyContent": "flex-start",
           }
         }
       >
         <div>
-          <div>
-            <a
-              href="/students/55"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
+          <a
+            href="/students/55"
+            style={
+              Object {
+                "fontWeight": "bold",
               }
-            >
-              Mari
-               
-              Skywalker
-            </a>
-          </div>
-          <div>
-            9th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
-              <a
-                href="/homerooms/13"
-              >
-                SHS-052
-              </a>
-              <span>
-                <span>
-                   
-                </span>
-                 with 
-                <a
-                  className="Educator"
-                  href="mailto:lt@demo.studentinsights.org"
-                  style={Object {}}
-                >
-                  Lois Teacher
-                </a>
-              </span>
-            </span>
-          </div>
+            }
+          >
+            Mari
+             
+            Skywalker
+          </a>
         </div>
+        <div>
+          9th grade
+        </div>
+        <div />
       </div>
       <div
         style={

--- a/app/assets/javascripts/feed/__snapshots__/FeedView.test.js.snap
+++ b/app/assets/javascripts/feed/__snapshots__/FeedView.test.js.snap
@@ -55,7 +55,7 @@ exports[`FeedView pure component matches snapshot 1`] = `
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -65,54 +65,54 @@ exports[`FeedView pure component matches snapshot 1`] = `
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/18"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/18"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
+              }
+            >
+              Winnie
+               
+              Disney
+            </a>
+          </div>
+          <div>
+            Kindergarten
+          </div>
+          <div>
+            <span
+              className="Homeroom"
+              style={Object {}}
+            >
+              <a
+                href="/homerooms/1"
               >
-                Winnie
-                 
-                Disney
+                HEA 003
               </a>
-            </div>
-            <div>
-              Kindergarten
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/1"
-                >
-                  HEA 003
-                </a>
+              <span>
                 <span>
-                  <span>
-                     
-                  </span>
-                   with 
-                  <a
-                    className="Educator"
-                    href="mailto:vivian@demo.studentinsights.org"
-                    style={Object {}}
-                  >
-                    Vivian Teacher
-                  </a>
+                   
                 </span>
+                 with 
+                <a
+                  className="Educator"
+                  href="mailto:vivian@demo.studentinsights.org"
+                  style={Object {}}
+                >
+                  Vivian Teacher
+                </a>
               </span>
-            </div>
+            </span>
           </div>
         </div>
         <div
@@ -233,7 +233,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -243,42 +243,31 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/103"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/103"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
-              >
-                Donald
-                 
-                Duck
-              </a>
-            </div>
-            <div>
-              10th grade
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/4"
-                >
-                  SHS ALL
-                </a>
-              </span>
-            </div>
+              }
+            >
+              Donald
+               
+              Duck
+            </a>
           </div>
+          <div>
+            10th grade
+          </div>
+          <div />
         </div>
         <div
           style={
@@ -410,7 +399,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -420,42 +409,31 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/72"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/72"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
-              >
-                Rapunzel
-                 
-                White
-              </a>
-            </div>
-            <div>
-              10th grade
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/4"
-                >
-                  SHS ALL
-                </a>
-              </span>
-            </div>
+              }
+            >
+              Rapunzel
+               
+              White
+            </a>
           </div>
+          <div>
+            10th grade
+          </div>
+          <div />
         </div>
         <div
           style={
@@ -587,7 +565,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -597,54 +575,54 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/18"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/18"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
+              }
+            >
+              Winnie
+               
+              Disney
+            </a>
+          </div>
+          <div>
+            Kindergarten
+          </div>
+          <div>
+            <span
+              className="Homeroom"
+              style={Object {}}
+            >
+              <a
+                href="/homerooms/1"
               >
-                Winnie
-                 
-                Disney
+                HEA 003
               </a>
-            </div>
-            <div>
-              Kindergarten
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/1"
-                >
-                  HEA 003
-                </a>
+              <span>
                 <span>
-                  <span>
-                     
-                  </span>
-                   with 
-                  <a
-                    className="Educator"
-                    href="mailto:vivian@demo.studentinsights.org"
-                    style={Object {}}
-                  >
-                    Vivian Teacher
-                  </a>
+                   
                 </span>
+                 with 
+                <a
+                  className="Educator"
+                  href="mailto:vivian@demo.studentinsights.org"
+                  style={Object {}}
+                >
+                  Vivian Teacher
+                </a>
               </span>
-            </div>
+            </span>
           </div>
         </div>
         <div
@@ -763,7 +741,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -773,42 +751,31 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/38"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/38"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
-              >
-                Winnie
-                 
-                Disney
-              </a>
-            </div>
-            <div>
-              10th grade
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/4"
-                >
-                  SHS ALL
-                </a>
-              </span>
-            </div>
+              }
+            >
+              Winnie
+               
+              Disney
+            </a>
           </div>
+          <div>
+            10th grade
+          </div>
+          <div />
         </div>
         <div
           style={
@@ -940,7 +907,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -950,42 +917,31 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/69"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/69"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
-              >
-                Rapunzel
-                 
-                Skywalker
-              </a>
-            </div>
-            <div>
-              10th grade
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/4"
-                >
-                  SHS ALL
-                </a>
-              </span>
-            </div>
+              }
+            >
+              Rapunzel
+               
+              Skywalker
+            </a>
           </div>
+          <div>
+            10th grade
+          </div>
+          <div />
         </div>
         <div
           style={
@@ -1117,7 +1073,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -1127,55 +1083,31 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/51"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/51"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
-              >
-                Daisy
-                 
-                Poppins
-              </a>
-            </div>
-            <div>
-              9th grade
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/5"
-                >
-                  SHS 942
-                </a>
-                <span>
-                  <span>
-                     
-                  </span>
-                   with 
-                  <a
-                    className="Educator"
-                    href="mailto:jodi@demo.studentinsights.org"
-                    style={Object {}}
-                  >
-                    Jodi Teacher
-                  </a>
-                </span>
-              </span>
-            </div>
+              }
+            >
+              Daisy
+               
+              Poppins
+            </a>
           </div>
+          <div>
+            9th grade
+          </div>
+          <div />
         </div>
         <div
           style={
@@ -1307,7 +1239,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -1317,54 +1249,54 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/13"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/13"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
+              }
+            >
+              Rapunzel
+               
+              Poppins
+            </a>
+          </div>
+          <div>
+            Kindergarten
+          </div>
+          <div>
+            <span
+              className="Homeroom"
+              style={Object {}}
+            >
+              <a
+                href="/homerooms/1"
               >
-                Rapunzel
-                 
-                Poppins
+                HEA 003
               </a>
-            </div>
-            <div>
-              Kindergarten
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/1"
-                >
-                  HEA 003
-                </a>
+              <span>
                 <span>
-                  <span>
-                     
-                  </span>
-                   with 
-                  <a
-                    className="Educator"
-                    href="mailto:vivian@demo.studentinsights.org"
-                    style={Object {}}
-                  >
-                    Vivian Teacher
-                  </a>
+                   
                 </span>
+                 with 
+                <a
+                  className="Educator"
+                  href="mailto:vivian@demo.studentinsights.org"
+                  style={Object {}}
+                >
+                  Vivian Teacher
+                </a>
               </span>
-            </div>
+            </span>
           </div>
         </div>
         <div
@@ -1483,7 +1415,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -1493,54 +1425,54 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/6"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/6"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
+              }
+            >
+              Snow
+               
+              Kenobi
+            </a>
+          </div>
+          <div>
+            5th grade
+          </div>
+          <div>
+            <span
+              className="Homeroom"
+              style={Object {}}
+            >
+              <a
+                href="/homerooms/2"
               >
-                Snow
-                 
-                Kenobi
+                HEA 500
               </a>
-            </div>
-            <div>
-              5th grade
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/2"
-                >
-                  HEA 500
-                </a>
+              <span>
                 <span>
-                  <span>
-                     
-                  </span>
-                   with 
-                  <a
-                    className="Educator"
-                    href="mailto:sarah@demo.studentinsights.org"
-                    style={Object {}}
-                  >
-                    Sarah Teacher
-                  </a>
+                   
                 </span>
+                 with 
+                <a
+                  className="Educator"
+                  href="mailto:sarah@demo.studentinsights.org"
+                  style={Object {}}
+                >
+                  Sarah Teacher
+                </a>
               </span>
-            </div>
+            </span>
           </div>
         </div>
         <div
@@ -1659,7 +1591,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -1669,42 +1601,31 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/103"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/103"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
-              >
-                Donald
-                 
-                Duck
-              </a>
-            </div>
-            <div>
-              10th grade
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/4"
-                >
-                  SHS ALL
-                </a>
-              </span>
-            </div>
+              }
+            >
+              Donald
+               
+              Duck
+            </a>
           </div>
+          <div>
+            10th grade
+          </div>
+          <div />
         </div>
         <div
           style={
@@ -1836,7 +1757,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -1846,55 +1767,31 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/56"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/56"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
-              >
-                Rapunzel
-                 
-                Skywalker
-              </a>
-            </div>
-            <div>
-              9th grade
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/5"
-                >
-                  SHS 942
-                </a>
-                <span>
-                  <span>
-                     
-                  </span>
-                   with 
-                  <a
-                    className="Educator"
-                    href="mailto:jodi@demo.studentinsights.org"
-                    style={Object {}}
-                  >
-                    Jodi Teacher
-                  </a>
-                </span>
-              </span>
-            </div>
+              }
+            >
+              Rapunzel
+               
+              Skywalker
+            </a>
           </div>
+          <div>
+            9th grade
+          </div>
+          <div />
         </div>
         <div
           style={
@@ -2026,7 +1923,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -2036,55 +1933,31 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/53"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/53"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
-              >
-                Olaf
-                 
-                Mouse
-              </a>
-            </div>
-            <div>
-              9th grade
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/5"
-                >
-                  SHS 942
-                </a>
-                <span>
-                  <span>
-                     
-                  </span>
-                   with 
-                  <a
-                    className="Educator"
-                    href="mailto:jodi@demo.studentinsights.org"
-                    style={Object {}}
-                  >
-                    Jodi Teacher
-                  </a>
-                </span>
-              </span>
-            </div>
+              }
+            >
+              Olaf
+               
+              Mouse
+            </a>
           </div>
+          <div>
+            9th grade
+          </div>
+          <div />
         </div>
         <div
           style={
@@ -2216,7 +2089,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -2226,54 +2099,54 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/21"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/21"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
+              }
+            >
+              Elsa
+               
+              Kenobi
+            </a>
+          </div>
+          <div>
+            5th grade
+          </div>
+          <div>
+            <span
+              className="Homeroom"
+              style={Object {}}
+            >
+              <a
+                href="/homerooms/3"
               >
-                Elsa
-                 
-                Kenobi
+                WSNS 501
               </a>
-            </div>
-            <div>
-              5th grade
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/3"
-                >
-                  WSNS 501
-                </a>
+              <span>
                 <span>
-                  <span>
-                     
-                  </span>
-                   with 
-                  <a
-                    className="Educator"
-                    href="mailto:marcus@demo.studentinsights.org"
-                    style={Object {}}
-                  >
-                    Marcus Teacher
-                  </a>
+                   
                 </span>
+                 with 
+                <a
+                  className="Educator"
+                  href="mailto:marcus@demo.studentinsights.org"
+                  style={Object {}}
+                >
+                  Marcus Teacher
+                </a>
               </span>
-            </div>
+            </span>
           </div>
         </div>
         <div
@@ -2392,7 +2265,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -2402,42 +2275,31 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/72"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/72"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
-              >
-                Rapunzel
-                 
-                White
-              </a>
-            </div>
-            <div>
-              10th grade
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/4"
-                >
-                  SHS ALL
-                </a>
-              </span>
-            </div>
+              }
+            >
+              Rapunzel
+               
+              White
+            </a>
           </div>
+          <div>
+            10th grade
+          </div>
+          <div />
         </div>
         <div
           style={
@@ -2569,7 +2431,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -2579,42 +2441,31 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/114"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/114"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
-              >
-                Rapunzel
-                 
-                Pan
-              </a>
-            </div>
-            <div>
-              10th grade
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/4"
-                >
-                  SHS ALL
-                </a>
-              </span>
-            </div>
+              }
+            >
+              Rapunzel
+               
+              Pan
+            </a>
           </div>
+          <div>
+            10th grade
+          </div>
+          <div />
         </div>
         <div
           style={
@@ -2746,7 +2597,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -2756,42 +2607,31 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/109"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/109"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
-              >
-                Donald
-                 
-                Pan
-              </a>
-            </div>
-            <div>
-              10th grade
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/4"
-                >
-                  SHS ALL
-                </a>
-              </span>
-            </div>
+              }
+            >
+              Donald
+               
+              Pan
+            </a>
           </div>
+          <div>
+            10th grade
+          </div>
+          <div />
         </div>
         <div
           style={
@@ -2923,7 +2763,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -2933,42 +2773,31 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/99"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/99"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
-              >
-                Aladdin
-                 
-                White
-              </a>
-            </div>
-            <div>
-              10th grade
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/4"
-                >
-                  SHS ALL
-                </a>
-              </span>
-            </div>
+              }
+            >
+              Aladdin
+               
+              White
+            </a>
           </div>
+          <div>
+            10th grade
+          </div>
+          <div />
         </div>
         <div
           style={
@@ -3100,7 +2929,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -3110,54 +2939,54 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/18"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/18"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
+              }
+            >
+              Winnie
+               
+              Disney
+            </a>
+          </div>
+          <div>
+            Kindergarten
+          </div>
+          <div>
+            <span
+              className="Homeroom"
+              style={Object {}}
+            >
+              <a
+                href="/homerooms/1"
               >
-                Winnie
-                 
-                Disney
+                HEA 003
               </a>
-            </div>
-            <div>
-              Kindergarten
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/1"
-                >
-                  HEA 003
-                </a>
+              <span>
                 <span>
-                  <span>
-                     
-                  </span>
-                   with 
-                  <a
-                    className="Educator"
-                    href="mailto:vivian@demo.studentinsights.org"
-                    style={Object {}}
-                  >
-                    Vivian Teacher
-                  </a>
+                   
                 </span>
+                 with 
+                <a
+                  className="Educator"
+                  href="mailto:vivian@demo.studentinsights.org"
+                  style={Object {}}
+                >
+                  Vivian Teacher
+                </a>
               </span>
-            </div>
+            </span>
           </div>
         </div>
         <div
@@ -3276,7 +3105,7 @@ Philis is meeting with parent next week and will present an attendance contract.
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -3286,42 +3115,31 @@ Philis is meeting with parent next week and will present an attendance contract.
         <div
           style={
             Object {
-              "alignItems": "center",
+              "alignItems": "flex-start",
               "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
             }
           }
         >
           <div>
-            <div>
-              <a
-                href="/students/70"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
+            <a
+              href="/students/70"
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
-              >
-                Mowgli
-                 
-                Pan
-              </a>
-            </div>
-            <div>
-              10th grade
-            </div>
-            <div>
-              <span
-                className="Homeroom"
-                style={Object {}}
-              >
-                <a
-                  href="/homerooms/4"
-                >
-                  SHS ALL
-                </a>
-              </span>
-            </div>
+              }
+            >
+              Mowgli
+               
+              Pan
+            </a>
           </div>
+          <div>
+            10th grade
+          </div>
+          <div />
         </div>
         <div
           style={

--- a/app/assets/javascripts/feed/__snapshots__/IncidentCard.test.js.snap
+++ b/app/assets/javascripts/feed/__snapshots__/IncidentCard.test.js.snap
@@ -17,7 +17,7 @@ exports[`matches snapshot 1`] = `
     <div
       style={
         Object {
-          "alignItems": "center",
+          "alignItems": "flex-start",
           "display": "flex",
           "flexDirection": "row",
           "justifyContent": "space-between",
@@ -27,42 +27,31 @@ exports[`matches snapshot 1`] = `
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
+            "flexDirection": "column",
+            "justifyContent": "flex-start",
           }
         }
       >
         <div>
-          <div>
-            <a
-              href="/students/100"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
+          <a
+            href="/students/100"
+            style={
+              Object {
+                "fontWeight": "bold",
               }
-            >
-              Mowgli
-               
-              Pan
-            </a>
-          </div>
-          <div>
-            10th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
-              <a
-                href="/homerooms/4"
-              >
-                SHS ALL
-              </a>
-            </span>
-          </div>
+            }
+          >
+            Mowgli
+             
+            Pan
+          </a>
         </div>
+        <div>
+          10th grade
+        </div>
+        <div />
       </div>
       <div
         style={
@@ -168,7 +157,7 @@ exports[`matches when no location 1`] = `
     <div
       style={
         Object {
-          "alignItems": "center",
+          "alignItems": "flex-start",
           "display": "flex",
           "flexDirection": "row",
           "justifyContent": "space-between",
@@ -178,42 +167,31 @@ exports[`matches when no location 1`] = `
       <div
         style={
           Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "display": "flex",
+            "flexDirection": "column",
+            "justifyContent": "flex-start",
           }
         }
       >
         <div>
-          <div>
-            <a
-              href="/students/100"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
+          <a
+            href="/students/100"
+            style={
+              Object {
+                "fontWeight": "bold",
               }
-            >
-              Mowgli
-               
-              Pan
-            </a>
-          </div>
-          <div>
-            10th grade
-          </div>
-          <div>
-            <span
-              className="Homeroom"
-              style={Object {}}
-            >
-              <a
-                href="/homerooms/4"
-              >
-                SHS ALL
-              </a>
-            </span>
-          </div>
+            }
+          >
+            Mowgli
+             
+            Pan
+          </a>
         </div>
+        <div>
+          10th grade
+        </div>
+        <div />
       </div>
       <div
         style={

--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -153,6 +153,13 @@ export function supportsExcusedAbsences(districtKey) {
   return false;
 }
 
+// In high school, homeroom is a logical administrative assignment,
+// but isn't meaningful to teachers or educators.  If there is
+// a homeroom, it might not necessarily be worth showing.
+export function isHomeroomMeaningful(schoolType) {
+  return (schoolType !== 'HS');
+}
+
 // What is the eventNoteTypeId to use in user-facing text about how to support
 // students with high absences?
 export function eventNoteTypeIdForAbsenceSupportMeeting(districtKey) {

--- a/app/assets/javascripts/home/HomeFeed.test.js
+++ b/app/assets/javascripts/home/HomeFeed.test.js
@@ -43,6 +43,10 @@ function moreCardsJson() {
           "first_name": "Winnie",
           "last_name": "Disney",
           "house": null,
+          "school": {
+            "local_id": "SHS",
+            "school_type": "HS"
+          },
           "homeroom": {
             "id": 1,
             "name": "HEA 003",

--- a/app/assets/javascripts/testing/fixtures/home_feed_json.js
+++ b/app/assets/javascripts/testing/fixtures/home_feed_json.js
@@ -29,6 +29,10 @@ export default {
           "first_name": "Winnie",
           "last_name": "Disney",
           "house": null,
+          "school": {
+            "local_id": "HEA",
+            "school_type": "ESMS"
+          },
           "homeroom": {
             "id": 1,
             "name": "HEA 003",
@@ -60,6 +64,10 @@ export default {
           "first_name": "Donald",
           "last_name": "Duck",
           "house": "Broadway",
+          "school": {
+            "local_id": "SHS",
+            "school_type": "HS"
+          },
           "homeroom": {
             "id": 4,
             "name": "SHS ALL"
@@ -86,6 +94,10 @@ export default {
           "first_name": "Rapunzel",
           "last_name": "White",
           "house": "Highland",
+          "school": {
+            "local_id": "SHS",
+            "school_type": "HS"
+          },
           "homeroom": {
             "id": 4,
             "name": "SHS ALL"
@@ -112,6 +124,10 @@ export default {
           "first_name": "Winnie",
           "last_name": "Disney",
           "house": null,
+          "school": {
+            "local_id": "HEA",
+            "school_type": "ESMS"
+          },
           "homeroom": {
             "id": 1,
             "name": "HEA 003",
@@ -143,6 +159,10 @@ export default {
           "first_name": "Winnie",
           "last_name": "Disney",
           "house": "Highland",
+          "school": {
+            "local_id": "SHS",
+            "school_type": "HS"
+          },
           "homeroom": {
             "id": 4,
             "name": "SHS ALL"
@@ -169,6 +189,10 @@ export default {
           "first_name": "Rapunzel",
           "last_name": "Skywalker",
           "house": "Highland",
+          "school": {
+            "local_id": "SHS",
+            "school_type": "HS"
+          },
           "homeroom": {
             "id": 4,
             "name": "SHS ALL"
@@ -195,6 +219,10 @@ export default {
           "first_name": "Daisy",
           "last_name": "Poppins",
           "house": "Highland",
+          "school": {
+            "local_id": "SHS",
+            "school_type": "HS"
+          },
           "homeroom": {
             "id": 5,
             "name": "SHS 942",
@@ -226,6 +254,10 @@ export default {
           "first_name": "Rapunzel",
           "last_name": "Poppins",
           "house": null,
+          "school": {
+            "local_id": "HEA",
+            "school_type": "ESMS"
+          },
           "homeroom": {
             "id": 1,
             "name": "HEA 003",
@@ -257,6 +289,10 @@ export default {
           "first_name": "Snow",
           "last_name": "Kenobi",
           "house": null,
+          "school": {
+            "local_id": "HEA",
+            "school_type": "ESMS"
+          },
           "homeroom": {
             "id": 2,
             "name": "HEA 500",
@@ -288,6 +324,10 @@ export default {
           "first_name": "Donald",
           "last_name": "Duck",
           "house": "Broadway",
+          "school": {
+            "local_id": "SHS",
+            "school_type": "HS"
+          },
           "homeroom": {
             "id": 4,
             "name": "SHS ALL"
@@ -314,6 +354,10 @@ export default {
           "first_name": "Rapunzel",
           "last_name": "Skywalker",
           "house": "Beacon",
+          "school": {
+            "local_id": "SHS",
+            "school_type": "HS"
+          },
           "homeroom": {
             "id": 5,
             "name": "SHS 942",
@@ -345,6 +389,10 @@ export default {
           "first_name": "Olaf",
           "last_name": "Mouse",
           "house": "Elm",
+          "school": {
+            "local_id": "SHS",
+            "school_type": "HS"
+          },
           "homeroom": {
             "id": 5,
             "name": "SHS 942",
@@ -376,6 +424,10 @@ export default {
           "first_name": "Elsa",
           "last_name": "Kenobi",
           "house": null,
+          "school": {
+            "local_id": "WSNS",
+            "school_type": "ESMS"
+          },
           "homeroom": {
             "id": 3,
             "name": "WSNS 501",
@@ -407,6 +459,10 @@ export default {
           "first_name": "Rapunzel",
           "last_name": "White",
           "house": "Highland",
+          "school": {
+            "local_id": "SHS",
+            "school_type": "HS"
+          },
           "homeroom": {
             "id": 4,
             "name": "SHS ALL"
@@ -433,6 +489,10 @@ export default {
           "first_name": "Rapunzel",
           "last_name": "Pan",
           "house": "Highland",
+          "school": {
+            "local_id": "SHS",
+            "school_type": "HS"
+          },
           "homeroom": {
             "id": 4,
             "name": "SHS ALL"
@@ -459,6 +519,10 @@ export default {
           "first_name": "Donald",
           "last_name": "Pan",
           "house": "Beacon",
+          "school": {
+            "local_id": "SHS",
+            "school_type": "HS"
+          },
           "homeroom": {
             "id": 4,
             "name": "SHS ALL"
@@ -485,6 +549,10 @@ export default {
           "first_name": "Aladdin",
           "last_name": "White",
           "house": "Highland",
+          "school": {
+            "local_id": "SHS",
+            "school_type": "HS"
+          },
           "homeroom": {
             "id": 4,
             "name": "SHS ALL"
@@ -511,6 +579,10 @@ export default {
           "first_name": "Winnie",
           "last_name": "Disney",
           "house": null,
+          "school": {
+            "local_id": "HEA",
+            "school_type": "ESMS"
+          },
           "homeroom": {
             "id": 1,
             "name": "HEA 003",
@@ -542,6 +614,10 @@ export default {
           "first_name": "Mowgli",
           "last_name": "Pan",
           "house": "Beacon",
+          "school": {
+            "local_id": "SHS",
+            "school_type": "HS"
+          },
           "homeroom": {
             "id": 4,
             "name": "SHS ALL"

--- a/app/lib/feed.rb
+++ b/app/lib/feed.rb
@@ -52,7 +52,7 @@ class Feed
       .where('recorded_at < ?', from_time)
       .order(recorded_at: :desc)
       .limit(limit)
-      .includes(student: :homeroom)
+      .includes(student: [:homeroom, :school])
     recent_event_notes.map {|event_note| event_note_card(event_note) }
   end
 
@@ -79,7 +79,7 @@ class Feed
       .where('occurred_at < ?', time_now)
       .order(occurred_at: :desc)
       .limit(limit)
-      .includes(student: :homeroom)
+      .includes(student: [:homeroom, :school])
     incidents.map {|incident| incident_card(incident) }
   end
 
@@ -99,6 +99,9 @@ class Feed
         :student => {
           :only => [:id, :email, :first_name, :last_name, :grade, :house],
           :include => {
+            :school => {
+              :only => [:local_id, :school_type]
+            },
             :homeroom => {
               :only => [:id, :name],
               :include => {
@@ -127,6 +130,9 @@ class Feed
         :student => {
           :only => [:id, :email, :first_name, :last_name, :grade, :house],
           :include => {
+            :school => {
+              :only => [:local_id, :school_type]
+            },
             :homeroom => {
               :only => [:id, :name],
               :include => {

--- a/spec/lib/feed_spec.rb
+++ b/spec/lib/feed_spec.rb
@@ -102,6 +102,10 @@ RSpec.describe Feed do
             "first_name"=>"Mari",
             "last_name"=>"Kenobi",
             "house"=>"Beacon",
+            "school"=>{
+              "local_id"=>"SHS",
+              "school_type"=>"HS"
+            },
             "homeroom"=>{
               "id"=>pals.shs_jodi_homeroom.id,
               "name"=>"SHS 942",
@@ -132,6 +136,10 @@ RSpec.describe Feed do
             "first_name"=>"Mari",
             "last_name"=>"Kenobi",
             "house"=>'Beacon',
+            "school"=>{
+              "local_id"=>"SHS",
+              "school_type"=>"HS"
+            },
             "homeroom"=>{
               "id"=>pals.shs_jodi_homeroom.id,
               "name"=>"SHS 942",
@@ -215,6 +223,10 @@ RSpec.describe Feed do
           "first_name"=>"Mari",
           "last_name"=>"Kenobi",
           "house"=>"Beacon",
+          "school"=>{
+            "local_id"=>"SHS",
+            "school_type"=>"HS"
+          },
           "homeroom"=>{
             "id"=>pals.shs_jodi_homeroom.id,
             "name"=>"SHS 942",


### PR DESCRIPTION
# Who is this PR for?
HS educators

# What problem does this PR fix?
https://rollbar.com/somerville-teacher-tool/somerville-teacher-tool/items/246/?item_page=0&#instances, the feed shows homerooms for HS students, but educators won't necessarily have access to that homeroom if they teach a student in another section.  Further, homerooms in HS aren't meaningful to educators anyway.

# What does this PR do?
Removes homeroom from the feed cards for HS students.  Also fixes a minor text alignment bug when no homeroom.

# Screenshot (if adding a client-side feature)
<img width="519" alt="screen shot 2018-10-16 at 8 32 33 am" src="https://user-images.githubusercontent.com/1056957/47016672-634cc600-d11e-11e8-8a86-dd12ab01b66d.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Home page
+ [x] Class lists

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage