### PR TITLE
Feed: Add ELL-based feed filter for teachers in NEST and ELL department

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -309,7 +309,7 @@ class PerDistrict
     elsif @district_key == BEDFORD
       ['Limited English', 'Not Capable'].include?(student.limited_english_proficiency)
     else
-      raise_not_handled!  
+      raise_not_handled!
     end
   end
 

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -111,6 +111,11 @@ class PerDistrict
     end
   end
 
+  # Controls feed filter based on ELL status
+  def enable_ell_based_feed?
+    EnvironmentVariable.is_true('ENABLE_ELL_BASED_FEED')
+  end
+
   # If this is enabled, filter students on the home page feed
   # based on a mapping of the `house` field on the student and a specific
   # `Educator`.  It may be individually feature switched as well.
@@ -293,6 +298,19 @@ class PerDistrict
 
   def is_research_matters_analysis_supported?
     @district_key == SOMERVILLE
+  end
+
+  # See also language.js
+  def is_student_english_learner_now?(student)
+    if @district_key == SOMERVILLE
+      ['Limited'].include?(student.limited_english_proficiency)
+    elsif @district_key == NEW_BEDFORD
+      ['Limited English' || 'Non-English'].include?(student.limited_english_proficiency)
+    elsif @district_key == BEDFORD
+      ['Limited English', 'Not Capable'].include?(student.limited_english_proficiency)
+    else
+      raise_not_handled!  
+    end
   end
 
   def current_quarter(date_time)

--- a/app/lib/feed_filter.rb
+++ b/app/lib/feed_filter.rb
@@ -8,7 +8,8 @@ class FeedFilter
     filters = [
       CounselorFilter.new(@educator),
       HouseFilter.new(@educator),
-      SectionsFilter.new(@educator)
+      SectionsFilter.new(@educator),
+      EnglishLanguageLearnerFilter.new(@educator)
     ]
 
     filtered_students = students
@@ -21,6 +22,24 @@ class FeedFilter
   end
 
   private
+  # For building-level ELL teachers, who have schoolwide access, but only
+  # want to see students actively learning English in their feed (on their
+  # caseload).
+  class EnglishLanguageLearnerFilter
+    def initialize(educator)
+      @educator = educator
+    end
+
+    def should_use?
+      return false unless PerDistrict.new.enable_ell_based_feed?
+      EducatorLabel.has_static_label?(@educator.id, 'use_ell_based_feed')
+    end
+
+    def keep?(student)
+      PerDistrict.new.is_student_english_learner_now?(student)
+    end
+  end
+
   # Filters by students in sections that a teacher is currently teaching.
   # For HS teachers who need schoolwide access for admin parts of their role (eg, data coordinator,
   # department head), but who also serve as classroom teachers and really want to just focus on those

--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -15,6 +15,7 @@ class EducatorLabel < ApplicationRecord
         'use_counselor_based_feed',
         'use_housemaster_based_feed',
         'use_section_based_feed',
+        'use_ell_based_feed',
         'enable_class_lists_override',
         'can_upload_student_voice_surveys'
       ]

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -449,7 +449,6 @@ class TestPals
       grade_letter: 'F'
     )
 
-
     add_team_memberships unless skip_team_memberships
 
     reindex!

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -449,6 +449,7 @@ class TestPals
       grade_letter: 'F'
     )
 
+
     add_team_memberships unless skip_team_memberships
 
     reindex!


### PR DESCRIPTION
# Who is this PR for?
teachers in NEST and ELL department at HS

# What problem does this PR fix?
Teachers with schoolwide access who work only with ELL students see students in their feed that they won't focus on, since they're outside their core caseload.

# What does this PR do?
Adds a new `FeedFilter` to filter feed students based on their ELL status.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Home page
+ [x] Included specs for changes