### PR TITLE
Levels: Release link for all SHS educators

### DIFF
--- a/app/lib/paths_for_educator.rb
+++ b/app/lib/paths_for_educator.rb
@@ -12,6 +12,10 @@ class PathsForEducator
       links[:classlists] = '/classlists'
     end
 
+    if PerDistrict.new.enabled_high_school_levels? && SomervilleHighLevels.is_link_relevant_for_educator?(@educator)
+      links[:levels_shs] = '/levels/shs'
+    end
+
     if @educator.districtwide_access?
       links[:district] = url_helpers.educators_districtwide_path
     end

--- a/app/lib/somerville_high_levels.rb
+++ b/app/lib/somerville_high_levels.rb
@@ -5,6 +5,13 @@
 class SomervilleHighLevels
   FAILING_GRADE = 65
 
+  # Show the link for teachers in SHS only
+  def self.is_link_relevant_for_educator?(educator)
+    shs_school_id = School.find_by_local_id('SHS').try(:id)
+    return false if shs_school_id.nil?
+    educator.school_id == shs_school_id
+  end
+
   def initialize(options = {})
     @time_interval = options.fetch(:time_interval, 45.days)
     if !PerDistrict.new.enabled_high_school_levels?

--- a/app/views/shared/_navbar_signed_in.html.erb
+++ b/app/views/shared/_navbar_signed_in.html.erb
@@ -8,6 +8,11 @@
     <span class="navbar-spacer"></span>
   <% end %>
 
+  <% if links.has_key?(:levels_shs) %>
+    <%= link_to 'Levels', links[:levels_shs] %>
+    <span class="navbar-spacer"></span>
+  <% end %>
+
   <% if links.has_key?(:district) %>
     <%= link_to 'District', links[:district] %>
     <span class="navbar-spacer"></span>

--- a/spec/lib/paths_for_educator_spec.rb
+++ b/spec/lib/paths_for_educator_spec.rb
@@ -53,23 +53,30 @@ RSpec.describe PathsForEducator do
 
         # high school (TestPals doesn't match actual production HS roles and permisssions)
         expect(navbar_links(pals.shs_harry_housemaster)).to eq({
+          levels_shs: '/levels/shs',
           school: '/schools/shs',
           absences: '/schools/shs/absences',
           tardies: '/schools/shs/tardies'
         })
-        expect(navbar_links(pals.shs_jodi)).to eq({})
+        expect(navbar_links(pals.shs_jodi)).to eq({
+          levels_shs: '/levels/shs'
+        })
         expect(navbar_links(pals.shs_sofia_counselor)).to eq({
+          levels_shs: '/levels/shs',
           school: '/schools/shs',
           absences: '/schools/shs/absences',
           tardies: '/schools/shs/tardies'
         })
         expect(navbar_links(pals.shs_bill_nye)).to eq({
+          levels_shs: '/levels/shs',
           section: '/educators/my_sections'
         })
         expect(navbar_links(pals.shs_hugo_art_teacher)).to eq({
+          levels_shs: '/levels/shs',
           section: '/educators/my_sections'
         })
         expect(navbar_links(pals.shs_fatima_science_teacher)).to eq({
+          levels_shs: '/levels/shs',
           absences: '/schools/shs/absences',
           school: '/schools/shs',
           section: '/educators/my_sections',


### PR DESCRIPTION
# Who is this PR for?
SHS educators

# What problem does this PR fix?
The `/levels/shs` page has been accessible only by direct navigation (eg, through a link in slides).  This is ready to be used more generally now, so let's remove that friction.

# What does this PR do?
Adds a link to anyone with their school set as SHS.  This doesn't change authorization, just rendering the link.

# Screenshot (if adding a client-side feature)
<img width="1054" alt="screen shot 2018-10-16 at 7 24 02 pm" src="https://user-images.githubusercontent.com/1056957/47053108-91abbf00-d179-11e8-8eb6-e513da6167df.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Navbar

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here