### PR TITLE
Levels: Fix bug with rendering grade strengths

### DIFF
--- a/app/assets/javascripts/levels/StudentLevelsTable.js
+++ b/app/assets/javascripts/levels/StudentLevelsTable.js
@@ -20,7 +20,6 @@ import {
   STUDY_SKILLS
 } from './Courses';
 
-
 // Render a virtualized table, with information and triggers on the
 // left columns and supports on the right.  Exports the description
 // of the column and the ordering functions for re-use in exporting

--- a/app/assets/javascripts/levels/StudentLevelsTable.js
+++ b/app/assets/javascripts/levels/StudentLevelsTable.js
@@ -110,7 +110,7 @@ StudentLevelsTable.propTypes = {
 
 const supportColor = 'rgb(74, 143, 225)';
 const warningColor = 'rgb(255, 231, 214)';
-const strengthColor = 'rgb(77, 136, 77, 0.9)';
+const strengthColor = 'rgba(77, 136, 77, 0.9)';
 const structureColor = 'rgba(51, 51, 51, 0.5)';
 const styles = {
   root: {

--- a/app/assets/javascripts/levels/StudentLevelsTable.test.js
+++ b/app/assets/javascripts/levels/StudentLevelsTable.test.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import _ from 'lodash';
 import {SortDirection} from 'react-virtualized';
 import {withDefaultNowContext} from '../testing/NowContainer';
-import StudentLevelsTable from './StudentLevelsTable';
+import StudentLevelsTable, {orderedStudents} from './StudentLevelsTable';
 import levelsShowJson from './levelsShowJson.fixture';
 
 function testProps(props = {}) {
@@ -22,6 +23,19 @@ it('renders without crashing', () => {
     <StudentLevelsTable {...props} />
   ), el);
   expect($(el).find('.StudentLevelsTable').length).toEqual(1);
+});
+
+describe('orderedStudents', () => {
+  it('works', () => {
+    const filteredStudents = levelsShowJson.students_with_levels;
+    const orderedStudentsList = orderedStudents(filteredStudents, 'science', SortDirection.ASC);
+    const orderedGrades = _.compact(_.flatten(orderedStudentsList.map(student => {
+      return student.student_section_assignments_right_now.filter(assignment => {
+        return assignment.section.id == 6;
+      }).map(assignment => assignment.grade_letter);
+    })));
+    expect(orderedGrades).toEqual(['A', 'C', 'C', 'C', 'F', 'F', 'F', 'F', 'F']);
+  });
 });
 
 // can't add snapshots with react-virtualized without

--- a/app/assets/javascripts/levels/StudentLevelsTable.test.js
+++ b/app/assets/javascripts/levels/StudentLevelsTable.test.js
@@ -1,10 +1,22 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import renderer from 'react-test-renderer';
 import _ from 'lodash';
-import {SortDirection} from 'react-virtualized';
+import * as Virtualized from 'react-virtualized';
 import {withDefaultNowContext} from '../testing/NowContainer';
+import unvirtualize from '../testing/unvirtualize';
 import StudentLevelsTable, {orderedStudents} from './StudentLevelsTable';
 import levelsShowJson from './levelsShowJson.fixture';
+const {SortDirection} = Virtualized;
+
+
+// can't add snapshots with react-virtualized without
+// some work, see https://github.com/bvaughn/react-virtualized/issues/1117
+// instead, we stub these implementations with naive simple unvirtualized
+// ones, to verify the substance of the rendering works
+jest.mock('react-virtualized');
+unvirtualize(Virtualized, jest.fn);
+
 
 function testProps(props = {}) {
   return {
@@ -38,5 +50,11 @@ describe('orderedStudents', () => {
   });
 });
 
-// can't add snapshots with react-virtualized without
-// some work, see https://github.com/bvaughn/react-virtualized/issues/1117
+
+it('snapshots with unvirtualized render', () => {
+  const props = testProps();
+  const tree = renderer
+    .create(withDefaultNowContext(<StudentLevelsTable {...props} />))
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/assets/javascripts/levels/__snapshots__/StudentLevelsTable.test.js.snap
+++ b/app/assets/javascripts/levels/__snapshots__/StudentLevelsTable.test.js.snap
@@ -1,0 +1,6125 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshots with unvirtualized render 1`] = `
+<div
+  className="StudentLevelsTable"
+  style={
+    Object {
+      "display": "block",
+      "flex": 1,
+      "flexDirection": "column",
+      "overflow": "hidden",
+    }
+  }
+>
+  <div
+    className="Mock-AutoSizer"
+  >
+    <table
+      className="MockReactVirtualized"
+    >
+      <thead>
+        <tr>
+          <td>
+            Student
+          </td>
+          <td>
+            Level
+          </td>
+          <td>
+            Attendance Rate
+          </td>
+          <td>
+            Discipline Incidents
+          </td>
+          <td>
+            EN or ELL
+          </td>
+          <td>
+            Social Studies
+          </td>
+          <td>
+            Math
+          </td>
+          <td>
+            Science
+          </td>
+          <td>
+            Last xGE or NEST
+          </td>
+          <td>
+            Last SST
+          </td>
+          <td>
+            Other notes
+          </td>
+          <td>
+            Study skills
+          </td>
+          <td>
+            Academic Support
+          </td>
+          <td>
+            Redirect
+          </td>
+          <td>
+            Credit Recovery
+          </td>
+          <td>
+            Program or SPED
+          </td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <a
+              href="/students/3"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Mari
+               
+              Kenobi
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/4"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Amir
+               
+              Solo
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(77, 136, 77, 0.9)",
+                  "color": "white",
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              B
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/5"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Kylo
+               
+              Ren
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/24"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Aladdin
+               
+              Duck
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/25"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Daisy
+               
+              Duck
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/26"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Donald
+               
+              Skywalker
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              Partial Inclusion
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/29"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Pocahontas
+               
+              Skywalker
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/30"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Rapunzel
+               
+              Poppins
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              Private Separate
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/32"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Chip
+               
+              Disney
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              Partial Inclusion
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/33"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Mowgli
+               
+              White
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              Full Inclusion
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/34"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Pocahontas
+               
+              Disney
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              97
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/37"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Mowgli
+               
+              Poppins
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/39"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Aladdin
+               
+              Poppins
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/40"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Olaf
+               
+              White
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/42"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Pocahontas
+               
+              White
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              1
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/43"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Elsa
+               
+              Kenobi
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/44"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Donald
+               
+              Kenobi
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              97
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/46"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Mickey
+               
+              Poppins
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              97
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/47"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Mowgli
+               
+              Pan
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way English
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/48"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Olaf
+               
+              Pan
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              1
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/50"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Elsa
+               
+              Poppins
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/101"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Elsa
+               
+              Disney
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way English
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/70"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Chip
+               
+              Poppins
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/72"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Mickey
+               
+              Skywalker
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/73"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Donald
+               
+              Pan
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              97
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/75"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Snow
+               
+              Kenobi
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              1
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way English
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/76"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Minnie
+               
+              Kenobi
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/77"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Snow
+               
+              Disney
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              97
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              2
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              Private Separate
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/78"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Mickey
+               
+              Poppins
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way English
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/81"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Mickey
+               
+              Kenobi
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/82"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Daisy
+               
+              Disney
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/83"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Minnie
+               
+              Pan
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/85"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Mowgli
+               
+              White
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/86"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Rapunzel
+               
+              Mouse
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/87"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Aladdin
+               
+              Skywalker
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way English
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/89"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Daisy
+               
+              Skywalker
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/90"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Aladdin
+               
+              Skywalker
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              97
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way English
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/93"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Rapunzel
+               
+              Mouse
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              Partial Inclusion
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/94"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Olaf
+               
+              Pan
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/97"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Elsa
+               
+              Skywalker
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              97
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/98"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Chip
+               
+              Mouse
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/99"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Daisy
+               
+              Pan
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              Full Inclusion
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/100"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Snow
+               
+              White
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/104"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Snow
+               
+              Pan
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/105"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Elsa
+               
+              White
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgb(255, 231, 214)",
+                  "color": "#666",
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              D
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              Private Separate
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/106"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Rapunzel
+               
+              Pan
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              C
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              Full Inclusion
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/107"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Pocahontas
+               
+              White
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(77, 136, 77, 0.9)",
+                  "color": "white",
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              A
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way English
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/108"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Pluto
+               
+              Kenobi
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              C
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way English
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/109"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Rapunzel
+               
+              Pan
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(77, 136, 77, 0.9)",
+                  "color": "white",
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              A
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              Private Separate
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/110"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Chip
+               
+              White
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              97
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(77, 136, 77, 0.9)",
+                  "color": "white",
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              A
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/111"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Winnie
+               
+              Mouse
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              97
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(77, 136, 77, 0.9)",
+                  "color": "white",
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              B
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/112"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Donald
+               
+              Mouse
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              97
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgb(255, 231, 214)",
+                  "color": "#666",
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              D
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/113"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Winnie
+               
+              Poppins
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              97
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(77, 136, 77, 0.9)",
+                  "color": "white",
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              B
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              Full Inclusion
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/114"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Snow
+               
+              White
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgb(255, 231, 214)",
+                  "color": "#666",
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              F
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/115"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Chip
+               
+              Kenobi
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgb(255, 231, 214)",
+                  "color": "#666",
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              F
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/116"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Pluto
+               
+              Kenobi
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(77, 136, 77, 0.9)",
+                  "color": "white",
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              A
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/117"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Snow
+               
+              Skywalker
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              97
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              C
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              Full Inclusion
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/118"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Minnie
+               
+              Disney
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgb(255, 231, 214)",
+                  "color": "#666",
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              F
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/119"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Minnie
+               
+              Disney
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgb(255, 231, 214)",
+                  "color": "#666",
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              F
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              Partial Inclusion
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/120"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Aladdin
+               
+              Kenobi
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgb(255, 231, 214)",
+                  "color": "#666",
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              F
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/121"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Aladdin
+               
+              Disney
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              C
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way English
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/27"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Pluto
+               
+              Mouse
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/31"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Mowgli
+               
+              Duck
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/35"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Pocahontas
+               
+              Poppins
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/41"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Winnie
+               
+              White
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/45"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Rapunzel
+               
+              Pan
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way English
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/49"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Chip
+               
+              Skywalker
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/69"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Winnie
+               
+              Mouse
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              Partial Inclusion
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/80"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Aladdin
+               
+              Mouse
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/84"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Aladdin
+               
+              Kenobi
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way Spanish
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/88"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Mowgli
+               
+              Pan
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              97
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way English
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/92"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Pocahontas
+               
+              Skywalker
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/96"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Rapunzel
+               
+              Pan
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              1
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              Full Inclusion
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/students/122"
+              style={
+                Object {
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                }
+              }
+              target="_blank"
+            >
+              Donald
+               
+              Skywalker
+            </a>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              100
+              %
+            </span>
+          </td>
+          <td>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "padding": 8,
+                }
+              }
+            >
+              1
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "cursor": "default",
+                  "display": "inline-block",
+                  "padding": 8,
+                  "textAlign": "center",
+                  "width": 35,
+                }
+              }
+              title="PHYSICS 1"
+            >
+              C
+            </span>
+          </td>
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td />
+          <td>
+            <span
+              style={
+                Object {
+                  "backgroundColor": "rgba(51, 51, 51, 0.5)",
+                  "color": "white",
+                  "display": "inline-block",
+                  "fontSize": 12,
+                  "height": "95%",
+                  "padding": 4,
+                  "textAlign": "center",
+                  "width": "95%",
+                }
+              }
+            >
+              2Way English
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;

--- a/app/assets/javascripts/testing/unvirtualize.js
+++ b/app/assets/javascripts/testing/unvirtualize.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import _ from 'lodash';
+
+// react-virtualized is complex and doesn't allow snapshot testing because
+// it can't run in jsdom, and doesn't allow snapshotting the full
+// content of the data that would be rendered (since it's virtualized).
+//
+// In tests, it can be useful to just throw the whole data set at a table
+// and snapshot how it all renders in a table (eg, for a coarse integration
+// test).
+//
+// This implementation is minimal and fragile, only implementing the
+// most bare bones use of <Table/> and <Column/>
+export default function unvirtualize(ReactVirtualized, wrapFn) {
+  ReactVirtualized.AutoSizer = wrapFn(props => <div className="Mock-AutoSizer">{props.children({width: 1024, height: 768})}</div>);
+  ReactVirtualized.Table = wrapFn(tableProps => {
+    return (
+      <table className="MockReactVirtualized">
+        <thead>
+          <tr>{tableProps.children.map(column => <td key={column.props.dataKey}>{column.props.label}</td>)}</tr>
+        </thead>
+        <tbody>
+          {_.range(0, tableProps.rowCount).map(index => (
+            <tr key={index}>
+              {tableProps.children.map(column => (
+                <td key={column.props.dataKey}>
+                  {column.props.cellRenderer({rowData: tableProps.rowGetter({index})})}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  });
+  ReactVirtualized.Column = wrapFn(props => props);
+}


### PR DESCRIPTION
# Who is this PR for?
HS educators

# What problem does this PR fix?
On IE, background colors for "strengths" grades aren't being set, resulting in those grades not appearing on the page.  This doesn't impact other browsers, which interpret `rgb(x,y,z,a)` as if it were `rgba(x,y,z,a)`, which IE ignores the rule.

# What does this PR do?
Fixes it.  Adds an unrelated test to the ordering function in JS, since that's what I initially thought the problem was.

This PR also adds a new method for testing, `unvirtualize` which can be used in tests to swap in an naive unvirtualized implementation of `react-virtualized` `<Table />` that can be used for snapshot testing.  And this adds a snapshot test for `<StudentsLevelsTable />` that will catch regressions in individual styling of the cells going forward.

# Screenshot (if adding a client-side feature)
<img width="576" alt="screen shot 2018-10-18 at 7 35 39 pm" src="https://user-images.githubusercontent.com/1056957/47189952-095e2300-d30d-11e8-8d4e-87a330b47fd9.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Levels page

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here