### PR TITLE
Update Levels link to be from EducatorLabel, to enable one-off access too

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,13 +31,13 @@ Layout/EmptyLines:
 Layout/Tab:
   Enabled: true
 
+Layout/ConditionPosition:
+  Enabled: true
+
 Layout/SpaceInsideStringInterpolation:
   Enabled: true
 
 Lint/AssignmentInCondition:
-  Enabled: true
-
-Lint/ConditionPosition:
   Enabled: true
 
 Lint/Debugger:

--- a/app/lib/paths_for_educator.rb
+++ b/app/lib/paths_for_educator.rb
@@ -12,7 +12,7 @@ class PathsForEducator
       links[:classlists] = '/classlists'
     end
 
-    if PerDistrict.new.enabled_high_school_levels? && SomervilleHighLevels.is_link_relevant_for_educator?(@educator)
+    if PerDistrict.new.enabled_high_school_levels? && @educator.labels.include?('should_show_levels_shs_link')
       links[:levels_shs] = '/levels/shs'
     end
 

--- a/app/lib/somerville_high_levels.rb
+++ b/app/lib/somerville_high_levels.rb
@@ -4,14 +4,7 @@
 # the level of support and service they need.
 class SomervilleHighLevels
   FAILING_GRADE = 65
-
-  # Show the link for teachers in SHS only
-  def self.is_link_relevant_for_educator?(educator)
-    shs_school_id = School.find_by_local_id('SHS').try(:id)
-    return false if shs_school_id.nil?
-    educator.school_id == shs_school_id
-  end
-
+  
   def initialize(options = {})
     @time_interval = options.fetch(:time_interval, 45.days)
     if !PerDistrict.new.enabled_high_school_levels?

--- a/app/lib/somerville_high_levels.rb
+++ b/app/lib/somerville_high_levels.rb
@@ -4,7 +4,7 @@
 # the level of support and service they need.
 class SomervilleHighLevels
   FAILING_GRADE = 65
-  
+
   def initialize(options = {})
     @time_interval = options.fetch(:time_interval, 45.days)
     if !PerDistrict.new.enabled_high_school_levels?

--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -17,7 +17,8 @@ class EducatorLabel < ApplicationRecord
         'use_section_based_feed',
         'use_ell_based_feed',
         'enable_class_lists_override',
-        'can_upload_student_voice_surveys'
+        'can_upload_student_voice_surveys',
+        'should_show_levels_shs_link'
       ]
     }
   }
@@ -34,12 +35,19 @@ class EducatorLabel < ApplicationRecord
   def self.dynamic_labels_for_educator(educator)
     dynamic_labels = []
 
+    # Low grades box: Anyone in SHS with sections
     authorizer = Authorizer.new(educator)
     authorized_sections = educator.sections.select do |section|
       authorizer.is_authorized_for_section?(section)
     end
     if authorized_sections.size > 0 && educator.school.is_high_school?
       dynamic_labels << 'should_show_low_grades_box'
+    end
+
+    # Levels link: Anyone at SHS (can also be added manually)
+    shs_school_id = School.find_by_local_id('SHS').try(:id)
+    if shs_school_id.present? && educator.school_id == shs_school_id
+      dynamic_labels << 'should_show_levels_shs_link'
     end
 
     dynamic_labels

--- a/app/views/shared/_navbar_signed_in.html.erb
+++ b/app/views/shared/_navbar_signed_in.html.erb
@@ -3,21 +3,19 @@
   <% # Show different links based on role and access %>
   <% links = PathsForEducator.new(educator).navbar_links %>
 
-  <% if links.has_key?(:classlists) %>
-    <%= link_to 'Class lists', links[:classlists] %>
-    <span class="navbar-spacer"></span>
-  <% end %>
-
-  <% if links.has_key?(:levels_shs) %>
-    <%= link_to 'Levels', links[:levels_shs] %>
-    <span class="navbar-spacer"></span>
-  <% end %>
-
   <% if links.has_key?(:district) %>
     <%= link_to 'District', links[:district] %>
     <span class="navbar-spacer"></span>
   <% end %>
 
+  <% if links.has_key?(:classlists) %>
+    <%= link_to 'Class lists', links[:classlists] %>
+    <span class="navbar-spacer"></span>
+  <% end %>
+  
+  <% if links.has_key?(:levels_shs) %>
+    <%= link_to 'Levels', links[:levels_shs] %>
+  <% end %>
   <% if links.has_key?(:school) %>
     <%= link_to 'Roster', links[:school] %>
   <% end %>

--- a/spec/controllers/educators_controller_spec.rb
+++ b/spec/controllers/educators_controller_spec.rb
@@ -32,7 +32,10 @@ describe EducatorsController, :type => :controller do
           "name"=>"Arthur D Healey"
         },
         "sections"=>[],
-        "labels"=>['can_upload_student_voice_surveys']
+        "labels"=>[
+          'can_upload_student_voice_surveys',
+          'should_show_levels_shs_link'
+        ]
       })
     end
 

--- a/spec/controllers/ui_controller_spec.rb
+++ b/spec/controllers/ui_controller_spec.rb
@@ -18,7 +18,10 @@ describe UiController, :type => :controller do
           "id" => pals.uri.id,
           "admin" => true,
           "school_id" => pals.healey.id,
-          "labels" => ['can_upload_student_voice_surveys']
+          "labels" => [
+            'can_upload_student_voice_surveys',
+            'should_show_levels_shs_link'
+          ]
         }
       }.deep_stringify_keys)
     end
@@ -32,7 +35,11 @@ describe UiController, :type => :controller do
           "id" => pals.shs_bill_nye.id,
           "admin" => false,
           "school_id" => pals.shs.id,
-          "labels" => ['shs_experience_team', 'should_show_low_grades_box']
+          "labels" => [
+            'shs_experience_team',
+            'should_show_low_grades_box',
+            'should_show_levels_shs_link'
+          ]
         }
       }.deep_stringify_keys)
     end

--- a/spec/lib/paths_for_educator_spec.rb
+++ b/spec/lib/paths_for_educator_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe PathsForEducator do
 
       it 'respects PerDistrict for /classlists' do
         expect(navbar_links(pals.uri)).to eq({
-          district: '/educators/districtwide'
+          district: '/educators/districtwide',
+          levels_shs: '/levels/shs'
         })
       end
     end
@@ -23,8 +24,9 @@ RSpec.describe PathsForEducator do
     context 'with all feature switches enabled' do
       it 'works across educators, with classlists enabled' do
         expect(navbar_links(pals.uri)).to eq({
+          district: '/educators/districtwide',
           classlists: '/classlists',
-          district: '/educators/districtwide'
+          levels_shs: '/levels/shs'
         })
 
         # healey

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -321,9 +321,9 @@ RSpec.describe Educator do
   describe '#labels' do
     let!(:pals) { TestPals.create! }
     it 'works' do
-      expect(pals.shs_bill_nye.labels).to eq ['shs_experience_team', 'should_show_low_grades_box']
-      expect(pals.shs_jodi.labels).to eq ['shs_experience_team', 'can_upload_student_voice_surveys']
-      expect(pals.uri.labels).to eq ['can_upload_student_voice_surveys']
+      expect(pals.shs_bill_nye.labels).to eq ['shs_experience_team', 'should_show_low_grades_box', 'should_show_levels_shs_link']
+      expect(pals.shs_jodi.labels).to eq ['shs_experience_team', 'can_upload_student_voice_surveys', 'should_show_levels_shs_link']
+      expect(pals.uri.labels).to eq ['can_upload_student_voice_surveys', 'should_show_levels_shs_link']
     end
   end
 end

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -95,6 +95,10 @@ class TestPals
       educator: @uri,
       label_key: 'can_upload_student_voice_surveys'
     )
+    EducatorLabel.create!(
+      educator: @uri,
+      label_key: 'should_show_levels_shs_link'
+    )
 
     # Rich works in the central office and has districwide access, but
     # not project lead access.


### PR DESCRIPTION
# Who is this PR for?
districtwide admin, project lead

# What problem does this PR fix?
The SHS Levels link is switched different than with labels, so there's no way to add one-off access.

# What does this PR do?
Moves this into `dynamic_labels` and stills also it to be set with a normal static `EducatorLabel`.

Note that this is just about the link, not authorization.

# Checklists
+ [x] Levels
+ [x] Navbar

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
