### PR TITLE
Roster: Improve precomputing keying for school overview, simplify authorization

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -113,7 +113,7 @@ class SchoolsController < ApplicationController
     fallback_message = "falling back to full load_precomputed_student_hashes query for key: #{key}"
     logger.error fallback_message
     Rollbar.error(fallback_message)
-    authorized_students = Student.find(authorized_student_ids)
+    authorized_students = Student.where(id: authorized_student_ids)
     authorized_students.map {|student| student_hash_for_slicing(student) }
   end
 

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -74,8 +74,8 @@ class SchoolsController < ApplicationController
 
   def json_for_overview(school)
     authorized_students = authorized { school.students.active }
-    if authorized_students.size
-      Rollbar.warn("json_for_overview found 0 authorized students for educator_id: #{current_educator.id}")
+    if authorized_students.size == 0
+      Rollbar.error("json_for_overview found 0 authorized students for educator_id: #{current_educator.id}")
     end
 
     student_hashes = log_timing('schools#show student_hashes') do

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -97,13 +97,9 @@ class SchoolsController < ApplicationController
   # Results an array of student_hashes.
   def load_precomputed_student_hashes(time_now, authorized_student_ids)
     begin
-      # the precompute job runs at 8am UTC, and takes a few minutes to run,
-      # so keep a buffer that makes sure the import task and precompute job
-      # can finish before cutting over to the next day.
-      query_time = time_now - 9.hours
-      key = PrecomputedQueryDoc.precomputed_student_hashes_key(query_time, authorized_student_ids)
+      key = PrecomputedQueryDoc.precomputed_student_hashes_key(authorized_student_ids)
       logger.warn "load_precomputed_student_hashes querying key: #{key}..."
-      doc = PrecomputedQueryDoc.find_by_key(key)
+      doc = PrecomputedQueryDoc.where(key: key).order(created_at: :desc).limit(1).first(1)
       return parse_hashes_from_doc(doc) unless doc.nil?
     rescue ActiveRecord::StatementInvalid => err
       logger.error "load_precomputed_student_hashes raised error #{err.inspect}"

--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -163,6 +163,11 @@ class ImportTask
     begin
       log('Calling Student.update_recent_student_assessments...')
       Student.update_recent_student_assessments
+
+      log('Calling PrecomputeStudentHashesJob.precompute_all!...')
+      PrecomputeStudentHashesJob.new(@log).precompute_all!
+
+      log('Done index updates.')
     rescue => error
       Rollbar.error('ImportTask#run_update_tasks', error)
       raise error

--- a/app/importers/precompute/precompute_student_hashes_job.rb
+++ b/app/importers/precompute/precompute_student_hashes_job.rb
@@ -30,11 +30,11 @@ class PrecomputeStudentHashesJob < Struct.new :log
     School.all.each do |school|
       # Skip if they're not authorized for the school
       next unless authorizer.is_authorized_for_school?(school)
-    
+
       # Skip if they're not authorized for any students within that school
       authorized_students = authorizer.authorized { school.students.active.to_a }
       next unless authorized_students.size > 0
-      
+
       # Add a job for students that we need to compute for them within that school
       jobs << { authorized_student_ids: authorized_students.map(&:id) }
     end
@@ -43,7 +43,7 @@ class PrecomputeStudentHashesJob < Struct.new :log
 
   def precompute_and_write_doc!(job)
     authorized_student_ids = job[:authorized_student_ids]
-    
+
     # compute
     authorized_students = Student.where(id: authorized_student_ids)
     student_hashes = authorized_students.map {|student| student_hash_for_slicing(student) }

--- a/app/importers/precompute/precompute_student_hashes_job.rb
+++ b/app/importers/precompute/precompute_student_hashes_job.rb
@@ -10,53 +10,56 @@ class PrecomputeStudentHashesJob < Struct.new :log
 
     log.puts 'Starting precomputing...'
     jobs.each_with_index do |job, index|
-      precompute_and_write_student_hashes!(job)
+      precompute_and_write_doc!(job)
       log.puts "Wrote document #{index+1}..."
     end
     log.puts 'Done.'
+    nil
   end
 
   private
-
   def school_overview_precompute_jobs
-    Educator.all.order(:id).flat_map { |educator| educator_to_jobs(educator) }.uniq
+    Educator.all.order(:id).flat_map { |educator| jobs_for_educator(educator) }.uniq
   end
 
   # Educators may have access to this for multiple schools, and with different
   # sets of students within each school.
-  def educator_to_jobs(educator)
+  def jobs_for_educator(educator)
+    jobs = []
     authorizer = Authorizer.new(educator)
-    School.all.flat_map do |school|
-      # Nothing if they're not authorized for the school
-      return [] unless authorizer.is_authorized_for_school?(school)
+    School.all.each do |school|
+      # Skip if they're not authorized for the school
+      next unless authorizer.is_authorized_for_school?(school)
     
-      # Nothing if they're not authorized for any students within that school
+      # Skip if they're not authorized for any students within that school
       authorized_students = authorizer.authorized { school.students.active.to_a }
-      return [] if authorized_students.size == 0
+      next unless authorized_students.size > 0
       
-      # The students that we need to compute for them for that school
-      [{ authorized_student_ids: authorized_students.map(&:id) }]
+      # Add a job for students that we need to compute for them within that school
+      jobs << { authorized_student_ids: authorized_students.map(&:id) }
     end
+    jobs
   end
 
-  def precompute_and_write_student_hashes!(authorized_student_ids)
+  def precompute_and_write_doc!(job)
+    authorized_student_ids = job[:authorized_student_ids]
+    
     # compute
     authorized_students = Student.where(id: authorized_student_ids)
     student_hashes = authorized_students.map {|student| student_hash_for_slicing(student) }
 
     # write
     create_document!(authorized_student_ids, student_hashes)
-
-    nil
   end
 
   def create_document!(authorized_student_ids, student_hashes)
     key = PrecomputedQueryDoc.precomputed_student_hashes_key(authorized_student_ids)
     authorized_students_digest = PrecomputedQueryDoc.authorized_students_digest(authorized_student_ids)
+    json_string = { student_hashes: student_hashes }.to_json
     begin
       PrecomputedQueryDoc.create!(
         key: key,
-        json: json_hash.to_json,
+        json: json_string,
         authorized_students_digest: authorized_students_digest
       )
     rescue => error

--- a/app/importers/precompute/precompute_student_hashes_job.rb
+++ b/app/importers/precompute/precompute_student_hashes_job.rb
@@ -3,14 +3,14 @@ class PrecomputeStudentHashesJob < Struct.new :log
 
   # Runs the job for a particular day, querying for all educators' authorizations,
   # precomputing the `student_hashes` for them and writing them to the database.
-  def precompute_all!(date_timestamp)
+  def precompute_all!
     log.puts 'Querying for jobs...'
-    jobs = school_overview_precompute_jobs(date_timestamp)
+    jobs = school_overview_precompute_jobs
     log.puts "Found #{jobs.size} jobs."
 
     log.puts 'Starting precomputing...'
     jobs.each_with_index do |job, index|
-      precompute_and_write_student_hashes!(job[:date_timestamp], job[:authorized_student_ids])
+      precompute_and_write_student_hashes!(job)
       log.puts "Wrote document #{index+1}..."
     end
     log.puts 'Done.'
@@ -18,17 +18,16 @@ class PrecomputeStudentHashesJob < Struct.new :log
 
   private
 
-  def school_overview_precompute_jobs(date_timestamp)
-    Educator.all.flat_map { |educator| educator_to_jobs(educator, date_timestamp) }.uniq
+  def school_overview_precompute_jobs
+    Educator.all.order(:id).flat_map { |educator| educator_to_jobs(educator) }.uniq
   end
 
   # Educators with district-wide access will have different authorization
   # for each school than other users.
-  def educator_to_jobs(educator, date_timestamp)
+  def educator_to_jobs(educator)
     if educator.districtwide_access?
       return School.all.map do |school|
         {
-          date_timestamp: date_timestamp,
           authorized_student_ids: school.students.active.map(&:id)
         }
       end
@@ -36,26 +35,23 @@ class PrecomputeStudentHashesJob < Struct.new :log
 
     student_ids = educator.students_for_school_overview.map(&:id)
     return [] if student_ids.size == 0
-    return [{ date_timestamp: date_timestamp, authorized_student_ids: student_ids }]
+    return [{ authorized_student_ids: student_ids }]
   end
 
-  def precompute_and_write_student_hashes!(date_timestamp, authorized_student_ids)
-    precomputed_time = Time.at(date_timestamp)
-    authorized_students = Student.find(authorized_student_ids)
+  def precompute_and_write_student_hashes!(authorized_student_ids)
+    # compute
+    authorized_students = Student.where(id: authorized_student_ids)
     student_hashes = authorized_students.map {|student| student_hash_for_slicing(student) }
 
-    key = PrecomputedQueryDoc.precomputed_student_hashes_key(precomputed_time, authorized_student_ids)
-    write_doc_or_log(key, { student_hashes: student_hashes })
+    # write
+    create_document!(authorized_student_ids, student_hashes)
+
     nil
   end
 
-  # This is a non-atomic upsert
-  # This catches errors, emails, logs and returns nil
-  def write_doc_or_log(key, json_hash)
-    pre_existing_doc = PrecomputedQueryDoc.find_by_key(key)
-    pre_existing_doc.destroy! if pre_existing_doc.present?
-    authorized_students_digest = key.split(':').last
-
+  def create_document!(authorized_student_ids, student_hashes)
+    key = PrecomputedQueryDoc.precomputed_student_hashes_key(authorized_student_ids)
+    authorized_students_digest = PrecomputedQueryDoc.authorized_students_digest(authorized_student_ids)
     begin
       PrecomputedQueryDoc.create!(
         key: key,
@@ -63,9 +59,8 @@ class PrecomputeStudentHashesJob < Struct.new :log
         authorized_students_digest: authorized_students_digest
       )
     rescue => error
-      Rollbar.error('PrecomputeStudentHashesJob#write_doc_or_log', error, { key: key })
-      log.puts "write_doc_or_log failed for key: #{key}"
-      log.puts err.inspect
+      Rollbar.error('PrecomputeStudentHashesJob#create_document!', error, { key: key })
+      log.puts "create_document! failed for key: #{key}"
       nil
     end
   end

--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -169,21 +169,6 @@ class Authorizer
   end
 
   # TODO(kr) remove implementation
-  def students_for_school_overview
-    return [] unless @educator.school.present?
-
-    if @educator.schoolwide_access?
-      @educator.school.students.active
-    elsif @educator.has_access_to_grade_levels?
-      @educator.school.students
-        .active
-        .where(grade: @educator.grade_level_access)
-    else
-      []
-    end
-  end
-
-  # TODO(kr) remove implementation
   def homerooms
     if @educator.districtwide_access?
       Homeroom.all

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -48,19 +48,6 @@ class Educator < ApplicationRecord
     Authorizer.new(self).is_authorized_for_section?(section)
   end
 
-  def students_for_school_overview(*additional_includes)
-    students = Authorizer.new(self).students_for_school_overview
-
-    if students.respond_to?(:includes)
-      students.includes(additional_includes || [])
-    elsif students.size == 0
-      logger.warn("Fell through to empty array in #students_for_school_overview for educator_id: #{self.id}")
-      []
-    else
-      students
-    end
-  end
-
   def labels
     EducatorLabel.labels(self)
   end

--- a/app/models/precomputed_query_doc.rb
+++ b/app/models/precomputed_query_doc.rb
@@ -2,7 +2,15 @@ class PrecomputedQueryDoc < ApplicationRecord
   # A key-value store for holding a precomputed JSON doc (eg, for a query that's hard to optimize
   # or wants to use arbitrary Ruby code).  It's intended to be precomputed and durable, not a
   # read-through cache (since the computations are expensive).
-  #
+
+  # Read back precomputed hashes for students
+  def self.latest_precomputed_student_hashes_for(authorized_student_ids)
+    key = PrecomputedQueryDoc.precomputed_student_hashes_key(authorized_student_ids)
+    doc = PrecomputedQueryDoc.where(key: key).order(created_at: :desc).limit(1).first
+    return nil if doc.nil?
+    JSON.parse(doc.json).deep_symbolize_keys![:student_hashes]
+  end
+
   # The primary key means nothing, and reads and writes should be done based on the `key` column.
   #
   # There are a few variations on this over time.

--- a/app/models/precomputed_query_doc.rb
+++ b/app/models/precomputed_query_doc.rb
@@ -1,21 +1,44 @@
 class PrecomputedQueryDoc < ApplicationRecord
-  # A key-value store for holding a precomputed JSON doc, like Redis but durable since it's precomputed
-  # and not a read-through cache.
-  # The primary key means nothing, and reads and writes should be done on the `key` column, which
-  # has an index and uniqueness constraint.
-
+  # A key-value store for holding a precomputed JSON doc (eg, for a query that's hard to optimize
+  # or wants to use arbitrary Ruby code).  It's intended to be precomputed and durable, not a
+  # read-through cache (since the computations are expensive).
+  #
+  # The primary key means nothing, and reads and writes should be done based on the `key` column.
+  #
+  # There are a few variations on this over time.
+  #
+  # 1) precomputed_student_hashes / :force_deprecated_key
   # The original formats to this key concatenated all student_ids but is deprecated and
   # no longer used (although it's still here since data still exists thats keyed like that).
   # That can be accessed with `force_deprecated_key`.
-
-  def self.precomputed_student_hashes_key(time_now, authorized_student_ids, options = {})
-    timestamp = time_now.beginning_of_day.to_i
-    authorized_students_key = authorized_student_ids.sort.join(',')
+  #
+  # 2) short / :force_deprecated_day_based_key
+  # This hashes all the student_ids, since plain concatenation led to really long strings that
+  # were outside the length limit for the key column.
+  # 
+  # 3) continuous_for_student_ids
+  # originally we ran the import every day, and scheduled the precompute task to come after,
+  # so it made sense for the key to be "give me the value for this day"  but running more 
+  # frequent imports means this doesn't fit as well, and then complicates the fallback from
+  # simply "last computed value".  this no longer uses the "date" as a key, and we add this
+  # precompute task to the end of the import job.
+  def self.precomputed_student_hashes_key(authorized_student_ids, options = {})
     if options[:force_deprecated_key]
-      ['precomputed_student_hashes', timestamp, authorized_students_key].join('_')
+      timestamp = options.fetch(:time_now, Time.now).beginning_of_day.to_i
+      students_key = authorized_student_ids.sort.join(',')
+      ['precomputed_student_hashes', timestamp, students_key].join('_')
+    elsif options[:force_deprecated_day_based_key]
+      timestamp = options.fetch(:time_now, Time.now).beginning_of_day.to_i
+      students_digest = self.authorized_students_digest(authorized_student_ids)
+      ['short', timestamp, authorized_student_ids.size, students_digest].join(':')
     else
-      ['short', timestamp, authorized_student_ids.size, Digest::SHA256.hexdigest(authorized_students_key)].join(':')
+      students_digest = self.authorized_students_digest(authorized_student_ids)
+      ['continuous_for_student_ids', authorized_student_ids.size, students_digest].join(':')
     end
   end
 
+  def self.authorized_students_digest(authorized_student_ids)
+    authorized_students_key = authorized_student_ids.sort.join(',')
+    Digest::SHA256.hexdigest(authorized_students_key)
+  end
 end

--- a/app/models/precomputed_query_doc.rb
+++ b/app/models/precomputed_query_doc.rb
@@ -8,7 +8,7 @@ class PrecomputedQueryDoc < ApplicationRecord
   def self.latest_precomputed_student_hashes_for(authorized_student_ids, options = {})
     time_now = options.fetch(:time_now, Time.now)
     is_fresh_window = options.fetch(:is_fresh_window, 48.hours)
-    
+
     key = PrecomputedQueryDoc.precomputed_student_hashes_key(authorized_student_ids)
     doc = PrecomputedQueryDoc
       .where(key: key)
@@ -33,10 +33,10 @@ class PrecomputedQueryDoc < ApplicationRecord
   # 2) short / :force_deprecated_day_based_key
   # This hashes all the student_ids, since plain concatenation led to really long strings that
   # were outside the length limit for the key column.
-  # 
+  #
   # 3) continuous_for_student_ids
   # originally we ran the import every day, and scheduled the precompute task to come after,
-  # so it made sense for the key to be "give me the value for this day"  but running more 
+  # so it made sense for the key to be "give me the value for this day"  but running more
   # frequent imports means this doesn't fit as well, and then complicates the fallback from
   # simply "last computed value".  this no longer uses the "date" as a key, and we add this
   # precompute task to the end of the import job.

--- a/db/migrate/20181021171958_relax_uniquness_on_precomputed.rb
+++ b/db/migrate/20181021171958_relax_uniquness_on_precomputed.rb
@@ -1,0 +1,6 @@
+class RelaxUniqunessOnPrecomputed < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :precomputed_query_docs, :key
+    add_index :precomputed_query_docs, :key, unique: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -431,17 +431,6 @@ ActiveRecord::Schema.define(version: 2018_10_21_171958) do
     t.index ["student_id"], name: "index_student_section_assignments_on_student_id"
   end
 
-  create_table "student_section_changes", force: :cascade do |t|
-    t.string "syncer_key"
-    t.integer "student_id"
-    t.json "student_section_assignment_json"
-    t.json "section_json"
-    t.json "course_json"
-    t.json "student_json"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "student_voice_completed_surveys", force: :cascade do |t|
     t.integer "student_voice_survey_upload_id", null: false
     t.integer "student_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_16_215409) do
+ActiveRecord::Schema.define(version: 2018_10_21_171958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -320,7 +320,7 @@ ActiveRecord::Schema.define(version: 2018_10_16_215409) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "authorized_students_digest"
-    t.index ["key"], name: "index_precomputed_query_docs_on_key", unique: true
+    t.index ["key"], name: "index_precomputed_query_docs_on_key"
   end
 
   create_table "schools", id: :serial, force: :cascade do |t|
@@ -429,6 +429,17 @@ ActiveRecord::Schema.define(version: 2018_10_16_215409) do
     t.datetime "updated_at", null: false
     t.index ["section_id"], name: "index_student_section_assignments_on_section_id"
     t.index ["student_id"], name: "index_student_section_assignments_on_student_id"
+  end
+
+  create_table "student_section_changes", force: :cascade do |t|
+    t.string "syncer_key"
+    t.integer "student_id"
+    t.json "student_section_assignment_json"
+    t.json "section_json"
+    t.json "course_json"
+    t.json "student_json"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "student_voice_completed_surveys", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -111,7 +111,7 @@ end
 
 puts 'Updating indexes...'
 Student.update_recent_student_assessments
-PrecomputeStudentHashesJob.new(STDOUT).precompute_all!(Time.now)
+PrecomputeStudentHashesJob.new(STDOUT).precompute_all!
 
 puts "Total number of homerooms: #{Homeroom.count}."
 puts "Total number of students: #{Student.count}."

--- a/lib/tasks/precompute.rake
+++ b/lib/tasks/precompute.rake
@@ -1,6 +1,6 @@
 namespace :precompute do
   desc 'Precompute views of daily import data for school overview page'
   task school_overview: :environment do
-    PrecomputeStudentHashesJob.new(STDOUT).precompute_all!(Time.now)
+    PrecomputeStudentHashesJob.new(STDOUT).precompute_all!
   end
 end

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -38,12 +38,11 @@ describe SchoolsController, :type => :controller do
     let!(:pals) { TestPals.create! }
 
     it 'is successful when not precomputed, when precomputed, and the data is the same' do
-      # Verify we log to Rollbar when falling through, and that this test case does fall through only
-      # once
+      # Verify we log to Rollbar when falling through, and that this test case does fall through only once
       allow(Rollbar).to receive(:error)
       expect(Rollbar).to receive(:error).once.with("falling back to full load_precomputed_student_hashes query for current_educator: #{pals.uri.id}")
 
-      # clear any precomputing
+      # clear any precomputing to force on-demand querying
       PrecomputedQueryDoc.all.each {|doc| doc.destroy! }
 
       # querying on demand should work

--- a/spec/jobs/precompute_student_hashes_job_spec.rb
+++ b/spec/jobs/precompute_student_hashes_job_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.describe PrecomputeStudentHashesJob do
 
-  # set time at 2017-06-22 10:07:42
-  let(:time_now) { Time.at(1498126062) }
   let(:outcome) { PrecomputedQueryDoc.all }
   let(:first_json_blob) { JSON.parse!(outcome.first.json) }
   let(:log) { LogHelper::Redirect.instance.file }
@@ -15,7 +13,7 @@ RSpec.describe PrecomputeStudentHashesJob do
       let!(:educator) { FactoryBot.create(:educator, school: school, schoolwide_access: true) }
       let!(:student) { FactoryBot.create(:student, school: school) }
 
-      before { PrecomputeStudentHashesJob.new(log).precompute_all!(time_now) }
+      before { PrecomputeStudentHashesJob.new(log).precompute_all! }
 
       let(:first_json_blob_key) { first_json_blob.keys.first }
       let(:first_json_blob_value) { first_json_blob[first_json_blob_key] }
@@ -36,7 +34,7 @@ RSpec.describe PrecomputeStudentHashesJob do
       let!(:educator) { FactoryBot.create(:educator, school: school, schoolwide_access: true) }
       let!(:educator_not_schoolwide) { FactoryBot.create(:educator, school: school) }
 
-      before { PrecomputeStudentHashesJob.new(log).precompute_all!(Time.now) }
+      before { PrecomputeStudentHashesJob.new(log).precompute_all! }
 
       it 'returns an empty array' do
         expect(outcome).to eq []

--- a/spec/jobs/precompute_student_hashes_job_spec.rb
+++ b/spec/jobs/precompute_student_hashes_job_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe PrecomputeStudentHashesJob do
       log = LogHelper::FakeLog.new
       job = PrecomputeStudentHashesJob.new(log)
       doc = job.send(:precompute_and_write_doc!, { authorized_student_ids: [pals.west_eighth_ryan.id] })
-      
+
       expect(PrecomputedQueryDoc.all.size).to eq(1)
       expect(doc.as_json(only: [:key, :json, :authorized_students_digest])).to include({
         'key' => a_kind_of(String),

--- a/spec/jobs/precompute_student_hashes_job_spec.rb
+++ b/spec/jobs/precompute_student_hashes_job_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe PrecomputeStudentHashesJob do
     it 'writes the expected document shape' do
       log = LogHelper::FakeLog.new
       job = PrecomputeStudentHashesJob.new(log)
-      doc = job.send(:precompute_and_write_doc!, [pals.west_eighth_ryan.id])
+      doc = job.send(:precompute_and_write_doc!, { authorized_student_ids: [pals.west_eighth_ryan.id] })
       
       expect(PrecomputedQueryDoc.all.size).to eq(1)
       expect(doc.as_json(only: [:key, :json, :authorized_students_digest])).to include({
@@ -153,19 +153,25 @@ RSpec.describe PrecomputeStudentHashesJob do
       healey_student_hashes = PrecomputedQueryDoc.latest_precomputed_student_hashes_for([pals.healey_kindergarten_student.id])
       expect(healey_student_hashes).to contain_exactly(*[
         include({
-          id: 1,
+          id: pals.healey_kindergarten_student.id,
           grade: "KF",
-          hispanic_latino: nil,
-          race: nil,
-          free_reduced_lunch: nil,
-          homeroom_id: 1,
+          homeroom_id: pals.healey_kindergarten_student.homeroom_id,
           first_name: "Garfield",
           last_name: "Skywalker",
           state_id: "991111111",
-          home_language: nil,
-          school_id: 2,
-          registration_date: nil,
+          school_id: pals.healey.id,
           local_id: "111111111",
+          enrollment_status: "Active",
+          missing_from_last_export: false,
+          discipline_incidents_count: 0,
+          absences_count: 0,
+          tardies_count: 0,
+          homeroom_name: "HEA 003",
+          registration_date: nil,
+          home_language: nil,
+          hispanic_latino: nil,
+          race: nil,
+          free_reduced_lunch: nil,
           program_assigned: nil,
           sped_placement: nil,
           disability: nil,
@@ -180,17 +186,11 @@ RSpec.describe PrecomputeStudentHashesJob do
           most_recent_mcas_ela_scaled: nil,
           most_recent_star_reading_percentile: nil,
           most_recent_star_math_percentile: nil,
-          enrollment_status: "Active",
           date_of_birth: nil,
           gender: nil,
           house: nil,
           counselor: nil,
-          sped_liaison: nil,
-          missing_from_last_export: false,
-          discipline_incidents_count: 0,
-          absences_count: 0,
-          tardies_count: 0,
-          homeroom_name: "HEA 003"
+          sped_liaison: nil
         })
       ])
     end

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -125,36 +125,6 @@ RSpec.describe Educator do
     end
   end
 
-  describe '#students_for_school_overview' do
-    let!(:school) { FactoryBot.create(:school) }
-
-    context 'schoolwide_access' do
-      let(:educator) { FactoryBot.create(:educator, schoolwide_access: true, school: school) }
-      let!(:include_me) { FactoryBot.create(:student, school: school) }
-      let!(:include_me_too) { FactoryBot.create(:student, school: school) }
-      let!(:include_me_not) { FactoryBot.create(:student) }
-
-      let(:students_for_school_overview) { educator.students_for_school_overview }
-
-      it 'returns all students in the school' do
-        expect(students_for_school_overview).to include include_me
-        expect(students_for_school_overview).to include include_me_too
-      end
-    end
-
-    context 'has_access_to_grade_levels' do
-      let(:educator) { FactoryBot.create(:educator, grade_level_access: ['2'], school: school) }
-      let!(:include_me) { FactoryBot.create(:student, school: school, grade: '2') }
-      let!(:include_me_not) { FactoryBot.create(:student, school: school, grade: '1') }
-      let!(:include_me_not) { FactoryBot.create(:student, grade: '2') }
-
-      it 'returns students at the appropriate grade levels' do
-        expect(educator.students_for_school_overview).to include include_me
-      end
-    end
-
-  end
-
   describe '#allowed_homerooms' do
     let!(:school) { FactoryBot.create(:healey) }
     let!(:other_school) { FactoryBot.create(:brown) }

--- a/spec/models/precomputed_query_doc_spec.rb
+++ b/spec/models/precomputed_query_doc_spec.rb
@@ -1,6 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe PrecomputedQueryDoc do
+  describe '.latest_precomputed_student_hashes_for' do
+    let!(:pals) { TestPals.create! }
+    
+    it 'returns nil when no documents have been precomputed ' do
+      doc = PrecomputedQueryDoc.latest_precomputed_student_hashes_for([pals.shs_freshman_mari.id])
+      expect(doc).to eq nil
+    end
+  end
+
   describe '.authorized_students_digest' do
     it 'hashes a list of ids as a set down into a consistent space' do
       expect(PrecomputedQueryDoc.authorized_students_digest([2,1])).to eq '17f8af97ad4a7f7639a4c9171d5185cbafb85462877a4746c21bdb0a4f940ca0'

--- a/spec/models/precomputed_query_doc_spec.rb
+++ b/spec/models/precomputed_query_doc_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe PrecomputedQueryDoc do
   describe '.latest_precomputed_student_hashes_for' do
     let!(:pals) { TestPals.create! }
-    
+
     it 'returns nil when no documents have been precomputed' do
       doc = PrecomputedQueryDoc.latest_precomputed_student_hashes_for([pals.shs_freshman_mari.id])
       expect(doc).to eq nil
@@ -12,7 +12,7 @@ RSpec.describe PrecomputedQueryDoc do
     it 'does not return if document is outside freshness window' do
       time_now = Time.now
       authorized_student_ids = [pals.shs_freshman_mari.id]
-      
+
       key = PrecomputedQueryDoc.precomputed_student_hashes_key(authorized_student_ids)
       authorized_students_digest = PrecomputedQueryDoc.authorized_students_digest(authorized_student_ids)
       json_string = '{"student_hashes":"foo"}'

--- a/spec/models/precomputed_query_doc_spec.rb
+++ b/spec/models/precomputed_query_doc_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe PrecomputedQueryDoc do
+  describe '.authorized_students_digest' do
+    it 'hashes a list of ids as a set down into a consistent space' do
+      expect(PrecomputedQueryDoc.authorized_students_digest([2,1])).to eq '17f8af97ad4a7f7639a4c9171d5185cbafb85462877a4746c21bdb0a4f940ca0'
+      expect(PrecomputedQueryDoc.authorized_students_digest([1,2])).to eq '17f8af97ad4a7f7639a4c9171d5185cbafb85462877a4746c21bdb0a4f940ca0'
+      expect(PrecomputedQueryDoc.authorized_students_digest([1,2,7])).to eq '8e2e5906844adcae6ce8cea8ad8abacc85d08e77b04a2c847f4387350b375a80'
+    end
+  end
+
+  describe '.precomputed_student_hashes_key' do
+    it 'works for default' do
+      key = PrecomputedQueryDoc.precomputed_student_hashes_key([1,2,7])
+      expect(key).to eq 'continuous_for_student_ids:3:8e2e5906844adcae6ce8cea8ad8abacc85d08e77b04a2c847f4387350b375a80'
+    end
+
+    it 'works for force_deprecated_key' do
+      expect(PrecomputedQueryDoc.precomputed_student_hashes_key([1,2,7], {
+        time_now: TestPals.new.time_now,
+        force_deprecated_key: true
+      })).to eq 'precomputed_student_hashes_1520899200_1,2,7'
+    end
+
+    it 'works for force_deprecated_day_based_key' do
+      expect(PrecomputedQueryDoc.precomputed_student_hashes_key([1,2,7], {
+        time_now: TestPals.new.time_now,
+        force_deprecated_day_based_key: true
+      })).to eq 'short:1520899200:3:8e2e5906844adcae6ce8cea8ad8abacc85d08e77b04a2c847f4387350b375a80'
+    end
+  end
+end


### PR DESCRIPTION
# Who is this PR for?
schoolwide admin, mostly at SHS

# What problem does this PR fix?
There have been instances of the school roster page falling back to doing queries that should be precomputed (since they're pretty slow).  This is happening because the way this was initially written relied on some coordinated timing that may no longer be true.  This code also uses some older duplicate authorization code.

# What does this PR do?
Reworks the precomputing:

1. Adds a new keying strategy that removes the "date" from the key. Relaxes a uniqueness constraint on `key` to support this.
2. Updates the write path to use the new keying strategy, and updates the read path to query for the latest document at the key, adding in some other guardrails around freshness of the document.
3. Remove the duplicate authorization code
4. Add precompute job to indexing step at the end of the import task

# Checklists
*Which features or pages does this PR touch?*
+ [x] School Overview
+ [x] Import task

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage