### PR TITLE
Add Student migration and import ELL dates

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -271,6 +271,12 @@ class PerDistrict
     false
   end
 
+  def import_student_ell_dates?
+    return true if @district_key == SOMERVILLE
+    return true if @district_key == DEMO
+    false
+  end
+
   def import_student_photos?
     @district_key == SOMERVILLE
   end

--- a/app/importers/rows/student_row.rb
+++ b/app/importers/rows/student_row.rb
@@ -115,6 +115,13 @@ class StudentRow < Struct.new(:row, :homeroom_id, :school_ids_dictionary, :log)
       included_attributes.merge!(sped_liaison: row[:sped_liaison])
     end
 
+    if per_district.import_student_ell_dates?
+      included_attributes.merge!({
+        ell_entry_date: per_district.parse_date_during_import(row[:ell_entry_date]),
+        ell_transition_date: per_district.parse_date_during_import(row[:ell_transition_date])
+      })
+    end
+
     included_attributes
   end
 end

--- a/db/migrate/20181022191915_students_importer_ell_entry_and_transition.rb
+++ b/db/migrate/20181022191915_students_importer_ell_entry_and_transition.rb
@@ -1,0 +1,6 @@
+class StudentsImporterEllEntryAndTransition < ActiveRecord::Migration[5.2]
+  def change
+    add_column :students, :ell_entry_date, :date, null: true
+    add_column :students, :ell_transition_date, :date, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_21_171958) do
+ActiveRecord::Schema.define(version: 2018_10_22_191915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -496,6 +496,8 @@ ActiveRecord::Schema.define(version: 2018_10_21_171958) do
     t.text "counselor"
     t.text "sped_liaison"
     t.boolean "missing_from_last_export", default: false, null: false
+    t.date "ell_entry_date"
+    t.date "ell_transition_date"
     t.index ["homeroom_id"], name: "index_students_on_homeroom_id"
     t.index ["local_id"], name: "index_students_on_local_id", unique: true
     t.index ["school_id"], name: "index_students_on_school_id"

--- a/spec/importers/rows/student_row_spec.rb
+++ b/spec/importers/rows/student_row_spec.rb
@@ -81,6 +81,38 @@ RSpec.describe StudentRow do
       end
     end
 
+    context 'ELL date fields' do
+      let(:row) do
+        {
+          ell_entry_date: '2013-09-24',
+          ell_transition_date: '2015-06-28',
+          limited_english_proficiency: 'FLEP',
+          full_name: 'Martinez, Juan'
+        } 
+      end
+
+      it 'correctly sets ELL date fields on the Student record' do
+        expect(student.ell_entry_date).to eq Date.parse('2013-09-24')
+        expect(student.ell_transition_date).to eq Date.parse('2015-06-28')
+        expect(student.limited_english_proficiency).to eq 'FLEP'
+      end
+    end
+
+    context 'when no ELL date fields' do
+      let(:row) do
+        {
+          limited_english_proficiency: 'FLEP',
+          full_name: 'Martinez, Juan'
+        } 
+      end
+
+      it 'does not raise and sets the ELL date fields as nil on the Student record' do
+        expect(student.ell_entry_date).to eq nil
+        expect(student.ell_transition_date).to eq nil
+        expect(student.limited_english_proficiency).to eq 'FLEP'
+      end
+    end
+
     context 'when PerDistrict attributes are not exported' do
       before do
         mock_per_district = PerDistrict.new


### PR DESCRIPTION
Part of https://github.com/studentinsights/studentinsights/issues/2204.

Follow-on to https://github.com/studentinsights/studentinsights/pull/2205, import these ELL dates for Somerville.  Showing them in the product would be next.

# Checklists
+ [x] Included specs for changes
