### PR TITLE
Support mapping from Google email address to Insights/SIS/LDAP email in form importer

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -336,7 +336,7 @@ class PerDistrict
   # as the in the district SIS or LDAP system (eg, a name change happens in one system
   # but not the other).  This allow mapping one way from Google email > Educator#email
   def google_email_address_mapping
-    JSON.parse(ENV['GOOGLE_EMAIL_ADDRESS_MAPPING'] || '{}')
+    JSON.parse(ENV.fetch('GOOGLE_EMAIL_ADDRESS_MAPPING_JSON', '{}'))
   end
 
   private

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -332,6 +332,13 @@ class PerDistrict
     'SUMMER'
   end
 
+  # When importing data from Google Forms, educator emails may not be the same
+  # as the in the district SIS or LDAP system (eg, a name change happens in one system
+  # but not the other).  This allow mapping one way from Google email > Educator#email
+  def google_email_address_mapping
+    JSON.parse(ENV['GOOGLE_EMAIL_ADDRESS_MAPPING'] || '{}')
+  end
+
   private
   def yaml
     config_map = {


### PR DESCRIPTION
# Who is this PR for?
HS educators, for student meetings

# What problem does this PR fix?
Right now importing this needs a manual step to map between differences in email addresses within district Google systems and SIS/LDAP systems.  This is likely from people changing names.

# What does this PR do?
Adds a mapping step, where this map can be set in an ENV variable for now.

# Checklists
+ [x] Student meeting imports
+ [x] Included specs for changes
+ [x] Manual testing made more sense here