### PR TITLE
StudentsImporter: Workaround upstream data quality bug for Bedford

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -339,6 +339,15 @@ class PerDistrict
     JSON.parse(ENV.fetch('GOOGLE_EMAIL_ADDRESS_MAPPING_JSON', '{}'))
   end
 
+  # For Bedford, we should fix this upstream with them
+  def map_free_reduced_lunch_value_as_workaround(free_reduced_lunch_value)
+    if @district_key == BEDFORD && free_reduced_lunch_value == 'Not Eligibile'
+      'Not Eligible'
+    else
+      free_reduced_lunch_value
+    end
+  end
+
   private
   def yaml
     config_map = {

--- a/app/importers/rows/student_row.rb
+++ b/app/importers/rows/student_row.rb
@@ -52,24 +52,26 @@ class StudentRow < Struct.new(:row, :homeroom_id, :school_ids_dictionary, :log)
       :sped_level_of_need,
       :plan_504,
       :student_address,
-      :free_reduced_lunch,
       :race,
       :hispanic_latino,
       :gender,
       :primary_phone,
       :primary_email,
     ].map do |key|
-      value = row[key]
-      if value.nil? # set nil if column not in import
-        attrs[key] = nil
-      elsif value == '' # set nil if column is in import, but there's an empty string value
-        attrs[key] = nil
-      else
-        attrs[key] = value
-      end
+      attrs[key] = map_empty_to_nil(row[key])
     end
 
     attrs
+  end
+
+  def map_empty_to_nil(value)
+    if value.nil? # set nil if column not in import
+      nil
+    elsif value == '' # set nil if column is in import, but there's an empty string value
+      nil
+    else
+      value
+    end
   end
 
   def school_attributes
@@ -99,7 +101,8 @@ class StudentRow < Struct.new(:row, :homeroom_id, :school_ids_dictionary, :log)
     # date parsing
     included_attributes = {
       registration_date: per_district.parse_date_during_import(row[:registration_date]),
-      date_of_birth: per_district.parse_date_during_import(row[:date_of_birth])
+      date_of_birth: per_district.parse_date_during_import(row[:date_of_birth]),
+      free_reduced_lunch: per_district.map_free_reduced_lunch_value_as_workaround(map_empty_to_nil(row[:free_reduced_lunch]))
     }
 
     if per_district.import_student_house?


### PR DESCRIPTION
# Who is this PR for?
Bedford educators

# What problem does this PR fix?
One Bedford educator reported not all students were appearing on the school roster page.  In looking at this, it appears there are three separate issues interacting.

First, the Bedford export scripts are exporting "Not Eligibile" (with typo) for the `free_and_reduced_lunch` field.  This results in a violation of the Insights validations, and the record is not imported.  This is a bug upstream in their data systems or the export code.

Second, the `RecordSyncer` in Insights handles incoming validation failures by not marking the record as synced (see comments in `#validate_mark_and_sync`).  This is intentional, and I think still what we want here, but can result in large numbers of records being removed if the validation changes or there are upstream data quality issues.  We log stats on this, but there's no monitoring of large changes here (like this case where the logs show `:validation_failure_counts_by_field=>{:free_reduced_lunch=>1052}`).

Third, for Bedford `StudentsImporter` marks student records that are missing from the current export with `missing_from_last_export: true`.  This will happen if the record is invalid and not marked.  While other importers would delete the record, `StudentsImporter` preserves these records, and doesn't currently handle cases where the Student record is marked as missing, but then comes back.  This meant that in order to address this issue for Bedford, I manually flipped `missing_from_last_export` for these records, but this should be handled by the import process.

# What does this PR do?
Adds a mapping to work around the upstream data quality bug for now.  We can resolve the upstream error with Bedford staff separately.

A separate PR, https://github.com/studentinsights/studentinsights/compare/patch/missing-from-last-export-students-importer?expand=1, updates `StudentRow` to set `missing_from_last_export: false` for imported rows, depending on the export setting for the district.

# Checklists
+ [x] Core student data

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes