### PR TITLE
StudentsImporter: Update StudentRow to set missing_from_export: false depending on export config

### DIFF
--- a/app/importers/helpers/record_syncer.rb
+++ b/app/importers/helpers/record_syncer.rb
@@ -107,6 +107,13 @@ class RecordSyncer
     records_to_process.size
   end
 
+  def process_marked_records!(&block)
+    log('process_marked_records! starting...')
+    block.call(@marked_ids)
+    log('process_marked_records! done.')
+    @marked_ids.size
+  end
+
   # For debugging and testing - total counts for instance lifetime
   def stats
     {

--- a/app/importers/rows/student_row.rb
+++ b/app/importers/rows/student_row.rb
@@ -21,11 +21,24 @@ class StudentRow < Struct.new(:row, :homeroom_id, :school_ids_dictionary, :log)
 
   def attributes
     demographic_attributes
+      .merge(import_metadata_attributes)
       .merge(name_attributes)
       .merge(school_attributes)
       .merge(per_district_attributes)
       .merge({ grade: grade })
       .merge({ homeroom_id: homeroom_id })
+  end
+
+  # If the district does not always send all student records in the export,
+  # update any rows we read in to indicate that they were present in this
+  # export.
+  # See also the way `RecordSyncer#process_unmarked_records` is used in `StudentsImporter`.
+  def import_metadata_attributes
+    if PerDistrict.new.does_students_export_include_rows_for_inactive_students?
+      {}
+    else
+      { missing_from_last_export: false }
+    end
   end
 
   def name_attributes

--- a/spec/importers/rows/student_row_spec.rb
+++ b/spec/importers/rows/student_row_spec.rb
@@ -131,6 +131,26 @@ RSpec.describe StudentRow do
         expect(student.sped_liaison).to eq nil
       end
     end
+
+    it 'updates missing_from_last_export to false' do
+      expect(StudentRow.build({ full_name: 'Hoag, George' }).missing_from_last_export).to eq false
+    end
+  end
+
+  describe '#import_metadata_attributes' do
+    it 'sets missing_from_last_export when district does not always export all rows' do
+      mock_per_district = PerDistrict.new
+      allow(mock_per_district).to receive(:does_students_export_include_rows_for_inactive_students?).and_return(false)
+      allow(PerDistrict).to receive(:new).and_return(mock_per_district)
+      expect(StudentRow.new({ full_name: 'Hoag, George' }).send(:import_metadata_attributes)).to eq(missing_from_last_export: false)
+    end
+
+    it 'does not set missing_from_last_export if district always exports all rows' do
+      mock_per_district = PerDistrict.new
+      allow(mock_per_district).to receive(:does_students_export_include_rows_for_inactive_students?).and_return(true)
+      allow(PerDistrict).to receive(:new).and_return(mock_per_district)
+      expect(StudentRow.new({ full_name: 'Hoag, George' }).send(:import_metadata_attributes)).to eq({})
+    end
   end
 
 end


### PR DESCRIPTION
Related to https://github.com/studentinsights/studentinsights/pull/2211/files, but split out to see the diffs.  See that PR for description.

Updates `StudentRow` to set `missing_from_last_export: false` for imported rows, depending on the export setting for the district.