### PR TITLE
RecordSyncer: Notify on changes outside expected norms

### DIFF
--- a/app/importers/file_importers/behavior_importer.rb
+++ b/app/importers/file_importers/behavior_importer.rb
@@ -5,6 +5,7 @@ class BehaviorImporter
     @log = options.fetch(:log)
     @inclusive_date_range = create_inclusive_date_range(options)
     @record_syncer = ::RecordSyncer.new(log: @log)
+    reset_counters!
   end
 
   def import
@@ -15,11 +16,7 @@ class BehaviorImporter
     ).get_data
 
     log('Starting loop...')
-    @skipped_from_school_filter = 0
-    @skipped_from_invalid_student_id = 0
-    @skipped_old_rows_count = 0
-    @invalid_rows_count = 0
-    @touched_rows_count = 0
+    reset_counters!
 
     streaming_csv.each_with_index do |row, index|
       import_row(row)
@@ -40,6 +37,14 @@ class BehaviorImporter
   end
 
   private
+  def reset_counters!
+    @skipped_from_school_filter = 0
+    @skipped_from_invalid_student_id = 0
+    @skipped_old_rows_count = 0
+    @invalid_rows_count = 0
+    @touched_rows_count = 0
+  end
+
   def create_inclusive_date_range(options)
     time_window = options.fetch(:time_window, 90.days)
     time_now = options.fetch(:time_now, Time.now)

--- a/app/importers/helpers/record_syncer.rb
+++ b/app/importers/helpers/record_syncer.rb
@@ -37,7 +37,7 @@ class RecordSyncer
     raise 'already set has_processed_unmarked_records' if @has_processed_unmarked_records
 
     # Always count this
-    @total_sync_calls_count += 1 
+    @total_sync_calls_count += 1
 
     # Passed nil, something failed upstream
     if insights_record.nil?
@@ -184,7 +184,7 @@ class RecordSyncer
     @alert_on_stats.each do |key|
       count = computed_stats[key]
       next if count == 0
-      
+
       percentage = (count.to_f / @total_sync_calls_count)
       next unless @alert_tuning.should_alert?(key, count, percentage)
 

--- a/spec/importers/helpers/record_syncer_spec.rb
+++ b/spec/importers/helpers/record_syncer_spec.rb
@@ -195,6 +195,7 @@ RSpec.describe RecordSyncer do
         RecordSyncer:   @marked_ids.size = 2 from this import
         RecordSyncer:   unmarked_ids: [#{c.id}]
         RecordSyncer:   records_to_process.size: 1 within scope
+        RecordSyncer:   checking if stats seem outside expected bounds...
         RecordSyncer: process_unmarked_records done.
         RecordSyncer: delete_unmarked_records done.
       HEREDOC

--- a/spec/importers/helpers/record_syncer_spec.rb
+++ b/spec/importers/helpers/record_syncer_spec.rb
@@ -28,12 +28,14 @@ RSpec.describe RecordSyncer do
       syncer = make_syncer
       expect(syncer.validate_mark_and_sync!(nil)).to eq(:nil)
       expect(syncer.stats).to eq({
+        total_sync_calls_count: 1,
         passed_nil_record_count: 1,
         invalid_rows_count: 0,
         validation_failure_counts_by_field: {},
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
+        has_processed_unmarked_records: false,
         marked_ids_count: 0,
         destroyed_records_count: 0
       })
@@ -43,6 +45,7 @@ RSpec.describe RecordSyncer do
       syncer = make_syncer
       expect(syncer.validate_mark_and_sync!(Absence.new)).to eq(:invalid)
       expect(syncer.stats).to eq({
+        total_sync_calls_count: 1,
         passed_nil_record_count: 0,
         invalid_rows_count: 1,
         validation_failure_counts_by_field: {
@@ -52,6 +55,7 @@ RSpec.describe RecordSyncer do
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
+        has_processed_unmarked_records: false,
         marked_ids_count: 0,
         destroyed_records_count: 0
       })
@@ -63,6 +67,7 @@ RSpec.describe RecordSyncer do
       absence.assign_attributes(student: nil)
       expect(syncer.validate_mark_and_sync!(absence)).to eq(:invalid)
       expect(syncer.stats).to eq({
+        total_sync_calls_count: 1,
         passed_nil_record_count: 0,
         invalid_rows_count: 1,
         validation_failure_counts_by_field: {
@@ -71,6 +76,7 @@ RSpec.describe RecordSyncer do
         unchanged_rows_count: 0,
         updated_rows_count: 0,
         created_rows_count: 0,
+        has_processed_unmarked_records: false,
         marked_ids_count: 0,
         destroyed_records_count: 0
       })
@@ -81,6 +87,7 @@ RSpec.describe RecordSyncer do
       absence = create_test_absence!
       expect(syncer.validate_mark_and_sync!(absence)).to eq(:unchanged)
       expect(syncer.stats).to eq({
+        total_sync_calls_count: 1,
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
         validation_failure_counts_by_field: {},
@@ -88,6 +95,7 @@ RSpec.describe RecordSyncer do
         updated_rows_count: 0,
         created_rows_count: 0,
         marked_ids_count: 1,
+        has_processed_unmarked_records: false,
         destroyed_records_count: 0
       })
     end
@@ -98,6 +106,7 @@ RSpec.describe RecordSyncer do
       absence.assign_attributes(reason: 'new reason added!')
       expect(syncer.validate_mark_and_sync!(absence)).to eq(:updated)
       expect(syncer.stats).to eq({
+        total_sync_calls_count: 1,
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
         validation_failure_counts_by_field: {},
@@ -105,6 +114,7 @@ RSpec.describe RecordSyncer do
         updated_rows_count: 1,
         created_rows_count: 0,
         marked_ids_count: 1,
+        has_processed_unmarked_records: false,
         destroyed_records_count: 0
       })
     end
@@ -114,6 +124,7 @@ RSpec.describe RecordSyncer do
       absence = new_test_absence
       expect(syncer.validate_mark_and_sync!(absence)).to eq(:created)
       expect(syncer.stats).to eq({
+        total_sync_calls_count: 1,
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
         validation_failure_counts_by_field: {},
@@ -121,6 +132,7 @@ RSpec.describe RecordSyncer do
         updated_rows_count: 0,
         created_rows_count: 1,
         marked_ids_count: 1,
+        has_processed_unmarked_records: false,
         destroyed_records_count: 0
       })
       expect(syncer.instance_variable_get(:@marked_ids)).to eq [absence.id]
@@ -163,6 +175,7 @@ RSpec.describe RecordSyncer do
       expect(Absence.count).to eq(1)
 
       expect(syncer.stats).to eq({
+        total_sync_calls_count: 0,
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
         validation_failure_counts_by_field: {},
@@ -170,6 +183,7 @@ RSpec.describe RecordSyncer do
         updated_rows_count: 0,
         created_rows_count: 0,
         marked_ids_count: 0,
+        has_processed_unmarked_records: true,
         destroyed_records_count: 0
       })
     end
@@ -202,6 +216,7 @@ RSpec.describe RecordSyncer do
       expect(log.output).to eq expected_log_output.strip
 
       expect(syncer.stats).to eq({
+        total_sync_calls_count: 2,
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
         validation_failure_counts_by_field: {},
@@ -209,6 +224,7 @@ RSpec.describe RecordSyncer do
         updated_rows_count: 0,
         created_rows_count: 0,
         marked_ids_count: 2,
+        has_processed_unmarked_records: true,
         destroyed_records_count: 1
       })
     end
@@ -223,6 +239,7 @@ RSpec.describe RecordSyncer do
       expect(Absence.count).to eq(0)
 
       expect(syncer.stats).to eq({
+        total_sync_calls_count: 0,
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
         validation_failure_counts_by_field: {},
@@ -230,6 +247,7 @@ RSpec.describe RecordSyncer do
         updated_rows_count: 0,
         created_rows_count: 0,
         marked_ids_count: 0,
+        has_processed_unmarked_records: true,
         destroyed_records_count: 5
       })
     end
@@ -243,6 +261,7 @@ RSpec.describe RecordSyncer do
       expect(syncer.delete_unmarked_records!(Absence.all)).to eq(0)
 
       expect(syncer.stats).to eq({
+        total_sync_calls_count: 1,
         passed_nil_record_count: 0,
         invalid_rows_count: 0,
         validation_failure_counts_by_field: {},
@@ -250,6 +269,7 @@ RSpec.describe RecordSyncer do
         updated_rows_count: 0,
         created_rows_count: 1,
         marked_ids_count: 1,
+        has_processed_unmarked_records: true,
         destroyed_records_count: 0
       })
     end
@@ -265,6 +285,7 @@ RSpec.describe RecordSyncer do
       expect(Absence.count).to eq(0)
 
       expect(syncer.stats).to eq({
+        total_sync_calls_count: 1,
         passed_nil_record_count: 0,
         invalid_rows_count: 1,
         validation_failure_counts_by_field: {
@@ -274,6 +295,7 @@ RSpec.describe RecordSyncer do
         updated_rows_count: 0,
         created_rows_count: 0,
         marked_ids_count: 0,
+        has_processed_unmarked_records: true,
         destroyed_records_count: 1
       })
     end
@@ -326,6 +348,7 @@ RSpec.describe RecordSyncer do
         created_rows_count: 13,
         marked_ids_count: 83,
         destroyed_records_count: 0,
+        has_processed_unmarked_records: true,
         validation_failure_counts_by_field: {
           student_id: 17
         }
@@ -354,6 +377,7 @@ RSpec.describe RecordSyncer do
         created_rows_count: 6,
         marked_ids_count: 96,
         destroyed_records_count: 0,
+        has_processed_unmarked_records: true,
         validation_failure_counts_by_field: {
           student_id: 4
         }

--- a/spec/importers/survey_note_importer/student_meeting_importer_spec.rb
+++ b/spec/importers/survey_note_importer/student_meeting_importer_spec.rb
@@ -24,14 +24,16 @@ RSpec.describe StudentMeetingImporter do
         }
       ])
       expect(syncer.send(:stats)).to eq({
-        :created_rows_count => 2,
-        :destroyed_records_count => 0,
-        :invalid_rows_count => 0,
-        :marked_ids_count => 2,
-        :passed_nil_record_count => 0,
-        :unchanged_rows_count => 0,
-        :updated_rows_count => 0,
-        :validation_failure_counts_by_field => {},
+        total_sync_calls_count: 2,
+        created_rows_count: 2,
+        destroyed_records_count: 0,
+        invalid_rows_count: 0,
+        marked_ids_count: 2,
+        passed_nil_record_count: 0,
+        unchanged_rows_count: 0,
+        updated_rows_count: 0,
+        has_processed_unmarked_records: true,
+        validation_failure_counts_by_field: {},
       })
     end
 
@@ -41,14 +43,16 @@ RSpec.describe StudentMeetingImporter do
       # first run
       first_survey, first_syncer = StudentMeetingImporter.new.import(fixture_file_text)
       expect(first_syncer.send(:stats)).to eq({
-        :created_rows_count => 2,
-        :destroyed_records_count => 0,
-        :invalid_rows_count => 0,
-        :marked_ids_count => 2,
-        :passed_nil_record_count => 0,
-        :unchanged_rows_count => 0,
-        :updated_rows_count => 0,
-        :validation_failure_counts_by_field => {},
+        total_sync_calls_count: 2,
+        created_rows_count: 2,
+        destroyed_records_count: 0,
+        invalid_rows_count: 0,
+        marked_ids_count: 2,
+        passed_nil_record_count: 0,
+        unchanged_rows_count: 0,
+        updated_rows_count: 0,
+        has_processed_unmarked_records: true,
+        validation_failure_counts_by_field: {},
       })
       first_records_json = EventNote.all.as_json
       expect(first_records_json.size).to eq 2
@@ -56,14 +60,16 @@ RSpec.describe StudentMeetingImporter do
       # second run
       second_survey, second_syncer = StudentMeetingImporter.new.import(fixture_file_text)
       expect(second_syncer.send(:stats)).to eq({
-        :created_rows_count => 0,
-        :destroyed_records_count => 0,
-        :invalid_rows_count => 0,
-        :marked_ids_count => 2,
-        :passed_nil_record_count => 0,
-        :unchanged_rows_count => 2,
-        :updated_rows_count => 0,
-        :validation_failure_counts_by_field => {},
+        total_sync_calls_count: 2,
+        created_rows_count: 0,
+        destroyed_records_count: 0,
+        invalid_rows_count: 0,
+        marked_ids_count: 2,
+        passed_nil_record_count: 0,
+        unchanged_rows_count: 2,
+        updated_rows_count: 0,
+        has_processed_unmarked_records: true,
+        validation_failure_counts_by_field: {},
       })
       second_records_json = EventNote.all.as_json
       expect(second_records_json).to eq first_records_json
@@ -75,14 +81,16 @@ RSpec.describe StudentMeetingImporter do
 
       survey, syncer = StudentMeetingImporter.new.import(fixture_file_text)
       expect(syncer.send(:stats)).to eq({
-        :created_rows_count => 2,
-        :destroyed_records_count => 0,
-        :invalid_rows_count => 0,
-        :marked_ids_count => 2,
-        :passed_nil_record_count => 0,
-        :unchanged_rows_count => 0,
-        :updated_rows_count => 0,
-        :validation_failure_counts_by_field => {},
+        total_sync_calls_count: 2,
+        created_rows_count: 2,
+        destroyed_records_count: 0,
+        invalid_rows_count: 0,
+        marked_ids_count: 2,
+        passed_nil_record_count: 0,
+        unchanged_rows_count: 0,
+        updated_rows_count: 0,
+        has_processed_unmarked_records: true,
+        validation_failure_counts_by_field: {},
       })
       expect(EventNote.all.size).to eq 6
     end
@@ -98,14 +106,16 @@ RSpec.describe StudentMeetingImporter do
       file_text = fixture_file_text.split("\n").first + "\n" + '"03/05/2018 08:11:11","fatima_google@demo.studentinsights.org","Amir Solo","Fatima Teacher","2222222211   ","Biology, Spanish","one","two","three","four","five","six","seven"'
       survey, syncer = StudentMeetingImporter.new.import(file_text)
       expect(syncer.send(:stats)).to eq({
-        :created_rows_count => 1,
-        :destroyed_records_count => 0,
-        :invalid_rows_count => 0,
-        :marked_ids_count => 1,
-        :passed_nil_record_count => 0,
-        :unchanged_rows_count => 0,
-        :updated_rows_count => 0,
-        :validation_failure_counts_by_field => {},
+        total_sync_calls_count: 1,
+        created_rows_count: 1,
+        destroyed_records_count: 0,
+        invalid_rows_count: 0,
+        marked_ids_count: 1,
+        passed_nil_record_count: 0,
+        unchanged_rows_count: 0,
+        updated_rows_count: 0,
+        has_processed_unmarked_records: true,
+        validation_failure_counts_by_field: {},
       })
       expect(EventNote.all.size).to eq 1
       expect(EventNote.first.educator_id).to eq pals.shs_fatima_science_teacher.id


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
We collect stats on what happens in each call to `RecordSyncer` and log data on this, but if there are unexpected outcomes we aren't proactively alerted.

# What does this PR do?
Adds basic alerting through Rollbar if changes are above an absolute and percentage threshold.  Adds integration tests, and also adds guardrails to help ensure proper `RecordSyncer` usage.

Also updates `BehaviorImporter` to fix improper re-use of importer and syncer during spec, factor out `reset_counters!` and isolate specs.
# Checklists
+ [x] Core 

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage