### PR TITLE
Update profile to only render homeroom as link when meaningful

### DIFF
--- a/app/assets/javascripts/student_profile/LightProfileHeader.js
+++ b/app/assets/javascripts/student_profile/LightProfileHeader.js
@@ -5,7 +5,8 @@ import {AutoSizer} from 'react-virtualized';
 import * as Routes from '../helpers/Routes';
 import {
   hasStudentPhotos,
-  supportsHouse
+  supportsHouse,
+  isHomeroomMeaningful
 } from '../helpers/PerDistrict';
 import HelpBubble, {
   modalFromLeft,
@@ -128,22 +129,33 @@ export default class LightProfileHeader extends React.Component {
 
   renderHomeroomOrEnrollmentStatus() {
     const student =  this.props.student;
-    if (student.enrollment_status === 'Active') {
-      if (student.homeroom_name) return (
+
+    // Not enrolled
+    if (student.enrollment_status !== 'Active') {
+      return (
+        <span style={styles.subtitleItem}>
+          {student.enrollment_status}
+        </span>
+      );
+    }
+
+    // No homeroom set
+    if (!student.homeroom_name) {
+      return <span style={styles.subtitleItem}>No homeroom</span>;
+    }
+
+    // Render as link or plain text (HS homeroom doesn't mean anything, and authorization
+    // rules are more complex).
+    if (!isHomeroomMeaningful(student.school_type)) {
+      return <span style={styles.subtitleItem}>{'Homeroom ' + student.homeroom_name}</span>;
+    } else {
+      return (
         <a
           className="homeroom-link"
           href={Routes.homeroom(student.homeroom_id)}
           style={styles.subtitleItem}>
           {'Homeroom ' + student.homeroom_name}
         </a>
-      );
-
-      return (<span style={styles.subtitleItem}>No homeroom</span>);
-    } else {
-      return (
-        <span style={styles.subtitleItem}>
-          {student.enrollment_status}
-        </span>
       );
     }
   }
@@ -292,6 +304,7 @@ LightProfileHeader.propTypes = {
     sped_liaison: PropTypes.string,
     homeroom_id: PropTypes.number,
     school_name: PropTypes.string,
+    school_type: PropTypes.string,
     school_local_id: PropTypes.string,
     homeroom_name: PropTypes.string,
     has_photo: PropTypes.bool

--- a/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
@@ -128,9 +128,7 @@ exports[`snapshots works for aladdin grades 1`] = `
           >
             Aladdin Mouse
           </a>
-          <a
-            className="homeroom-link"
-            href="/homerooms/4"
+          <span
             style={
               Object {
                 "display": "inline-block",
@@ -139,7 +137,7 @@ exports[`snapshots works for aladdin grades 1`] = `
             }
           >
             Homeroom SHS ALL
-          </a>
+          </span>
           <div
             style={
               Object {
@@ -1202,9 +1200,7 @@ exports[`snapshots works for aladdin notes 1`] = `
           >
             Aladdin Mouse
           </a>
-          <a
-            className="homeroom-link"
-            href="/homerooms/4"
+          <span
             style={
               Object {
                 "display": "inline-block",
@@ -1213,7 +1209,7 @@ exports[`snapshots works for aladdin notes 1`] = `
             }
           >
             Homeroom SHS ALL
-          </a>
+          </span>
           <div
             style={
               Object {
@@ -2276,9 +2272,7 @@ exports[`snapshots works for aladdin testing 1`] = `
           >
             Aladdin Mouse
           </a>
-          <a
-            className="homeroom-link"
-            href="/homerooms/4"
+          <span
             style={
               Object {
                 "display": "inline-block",
@@ -2287,7 +2281,7 @@ exports[`snapshots works for aladdin testing 1`] = `
             }
           >
             Homeroom SHS ALL
-          </a>
+          </span>
           <div
             style={
               Object {


### PR DESCRIPTION
# Who is this PR for?
HS educators

# What problem does this PR fix?
The profile page shows links to the homeroom page, but this isn't meaningful for HS teachers.  Worse, it leads to them clicking the link and possibly not having authorization to see the homeroom and seeing an error.

# What does this PR do?
Removes the link if homerooms aren't meaningful for that student's school type.

# Screenshot (if adding a client-side feature)
### HS
<img width="409" alt="screen shot 2018-10-29 at 2 13 25 pm" src="https://user-images.githubusercontent.com/1056957/47671017-053fca00-db85-11e8-972d-b1245e7aa3a3.png">

### K8
<img width="385" alt="screen shot 2018-10-29 at 2 13 22 pm" src="https://user-images.githubusercontent.com/1056957/47671021-083aba80-db85-11e8-9efb-ae18e3620f3d.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here