### PR TITLE
Allow querying on demand for school overview, and echo that back

### DIFF
--- a/app/assets/javascripts/school_overview/SchoolRosterPage.js
+++ b/app/assets/javascripts/school_overview/SchoolRosterPage.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import qs from 'query-string';
 import {apiFetchJson} from '../helpers/apiFetchJson';
 import GenericLoader from '../components/GenericLoader';
 import SchoolRoster from './SchoolRoster';
@@ -17,7 +18,11 @@ export default class SchoolRosterPage extends React.Component {
 
   fetchJson() {
     const {schoolIdOrSlug} = this.props;
-    const url = `/schools/${schoolIdOrSlug}/overview_json`;
+    const queryParams = qs.parse(window.location.search.slice(1));
+    const queryString = queryParams.force_querying_on_demand
+      ? `?${qs.stringify({ force_querying_on_demand: true })}`
+      : '';
+    const url = `/schools/${schoolIdOrSlug}/overview_json${queryString}`;
     return apiFetchJson(url);
   }
 

--- a/app/lib/school_overview_queries.rb
+++ b/app/lib/school_overview_queries.rb
@@ -36,7 +36,8 @@ class SchoolOverviewQueries
       school: school,
       district_key: PerDistrict.new.district_key,
       current_educator: educator,
-      constant_indexes: constant_indexes
+      constant_indexes: constant_indexes,
+      force_querying_on_demand: force_querying_on_demand
     }
   end
 

--- a/app/lib/school_overview_queries.rb
+++ b/app/lib/school_overview_queries.rb
@@ -37,7 +37,7 @@ class SchoolOverviewQueries
       district_key: PerDistrict.new.district_key,
       current_educator: educator,
       constant_indexes: constant_indexes,
-      force_querying_on_demand: force_querying_on_demand
+      force_querying_on_demand: @force_querying_on_demand
     }
   end
 

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -28,6 +28,7 @@ describe SchoolsController, :type => :controller do
         "students",
         "school",
         "district_key",
+        "force_querying_on_demand",
         "current_educator",
         "constant_indexes"
       ])
@@ -53,6 +54,7 @@ describe SchoolsController, :type => :controller do
         "students",
         "school",
         "district_key",
+        "force_querying_on_demand",
         "current_educator",
         "constant_indexes"
       ])
@@ -71,6 +73,7 @@ describe SchoolsController, :type => :controller do
         "students",
         "school",
         "district_key",
+        "force_querying_on_demand",
         "current_educator",
         "constant_indexes"
       ])


### PR DESCRIPTION
Follow on to https://github.com/studentinsights/studentinsights/pull/2215, which forgot to thread query param from HTML page to api request.