### PR TITLE
StudentsImporter: Improve improting for house, sped liaison, counselor and update validations

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -269,11 +269,11 @@ class PerDistrict
   # the full name).
   def parse_counselor_during_import(value)
     if @district_key == SOMERVILLE # eg, Robinson, Kevin
-      if row[:counselor] then row[:counselor].split(',').first else nil end
+      if value then value.split(',').first else nil end
     elsif @district_key == BEDFORD # eg, Kevin Robinson
-      if row[:counselor] then row[:counselor].split(' ').last else nil end
+      if value then value.split(' ').last else nil end
     else
-      if row[:counselor] == '' then nil else row[:counselor] end
+      raise_not_handled!
     end
   end
 
@@ -283,6 +283,7 @@ class PerDistrict
     false
   end
 
+  # Bedford exports "N/A" for all students
   def parse_sped_liaison_during_import(value)
     if @district_key == BEDFORD
       if value.try(:upcase) == "N/A" then nil else value end

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -264,11 +264,31 @@ class PerDistrict
     false
   end
 
+  # This always gets just the last name (there's no reason for this, it's just
+  # historical for what this did in Somerville and could be changed to import
+  # the full name).
+  def parse_counselor_during_import(value)
+    if @district_key == SOMERVILLE # eg, Robinson, Kevin
+      if row[:counselor] then row[:counselor].split(',').first else nil end
+    elsif @district_key == BEDFORD # eg, Kevin Robinson
+      if row[:counselor] then row[:counselor].split(' ').last else nil end
+    else
+      if row[:counselor] == '' then nil else row[:counselor] end
+    end
+  end
+
   def import_student_sped_liaison?
     return true if @district_key == SOMERVILLE
-    return true if @district_key == BEDFORD
     return true if @district_key == DEMO
     false
+  end
+
+  def parse_sped_liaison_during_import(value)
+    if @district_key == BEDFORD
+      if value.try(:upcase) == "N/A" then nil else value end
+    else
+      value
+    end
   end
 
   def import_student_ell_dates?

--- a/app/importers/rows/student_row.rb
+++ b/app/importers/rows/student_row.rb
@@ -119,16 +119,15 @@ class StudentRow < Struct.new(:row, :homeroom_id, :school_ids_dictionary, :log)
     }
 
     if per_district.import_student_house?
-      included_attributes.merge!(house: row[:house])
+      included_attributes.merge!(house: map_empty_to_nil(row[:house]))
     end
 
     if per_district.import_student_counselor?
-      counselor_last_name = if row[:counselor] then row[:counselor].split(",")[0] else nil end
-      included_attributes.merge!(counselor: counselor_last_name)
+      included_attributes.merge!(counselor: per_district.parse_counselor_during_import(row[:counselor]))
     end
 
     if per_district.import_student_sped_liaison?
-      included_attributes.merge!(sped_liaison: row[:sped_liaison])
+      included_attributes.merge!(sped_liaison: per_district.parse_sped_liaison_during_import(row[:sped_liaison]))
     end
 
     if per_district.import_student_ell_dates?

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -58,6 +58,9 @@ class Student < ApplicationRecord
   validates :gender, exclusion: { in: ['']}
   validates :primary_phone, exclusion: { in: ['']}
   validates :primary_email, exclusion: { in: ['']}
+  validates :sped_liaison, exclusion: { in: ['']}
+  validates :house, exclusion: { in: ['']}
+  validates :counselor, exclusion: { in: ['']}
 
   def self.with_school
     where.not(school: nil)

--- a/spec/config_objects/per_district_spec.rb
+++ b/spec/config_objects/per_district_spec.rb
@@ -129,4 +129,19 @@ RSpec.describe PerDistrict do
       expect(PerDistrict.new.current_quarter(DateTime.new(2018, 6, 24))).to eq 'SUMMER'
     end
   end
+
+  describe '#parse_counselor_during_import' do
+    it 'works' do
+      expect(for_somerville.parse_counselor_during_import('Robinson, Kevin')).to eq 'Robinson'
+      expect(for_bedford.parse_counselor_during_import('Kevin Robinson')).to eq 'Robinson'
+      expect { for_new_bedford.parse_counselor_during_import('Kevin Robinson') }.to raise_error Exceptions::DistrictKeyNotHandledError
+    end
+  end   
+
+  describe '#parse_sped_liaison_during_import' do
+    it 'works' do
+      expect(for_somerville.parse_sped_liaison_during_import('N/a')).to eq 'N/a'
+      expect(for_bedford.parse_sped_liaison_during_import('N/a')).to eq nil
+    end
+  end
 end

--- a/spec/config_objects/per_district_spec.rb
+++ b/spec/config_objects/per_district_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe PerDistrict do
       expect(for_bedford.parse_counselor_during_import('Kevin Robinson')).to eq 'Robinson'
       expect { for_new_bedford.parse_counselor_during_import('Kevin Robinson') }.to raise_error Exceptions::DistrictKeyNotHandledError
     end
-  end   
+  end
 
   describe '#parse_sped_liaison_during_import' do
     it 'works' do

--- a/spec/importers/file_importers/students_importer_spec.rb
+++ b/spec/importers/file_importers/students_importer_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe StudentsImporter do
           expect(first_student.race).to eq 'Black'
           expect(first_student.hispanic_latino).to eq false
           expect(first_student.gender).to eq 'F'
-          expect(first_student.house).to eq ''
+          expect(first_student.house).to eq nil
           expect(first_student.counselor).to eq nil
 
           second_student = Student.find_by_state_id('1000000002')


### PR DESCRIPTION
# Who is this PR for?
educators, primarily in Bedford

# What problem does this PR fix?
There are some special cases in Bedford around these values, and in the process of working around them, I found that there are many empty string values and no validations on these.

# What does this PR do?
Before this PR, I manually patched the `Student` records in each district to set empty strings or "N/A" for `sped_liaison` in Bedford to `nil`.

This PR adds validations enforcing that.  It also moves the parsing code for `sped_liaison` and `counselor` into `PerDistrict`.  And it disables importing `sped_liaison` for Bedford, since these values are all set to "N/A" right now.  Even though we are getting data in this field, it's not meaningful, so we effectively are not receiving this data at all and no value in importing it.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Core 

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here