### PR TITLE
Profile: Hide sheltered immersion from program

### DIFF
--- a/app/assets/javascripts/helpers/specialEducation.js
+++ b/app/assets/javascripts/helpers/specialEducation.js
@@ -9,7 +9,7 @@ export function hasAnySpecialEducationData(student, maybeIepDocument) {
   if (disability) return true;
   if (levelOfNeed) return true;
 
-  if (student.sped_liaison) return true;
+  // Do not consider `sped_liaison` here.
   
   return false;
 }
@@ -92,7 +92,12 @@ function isNullProgram(program) {
   // as SPED for the program.  So these values are excluded here.
   if (['Reg Ed', 'SEIP', 'Waivered SEIP', null].indexOf(program) !== -1) return true;
 
-  if (['Not Enrolled', '(NULL)'].indexOf(program) !== -1) return true; // Bedford
+  // Bedford only.  We blacklist the similar value for ELL here as well
+  if (['Not Enrolled', 'Sheltered Immersion', null].indexOf(program) !== -1) return true;
+
+  // New Bedford only
+  if ([null].indexOf(program) !== -1) return true;
+
   return false;
 }
 

--- a/app/assets/javascripts/helpers/specialEducation.test.js
+++ b/app/assets/javascripts/helpers/specialEducation.test.js
@@ -13,6 +13,16 @@ describe('#hasAnySpecialEducationData', () => {
       sped_level_of_need: null,
     }, null)).toEqual(false);
   });
+
+  it('ignores sped_liaison value', () => {
+    expect(hasAnySpecialEducationData({
+      program_assigned: 'Reg Ed',
+      sped_placement: null,
+      disability: null,
+      sped_level_of_need: null,
+      sped_liaison: 'Concepcion'
+    }, null)).toEqual(false);
+  });
 });
 
 describe('#prettyProgramOrPlacementText', () => {
@@ -44,6 +54,11 @@ describe('#prettyProgramOrPlacementText', () => {
 
     expect(prettyProgramOrPlacementText({
       program_assigned: 'Waivered SEIP',
+      sped_placement: null
+    })).toEqual(null);
+
+    expect(prettyProgramOrPlacementText({
+      program_assigned: 'Sheltered Immersion',
       sped_placement: null
     })).toEqual(null);
 


### PR DESCRIPTION
# Who is this PR for?
Bedford educators

# What problem does this PR fix?
The `program_assigned` field contains a mix of different information across districts.  The profile page now uses it to tell information about special education placement, and so for Somerville we hide values here about sheltered language immersion.  The values for this are different in Bedford.

Also, before shipping https://github.com/studentinsights/studentinsights/pull/2217, for students in Bedford where "N/A" was exported as the `sped_liaison`, this would incorrectly suggest there was an IEP with more info because it appeared as if there was a SPED liaison.

# What does this PR do?
Hides the value for Bedford.  Also doesn't consider `sped_liaison` when deciding whether to show IEP link.  If that's all there is, it's likely a data quality bug upstream.


# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile
+ [x] Included specs for changes
