### PR TITLE
Add community schools-based feed filter

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -116,6 +116,15 @@ class PerDistrict
     EnvironmentVariable.is_true('ENABLE_ELL_BASED_FEED')
   end
 
+  # For Somerville after school programs
+  def enable_community_school_based_feed?
+    if @district_key == SOMERVILLE || @district_key == DEMO
+      EnvironmentVariable.is_true('ENABLE_COMMUNITY_SCHOOL_BASED_FEED')
+    else
+      false
+    end
+  end
+
   # If this is enabled, filter students on the home page feed
   # based on a mapping of the `house` field on the student and a specific
   # `Educator`.  It may be individually feature switched as well.

--- a/app/lib/feed_filter.rb
+++ b/app/lib/feed_filter.rb
@@ -9,7 +9,8 @@ class FeedFilter
       CounselorFilter.new(@educator),
       HouseFilter.new(@educator),
       SectionsFilter.new(@educator),
-      EnglishLanguageLearnerFilter.new(@educator)
+      EnglishLanguageLearnerFilter.new(@educator),
+      CommunitySchoolFilter.new(@educator)
     ]
 
     filtered_students = students
@@ -22,6 +23,23 @@ class FeedFilter
   end
 
   private
+  # For Community School Coordinators who are working with students in after
+  # school programs.
+  class CommunitySchoolFilter
+    def initialize(educator)
+      @educator = educator
+    end
+
+    def should_use?
+      return false unless PerDistrict.new.enable_community_school_based_feed?
+      EducatorLabel.has_static_label?(@educator.id, 'use_community_school_based_feed')
+    end
+
+    def keep?(student)
+      Service.has_active_service?(student.id, ServiceType::COMMUNITY_SCHOOLS)
+    end
+  end
+
   # For building-level ELL teachers, who have schoolwide access, but only
   # want to see students actively learning English in their feed (on their
   # caseload).

--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -16,6 +16,7 @@ class EducatorLabel < ApplicationRecord
         'use_housemaster_based_feed',
         'use_section_based_feed',
         'use_ell_based_feed',
+        'use_community_school_based_feed',
         'enable_class_lists_override',
         'can_upload_student_voice_surveys',
         'should_show_levels_shs_link'

--- a/app/models/service_type.rb
+++ b/app/models/service_type.rb
@@ -1,6 +1,8 @@
 class ServiceType < ApplicationRecord
   has_many :services
 
+  COMMUNITY_SCHOOLS = 513
+  
   def self.seed_for_all_districts
     ServiceType.destroy_all
     ServiceType.create([

--- a/spec/lib/feed_filter_spec.rb
+++ b/spec/lib/feed_filter_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe FeedFilter do
       allow(ENV).to receive(:[]).with('ENABLE_COUNSELOR_BASED_FEED').and_return(nil)
       allow(ENV).to receive(:[]).with('ENABLE_SECTION_BASED_FEED').and_return(nil)
       allow(ENV).to receive(:[]).with('ENABLE_ELL_BASED_FEED').and_return(nil)
+      allow(ENV).to receive(:[]).with('ENABLE_COMMUNITY_SCHOOL_BASED_FEED').and_return(nil)
     end
 
     it 'does not filter for anyone when disabled globally' do
@@ -49,6 +50,7 @@ RSpec.describe FeedFilter do
       allow(ENV).to receive(:[]).with('ENABLE_HOUSEMASTER_BASED_FEED').and_return(nil)
       allow(ENV).to receive(:[]).with('ENABLE_SECTION_BASED_FEED').and_return(nil)
       allow(ENV).to receive(:[]).with('ENABLE_ELL_BASED_FEED').and_return(nil)
+      allow(ENV).to receive(:[]).with('ENABLE_COMMUNITY_SCHOOL_BASED_FEED').and_return(nil)
     end
 
     it 'does not filter for anyone when disabled globally' do
@@ -87,6 +89,7 @@ RSpec.describe FeedFilter do
       allow(ENV).to receive(:[]).with('ENABLE_COUNSELOR_BASED_FEED').and_return(nil)
       allow(ENV).to receive(:[]).with('ENABLE_HOUSEMASTER_BASED_FEED').and_return(nil)
       allow(ENV).to receive(:[]).with('ENABLE_ELL_BASED_FEED').and_return(nil)
+      allow(ENV).to receive(:[]).with('ENABLE_COMMUNITY_SCHOOL_BASED_FEED').and_return(nil)
     end
 
     it 'when disabled globally, does not filter for anyone' do
@@ -125,6 +128,7 @@ RSpec.describe FeedFilter do
       allow(ENV).to receive(:[]).with('ENABLE_COUNSELOR_BASED_FEED').and_return(nil)
       allow(ENV).to receive(:[]).with('ENABLE_HOUSEMASTER_BASED_FEED').and_return(nil)
       allow(ENV).to receive(:[]).with('ENABLE_SECTION_BASED_FEED').and_return(nil)
+      allow(ENV).to receive(:[]).with('ENABLE_COMMUNITY_SCHOOL_BASED_FEED').and_return(nil)
 
       # for this test case, make Kylo ELL and set the flag for Fatima
       pals.shs_senior_kylo.update!(limited_english_proficiency: 'Limited') # per district, Somerville
@@ -160,6 +164,73 @@ RSpec.describe FeedFilter do
       )
       expect(FeedFilter.new(pals.shs_fatima_science_teacher).filter_for_educator(unfiltered_students)).to contain_exactly(*[
         pals.shs_senior_kylo
+      ])
+    end
+  end
+
+  describe 'Community School-based feed only' do
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('ENABLE_COUNSELOR_BASED_FEED').and_return(nil)
+      allow(ENV).to receive(:[]).with('ENABLE_HOUSEMASTER_BASED_FEED').and_return(nil)
+      allow(ENV).to receive(:[]).with('ENABLE_SECTION_BASED_FEED').and_return(nil)
+      allow(ENV).to receive(:[]).with('ENABLE_ELL_BASED_FEED').and_return(nil)
+    end
+
+    # for this test case, make a new student who's active in Community Schools
+    # and make sure they're the only one
+    let!(:afterschool_student) do
+      Service.where(service_type_id: ServiceType::COMMUNITY_SCHOOLS).each {|service| service.destroy! }
+      afterschool_student = FactoryBot.create(:student, {
+        school_id: pals.west.id
+      })
+      FactoryBot.create(:service, {
+        student_id: afterschool_student.id,
+        date_started: Time.now - 20.days,
+        discontinued_at: nil,
+        service_type_id: ServiceType::COMMUNITY_SCHOOLS
+      })
+      afterschool_student
+    end
+
+    # and make a new educator
+    let!(:afterschool_coordinator) do
+      afterschool_coordinator = FactoryBot.create(:educator, {
+        school_id: afterschool_student.school_id,
+        schoolwide_access: true
+      })
+      EducatorLabel.create!(
+        educator: afterschool_coordinator,
+        label_key: 'use_community_school_based_feed'
+      )
+      afterschool_coordinator
+    end
+
+    it 'when disabled globally, does not filter for anyone' do
+      allow(ENV).to receive(:[]).with('ENABLE_COMMUNITY_SCHOOL_BASED_FEED').and_return(nil)
+      Educator.all.each do |educator|
+        unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
+        expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
+      end
+    end
+
+    it 'does not filter without mapping for educator' do
+      allow(ENV).to receive(:[]).with('ENABLE_COMMUNITY_SCHOOL_BASED_FEED').and_return('true')
+      (Educator.all - [afterschool_coordinator]).each do |educator|
+        unfiltered_students = Authorizer.new(educator).authorized { Student.active.to_a }
+        expect(FeedFilter.new(educator).filter_for_educator(unfiltered_students)).to contain_exactly(*unfiltered_students)
+      end
+    end
+
+    it 'filters to only Community Schools students when enabled globally' do
+      allow(ENV).to receive(:[]).with('ENABLE_COMMUNITY_SCHOOL_BASED_FEED').and_return('true')
+      unfiltered_students = Authorizer.new(afterschool_coordinator).authorized { Student.active.to_a }
+      expect(unfiltered_students).to contain_exactly(
+        pals.west_eighth_ryan,
+        afterschool_student
+      )
+      expect(FeedFilter.new(afterschool_coordinator).filter_for_educator(unfiltered_students)).to contain_exactly(*[
+        afterschool_student
       ])
     end
   end


### PR DESCRIPTION
# Who is this PR for?
K8 educators working in the community schools program

# What problem does this PR fix?
These educators work at a school building, but don't need to see data about every student in the home page feed.

# What does this PR do?
Adds a `FeedFilter` to limit the home page feed to students in the Community Schools program.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Home page

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
