### PR TITLE
Remove implicit type coercion for MCAS rows

### DIFF
--- a/app/importers/rows/mcas_row.rb
+++ b/app/importers/rows/mcas_row.rb
@@ -13,9 +13,9 @@ class McasRow < Struct.new :row, :student_id, :assessments_array
     )
 
     student_assessment.assign_attributes(
-      scale_score: row[:assessment_scale_score], # may be nil if "absent"
-      performance_level: row[:assessment_performance_level],
-      growth_percentile: parse_growth_percentile(row[:assessment_growth])
+      scale_score: parse_or_nil(row[:assessment_scale_score]),
+      growth_percentile: parse_or_nil(row[:assessment_growth]),
+      performance_level: row[:assessment_performance_level]
     )
 
     student_assessment
@@ -50,7 +50,7 @@ class McasRow < Struct.new :row, :student_id, :assessments_array
   end
 
   # Missing or unparseable values are ignored and converted to nil
-  def parse_growth_percentile(value)
+  def parse_or_nil(value)
     if value.nil? || value.to_i == 0 then nil else value.to_i end
   end
 end

--- a/app/models/student_assessment.rb
+++ b/app/models/student_assessment.rb
@@ -14,7 +14,10 @@ class StudentAssessment < ApplicationRecord
   validates_presence_of :date_taken, :student, :assessment
   validates :student, uniqueness: { scope: [:assessment_id, :date_taken] }
 
+  # Guard against sloppy type coercion
   validates :growth_percentile, exclusion: { in: [0]}
+  validates :scale_score, exclusion: { in: [0]}
+  validates :percentile_rank, exclusion: { in: [0]}
 
   # TODO: Add validation for MCAS and ACCESS assessments.
 


### PR DESCRIPTION
# Who is this PR for?
educators, came up in new Bedford import

# What problem does this PR fix?
There's implicit type coercion in the importer; this can let unexpected values be entered as `0` integer values when they probably should be `nil`.

# What does this PR do?
Explicitly converts types in the importer, adds a validation to the model for `0` values which don't make sense conceptually.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile
+ [x] Overview

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here