### PR TITLE
Disable New Bedford assessment import

### DIFF
--- a/config/district_new_bedford.yml
+++ b/config/district_new_bedford.yml
@@ -2,8 +2,8 @@ sftp_filenames:
   FILENAME_FOR_EDUCATORS_IMPORT:      ../newbedford/istaff.csv
   FILENAME_FOR_STUDENTS_IMPORT:       ../newbedford/istudent.csv
   FILENAME_FOR_BEHAVIOR_IMPORT:       ../newbedford/iconduct.csv
-  FILENAME_FOR_ASSESSMENT_IMPORT:     ../newbedford/iassessments.csv
   FILENAME_FOR_ATTENDANCE_IMPORT:     ../newbedford/iattendance.csv
+  # FILENAME_FOR_ASSESSMENT_IMPORT:     ../newbedford/iassessments.csv # disabled 11/2/18
 
 
 star_filenames:


### PR DESCRIPTION
Until the export problem is resolved, no need to keep alerting on this.