### PR TITLE
Profile: Allow showing MCAS in summary if no STAR, remove SGP graphs if no data

### DIFF
--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -221,3 +221,14 @@ export function isStudentActive(districtKey, student) {
   // Check both as fallback
   return student.enrollment_status === 'Active' && !student.missing_from_last_export;
 }
+
+
+// Should STAR be used instead of MCAS in K8 student profiles?
+export function useStarForProfileColumns(districtKey) {
+  if (districtKey === SOMERVILLE) return true;
+  if (districtKey === DEMO) return true;
+  if (districtKey === NEW_BEDFORD) return true;
+  if (districtKey === BEDFORD) return false; // no STAR data
+
+  return false;
+}

--- a/app/assets/javascripts/student_profile/ElaDetails.js
+++ b/app/assets/javascripts/student_profile/ElaDetails.js
@@ -162,12 +162,15 @@ export default class ElaDetails extends React.Component {
   }
 
   renderMCASELAGrowth() {
+    const data = this.props.chartData.mcas_series_ela_growth;
+    if (!data || data.length === 0) return null;
+    
     return (
       <DetailsSection anchorId="SGPs" title="Student growth percentile (SGP), last 4 years">
         <ProfileChart
           quadSeries={[{
             name: '',
-            data: this.props.chartData.mcas_series_ela_growth
+            data,
           }]}
           titleText="MCAS ELA SGPs, last 4 years"
           student={this.props.student}

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -6,7 +6,7 @@ import {updateGlobalStylesToRemoveHorizontalScrollbars, alwaysShowVerticalScroll
 import * as InsightsPropTypes from '../helpers/InsightsPropTypes';
 import {toMomentFromTimestamp} from '../helpers/toMoment';
 import * as FeedHelpers from '../helpers/FeedHelpers';
-import {isStudentActive} from '../helpers/PerDistrict';
+import {isStudentActive, useStarForProfileColumns} from '../helpers/PerDistrict';
 import PerDistrictContainer from '../components/PerDistrictContainer';
 import LightProfileHeader from './LightProfileHeader';
 import LightProfileTab, {LightShoutNumber} from './LightProfileTab';
@@ -21,7 +21,7 @@ import StudentSectionsRoster from './StudentSectionsRoster';
 import {tags} from './lightTagger';
 import DetailsSection from './DetailsSection';
 import FullCaseHistory from './FullCaseHistory';
-import testingColumnTexts from './testingColumnTexts';
+import testingColumnTexts, {interpretEla, interpretMath} from './testingColumnTexts';
 
 
 // Prototype of profile v3
@@ -216,9 +216,37 @@ export default class LightProfilePage extends React.Component {
   }
 
   renderReadingColumn() {
-    const {chartData, nowMomentFn, selectedColumnKey} = this.props;
-    const columnKey = 'reading';
+    const {districtKey} = this.props;
+    return (useStarForProfileColumns(districtKey))
+      ? this.renderReadingColumnAsStar()
+      : this.renderReadingColumnAsMcas();
+  }
+
+  renderReadingColumnAsMcas() {
+    const {chartData, nowMomentFn} = this.props;
+    const nowMoment = nowMomentFn();
+    const {scoreText, dateText} = interpretEla(nowMoment, chartData);
+    return this.renderReadingColumnUI({
+      number: scoreText,
+      firstLine: 'MCAS ELA',
+      secondLine: dateText
+    });
+  }
+
+  renderReadingColumnAsStar() {
+    const {chartData, nowMomentFn} = this.props;
     const {nDaysText, percentileText} = latestStar(chartData.star_series_reading_percentile, nowMomentFn());
+    return this.renderReadingColumnUI({
+      number: percentileText,
+      firstLine: 'STAR percentile',
+      secondLine: nDaysText
+    });
+  }
+
+  // Just the UI, regardless of content
+  renderReadingColumnUI({number, firstLine, secondLine}) {
+    const {selectedColumnKey} = this.props;
+    const columnKey = 'reading';
     return (
       <LightProfileTab
         style={styles.tab}
@@ -227,18 +255,46 @@ export default class LightProfilePage extends React.Component {
         intenseColor="#ff7f00"
         fadedColor="hsl(24, 100%, 92%)"
         text="Reading">
-          <LightShoutNumber number={percentileText}>
-            <div>STAR percentile</div>
-            <div>{nDaysText}</div>
+          <LightShoutNumber number={number}>
+            <div>{firstLine}</div>
+            <div>{secondLine}</div>
           </LightShoutNumber>
         </LightProfileTab>
     );
   }
 
   renderMathColumn() {
-    const {selectedColumnKey, chartData, nowMomentFn} = this.props;
-    const columnKey = 'math';
+    const {districtKey} = this.props;
+    return (useStarForProfileColumns(districtKey))
+      ? this.renderMathColumnAsStar()
+      : this.renderMathColumnAsMcas();
+  }
+
+  renderMathColumnAsMcas() {
+    const {chartData, nowMomentFn} = this.props;
+    const nowMoment = nowMomentFn();
+    const {scoreText, dateText} = interpretMath(nowMoment, chartData);
+    return this.renderMathColumnUI({
+      number: scoreText,
+      firstLine: 'MCAS Math',
+      secondLine: dateText
+    });
+  }
+
+  renderMathColumnAsStar() {
+    const {chartData, nowMomentFn} = this.props;
     const {nDaysText, percentileText} = latestStar(chartData.star_series_math_percentile, nowMomentFn());
+    return this.renderMathColumnUI({
+      number: percentileText,
+      firstLine: 'STAR percentile',
+      secondLine: nDaysText
+    });
+  }
+
+  // Just the UI
+  renderMathColumnUI({number, firstLine, secondLine}) {
+    const {selectedColumnKey} = this.props;
+    const columnKey = 'math';
     return (
       <LightProfileTab
         style={styles.tab}
@@ -247,9 +303,9 @@ export default class LightProfilePage extends React.Component {
         intenseColor="#6A2987"
         fadedColor="hsl(237,80%,95%)"
         text="Math">
-          <LightShoutNumber number={percentileText}>
-            <div>STAR percentile</div>
-            <div>{nDaysText}</div>
+          <LightShoutNumber number={number}>
+            <div>{firstLine}</div>
+            <div>{secondLine}</div>
           </LightShoutNumber>
         </LightProfileTab>
     );

--- a/app/assets/javascripts/student_profile/LightProfilePage.story.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.story.js
@@ -38,6 +38,7 @@ storiesOf('profile-v3/LightProfilePage', module) // eslint-disable-line no-undef
   .add('K8, wide: Pluto Poppins', () => storyRender(testPropsForPlutoPoppins()))
   .add('K8, no photo: Pluto Poppins', () => widthFrame(storyRender(testPropsForPlutoPoppins())))
   .add('K8: Olaf White', () => widthFrame(storyRender(testPropsForOlafWhite())))
+  .add('K8, Bedford: Olaf White', () => widthFrame(storyRender({...testPropsForOlafWhite(), districtKey: 'bedford' })))
   .add('K8, New Bedford: Olaf White', () => widthFrame(storyRender({...testPropsForOlafWhite(), districtKey: 'new_bedford' })))
   .add('HS: Aladdin Mouse', () => widthFrame(storyRender(testPropsForAladdinMouse())));
 

--- a/app/assets/javascripts/student_profile/LightProfilePage.test.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.test.js
@@ -11,8 +11,8 @@ import {
 } from './profileTestProps.fixture';
 
 
-function testingTabTextLines(el) {
-  const leafEls = $(el).find('.LightProfileTab:eq(2) *:not(:has(*))').toArray(); // magic selector from https://stackoverflow.com/questions/4602431/what-is-the-most-efficient-way-to-get-leaf-nodes-with-jquery#4602476
+function testingTabTextLines(tabIndex, el) {
+  const leafEls = $(el).find('.LightProfileTab:eq(' + tabIndex+ ') *:not(:has(*))').toArray(); // magic selector from https://stackoverflow.com/questions/4602431/what-is-the-most-efficient-way-to-get-leaf-nodes-with-jquery#4602476
   return leafEls.map(el => $(el).text());
 }
 
@@ -52,7 +52,7 @@ describe('HS testing tab', () => {
   it('works when missing', () => {
     const props = testPropsForAladdinMouse();
     const el = testRender(props);
-    expect(testingTabTextLines(el)).toEqual([
+    expect(testingTabTextLines(2, el)).toEqual([
       'Testing',
       '-',
       'ELA and Math MCAS',
@@ -73,7 +73,7 @@ describe('HS testing tab', () => {
       }
     };
     const el = testRender(props);
-    expect(testingTabTextLines(el)).toEqual([
+    expect(testingTabTextLines(2, el)).toEqual([
       'Testing',
       'M',
       'ELA and Math MCAS',
@@ -95,11 +95,41 @@ describe('HS testing tab', () => {
       }
     };
     const el = testRender(props);
-    expect(testingTabTextLines(el)).toEqual([
+    expect(testingTabTextLines(2, el)).toEqual([
       'Testing',
       'NI',
       'ELA and Math MCAS',
       '9 months ago'
+    ]);
+  });
+});
+
+describe('reading and math can show MCAS if STAR not enabled', () => {
+  it('for Bedford, shows MCAS in place of STAR', () => {
+    const olafProps = testPropsForOlafWhite();
+    const props = {
+      ...olafProps,
+      districtKey: 'bedford',
+      chartData: {
+        ...olafProps.chartData,
+        "next_gen_mcas_mathematics_scaled": [[2014,5,15,537]],
+        "next_gen_mcas_ela_scaled": [[2015,5,15,536]],
+        "mcas_series_math_scaled": [],
+        "mcas_series_ela_scaled": []
+      }
+    };
+    const el = testRender(props);
+    expect(testingTabTextLines(1, el)).toEqual([
+      'Reading',
+      'M',
+      'MCAS ELA',
+      '9 months ago'
+    ]);
+    expect(testingTabTextLines(2, el)).toEqual([
+      'Math',
+      'M',
+      'MCAS Math',
+      '2 years ago'
     ]);
   });
 });

--- a/app/assets/javascripts/student_profile/MathDetails.js
+++ b/app/assets/javascripts/student_profile/MathDetails.js
@@ -163,6 +163,9 @@ export default class MathDetails extends React.Component {
   }
 
   renderMCASMathGrowth() {
+    const data = this.props.chartData.mcas_series_math_growth;
+    if (!data || data.length === 0) return null;
+
     return (
       <DetailsSection anchorId="MCASMathGrowth" title="MCAS Math SGPs, last 4 years">
         <ProfileChart

--- a/app/assets/javascripts/student_profile/testingColumnTexts.js
+++ b/app/assets/javascripts/student_profile/testingColumnTexts.js
@@ -3,19 +3,28 @@ import {toMoment} from './QuadConverter';
 import {shortLabelFromNextGenMcasScore, shortLabelFromOldMcasScore} from '../helpers/mcasScores';
 
 
-// Look at ELA and Math next gen MCAS scores and make the different texts for the 'testing'
-// column summary for HS.  If those don't exist, fall back to old-school MCAS.
-export default function testingColumnTexts(nowMoment, chartData) {
-  const ela = (
+export function interpretEla(nowMoment, chartData) {
+  return (
     latestMcasScoreSummary(chartData.next_gen_mcas_ela_scaled, shortLabelFromNextGenMcasScore, nowMoment) ||
     latestMcasScoreSummary(chartData.mcas_series_ela_scaled, shortLabelFromOldMcasScore, nowMoment) ||
     missingMcasSummary()
   );
-  const math = (
+}
+
+export function interpretMath(nowMoment, chartData) {
+  return (
     latestMcasScoreSummary(chartData.next_gen_mcas_mathematics_scaled, shortLabelFromNextGenMcasScore, nowMoment) ||
     latestMcasScoreSummary(chartData.mcas_series_math_scaled, shortLabelFromOldMcasScore, nowMoment) ||
     missingMcasSummary()
   );
+}
+
+
+// Look at ELA and Math next gen MCAS scores and make the different texts for the 'testing'
+// column summary for HS.  If those don't exist, fall back to old-school MCAS.
+export default function testingColumnTexts(nowMoment, chartData) {
+  const ela = interpretEla(nowMoment, chartData);
+  const math = interpretMath(nowMoment, chartData);
 
   const scoreText = ela.scoreText === math.scoreText
     ? ela.scoreText


### PR DESCRIPTION
# Who is this PR for?
Bedford educators

# What problem does this PR fix?
In Bedford, they don't use STAR assessments, but the profile still assumes these are meaningful.

Separately, there's no SGP data for students in younger grades (or other students taking MCAS for the first time).  Yet these charts still appear.

# What does this PR do?
Adds a `PerDistrict.js` function that enables showing MCAS in place of STAR for the summary tabs on the student profile.

Updates the details sections to hide the SGP charts if there is no data.

# Screenshot (if adding a client-side feature)
<img width="676" alt="screen shot 2018-11-05 at 12 31 48 pm" src="https://user-images.githubusercontent.com/1056957/48015616-83f1b580-e0f7-11e8-9226-85814ad45ad6.png">

<img width="683" alt="screen shot 2018-11-05 at 12 33 54 pm" src="https://user-images.githubusercontent.com/1056957/48015618-85bb7900-e0f7-11e8-9761-343934ff2740.png">


# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here