### PR TITLE
Fix bug with sending null valued SGP to UI

### DIFF
--- a/app/charts/student_profile_chart.rb
+++ b/app/charts/student_profile_chart.rb
@@ -1,32 +1,5 @@
 class StudentProfileChart < Struct.new :student
 
-  def percentile_ranks_to_highcharts(star_results)
-    return nil unless star_results
-
-    star_results.select(:id, :date_taken, :percentile_rank, :grade_equivalent, :total_time)
-  end
-
-  def interventions_to_highcharts
-    return if student.interventions.blank?
-    student.interventions.with_start_and_end_dates.map do |intervention|
-      intervention.to_highcharts
-    end
-  end
-
-  def growth_percentiles_to_highcharts(student_assessments)
-    return if student_assessments.blank?
-    student_assessments.map do |s|
-      [s.date_taken.year, s.date_taken.month, s.date_taken.day, s.growth_percentile]
-    end
-  end
-
-  def scale_scores_to_highcharts(student_assessments)
-    return if student_assessments.blank?
-    student_assessments.map do |s|
-      [s.date_taken.year, s.date_taken.month, s.date_taken.day, s.scale_score]
-    end
-  end
-
   def chart_data
     data = serialize_student_for_profile_chart(student)
     {
@@ -42,6 +15,7 @@ class StudentProfileChart < Struct.new :student
     }
   end
 
+  private
   def serialize_student_for_profile_chart(student)
     {
       student: student,
@@ -54,5 +28,32 @@ class StudentProfileChart < Struct.new :student
       next_gen_mcas_ela_results: student.next_gen_mcas_ela_results,
       interventions: student.interventions
     }
+  end
+
+  def percentile_ranks_to_highcharts(star_results)
+    return nil unless star_results
+
+    star_results.select(:id, :date_taken, :percentile_rank, :grade_equivalent, :total_time)
+  end
+
+  def interventions_to_highcharts
+    return if student.interventions.blank?
+    student.interventions.with_start_and_end_dates.map do |intervention|
+      intervention.to_highcharts
+    end
+  end
+
+  def growth_percentiles_to_highcharts(student_assessments)
+    return if student_assessments.blank?
+    student_assessments.select {|a| a.growth_percentile.present? }.map do |s|
+      [s.date_taken.year, s.date_taken.month, s.date_taken.day, s.growth_percentile]
+    end
+  end
+
+  def scale_scores_to_highcharts(student_assessments)
+    return if student_assessments.blank?
+    student_assessments.select {|a| a.scale_score.present? }.map do |s|
+      [s.date_taken.year, s.date_taken.month, s.date_taken.day, s.scale_score]
+    end
   end
 end

--- a/app/charts/student_profile_chart.rb
+++ b/app/charts/student_profile_chart.rb
@@ -1,35 +1,25 @@
 class StudentProfileChart < Struct.new :student
 
   def chart_data
-    data = serialize_student_for_profile_chart(student)
+    mcas_mathematics_results = student.mcas_mathematics_results
+    mcas_ela_results = student.mcas_ela_results
+    next_gen_mcas_mathematics_results = student.next_gen_mcas_mathematics_results
+    next_gen_mcas_ela_results = student.next_gen_mcas_ela_results
+
     {
-      star_series_math_percentile: percentile_ranks_to_highcharts(data[:star_math_results]),
-      star_series_reading_percentile: percentile_ranks_to_highcharts(data[:star_reading_results]),
-      next_gen_mcas_mathematics_scaled: scale_scores_to_highcharts(data[:next_gen_mcas_mathematics_results]),
-      next_gen_mcas_ela_scaled: scale_scores_to_highcharts(data[:next_gen_mcas_ela_results]),
-      mcas_series_math_scaled: scale_scores_to_highcharts(data[:mcas_mathematics_results]),
-      mcas_series_ela_scaled: scale_scores_to_highcharts(data[:mcas_ela_results]),
-      mcas_series_math_growth: growth_percentiles_to_highcharts(data[:mcas_mathematics_results] + data[:next_gen_mcas_mathematics_results]),
-      mcas_series_ela_growth: growth_percentiles_to_highcharts(data[:mcas_ela_results] + data[:next_gen_mcas_ela_results]),
+      star_series_math_percentile: percentile_ranks_to_highcharts(student.star_math_results),
+      star_series_reading_percentile: percentile_ranks_to_highcharts(student.star_reading_results),
+      next_gen_mcas_mathematics_scaled: scale_scores_to_highcharts(next_gen_mcas_mathematics_results),
+      next_gen_mcas_ela_scaled: scale_scores_to_highcharts(next_gen_mcas_ela_results),
+      mcas_series_math_scaled: scale_scores_to_highcharts(mcas_mathematics_results),
+      mcas_series_ela_scaled: scale_scores_to_highcharts(mcas_ela_results),
+      mcas_series_math_growth: growth_percentiles_to_highcharts(mcas_mathematics_results + next_gen_mcas_mathematics_results),
+      mcas_series_ela_growth: growth_percentiles_to_highcharts(mcas_ela_results + next_gen_mcas_ela_results),
       interventions: interventions_to_highcharts
     }
   end
 
   private
-  def serialize_student_for_profile_chart(student)
-    {
-      student: student,
-      student_assessments: student.student_assessments,
-      star_math_results: student.star_math_results,
-      star_reading_results: student.star_reading_results,
-      mcas_mathematics_results: student.mcas_mathematics_results,
-      mcas_ela_results: student.mcas_ela_results,
-      next_gen_mcas_mathematics_results: student.next_gen_mcas_mathematics_results,
-      next_gen_mcas_ela_results: student.next_gen_mcas_ela_results,
-      interventions: student.interventions
-    }
-  end
-
   def percentile_ranks_to_highcharts(star_results)
     return nil unless star_results
 

--- a/spec/charts/student_profile_chart_spec.rb
+++ b/spec/charts/student_profile_chart_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe StudentProfileChart do
 
   describe '#chart_data' do
     let(:student) { FactoryBot.create(:student) }
+
     it 'has the expected keys' do
       chart_data = StudentProfileChart.new(student).chart_data
       expect(chart_data.keys).to match_array([
@@ -15,6 +16,33 @@ RSpec.describe StudentProfileChart do
         :mcas_series_ela_growth,
         :interventions
       ])
+    end
+
+    it 'filters assessments with null SGP' do
+      with_growth_percentile = FactoryBot.create(:student_assessment, {
+        student: student,
+        scale_score: 504,
+        growth_percentile: 26,
+        assessment: Assessment.find_by(family: 'Next Gen MCAS', subject: 'Mathematics')
+      })
+      without_growth_percentile = FactoryBot.create(:student_assessment, {
+        student: student,
+        scale_score: 502,
+        growth_percentile: nil,
+        assessment: Assessment.find_by(family: 'Next Gen MCAS', subject: 'ELA')
+      })
+
+      expect(StudentProfileChart.new(student).chart_data.as_json).to eq({
+        'next_gen_mcas_ela_scaled' => [[2015, 6, 19, 502]],
+        'next_gen_mcas_mathematics_scaled' => [[2015, 6, 19, 504]],
+        'mcas_series_ela_scaled' => nil,
+        'mcas_series_math_scaled' => nil,
+        'star_series_math_percentile' => [],
+        'star_series_reading_percentile' => [],
+        'interventions' => nil,
+        'mcas_series_math_growth' => [[2015, 6, 19, 26]],
+        'mcas_series_ela_growth' => []
+      })
     end
   end
 end


### PR DESCRIPTION
# Who is this PR for?
Bedford educators

# What problem does this PR fix?
Bedford doesn't have SGP data, but these charts still appear on the profile page.  This is from the server sending down data points that have null, when it should be filtering these out.

# What does this PR do?
Filters these values out; same for scale score.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here