### PR TITLE
Add folders for GitHub pages to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ public/dev
 
 # For qgsocksify
 socks.conf
+
+# Specifically for gh-pages and jekyll
+_site/
+.sass-cache/
+.jekyll-metadata


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
making this work for both `master` and `gh-pages`