### PR TITLE
Remove Jekyll config added through Github UI; move to gh-pages instead

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
I tried setting this to the `docs` folder first, but think it's better to keep code and website on distinct branches.  This file was committed from the UI; this removes it since this is on the `gh-pages` branch now.
