### PR TITLE
Filter out schools without active students on districtwide page (eg, PIC)

### DIFF
--- a/app/controllers/educators_controller.rb
+++ b/app/controllers/educators_controller.rb
@@ -64,7 +64,8 @@ class EducatorsController < ApplicationController
   end
 
   def districtwide_admin_homepage
-    @schools = School.all.sort_by do |school|
+    schools_with_active_students = School.all.includes(:students).select {|school| school.students.active.size > 0 }
+    @schools = schools_with_active_students.sort_by do |school|
       [School::ORDERED_SCHOOL_TYPES.find_index(school.school_type), school.name]
     end
   end

--- a/spec/controllers/educators_controller_spec.rb
+++ b/spec/controllers/educators_controller_spec.rb
@@ -261,4 +261,25 @@ describe EducatorsController, :type => :controller do
       end
     end
   end
+
+  describe '#districtwide_admin_homepage' do
+    let!(:pals) { TestPals.create! }
+
+    def request_page
+      sign_in(pals.uri)
+      request.env['HTTPS'] = 'on'
+      get :districtwide_admin_homepage
+      response
+    end
+
+    it 'works and filters out schools without active students (eg, PIC)' do
+      response = request_page()
+      expect(response.status).to eq 200
+      expect(assigns(:schools)).to contain_exactly(*[
+        pals.healey,
+        pals.shs,
+        pals.west
+      ])
+    end
+  end
 end


### PR DESCRIPTION
Related https://rollbar.com/somerville-teacher-tool/somerville-teacher-tool/items/267/?item_page=0&item_count=100&#traceback

# Who is this PR for?
districtwide educators

# What problem does this PR fix?
Certain school codes that serve only administrative purposes can appear on the districtwide admin page, but they have no students when folks click in.

# What does this PR do?
Removes those schools.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Districtwide admin page

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here