### PR TITLE
Search notes: Remove minLength from DebounceInput, guard at fetch instead

### DIFF
--- a/app/assets/javascripts/search_notes/SearchNotesBar.js
+++ b/app/assets/javascripts/search_notes/SearchNotesBar.js
@@ -56,7 +56,6 @@ export default class SearchNotesBar extends React.Component {
     const {debounceInputMs} = this.props;
     return (
       <DebounceInput
-        minLength={3}
         debounceTimeout={debounceInputMs}
         style={styles.search}
         inputRef={el => this.searchInputEl = el}

--- a/app/assets/javascripts/search_notes/SearchNotesPage.js
+++ b/app/assets/javascripts/search_notes/SearchNotesPage.js
@@ -58,10 +58,7 @@ export default class SearchNotesPage extends React.Component {
 
   renderResultsSection() {
     const {query} = this.state;
-
-    if (_.isEqual(query, initialQuery())) {
-      return <div style={styles.searchAway}>What do you want to know about?</div>;
-    }
+    if (_.isEqual(query, initialQuery())) return this.renderPrompt();
 
     return (
       <SearchQueryFetcher
@@ -73,6 +70,8 @@ export default class SearchNotesPage extends React.Component {
   }
 
   renderQueryResults(json) {
+    if (!json) return this.renderPrompt();
+    
     const feedCards = json.event_note_cards;
     const allResultsSize = json.meta.all_results_size;
     return (
@@ -81,6 +80,10 @@ export default class SearchNotesPage extends React.Component {
         <FeedView feedCards={feedCards} />
       </div>
     );
+  }
+
+  renderPrompt() {
+    return <div style={styles.searchAway}>What do you want to know about?</div>;
   }
 
   renderMeta(allResultsSize, feedCards) {

--- a/app/assets/javascripts/search_notes/SearchNotesPage.test.js
+++ b/app/assets/javascripts/search_notes/SearchNotesPage.test.js
@@ -45,18 +45,34 @@ describe('integration tests', () => {
     ReactDOM.render(testEl(props), el);
     expect($(el).text()).toContain('What do you want to know about?');
     
-    // change text, wait for debounce, fetch, render
+    // change text, wait for debounce
     changeTextValue($(el).find('input:first').get(0), 'read');
     setTimeout(() => {
-      expect($(el).html()).not.toContain('Loading');
       expect($(el).html()).not.toContain('Showing all 2 results.');
     
+      // wait for fetch and render
       setTimeout(() => {
         expect($(el).html()).toContain('Search notes');
         expect($(el).text()).toContain('Showing all 2 results.');
         expect($(el).find('.EventNoteCard').length).toEqual(2);
         done();
-      }, 400);
-    });
+      }, 0);
+    }, 400);
+  });
+
+  it('enforces minimum search length', done => {
+    const props = testProps();
+    const el = document.createElement('div');
+    ReactDOM.render(testEl(props), el);
+    
+    changeTextValue($(el).find('input:first').get(0), 're');
+
+    // wait for debounce
+    setTimeout(() => {
+      expect($(el).html()).not.toContain('Loading');
+      expect($(el).html()).not.toContain('Showing all 2 results.');
+      expect($(el).text()).toContain('What do you want to know about?');
+      done();
+    }, 400);
   });
 });

--- a/app/assets/javascripts/search_notes/SearchQueryFetcher.js
+++ b/app/assets/javascripts/search_notes/SearchQueryFetcher.js
@@ -15,7 +15,10 @@ export default class SearchQueryFetcher extends React.Component {
   }
 
   fetchNotes() {
+    const MIN_SEARCH_LENGTH = 3;
     const {searchText, grade, eventNoteTypeId, scopeKey, limit} = this.props.query;
+    if (searchText.length < MIN_SEARCH_LENGTH) return Promise.resolve(null);
+
     const queryString = qs.stringify({
       text: searchText,
       grade: valueOrNull(grade),


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
Using a controlled `DebounceInput` with `minLength` means user input gets erased.

# What does this PR do?
Instead, just guard the fetching, which is what we really care about anyway.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Search notes


*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here