### PR TITLE
Search: Swap in fulltext, allow querying by time range, clamp start_time and limit

### DIFF
--- a/app/assets/javascripts/components/SelectTimeRange.js
+++ b/app/assets/javascripts/components/SelectTimeRange.js
@@ -1,19 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SimpleFilterSelect from './SimpleFilterSelect';
-import {firstDayOfSchoolForMoment} from '../helpers/schoolYear';
+import {
+  firstDayOfSchoolForMoment,
+  toSchoolYear,
+  firstDayOfSchool
+} from '../helpers/schoolYear';
 
 
 // A UI component for selecting a time range.  It limits date range choices
 // to ones that are most relevant or useful for teachers (ie, it's opinionated about
 // only looking at recent data rather than allowing arbitrary dates as endpoints).
 export default function SelectTimeRange(props) {
-  const {timeRangeKey, onChange} = props;
-  const options = [
+  const {timeRangeKey, onChange, timeRangeKeys} = props;
+  const options = (timeRangeKeys || [
     TIME_RANGE_45_DAYS_AGO,
     TIME_RANGE_90_DAYS_AGO,
     TIME_RANGE_SCHOOL_YEAR
-  ].map(timeRangeKey => {
+  ]).map(timeRangeKey => {
     return { value: timeRangeKey, label: timeRangeText(timeRangeKey) };
   });
   return (
@@ -27,7 +31,8 @@ export default function SelectTimeRange(props) {
 }
 SelectTimeRange.propTypes = {
   timeRangeKey: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  timeRangeKeys: PropTypes.arrayOf(PropTypes.string)
 };
 
 
@@ -37,7 +42,8 @@ export function momentRange(timeRangeKey, nowMoment) {
   const startMoment = {
     [TIME_RANGE_45_DAYS_AGO]: nowMoment.clone().subtract(45, 'days'),
     [TIME_RANGE_90_DAYS_AGO]: nowMoment.clone().subtract(90, 'days'),
-    [TIME_RANGE_SCHOOL_YEAR]: firstDayOfSchoolForMoment(nowMoment)
+    [TIME_RANGE_SCHOOL_YEAR]: firstDayOfSchoolForMoment(nowMoment),
+    [TIME_RANGE_FOUR_YEARS]: firstDayOfSchool(toSchoolYear(nowMoment) - 4)
   }[timeRangeKey];
 
   return [startMoment.startOf('day'), nowMoment.startOf('day')];
@@ -48,9 +54,11 @@ export function timeRangeText(timeRangeKey) {
   return {
     TIME_RANGE_45_DAYS_AGO: 'Last 45 days',
     TIME_RANGE_90_DAYS_AGO: 'Last 90 days',
-    TIME_RANGE_SCHOOL_YEAR: 'School year'
+    TIME_RANGE_SCHOOL_YEAR: 'This school year',
+    TIME_RANGE_FOUR_YEARS: 'Last four years'
   }[timeRangeKey];
 }
 export const TIME_RANGE_45_DAYS_AGO = 'TIME_RANGE_45_DAYS_AGO';
 export const TIME_RANGE_90_DAYS_AGO = 'TIME_RANGE_90_DAYS_AGO';
 export const TIME_RANGE_SCHOOL_YEAR = 'TIME_RANGE_SCHOOL_YEAR';
+export const TIME_RANGE_FOUR_YEARS = 'TIME_RANGE_FOUR_YEARS';

--- a/app/assets/javascripts/search_notes/SearchNotesBar.js
+++ b/app/assets/javascripts/search_notes/SearchNotesBar.js
@@ -5,7 +5,11 @@ import FilterBar from '../components/FilterBar';
 import SelectHouse from '../components/SelectHouse';
 import SelectGrade from '../components/SelectGrade';
 import SelectEventNoteType from '../components/SelectEventNoteType';
-
+import SelectTimeRange, {
+  TIME_RANGE_45_DAYS_AGO,
+  TIME_RANGE_SCHOOL_YEAR,
+  TIME_RANGE_FOUR_YEARS
+} from '../components/SelectTimeRange';
 
 // UI for expressing a query for searching notes.
 export default class SearchNotesBar extends React.Component {
@@ -16,6 +20,7 @@ export default class SearchNotesBar extends React.Component {
     this.onGradeChanged = this.onGradeChanged.bind(this);
     this.onHouseChanged = this.onHouseChanged.bind(this);
     this.onEventNoteTypeIdChanged = this.onEventNoteTypeIdChanged.bind(this);
+    this.onTimeRangeKeyChanged = this.onTimeRangeKeyChanged.bind(this);
   }
 
   componentDidMount() {
@@ -38,6 +43,10 @@ export default class SearchNotesBar extends React.Component {
     this.props.onQueryChanged({eventNoteTypeId});
   }
 
+  onTimeRangeKeyChanged(timeRangeKey) {
+    this.props.onQueryChanged({timeRangeKey});
+  }
+
   render() {
     const {style} = this.props;
 
@@ -47,6 +56,9 @@ export default class SearchNotesBar extends React.Component {
         {this.renderGradeSelect()}
         {this.renderHouseSelect()}
         {this.renderEventNoteTypeSelect()}
+        <div style={{display: 'flex', flex: 1, justifyContent: 'flex-end'}}>
+          {this.renderTimeRangeSelect()}
+        </div>
       </FilterBar>
     );
   }
@@ -94,6 +106,20 @@ export default class SearchNotesBar extends React.Component {
         onChange={this.onEventNoteTypeIdChanged} />
     );
   }
+
+  renderTimeRangeSelect() {
+    const {timeRangeKey} = this.props.query;
+    return (
+      <SelectTimeRange
+        timeRangeKey={timeRangeKey}
+        timeRangeKeys={[
+          TIME_RANGE_45_DAYS_AGO,
+          TIME_RANGE_SCHOOL_YEAR,
+          TIME_RANGE_FOUR_YEARS
+        ]}
+        onChange={this.onTimeRangeKeyChanged} />
+    );
+  }
 }
 SearchNotesBar.propTypes = {
   query: PropTypes.shape({
@@ -101,6 +127,7 @@ SearchNotesBar.propTypes = {
     grade: PropTypes.string,
     house: PropTypes.string,
     eventNoteTypeId: PropTypes.any.isRequired, // number, but magic ALL string also
+    timeRangeKey: PropTypes.string.isRequired
   }).isRequired,
   onQueryChanged: PropTypes.func.isRequired,
   includeHouse: PropTypes.bool.isRequired,

--- a/app/assets/javascripts/search_notes/SearchNotesPage.js
+++ b/app/assets/javascripts/search_notes/SearchNotesPage.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import {updateGlobalStylesToTakeFullHeight} from '../helpers/globalStylingWorkarounds';
 import {supportsHouse} from '../helpers/PerDistrict';
 import {ALL} from '../components/SimpleFilterSelect';
+import {TIME_RANGE_SCHOOL_YEAR} from '../components/SelectTimeRange';
 import SectionHeading from '../components/SectionHeading';
 import FeedView from '../feed/FeedView';
 import SearchNotesBar from './SearchNotesBar';
@@ -99,7 +100,7 @@ export default class SearchNotesPage extends React.Component {
       return <div style={styles.meta}>Showing all {oneOrMoreResult(feedCards.length)}.</div>;
     }
 
-    return <div style={styles.meta}>About {oneOrMoreResult(allResultsSize)} total, showing first {oneOrMoreResult(feedCards.length)}.</div>;
+    return <div style={styles.meta}>Showing the first {oneOrMoreResult(feedCards.length)} of {oneOrMoreResult(allResultsSize)} total.</div>;
   }
 }
 SearchNotesPage.propTypes = {
@@ -138,8 +139,9 @@ function initialQuery() {
     grade: ALL,
     house: ALL,
     eventNoteTypeId: ALL,
-    scopeKeyf: ALL,
-    limit: null
+    scopeKey: ALL,
+    timeRangeKey: TIME_RANGE_SCHOOL_YEAR,
+    limit: 50
   };
 }
 

--- a/app/assets/javascripts/search_notes/SearchNotesPage.test.js
+++ b/app/assets/javascripts/search_notes/SearchNotesPage.test.js
@@ -25,8 +25,6 @@ function testEl(props = {}) {
 
 beforeEach(() => {
   fetchMock.restore();
-  fetchMock.get('/api/search_notes/query_json?event_note_type_id&grade&limit&scope_key&text=', searchJson);
-
 });
 
 it('renders without crashing', () => {
@@ -37,7 +35,7 @@ it('renders without crashing', () => {
 
 describe('integration tests', () => {
   it('renders after fetch', done => {
-    fetchMock.get('/api/search_notes/query_json?event_note_type_id&grade&limit&scope_key&text=read', searchJson);
+    fetchMock.get('/api/search_notes/query_json?end_time=1520899200&event_note_type_id&grade&limit=50&scope_key&start_time=1502755200&text=read', searchJson);
 
     // renders, without fetching yet
     const props = testProps();

--- a/app/assets/javascripts/search_notes/SearchQueryFetcher.js
+++ b/app/assets/javascripts/search_notes/SearchQueryFetcher.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import qs from 'query-string';
 import {apiFetchJson} from '../helpers/apiFetchJson';
 import GenericLoader from '../components/GenericLoader';
+import {momentRange} from '../components/SelectTimeRange';
 import {ALL} from '../components/SimpleFilterSelect';
 
 
@@ -16,10 +17,16 @@ export default class SearchQueryFetcher extends React.Component {
 
   fetchNotes() {
     const MIN_SEARCH_LENGTH = 3;
-    const {searchText, grade, eventNoteTypeId, scopeKey, limit} = this.props.query;
-    if (searchText.length < MIN_SEARCH_LENGTH) return Promise.resolve(null);
+    
+    const {searchText, grade, eventNoteTypeId, scopeKey, timeRangeKey, limit} = this.props.query;
+    if (searchText.length < MIN_SEARCH_LENGTH) return Promise.resolve(null); // minimum search text length
 
+    const {nowFn} = this.context;
+    const nowMoment = nowFn();
+    const startTimestamp = momentRange(timeRangeKey, nowMoment)[0].unix();
     const queryString = qs.stringify({
+      start_time: startTimestamp,
+      end_time: nowMoment.unix(),
       text: searchText,
       grade: valueOrNull(grade),
       event_note_type_id: valueOrNull(eventNoteTypeId),
@@ -46,6 +53,9 @@ export default class SearchQueryFetcher extends React.Component {
     return renderFn(json);
   }
 }
+SearchQueryFetcher.contextTypes = {
+  nowFn: PropTypes.func.isRequired
+};
 SearchQueryFetcher.propTypes = {
   query: PropTypes.shape({
     searchText: PropTypes.string.isRequired,
@@ -53,8 +63,8 @@ SearchQueryFetcher.propTypes = {
     house: PropTypes.string,
     eventNoteTypeId: PropTypes.any.isRequired, // number, but magic ALL string also
     scopeKey: PropTypes.string,
-    limit: PropTypes.number,
-    fromTimetamp: PropTypes.number
+    limit: PropTypes.number.isRequired,
+    timeRangeKey: PropTypes.string.isRequired
   }).isRequired,
   renderFn: PropTypes.func.isRequired
 };

--- a/app/controllers/search_notes_controller.rb
+++ b/app/controllers/search_notes_controller.rb
@@ -5,13 +5,14 @@ class SearchNotesController < ApplicationController
   # to what the caller asks for
   def query_json
     query = query_from_safe_params(params.permit(*[
-      :text,
+      :start_time,
+      :end_time,
+      :limit,
       :scope_key,
+      :text,
       :grade,
       :house,
-      :event_note_type_id,
-      :time_range_key,
-      :limit
+      :event_note_type_id
     ]))
 
     results = SearchNotesQueries.new(current_educator).query(query)
@@ -33,11 +34,11 @@ class SearchNotesController < ApplicationController
       start_time: Time.at(safe_params[:start_time].to_i),
       end_time: Time.at(safe_params[:end_time].to_i),
       limit: safe_params[:limit].to_i,
+      scope_key: safe_params[:scope_key],
       text: safe_params[:text],
       grade: safe_params[:grade],
       house: safe_params[:house],
       event_note_type_id: safe_params[:event_note_type_id],
-      scope_key: safe_params[:scope_key]
     }
   end
 

--- a/app/controllers/search_notes_controller.rb
+++ b/app/controllers/search_notes_controller.rb
@@ -10,7 +10,7 @@ class SearchNotesController < ApplicationController
       :grade,
       :house,
       :event_note_type_id,
-      :from_time,
+      :time_range_key,
       :limit
     ]))
 
@@ -30,8 +30,9 @@ class SearchNotesController < ApplicationController
   # Defaults are set in the query class
   def query_from_safe_params(safe_params)
     {
-      from_time: safe_params[:from_time],
-      limit: safe_params[:limit],
+      start_time: Time.at(safe_params[:start_time].to_i),
+      end_time: Time.at(safe_params[:end_time].to_i),
+      limit: safe_params[:limit].to_i,
       text: safe_params[:text],
       grade: safe_params[:grade],
       house: safe_params[:house],

--- a/app/lib/search_notes_queries.rb
+++ b/app/lib/search_notes_queries.rb
@@ -3,9 +3,14 @@ class SearchNotesQueries
   SCOPE_FEED_STUDENTS = 'SCOPE_FEED_STUDENTS'
   SCOPE_MY_NOTES_ONLY = 'SCOPE_MY_NOTES_ONLY'
 
-  def self.with_defaults(query = {})
+  MAX_YEARS_BACK = 4
+  MAX_LIMIT = 100
+
+  def self.clamped_with_defaults(query = {})
     query.merge({
-      scope_key: query[:scope_key] || SearchNotesQueries::SCOPE_ALL_STUDENTS
+      scope_key: query[:scope_key] || SearchNotesQueries::SCOPE_ALL_STUDENTS,
+      start_time: [query[:start_time], Time.now - MAX_YEARS_BACK.years].max, # clamp
+      limit: [query[:limit], MAX_LIMIT].min # clamp
     })
   end
 
@@ -14,7 +19,7 @@ class SearchNotesQueries
   end
 
   def query(passed_query = {})
-    query_with_defaults = SearchNotesQueries.with_defaults(passed_query)
+    clamped_query = SearchNotesQueries.clamped_with_defaults(passed_query)
 
     # query for both the total number of records, and then limit
     # what is actually returned.
@@ -22,19 +27,19 @@ class SearchNotesQueries
     # by deferring the `limit` until after the authorization scoping,
     # this fetches much more data than would be fetched otherwise,
     # and this is a good place to optimize if we need to
-    query_scope = authorized_query_scope(query_with_defaults)
+    query_scope = authorized_query_scope(clamped_query)
     all_results_size = query_scope.size
-    event_notes = query_scope.first(query_with_defaults[:limit])
+    event_notes = query_scope.first(clamped_query[:limit])
 
     # serialize, and return both actual data and metadata about
     # total other records
     event_note_cards_json = event_notes.map {|event_note| FeedCard.event_note_card(event_note) }
-    [event_note_cards_json, all_results_size, query_with_defaults]
+    [event_note_cards_json, all_results_size, clamped_query]
   end
 
   private
-  def authorized_query_scope(query_with_defaults)
-    start_time, end_time, scope_key, text, grade, house, event_note_type_id = query_with_defaults.values_at(*[
+  def authorized_query_scope(clamped_query)
+    start_time, end_time, scope_key, text, grade, house, event_note_type_id = clamped_query.values_at(*[
       :start_time,
       :end_time,
       :scope_key,
@@ -57,7 +62,7 @@ class SearchNotesQueries
       qs = qs.joins(:student).where(students: {grade: grade}) if grade.present?
       qs = qs.joins(:student).where(students: {house: house}) if house.present?
       qs = qs.where(event_note_type_id: event_note_type_id) if event_note_type_id.present?
-      qs = qs.where('text LIKE ?', "%#{text}%") if text.present?
+      qs = qs.where('to_tsvector(text) @@ plainto_tsquery(?)', text) if text.present?
 
       # adjust scope
       qs = qs.where(educator_id: @educator.id) if scope_key == SCOPE_MY_NOTES_ONLY

--- a/app/lib/search_notes_queries.rb
+++ b/app/lib/search_notes_queries.rb
@@ -35,7 +35,13 @@ class SearchNotesQueries
   private
   def authorized_query_scope(query_with_defaults)
     start_time, end_time, scope_key, text, grade, house, event_note_type_id = query_with_defaults.values_at(*[
-      :start_time, :from_time, :scope_key, :text, :grade, :house, :event_note_type_id
+      :start_time,
+      :end_time,
+      :scope_key,
+      :text,
+      :grade,
+      :house,
+      :event_note_type_id
     ])
 
     authorizer = Authorizer.new(@educator)

--- a/app/lib/search_notes_queries.rb
+++ b/app/lib/search_notes_queries.rb
@@ -5,8 +5,6 @@ class SearchNotesQueries
 
   def self.with_defaults(query = {})
     query.merge({
-      from_time: query[:from_time] || Time.now,
-      limit: query[:limit] || 20,
       scope_key: query[:scope_key] || SearchNotesQueries::SCOPE_ALL_STUDENTS
     })
   end
@@ -36,15 +34,16 @@ class SearchNotesQueries
 
   private
   def authorized_query_scope(query_with_defaults)
-    from_time, scope_key, text, grade, house, event_note_type_id = query_with_defaults.values_at(*[
-      :from_time, :scope_key, :text, :grade, :house, :event_note_type_id
+    start_time, end_time, scope_key, text, grade, house, event_note_type_id = query_with_defaults.values_at(*[
+      :start_time, :from_time, :scope_key, :text, :grade, :house, :event_note_type_id
     ])
 
     authorizer = Authorizer.new(@educator)
     authorizer.authorized do
       qs = EventNote.all
         .where(is_restricted: false)
-        .where('recorded_at < ?', from_time)
+        .where('recorded_at > ?', start_time)
+        .where('recorded_at < ?', end_time)
         .order(recorded_at: :desc)
         .includes(:educator, student: [:homeroom, :school])
 

--- a/spec/lib/search_notes_queries_spec.rb
+++ b/spec/lib/search_notes_queries_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe SearchNotesQueries do
     }.merge(params))
   end
 
+  def make_query(params = {})
+    params.merge({
+      end_time: Time.now,
+      start_time: Time.now - 45.days,
+      limit: 50
+    })
+  end
+
   describe '#queries' do
     let!(:pals) { TestPals.create! }
 
@@ -28,53 +36,53 @@ RSpec.describe SearchNotesQueries do
 
     it 'can find notes' do
       setup!
-      query = {
+      query = make_query({
         text: 'read',
         grade: '12',
         house: 'Broadway',
         event_note_type_id: EventNoteType.SST.id,
-      }
-      event_note_cards_json, all_results_size, query_with_defaults = SearchNotesQueries.new(pals.shs_sofia_counselor).query(query)
+      })
+      event_note_cards_json, all_results_size, _ = SearchNotesQueries.new(pals.shs_sofia_counselor).query(query)
       expect(event_note_cards_json.size).to eq 1
       expect(all_results_size).to eq 1
     end
 
     it 'can filter out by text' do
       setup!
-      query = { text: 'nonexistent-search-text' }
-      event_note_cards_json, all_results_size, query_with_defaults = SearchNotesQueries.new(pals.shs_sofia_counselor).query(query)
+      query = make_query({ text: 'nonexistent-search-text' })
+      event_note_cards_json, all_results_size, _ = SearchNotesQueries.new(pals.shs_sofia_counselor).query(query)
       expect(event_note_cards_json.size).to eq 0
       expect(all_results_size).to eq 0
     end
 
     it 'can filter out by grade' do
       setup!
-      query = { grade: '9' }
-      event_note_cards_json, all_results_size, query_with_defaults = SearchNotesQueries.new(pals.shs_sofia_counselor).query(query)
+      query = make_query({ grade: '9' })
+      event_note_cards_json, all_results_size, _ = SearchNotesQueries.new(pals.shs_sofia_counselor).query(query)
       expect(event_note_cards_json.size).to eq 0
       expect(all_results_size).to eq 0
     end
 
     it 'can filter out by house' do
       setup!
-      query = { house: 'Elm' }
-      event_note_cards_json, all_results_size, query_with_defaults = SearchNotesQueries.new(pals.shs_sofia_counselor).query(query)
+      query = make_query({ house: 'Elm' })
+      event_note_cards_json, all_results_size, _ = SearchNotesQueries.new(pals.shs_sofia_counselor).query(query)
       expect(event_note_cards_json.size).to eq 0
       expect(all_results_size).to eq 0
     end
 
     it 'can filter out by note type' do
       setup!
-      query = { event_note_type_id: EventNoteType.NGE.id }
-      event_note_cards_json, all_results_size, query_with_defaults = SearchNotesQueries.new(pals.shs_sofia_counselor).query(query)
+      query = make_query({ event_note_type_id: EventNoteType.NGE.id })
+      event_note_cards_json, all_results_size, _ = SearchNotesQueries.new(pals.shs_sofia_counselor).query(query)
       expect(event_note_cards_json.size).to eq 0
       expect(all_results_size).to eq 0
     end
 
     it 'can filter out by time' do
       setup!
-      query = { house: 'Elm' }
-      event_note_cards_json, all_results_size, query_with_defaults = SearchNotesQueries.new(pals.shs_sofia_counselor).query(query)
+      query = make_query({ house: 'Elm' })
+      event_note_cards_json, all_results_size, _ = SearchNotesQueries.new(pals.shs_sofia_counselor).query(query)
       expect(event_note_cards_json.size).to eq 0
       expect(all_results_size).to eq 0
     end


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
Searching notes didn't work with case mismatches, and didn't do any processing like stemming.  It also didn't allow setting the time range, and would let clients query for all data.

# What does this PR do?
First, it uses Postgres fulltext operators for matching text instead of LIKE.  This includes stemming and filtering stop words.  There's no ranking; all results are still time-ordered.  I looked at [websearch_to_tsquery](https://www.postgresql.org/docs/11/textsearch-controls.html) which would be great but this is new in Postgres 11.  It was just released as [beta on Heroku](https://devcenter.heroku.com/changelog-items/1511), but this requires a database migration so cutting it from this PR.

Second, it allows searching by time range, defaulting to just the school year.

Third, the server clamps the time range that the client sends and the limit that it sends as well.

# Screenshot (if adding a client-side feature)
<img width="1121" alt="screen shot 2018-11-20 at 5 44 54 pm" src="https://user-images.githubusercontent.com/1056957/48807600-024f7980-ecec-11e8-8487-2ada7b53eeb4.png">


# Checklists
*Which features or pages does this PR touch?*
+ [x] Search notes

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here