### PR TITLE
Avoid logging download filenames via send_data

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -64,7 +64,6 @@ class StudentsController < ApplicationController
     send_data object.body.read, filename: @s3_filename, type: 'image/jpeg'
   end
 
-  # Using `send_data` logs the filename; see send_data_log_subscriber.rb
   def latest_iep_document
     # guard
     safe_params = params.permit(:id)

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -64,6 +64,7 @@ class StudentsController < ApplicationController
     send_data object.body.read, filename: @s3_filename, type: 'image/jpeg'
   end
 
+  # Using `send_data` logs the filename; see send_data_log_subscriber.rb
   def latest_iep_document
     # guard
     safe_params = params.permit(:id)

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -66,7 +66,7 @@ class StudentsController < ApplicationController
 
   def latest_iep_document
     # guard
-    safe_params = params.permit(:id)
+    safe_params = params.permit(:id, :format)
     student = authorized_or_raise! { Student.find(safe_params[:id]) }
     iep_document = student.latest_iep_document
     raise ActiveRecord::RecordNotFound if iep_document.nil?

--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -343,7 +343,7 @@ class FakeStudent
 
   def add_ieps
     15.in(100) do
-      file_name = "#{@student.local_id}_IEPAtAGlance_{@student.first_name}_#{@student.last_name}.pdf"
+      file_name = "#{@student.local_id}_IEPAtAGlance_#{@student.first_name}_#{@student.last_name}.pdf"
       file_digest = SecureRandom.hex
       IepDocument.create!(
         student: @student,

--- a/config/initializers/send_data_log_subscriber.rb
+++ b/config/initializers/send_data_log_subscriber.rb
@@ -1,0 +1,12 @@
+# Monkey patching to override logging the filename; we want to give users
+# descriptive filenames, and that means they may have sensitive info that we
+# don't want logged.
+#
+# see https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/log_subscriber.rb#L53
+module ActionController
+  class LogSubscriber < ActiveSupport::LogSubscriber
+    def send_data(event)
+      info { "Sent data [FILTERED] (#{event.duration.round(1)}ms)" }
+    end
+  end
+end

--- a/spec/importers/photo_import/photo_storer_spec.rb
+++ b/spec/importers/photo_import/photo_storer_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PhotoStorer do
       local_id: student.local_id,
       path_to_file: '/path/to/file',
       s3_client: FakeAwsClient,
-      logger: LogHelper::QuietLogger.new,
+      logger: LogHelper::RailsLogger.new,
       time_now: Time.new(2017, 5, 11)
     }
     PhotoStorer.new(default_attributes.merge(attributes))
@@ -102,7 +102,7 @@ RSpec.describe PhotoStorer do
       end
 
       it 'logs the right error messages and doesn\'t blow up' do
-        logger = LogHelper::QuietLogger.new
+        logger = LogHelper::RailsLogger.new
         photo_storer(logger: logger).store_only_new
         expect(logger.msgs.as_json).to contain_exactly(*[
           {"type"=>"info", "message"=>"storing photo for student_id: ##{student.id} to s3..."},

--- a/spec/support/log_redirect_helper.rb
+++ b/spec/support/log_redirect_helper.rb
@@ -39,28 +39,57 @@ module LogHelper
     end
   end
 
-  # Rails logger
-  class QuietLogger
+  # Rails logger, at INFO level
+  class RailsLogger
     attr_reader :msgs
 
     def initialize
       @msgs = []
     end
 
+    def debug?
+      false
+    end
+
     def debug(message)
-      @msgs << {type: :debug, message: message }
+      log_with(:debug, if block_given? then yield else message end)
+    end
+
+    def info?
+      true
     end
 
     def info(message)
-      @msgs << {type: :info, message: message }
+      log_with(:info, if block_given? then yield else message end)
+    end
+
+    def warn?
+      true
     end
 
     def warn(message)
-      @msgs << {type: :warn, message: message }
+      log_with(:warn, if block_given? then yield else message end)
+    end
+
+    def error?
+      true
     end
 
     def error(message)
-      @msgs << {type: :error, message: message }
+      log_with(:error, if block_given? then yield else message end)
+    end
+
+    def calls
+      @msgs
+    end
+
+    def output
+      @msgs.map {|msg| msg[:message] }.join("\n")
+    end
+
+    private
+    def log_with(level, message)
+      @msgs << {type: level, message: message }
     end
   end
 end


### PR DESCRIPTION
# Who is this PR for?
students, families

# What problem does this PR fix?
Rails' `send_data` method logs the filename, and these filenames contain personally identifiable information that would be stored in Logentries.

# What does this PR do?
Patch Rails to remove this, update our fake Rails logger, add specs for this.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile (IEP, profile PDF)

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here