### PR TITLE
Add CoverageChecker

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -9,7 +9,7 @@
         "Procfile",
         ".eslintrc",
         "config/**/*.rb",
-        "app/controlleers/educators/sessions_controller.rb",
+        "app/controllers/educators/sessions_controller.rb",
         "lib/ldap_authenticatable_tiny/*.rb",
         "app/lib/shs_tiers.rb",
         "spec/lib/route_guards_spec.rb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,5 @@ script:
   - ./scripts/ci/detect_package_lock.sh
   - rubocop
   - bundle exec brakeman -z
-  - bundle exec rspec spec
+  - ENABLE_RSPEC_COVERAGE_CHECKER=true bundle exec rspec spec
   - yarn test-cli

--- a/spec/charts/student_profile_chart_spec.rb
+++ b/spec/charts/student_profile_chart_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe StudentProfileChart do
     end
 
     it 'filters assessments with null SGP' do
-      with_growth_percentile = FactoryBot.create(:student_assessment, {
+      FactoryBot.create(:student_assessment, {
         student: student,
         scale_score: 504,
         growth_percentile: 26,
         assessment: Assessment.find_by(family: 'Next Gen MCAS', subject: 'Mathematics')
       })
-      without_growth_percentile = FactoryBot.create(:student_assessment, {
+      FactoryBot.create(:student_assessment, {
         student: student,
         scale_score: 502,
         growth_percentile: nil,

--- a/spec/coverage_bot.yml
+++ b/spec/coverage_bot.yml
@@ -1,0 +1,7 @@
+# See rails_helpers.rb and coverage_checker.rb
+# This is our own file, which we use to fail the build if specific files fall do not have 100% test coverage.
+check_test_coverage_for_files:
+  - app/controllers/educators/sessions_controller.rb
+  - lib/authorizer.rb
+  - lib/ldap_authenticatable_tiny/model.rb
+  - lib/ldap_authenticatable_tiny/strategy.rb

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,6 @@
-# ---- Student Insights ----
+# This can't be moved and has to be run first.  See https://github.com/colszowka/simplecov#troubleshooting
 require 'simplecov'
 SimpleCov.start
-# --- end Student Insights
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
@@ -85,3 +84,6 @@ RSpec.configure do |config|
     end
   end
 end
+
+# Test coverage checker
+CoverageChecker.new.setup!

--- a/spec/support/coverage_checker.rb
+++ b/spec/support/coverage_checker.rb
@@ -1,0 +1,43 @@
+class CoverageChecker
+  ERROR_STATUS_CODE = 172
+
+  # By default, only run this on full test runs (eg, in Travis) or when explicitly asked.
+  # In the common development case where you only run a subset of tests, this will have
+  # frequent false positive failures (since only some of the tests were run).
+  def setup!
+    return unless EnvironmentVariable.is_true('ENABLE_RSPEC_COVERAGE_CHECKER')
+    SimpleCov.at_exit do
+      SimpleCov.result.format!
+      fail_if_uncovered!(SimpleCov.result.files)
+    end
+  end
+
+  private
+  def fail_if_uncovered!(files)
+    files_to_check = filtered_files(files)
+    uncovered_files = files_to_check.select {|file| file.covered_percent < 100 }
+
+    if files_to_check.size == 0
+      puts "CoverageChecker: On this run, found no files to check for full coverage, skipping..."
+    elsif uncovered_files.size == 0
+      puts "CoverageChecker: On this run, checked #{files_to_check.size} files for full coverage, all passed!"
+    else
+      puts "CoverageChecker: On this run, checked #{files_to_check.size} files for full coverage."
+      puts "CoverageChecker: Found #{uncovered_files.size} #{uncovered_files.size == 1 ? 'file that was not' : 'files that were not'} fully covered."
+      file_lines = uncovered_files.map do |file|
+        "#{file.filename} - #{file.covered_percent.round}%"
+      end
+      puts " - " + file_lines.join("\n - ")
+      puts "CoverageChecked: Exiting with error status #{ERROR_STATUS_CODE}"
+      Kernel.exit ERROR_STATUS_CODE
+    end
+  end
+
+  def filtered_files(files)
+    config_file = File.open(File.join(Rails.root, 'spec', 'coverage_bot.yml'))
+    files_to_check = YAML.load(config_file)['check_test_coverage_for_files']
+    files.select do |file|
+      files_to_check.any? {|file_to_check| file.filename.ends_with?(file_to_check)}
+    end
+  end
+end


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Enforces test coverage on particularly critical files.  This of course is not a great measure of code quality or even test quality, but for these files we have this level of coverage now and this can help us spot gaps if they are introduced.

# What does this PR do?
Fails CI if test coverage for particular files is not 100%.  It can be run locally with `ENABLE_RSPEC_COVERAGE_CHECKER`.  Also adds some test cases to `authorizer.rb` and fixes a typo in mentionbot.

# Screenshot (if adding a client-side feature)
<img width="933" alt="screen shot 2018-11-27 at 2 39 37 pm" src="https://user-images.githubusercontent.com/1056957/49108308-df761580-f255-11e8-87c9-d6f5c0fad6fc.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Travis build

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here