### PR TITLE
Update instructions to crawlers; remove referrer altogether

### DIFF
--- a/app/views/shared/_head.html.erb
+++ b/app/views/shared/_head.html.erb
@@ -4,3 +4,6 @@
 <%= content_tag('div', '', id: 'env-for-js', 'data-env-for-js-json': EnvForJs.new.to_json) %>
 <%= javascript_include_tag Webpack.bundle('rollbar.js') %>
 <%= csrf_meta_tags %>
+<% if educator_signed_in? %>
+  <meta name="robots" content="noindex" />
+<% end %>

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -6,7 +6,7 @@ SecureHeaders::Configuration.default do |config|
   config.x_content_type_options = 'nosniff'
   config.x_xss_protection = '1; mode=block'
   config.x_permitted_cross_domain_policies = 'none'
-  config.referrer_policy = %w(origin-when-cross-origin strict-origin-when-cross-origin)
+  config.referrer_policy = %w(no-referrer)
 
   # Unblock PDF downloading for student report and for IEP-at-a-glance
   config.x_download_options = nil

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,6 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+
+# This says "please don't index anything except for the root / page"
+User-agent: *
+Allow: /$
+Disallow: /


### PR DESCRIPTION
# Who is this PR for?
students, families

# What does this PR do?
Tell the nice search engines not to crawl anything beyond the root page; make referrer header policy stricter and remove it altogether.

# Checklists
+ [x] Manual testing made more sense here