### PR TITLE
Fix educator id logging

### DIFF
--- a/app/lib/log_tags.rb
+++ b/app/lib/log_tags.rb
@@ -31,8 +31,7 @@ class LogTags
       return nil if session_data.nil?
       warden_data = session_data['warden.user.educator.key']
       return nil if warden_data.nil?
-      educator_id = warden_data.try(:[], 0).try(:[], 0)
-      return nil if educator_id.nil?
+      warden_data.try(:[], 0).try(:[], 0)
     rescue
       Rollbar.error('read_educator_id raised')
       nil


### PR DESCRIPTION
One more for https://github.com/studentinsights/studentinsights/pull/2297, tried adding a spec but didn't see a clear way to get at the log output here.  The approach for testing log scrubbing or Rollbar log scrubbing didn't work the same as I hoped they might.