### PR TITLE
Search: Add link if feature switch was set

### DIFF
--- a/app/assets/javascripts/home/HomePage.js
+++ b/app/assets/javascripts/home/HomePage.js
@@ -16,7 +16,10 @@ class HomePage extends React.Component {
       <div className="HomePage">
         <div style={styles.columnsContainer}>
           <div style={styles.column}>
-            <SectionHeading>{`What's happening?`}</SectionHeading>
+            <SectionHeading titleStyle={styles.sectionTitleStyle}>
+              <div>What's happening?</div>
+              {this.renderSearch()}
+            </SectionHeading>
             <HomeFeed educatorId={educatorId} />
           </div>
           <div style={styles.column}>
@@ -27,6 +30,12 @@ class HomePage extends React.Component {
       </div>
     );
   }
+
+  renderSearch() {
+    const {educatorLabels} = this.props;
+    if (educatorLabels.indexOf('enable_searching_notes') === -1) return null;
+    return <a href="/search/notes">Search notes</a>;
+  }
 }
 HomePage.propTypes = {
   educatorId: PropTypes.number.isRequired,
@@ -36,6 +45,11 @@ HomePage.propTypes = {
 const styles = {
   columnsContainer: {
     display: 'flex'
+  },
+  sectionTitleStyle: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center'
   },
   column: {
     flex: 1,

--- a/app/assets/javascripts/home/HomePage.test.js
+++ b/app/assets/javascripts/home/HomePage.test.js
@@ -6,10 +6,11 @@ import HomeInsights from './HomeInsights';
 import SectionHeading from '../components/SectionHeading';
 import {testContext} from '../testing/NowContainer';
 
-function testProps() {
+function testProps(props = {}) {
   return {
     educatorId: 9999,
-    educatorLabels: ['foo']
+    educatorLabels: ['foo'],
+    ...props
   };
 }
 
@@ -21,4 +22,24 @@ it('shallow renders without crashing', () => {
   expect(wrapper.find(SectionHeading).length).toEqual(2);
   expect(wrapper.contains(<HomeFeed educatorId={9999} />)).toEqual(true);
   expect(wrapper.contains(<HomeInsights educatorId={9999} educatorLabels={['foo']} />)).toEqual(true);
+});
+
+
+it('does not show search', () => {
+  const props = testProps();
+  const context = testContext();
+  const wrapper = shallow(<HomePage {...props} />, {context});
+  expect(wrapper.find('.HomePage').length).toEqual(1);
+  expect(wrapper.find(SectionHeading).length).toEqual(2);
+  expect(wrapper.contains('Search notes')).toEqual(false);
+});
+
+
+it('can show search for `enable_searching_notes`', () => {
+  const props = testProps({educatorLabels: ['enable_searching_notes']});
+  const context = testContext();
+  const wrapper = shallow(<HomePage {...props} />, {context});
+  expect(wrapper.find('.HomePage').length).toEqual(1);
+  expect(wrapper.find(SectionHeading).length).toEqual(2);
+  expect(wrapper.contains('Search notes')).toEqual(true);
 });

--- a/app/models/logged_search.rb
+++ b/app/models/logged_search.rb
@@ -1,0 +1,5 @@
+class LoggedSearch < ApplicationRecord
+  validates :all_results_size, presence: true
+  validates :clamped_query_json, presence: true
+  validates :search_date, presence: true
+end

--- a/db/migrate/20181210135737_log_searches.rb
+++ b/db/migrate/20181210135737_log_searches.rb
@@ -1,0 +1,9 @@
+class LogSearches < ActiveRecord::Migration[5.2]
+  def change
+    create_table :logged_searches do |t|
+      t.json :clamped_query_json, null: false
+      t.integer :all_results_size, null: false
+      t.date :search_date, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_09_121238) do
+ActiveRecord::Schema.define(version: 2018_12_10_135737) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -363,6 +363,12 @@ ActiveRecord::Schema.define(version: 2018_12_09_121238) do
     t.integer "number_of_hours"
     t.text "goal"
     t.string "custom_intervention_name"
+  end
+
+  create_table "logged_searches", force: :cascade do |t|
+    t.json "clamped_query_json", null: false
+    t.integer "all_results_size", null: false
+    t.date "search_date", null: false
   end
 
   create_table "login_activities", force: :cascade do |t|

--- a/spec/lib/search_notes_queries_spec.rb
+++ b/spec/lib/search_notes_queries_spec.rb
@@ -106,5 +106,31 @@ RSpec.describe SearchNotesQueries do
       expect(event_note_cards_json.size).to eq 100
       expect(clamped_query[:limit]).to eq 100
     end
+
+    it 'logs queries coarsely' do
+      setup!
+      query = make_query({
+        text: 'read',
+        grade: '12',
+        house: 'Broadway',
+        event_note_type_id: EventNoteType.SST.id
+      })
+      event_note_cards_json, all_results_size, _ = SearchNotesQueries.new(pals.shs_sofia_counselor).query(query)
+      expect(event_note_cards_json.size).to eq 1
+      expect(all_results_size).to eq 1
+      expect(LoggedSearch.all.size).to eq 1
+      expect(LoggedSearch.all.as_json(except: [:id])).to eq([{
+        "clamped_query_json"=>{
+          "limit" => 50,
+          "text" => "read",
+          "grade" => "12",
+          "house" => "Broadway",
+          "event_note_type_id" => 300,
+          "scope_key" => "SCOPE_ALL_STUDENTS"
+        }.to_json,
+        "all_results_size"=>1,
+        "search_date"=>Date.today
+      }])
+    end
   end
 end


### PR DESCRIPTION
# Who is this PR for?
HS counselors

# What does this PR do?
Adds direct link to search notes pages for educators with feature switch enabled, also adds coarse logging (not tied to an individual or particular time) for reviewing how well this is working for different searches.

# Screenshot (if adding a client-side feature)
<img width="1056" alt="screen shot 2018-12-10 at 9 12 18 am" src="https://user-images.githubusercontent.com/1056957/49738900-8b5c2f80-fc5e-11e8-9d03-4932ded83b66.png">


# Checklists
*Which features or pages does this PR touch?*
+ [X] Home page
+ [x] Search notes

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here