### PR TITLE
504: Update plan_504 method on student record to read EdPlan for Somerville

### DIFF
--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -48,18 +48,22 @@ export function orderedDisabilityValues(districtKey) {
   return ORDERED_DISABILITY_VALUES_MAP[districtKey] || [];
 }
 
-// Includes if they "exited" the 504
-export function hasInfoAbout504Plan(maybeStudent504Field) {
+// Should not include if they "exited" the 504 plan or if
+// they had one previously.  For Somerville this is patched
+// separately on the server as well, since this is determined
+// by the presence of an active ed plan document, and the field
+// on the student record in Aspen in inaccurate.
+export function hasActive504Plan(maybeStudent504Field) {
   if (maybeStudent504Field === undefined) return false;
   if (maybeStudent504Field === null) return false;
   if (maybeStudent504Field === '') return false;
   if (maybeStudent504Field === '504') return true; // Somerville
   if (maybeStudent504Field === 'Not 504') return false; // Somerville
   if (maybeStudent504Field === 'NotIn504') return false; // Somerville & New Bedford
-  if (maybeStudent504Field === 'Exited') return true; // New Bedford
+  if (maybeStudent504Field === 'Exited') return false; // New Bedford
   if (maybeStudent504Field === 'Active') return true; // New Bedford
 
-  return true;
+  return false;
 }
 
 

--- a/app/assets/javascripts/helpers/PerDistrict.test.js
+++ b/app/assets/javascripts/helpers/PerDistrict.test.js
@@ -2,7 +2,8 @@ import {
   shouldShowLowGradesBox,
   sortSchoolSlugsByGrade,
   studentTableEventNoteTypeIds,
-  eventNoteTypeIdsForSearch
+  eventNoteTypeIdsForSearch,
+  hasActive504Plan
 } from './PerDistrict';
 
 it('#shouldShowLowGradesBox', () => {
@@ -45,5 +46,17 @@ describe('#eventNoteTypeIdsForSearch', () => {
 
   it('handles beford', () => {
     expect(eventNoteTypeIdsForSearch('bedford')).toEqual([500, 302, 304, 501, 502, 503]);
+  });
+});
+
+describe('#hasActive504Plan', () => {
+  it('works across test cases', () => {
+    expect(hasActive504Plan('504')).toEqual(true);
+    expect(hasActive504Plan('Active')).toEqual(true);
+    expect(hasActive504Plan(null)).toEqual(false);
+    expect(hasActive504Plan('Not 504')).toEqual(false);
+    expect(hasActive504Plan('NotIn504')).toEqual(false);
+    expect(hasActive504Plan('Exited')).toEqual(false);
+    expect(hasActive504Plan('unknown')).toEqual(false);
   });
 });

--- a/app/assets/javascripts/school_overview/StudentsTable.js
+++ b/app/assets/javascripts/school_overview/StudentsTable.js
@@ -12,7 +12,7 @@ import {
   studentTableEventNoteTypeIds,
   shouldDisplayHouse,
   shouldDisplayCounselor,
-  hasInfoAbout504Plan
+  hasActive504Plan
 } from '../helpers/PerDistrict';
 import {eventNoteTypeTextMini} from '../helpers/eventNoteType';
 import {mergeLatestNoteDateTextFields} from '../helpers/latestNote';
@@ -71,7 +71,7 @@ export default class StudentsTable extends React.Component {
       customEnum = ['FLEP-Transitioning', 'FLEP', 'Fluent'];
       return students.sort((a, b) => sortByCustomEnum(a, b, sortBy, customEnum));
     case 'plan_504':
-      return _.sortBy(students, student => hasInfoAbout504Plan(student.plan_504));
+      return _.sortBy(students, student => hasActive504Plan(student.plan_504));
     case 'program_assigned':
       customEnum = ['Reg Ed', '2Way English', '2Way Spanish', 'Sp Ed'];
       return students.sort((a, b) => sortByCustomEnum(a, b, sortBy, customEnum));
@@ -148,7 +148,7 @@ export default class StudentsTable extends React.Component {
                   <td>
                     <a href={Routes.homeroom(student.homeroom_id)}>{student.homeroom_name}</a>
                   </td>
-                  <td>{hasInfoAbout504Plan(student.plan_504) ? '504' : null}</td>
+                  <td>{hasActive504Plan(student.plan_504) ? '504' : null}</td>
                   <td>{this.renderUnless('None', student.sped_level_of_need)}</td>
                   <td style={{width: '2.5em'}}>{this.renderUnless('Fluent', student.limited_english_proficiency)}</td>
                   {this.renderNumberCell(student.most_recent_star_reading_percentile)}

--- a/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
+++ b/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import {
-  hasInfoAbout504Plan,
+  hasActive504Plan,
   supportsSpedLiaison,
   shouldShowIepLink
 } from '../helpers/PerDistrict';
@@ -235,7 +235,7 @@ export default class LightHeaderSupportBits extends React.Component {
   render504() {
     const {edPlans, student, educatorLabels} = this.props;
     const plan504 = student.plan_504;
-    if (!hasInfoAbout504Plan(plan504)) return null;
+    if (!hasActive504Plan(plan504)) return null;
 
     const plan504El = <div style={styles.subtitleItem}>504 plan</div>;
     if (edPlans.length === 0 || educatorLabels.indexOf('enable_viewing_504_data_in_profile') === -1) return plan504El;

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -53,8 +53,8 @@ class PerDistrict
   end
 
   # Support patching this for Somerville, so that it is derived
-  # from the actual 504 plan document, since the Aspen field from
-  # the student export has bugs (eg, not considering if status of
+  # from the actual 504 plan document, since the SIS field from
+  # the student export is inaccurate (eg, not considering if status of
   # the ed plan).
   def patched_plan_504(student)
     if @district_key == SOMERVILLE

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -52,6 +52,18 @@ class PerDistrict
     yaml.fetch('star_filenames', {}).fetch(key, fallback)
   end
 
+  # Support patching this for Somerville, so that it is derived
+  # from the actual 504 plan document, since the Aspen field from
+  # the student export has bugs (eg, not considering if status of
+  # the ed plan).
+  def patched_plan_504(student)
+    if @district_key == SOMERVILLE
+      student.ed_plans.active.size > 0 ? '504' : nil
+    else
+      student.plan_504(force: true)
+    end
+  end
+
   def valid_plan_504_values
     if @district_key == SOMERVILLE || @district_key == DEMO
       [nil, "Not 504", "504", "NotIn504", "Active"]

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -102,6 +102,6 @@ class ProfileController < ApplicationController
 
   def ed_plans_json(student)
     return [] unless current_educator.labels.include?('enable_viewing_504_data_in_profile')
-    student.ed_plans.includes(:ed_plan_accommodations).as_json(include: :ed_plan_accommodations)
+    student.ed_plans.active.includes(:ed_plan_accommodations).as_json(include: :ed_plan_accommodations)
   end
 end

--- a/app/models/ed_plan.rb
+++ b/app/models/ed_plan.rb
@@ -8,6 +8,17 @@ class EdPlan < ApplicationRecord
   validates :sep_fieldd_006, presence: true
   validates :sep_fieldd_007, presence: true
 
+  SEP_STATUS_MAP = {
+    draft: 0,
+    active: 1,
+    previous: 2,
+    discarded: 4
+  }
+
+  def self.active
+    where(sep_status: SEP_STATUS_MAP[:active])
+  end
+
   def specific_disability
     sep_fieldd_006
   end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -80,6 +80,7 @@ class Student < ApplicationRecord
 
   # Support deriving this and overriding it based on other
   # data sources (eg, the document itself).
+  # This can trigger another query.
   def plan_504(options = {})
     return attributes['plan_504'] if options[:force]
     PerDistrict.new.patched_plan_504(self)

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -81,7 +81,7 @@ class Student < ApplicationRecord
   # Support deriving this and overriding it based on other
   # data sources (eg, the document itself).
   def plan_504(options = {})
-    return attributes.plan_504 if options[:force]
+    return attributes['plan_504'] if options[:force]
     PerDistrict.new.patched_plan_504(self)
   end
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -78,6 +78,13 @@ class Student < ApplicationRecord
     where(enrollment_status: 'Active', missing_from_last_export: false)
   end
 
+  # Support deriving this and overriding it based on other
+  # data sources (eg, the document itself).
+  def plan_504(options = {})
+    return attributes.plan_504 if options[:force]
+    PerDistrict.new.patched_plan_504(self)
+  end
+
   def active?
     enrollment_status == 'Active' && !missing_from_last_export
   end

--- a/spec/config_objects/per_district_spec.rb
+++ b/spec/config_objects/per_district_spec.rb
@@ -168,4 +168,38 @@ RSpec.describe PerDistrict do
       expect { for_new_bedford.choose_assessment_importer_row_class(assessment_test: 'MCAS') }.to raise_error Exceptions::DistrictKeyNotHandledError
     end
   end
+
+  describe '#patched_plan_504' do
+    it 'works for Somerville when ed plan' do
+      student = FactoryBot.build(:student, plan_504: nil)
+      student.save!
+      EdPlan.create!({
+        student_id: student.id,
+        sep_status: 1,
+        sep_effective_date: Date.parse('2016-09-15'),
+        sep_fieldd_006: 'Health disability',
+        sep_fieldd_007: 'Rich Districtwide, Laura Principal, Sarah Teacher, Jon Arbuckle (parent)',
+        sep_oid: 'test-sep-oid'
+      })
+      expect(for_somerville.patched_plan_504(student)).to eq '504'
+    end
+
+    it 'works for Somerville when no ed plan' do
+      student = FactoryBot.build(:student, plan_504: '504')
+      student.save!
+      expect(for_somerville.patched_plan_504(student)).to eq nil
+    end
+
+    it 'works for Bedford' do
+      student = FactoryBot.build(:student, plan_504: '504')
+      student.save!
+      expect(for_bedford.patched_plan_504(student)).to eq '504'
+    end
+
+    it 'works for New Bedford' do
+      student = FactoryBot.build(:student, plan_504: '504')
+      student.save!
+      expect(for_new_bedford.patched_plan_504(student)).to eq '504'
+    end
+  end
 end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -105,18 +105,36 @@ describe ProfileController, :type => :controller do
     end
 
     describe 'ed_plans' do
-      let!(:pals) { TestPals.create! }
-      let!(:f_and_p) do
+      def create_ed_plan!(attrs = {})
         EdPlan.create!({
           student_id: pals.healey_kindergarten_student.id,
+          sep_status: 1,
           sep_effective_date: Date.parse('2016-09-15'),
           sep_fieldd_006: 'Health disability',
           sep_fieldd_007: 'Rich Districtwide, Laura Principal, Sarah Teacher, Jon Arbuckle (parent)',
           sep_oid: 'test-sep-oid'
-        })
+        }.merge(attrs))
       end
 
+      let!(:pals) { TestPals.create! }
+
       it 'guards access' do
+        create_ed_plan!
+        sign_in(pals.uri)
+        make_request(pals.uri, pals.healey_kindergarten_student.id)
+        expect(response.status).to eq 200
+        json = JSON.parse(response.body)
+        expect(json['ed_plans'].size).to eq(0)
+      end
+
+      it 'only includes active ed plans' do
+        create_ed_plan!(sep_status: 4, sep_oid: 'test-sep-discarded')
+        create_ed_plan!(sep_status: 2, sep_oid: 'test-sep-previous')
+        create_ed_plan!(sep_status: 0, sep_oid: 'test-sep-draft')
+        EducatorLabel.create!({
+          educator: pals.uri,
+          label_key: 'enable_viewing_504_data_in_profile'
+        })
         sign_in(pals.uri)
         make_request(pals.uri, pals.healey_kindergarten_student.id)
         expect(response.status).to eq 200
@@ -125,6 +143,7 @@ describe ProfileController, :type => :controller do
       end
 
       it 'works when enabled' do
+        create_ed_plan!
         EducatorLabel.create!({
           educator: pals.uri,
           label_key: 'enable_viewing_504_data_in_profile'

--- a/spec/importers/photo_import/photo_storer_spec.rb
+++ b/spec/importers/photo_import/photo_storer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe PhotoStorer do
   end
 
   before do
+    allow(ENV).to receive(:[]).and_call_original
     allow(ENV).to receive(:[]).with('AWS_S3_PHOTOS_BUCKET').and_return('mock-test-photo-bucket')
     allow(Digest::SHA256).to receive(:file).with('/path/to/file').and_return('HashedImageFile')
     allow(File).to receive(:size).with('/path/to/file').and_return 10

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -275,4 +275,37 @@ RSpec.describe Student do
       })
     end
   end
+
+  describe '#plan_504' do
+    it 'ignores student record value for Somerville' do
+      student = FactoryBot.build(:student, plan_504: '504')
+      per_district = PerDistrict.new(district_key: PerDistrict::SOMERVILLE)
+      allow(PerDistrict).to receive(:new).and_return(per_district)
+      expect(student.plan_504).to eq nil
+    end
+
+    it 'allows force:true' do
+      student = FactoryBot.build(:student, plan_504: '504')
+      per_district = PerDistrict.new(district_key: PerDistrict::SOMERVILLE)
+      allow(PerDistrict).to receive(:new).and_return(per_district)
+      expect(student.plan_504).to eq nil
+      expect(student.plan_504(force: true)).to eq '504'
+    end
+
+    it 'returns 504 if active ed plan for Somerville' do
+      student = FactoryBot.build(:student, plan_504: nil)
+      student.save!
+      EdPlan.create!({
+        student_id: student.id,
+        sep_status: 1,
+        sep_effective_date: Date.parse('2016-09-15'),
+        sep_fieldd_006: 'Health disability',
+        sep_fieldd_007: 'Rich Districtwide, Laura Principal, Sarah Teacher, Jon Arbuckle (parent)',
+        sep_oid: 'test-sep-oid'
+      })
+      per_district = PerDistrict.new(district_key: PerDistrict::SOMERVILLE)
+      allow(PerDistrict).to receive(:new).and_return(per_district)
+      expect(student.plan_504).to eq '504'
+    end
+  end
 end


### PR DESCRIPTION
Related to https://github.com/studentinsights/studentinsights/pull/2287.

# Who is this PR for?
Somerville educators

# What problem does this PR fix?
The `plan_504` value coming from the SIS export isn't accurate; it overcounts students who have an ed plan set to "previous" status.

# What does this PR do?
To work around this, this PR adds a method to the `Student` model to patch this for Somerville.  We could update the student export to solve this upstream, but this is a faster change and self-contained.  Aside from the complexity downside, this also means doing another query for each read of `plan_504`, which could be expensive for calls like `Student.active.as_json` with an eager include.

This also updates the JS function that decides about showing "504 plan" so that it is stricter, which isn't directly related to the server-side change (since the server-side change for Somerville keeps the same API with the UI).

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile
+ [x] School Overview

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here