### PR TITLE
Search: Prototype word cloud for reflection meetings

### DIFF
--- a/app/assets/javascripts/feed/FeedView.js
+++ b/app/assets/javascripts/feed/FeedView.js
@@ -8,9 +8,9 @@ import IncidentCard from './IncidentCard';
 // Pure UI component for rendering feed cards (eg, on the home page)
 export default class FeedView extends React.Component {
   render() {
-    const {feedCards, cardPropsFn} = this.props;
+    const {feedCards, cardPropsFn, style} = this.props;
     return (
-      <div className="FeedView">
+      <div className="FeedView" style={style}>
         {feedCards.map(feedCard => {
           const {type, json} = feedCard;
           const cardProps = cardPropsFn ? cardPropsFn(type, json) : {};
@@ -56,7 +56,8 @@ FeedView.propTypes = {
     timestamp: PropTypes.string.isRequired,
     json: PropTypes.object.isRequired
   })).isRequired,
-  cardPropsFn: PropTypes.func
+  cardPropsFn: PropTypes.func,
+  style: PropTypes.object
 };
 
 

--- a/app/assets/javascripts/feed/MutableFeedView.js
+++ b/app/assets/javascripts/feed/MutableFeedView.js
@@ -46,9 +46,11 @@ export default class MutableFeedView extends React.Component {
   }
 
   render() {
+    const {style} = this.props;
     const {feedCards} = this.state;
     return (
       <FeedView
+        style={style}
         feedCards={feedCards}
         cardPropsFn={this.cardPropsFn}
       />
@@ -75,5 +77,6 @@ export default class MutableFeedView extends React.Component {
 }
 MutableFeedView.propTypes = {
   defaultFeedCards: PropTypes.array.isRequired,
-  educatorLabels: PropTypes.arrayOf(PropTypes.string).isRequired
+  educatorLabels: PropTypes.arrayOf(PropTypes.string).isRequired,
+  style: PropTypes.object
 };

--- a/app/assets/javascripts/search_notes/SearchNotesPage.test.js
+++ b/app/assets/javascripts/search_notes/SearchNotesPage.test.js
@@ -10,6 +10,7 @@ import searchJson from './searchJson.fixture';
 
 function testProps() {
   return {
+    showWordCloud: true,
     educatorId: 9999,
     educatorLabels: []
   };

--- a/app/assets/javascripts/search_notes/WordCloud.js
+++ b/app/assets/javascripts/search_notes/WordCloud.js
@@ -13,9 +13,10 @@ export default class WordCloud extends React.Component {
 
   componentDidMount() {    
     const {words} = this.props;
-    const filteredWords = filtered(words);
+    const filteredWords = cleaned(words);
     const list = _.toPairs(_.countBy(filteredWords));
-    const weightFactor = (filteredWords.length / 300);
+    const weightFactor = Math.max(20, (filteredWords.length / 300));
+    console.log('weightFactor', weightFactor);
     WordCloudLib(this.el, {
       list,
       weightFactor,
@@ -54,11 +55,16 @@ function color(word, weight, fontSize, distance, theta) {
 }
 
 
-function filtered(words) {
-  return words.filter(word => {
-    if (stopWords.indexOf(word.toLowerCase()) !== -1) return false;
-    if (parseInt(word, 10).toString() === word) return false;
-    return true;
+function cleanWord(word) {
+  return word
+    .replace(/[\.,]*$/,'')
+    .replace(/^[\.,]*/,'');
+}
+function cleaned(words) {
+  return _.flatMap(words, word => {
+    if (stopWords.indexOf(word.toLowerCase()) !== -1) return [];
+    if (parseInt(word, 10).toString() === word) return [];
+    return [cleanWord(word)];
   });
 }
 const stopWords = [

--- a/app/assets/javascripts/search_notes/WordCloud.js
+++ b/app/assets/javascripts/search_notes/WordCloud.js
@@ -1,0 +1,239 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import WordCloudLib from 'wordcloud';
+
+// A word cloud visualization on canvas.  Tuning is tricky and
+// context-sensitive.
+export default class WordCloud extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onClick = this.onClick.bind(this);
+  }
+
+  componentDidMount() {    
+    const {words} = this.props;
+    const filteredWords = filtered(words);
+    const list = _.toPairs(_.countBy(filteredWords));
+    const weightFactor = (filteredWords.length / 300);
+    WordCloudLib(this.el, {
+      list,
+      weightFactor,
+      color,
+      shape: 'square',
+      click: this.onClick
+    });
+  }
+
+  onClick(e) {
+    alert(`The word "${e[0]}" appears ${e[1]} times.`);
+  }
+
+  render() {
+    const {width, height} = this.props;
+    return (
+      <canvas
+        className="WordCloud"
+        ref={el => this.el = el}
+        style={{cursor: 'pointer'}}
+        width={width}
+        height={height}
+      />
+    );
+  }
+}
+WordCloud.propTypes = {
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
+  words: PropTypes.arrayOf(PropTypes.string).isRequired
+};
+
+
+function color(word, weight, fontSize, distance, theta) {
+  return weight > 1 ? '#3177c9' : '#ccc';
+}
+
+
+function filtered(words) {
+  return words.filter(word => {
+    if (stopWords.indexOf(word.toLowerCase()) !== -1) return false;
+    if (parseInt(word, 10).toString() === word) return false;
+    return true;
+  });
+}
+const stopWords = [
+  "i",
+  "me",
+  "my",
+  "myself",
+  "we",
+  "our",
+  "ours",
+  "ourselves",
+  "you",
+  "your",
+  "yours",
+  "yourself",
+  "yourselves",
+  "he",
+  "him",
+  "his",
+  "himself",
+  "she",
+  "her",
+  "hers",
+  "herself",
+  "it",
+  "its",
+  "itself",
+  "they",
+  "them",
+  "their",
+  "theirs",
+  "themselves",
+  "what",
+  "which",
+  "who",
+  "whom",
+  "this",
+  "that",
+  "these",
+  "those",
+  "am",
+  "is",
+  "are",
+  "was",
+  "were",
+  "be",
+  "been",
+  "being",
+  "have",
+  "has",
+  "had",
+  "having",
+  "do",
+  "does",
+  "did",
+  "doing",
+  "would",
+  "should",
+  "could",
+  "ought",
+  "i'm",
+  "you're",
+  "he's",
+  "she's",
+  "it's",
+  "we're",
+  "they're",
+  "i've",
+  "you've",
+  "we've",
+  "they've",
+  "i'd",
+  "you'd",
+  "he'd",
+  "she'd",
+  "we'd",
+  "they'd",
+  "i'll",
+  "you'll",
+  "he'll",
+  "she'll",
+  "we'll",
+  "they'll",
+  "isn't",
+  "aren't",
+  "wasn't",
+  "weren't",
+  "hasn't",
+  "haven't",
+  "hadn't",
+  "doesn't",
+  "don't",
+  "didn't",
+  "won't",
+  "wouldn't",
+  "shan't",
+  "shouldn't",
+  "can't",
+  "cannot",
+  "couldn't",
+  "mustn't",
+  "let's",
+  "that's",
+  "who's",
+  "what's",
+  "here's",
+  "there's",
+  "when's",
+  "where's",
+  "why's",
+  "how's",
+  "a",
+  "an",
+  "the",
+  "and",
+  "but",
+  "if",
+  "or",
+  "because",
+  "as",
+  "until",
+  "while",
+  "of",
+  "at",
+  "by",
+  "for",
+  "with",
+  "about",
+  "against",
+  "between",
+  "into",
+  "through",
+  "during",
+  "before",
+  "after",
+  "above",
+  "below",
+  "to",
+  "from",
+  "up",
+  "down",
+  "in",
+  "out",
+  "on",
+  "off",
+  "over",
+  "under",
+  "again",
+  "further",
+  "then",
+  "once",
+  "here",
+  "there",
+  "when",
+  "where",
+  "why",
+  "how",
+  "all",
+  "any",
+  "both",
+  "each",
+  "few",
+  "more",
+  "most",
+  "other",
+  "some",
+  "such",
+  "no",
+  "nor",
+  "not",
+  "only",
+  "own",
+  "same",
+  "so",
+  "than",
+  "too",
+  "very"
+];

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "react-virtualized": "9.20",
     "rollbar-browser": "^1.9.5",
     "uuid": "^3.2.1",
-    "whatwg-fetch": "^2.0.3"
+    "whatwg-fetch": "^2.0.3",
+    "wordcloud": "^1.1.0"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.4.3",
@@ -71,6 +72,7 @@
     "eslint": "^3.3.1",
     "eslint-plugin-react": "^6.1.2",
     "jest": "^23.0.0",
+    "jest-canvas-mock": "^1.1.0",
     "react-addons-test-utils": "15.4.2",
     "script-loader": "^0.7.2",
     "style-loader": "^0.20.3",

--- a/ui/config/setupTests.js
+++ b/ui/config/setupTests.js
@@ -15,6 +15,9 @@ import './performance-timing-api';
 import {performance} from 'perf_hooks';
 window.performance = performance;
 
+// See https://github.com/hustcc/jest-canvas-mock#setup-file
+import 'jest-canvas-mock';
+
 // https://github.com/jefflau/jest-fetch-mock
 window.fetch = require('jest-fetch-mock'); // eslint-disable-line no-undef
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4604,6 +4604,11 @@ istanbul-reports@^1.3.0:
   dependencies:
     handlebars "^4.0.3"
 
+jest-canvas-mock@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-1.1.0.tgz#f6ed0998b6be3ae2b7e095d7173441ae62cc831e"
+  integrity sha512-D2VoKl+L6r9VpqTPygXKvIOQ1aou7gz3PvstlWDZqPT7EVYcSz0Nj+yjJ9G+Y9EqJd2X95f3dzcmmXb2dvQ1DQ==
+
 jest-changed-files@^23.4.2:
   version "23.4.2"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.4.2.tgz#1eed688370cd5eebafe4ae93d34bb3b64968fe83"
@@ -8525,6 +8530,11 @@ wide-align@^1.1.0:
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
+
+wordcloud@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/wordcloud/-/wordcloud-1.1.0.tgz#3a1c52f7d088d43ee5ee855d4f86280de57f0758"
+  integrity sha512-2PHPdgYYt6jxu7EIQIY3YAs1/3ONZpVn4hwgpWISdypbwqTByJAE7r9bsRDFG0WKL82i0Y28xRZ0wF00lqZzWg==
 
 wordwrap@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
# Who is this PR for?
prototype, for HS counselors or classroom teachers

# What problem does this PR fix?
Simplistic summary of themes in notes within search results, starting point for discussion.  This might not be a good idea, and might be sensitive to particular datasets, so it's shipped dark.

# What does this PR do?
Adds word cloud in the 'sidebar' panel, shipped dark with a querystring feature switch.

# Screenshot (if adding a client-side feature)
<img width="1065" alt="screen shot 2018-12-11 at 5 48 53 pm" src="https://user-images.githubusercontent.com/1056957/49835474-483cb200-fd6d-11e8-92f6-b4ba1ca7ed97.png">


# Checklists
*Which features or pages does this PR touch?*
+ [X] Search page

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here