### PR TITLE
Add redirect for /sections page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ Rails.application.routes.draw do
 
   # home page
   get '/home' => 'ui#ui'
+  get '/sections', to: redirect('/') # bing indexed this, keep redirect around for a bit
 
   # districtwide pages
   scope '/district' do


### PR DESCRIPTION
Bing is aggressive, and I'd guess indexed this URL from spying through browser search bars.  If users do click through from Bing, redirect them instead of 404ing.