### PR TITLE
504: Update EdPlanImporter validations, explicitly skip when 'specific disability' is missing

### DIFF
--- a/app/importers/file_importers/ed_plans_importer.rb
+++ b/app/importers/file_importers/ed_plans_importer.rb
@@ -31,6 +31,7 @@ class EdPlansImporter
     log('Done loop.')
     log("@skipped_from_school_filter: #{@skipped_from_school_filter}")
     log("@skipped_from_student_local_id_filter: #{@skipped_from_student_local_id_filter}")
+    log("@skipped_from_empty_sep_fieldd_006: #{@skipped_from_empty_sep_fieldd_006}")
 
     log('Calling #delete_unmarked_records...')
     @syncer.delete_unmarked_records!(records_within_scope)
@@ -42,6 +43,7 @@ class EdPlansImporter
   def reset_counters!
     @skipped_from_school_filter = 0
     @skipped_from_student_local_id_filter = 0
+    @skipped_from_empty_sep_fieldd_006 = 0
   end
 
   # Take param, or download it
@@ -76,6 +78,13 @@ class EdPlansImporter
     # Skip based on student filter
     if @student_local_ids.present? && !@student_local_ids.include?(row[:student_local_id])
       @skipped_from_student_local_id_filter += 1
+      return
+    end
+
+    # There are a good number of records without sep_fieldd_006
+    # set, skip these explicitly.
+    if row[:sep_fieldd_006].blank?
+      @skipped_from_empty_sep_fieldd_006 += 1
       return
     end
 

--- a/app/models/ed_plan.rb
+++ b/app/models/ed_plan.rb
@@ -6,14 +6,6 @@ class EdPlan < ApplicationRecord
   validates :sep_oid, presence: true, uniqueness: true
   validates :sep_effective_date, presence: true
   validates :sep_fieldd_006, presence: true
-  validates :sep_fieldd_007, presence: true
-
-  SEP_STATUS_MAP = {
-    draft: 0,
-    active: 1,
-    previous: 2,
-    discarded: 4
-  }
 
   def self.active
     where(sep_status: SEP_STATUS_MAP[:active])
@@ -26,4 +18,12 @@ class EdPlan < ApplicationRecord
   def persons_responsible
     sep_fieldd_007
   end
+
+  private
+  SEP_STATUS_MAP = {
+    draft: 0,
+    active: 1,
+    previous: 2,
+    discarded: 4
+  }
 end


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
The validation on 'specific disability' led to a large number of records failing (mostly for "draft" plans).

# What does this PR do?
Skips these explicitly in the importer.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here