### PR TITLE
504: Include 504 importer in x2 import group

### DIFF
--- a/app/importers/file_importers/file_importer_options.rb
+++ b/app/importers/file_importers/file_importer_options.rb
@@ -35,6 +35,8 @@ class FileImporterOptions
         StudentSectionAssignmentsImporter,
         StudentSectionGradesImporter,
         EducatorSectionAssignmentsImporter,
+        EdPlansImporter,
+        EdPlanAccommodationsImporter
       ],
       'star' => [
         StarReadingImporter,

--- a/app/models/ed_plan.rb
+++ b/app/models/ed_plan.rb
@@ -24,6 +24,7 @@ class EdPlan < ApplicationRecord
     draft: 0,
     active: 1,
     previous: 2,
+    rejected: 3,
     discarded: 4
   }
 end

--- a/spec/importers/file_importers/file_importer_options_spec.rb
+++ b/spec/importers/file_importers/file_importer_options_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe FileImporterOptions do
           StarMathImporter,
           StarReadingImporter,
           X2AssessmentImporter,
+          EdPlansImporter,
+          EdPlanAccommodationsImporter
         ])
       end
     end
@@ -60,6 +62,8 @@ RSpec.describe FileImporterOptions do
           BehaviorImporter,
           StudentSectionGradesImporter,
           X2AssessmentImporter,
+          EdPlansImporter,
+          EdPlanAccommodationsImporter
         ])
       end
     end


### PR DESCRIPTION
This wasn't included, which meant `thor import:start` didn't include these.

