### PR TITLE
My notes: Revise layout and add word cloud, shipped dark

### DIFF
--- a/app/assets/javascripts/components/BoxCard.js
+++ b/app/assets/javascripts/components/BoxCard.js
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import Card from './Card';
+
+
+// A visual UI element for a boxy card of information, with a title.
+// Does not have a defined or minimum height; style that in the child element.
+export default function BoxCard({title, children, style, className}) {
+  return (
+    <Card
+      className={`BoxCard ${className || ''}`}
+      style={styles.card}>
+      <div style={styles.cardTitle}>{title}</div>
+      {children}
+    </Card>
+  );
+}
+
+BoxCard.propTypes = {
+  title: PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  style: PropTypes.object
+};
+
+const styles = {
+  card: {
+    margin: 20,
+    padding: 0,
+    flexDirection: 'column',
+    display: 'flex'
+  },
+  cardTitle: {
+    backgroundColor: '#eee',
+    padding: 10,
+    color: 'black',
+    borderBottom: '1px solid #ccc',
+    display: 'flex',
+    justifyContent: 'space-between'
+  }
+};

--- a/app/assets/javascripts/components/WordCloud.js
+++ b/app/assets/javascripts/components/WordCloud.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import WordCloudLib from 'wordcloud';
 
+
 // A word cloud visualization on canvas.  Tuning is tricky and
 // context-sensitive.
 export default class WordCloud extends React.Component {
@@ -11,7 +12,18 @@ export default class WordCloud extends React.Component {
     this.onClick = this.onClick.bind(this);
   }
 
-  componentDidMount() {    
+  componentDidMount() {
+    this.doDrawWordCloud();
+  } 
+
+  componentDidUpdate(prevProps, prevState) {
+    if (_.isEqual(this.props, prevProps)) return;
+    this.doDrawWordCloud();
+  }
+
+  doDrawWordCloud() {
+    if (!this.el) return;
+    
     const {words} = this.props;
     const filteredWords = cleaned(words);
     const list = _.toPairs(_.countBy(filteredWords));

--- a/app/assets/javascripts/my_notes/NotesFeed.js
+++ b/app/assets/javascripts/my_notes/NotesFeed.js
@@ -1,7 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import _ from 'lodash';
 import SectionHeading from '../components/SectionHeading';
-import NotesList from '../student_profile/NotesList';
+import BoxCard from '../components/BoxCard';
+import WordCloud from '../components/WordCloud';
+import NotesList from '../student_profile/NotesList'; // refactor to feed
 
 
 export default class NotesFeed extends React.Component {
@@ -21,9 +24,9 @@ export default class NotesFeed extends React.Component {
     return (
       <div className="NotesFeed" style={styles.root}>
         <SectionHeading>My notes</SectionHeading>
-        <div style={styles.subTitle}> Past {eventNotes.length} notes.</div>
+        <div style={styles.subTitle}>Showing {eventNotes.length} notes</div>
         <div className="feed" style={styles.feed}>
-          <div className="notes-list">
+          <div style={styles.leftColumn} className="notes-list">
             <NotesList
               currentEducatorId={currentEducatorId}
               includeStudentPanel={true}
@@ -32,8 +35,29 @@ export default class NotesFeed extends React.Component {
               educatorsIndex={educatorsIndex}
               feed={feed} />
           </div>
+          <div style={styles.rightColumn}>
+            {this.renderSidebar()}
+          </div>
         </div>
           {this.renderFooter()}
+      </div>
+    );
+  }
+
+  renderSidebar() {
+    const {showWordCloud, eventNotes} = this.props;
+    if (!showWordCloud && window.location.search.indexOf('wordcloud') === -1) return null;
+    
+    const words = wordsFromEventNotes(eventNotes);
+    return (
+      <div style={styles.flexVertical}>
+        <BoxCard title="Most common words" style={{marginTop: 10}}>
+          <WordCloud
+            width={400}
+            height={400}
+            words={words}
+          />
+        </BoxCard>
       </div>
     );
   }
@@ -60,6 +84,7 @@ NotesFeed.propTypes = {
   eventNotes: PropTypes.arrayOf(PropTypes.object).isRequired,
   onClickLoadMoreNotes: PropTypes.func.isRequired,
   totalNotesCount: PropTypes.number.isRequired,
+  showWordCloud: PropTypes.bool
 };
 
 
@@ -73,17 +98,31 @@ const styles = {
     display: 'inline'
   },
   feed: {
-    margin: 'auto 10%'
+    display: 'flex',
+    flexDirection: 'row',
+    margin: 10
+  },
+  leftColumn: {
+    flex: 1
+  },
+  rightColumn: {
+    paddingLeft: 20,
+    flex: 1
   },
   footer: {
     margin: '5% 41%'
   },
   subTitle: {
-    margin: 20
-  },
-  title: {
-    fontSize: 28,
-    fontWeight: 'bold',
-    color: '#155094'
-  },
+    margin: 10,
+    marginTop: 20,
+    color: '#aaa'
+  }
 };
+
+
+// Quick and dirty grabbing the list of words
+function wordsFromEventNotes(eventNotes) {
+  return _.flatMap(eventNotes, eventNote => {
+    return eventNote.text.split(' ');
+  });
+}

--- a/app/assets/javascripts/my_notes/NotesFeed.test.js
+++ b/app/assets/javascripts/my_notes/NotesFeed.test.js
@@ -30,3 +30,10 @@ it('snapshots view', () => {
     .toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+it('snapshots view with wordcloud', () => {
+  const tree = renderer
+    .create(withDefaultNowContext(<NotesFeed {...testProps({showWordCloud: true})} />))
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/assets/javascripts/my_notes/__snapshots__/NotesFeed.test.js.snap
+++ b/app/assets/javascripts/my_notes/__snapshots__/NotesFeed.test.js.snap
@@ -33,24 +33,33 @@ exports[`snapshots view 1`] = `
   <div
     style={
       Object {
-        "margin": 20,
+        "color": "#aaa",
+        "margin": 10,
+        "marginTop": 20,
       }
     }
   >
-     Past 
+    Showing 
     5
-     notes.
+     notes
   </div>
   <div
     className="feed"
     style={
       Object {
-        "margin": "auto 10%",
+        "display": "flex",
+        "flexDirection": "row",
+        "margin": 10,
       }
     }
   >
     <div
       className="notes-list"
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
     >
       <div
         className="NotesList"
@@ -760,6 +769,839 @@ exports[`snapshots view 1`] = `
               Note
             </div>
           </div>
+        </div>
+      </div>
+    </div>
+    <div
+      style={
+        Object {
+          "flex": 1,
+          "paddingLeft": 20,
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
+exports[`snapshots view with wordcloud 1`] = `
+<div
+  className="NotesFeed"
+  style={
+    Object {
+      "fontSize": 14,
+      "margin": 10,
+    }
+  }
+>
+  <div
+    className="SectionHeading"
+    style={
+      Object {
+        "borderBottom": "1px solid #333",
+        "padding": 10,
+      }
+    }
+  >
+    <h4
+      style={
+        Object {
+          "color": "black",
+          "display": "inline",
+        }
+      }
+    >
+      My notes
+    </h4>
+  </div>
+  <div
+    style={
+      Object {
+        "color": "#aaa",
+        "margin": 10,
+        "marginTop": 20,
+      }
+    }
+  >
+    Showing 
+    5
+     notes
+  </div>
+  <div
+    className="feed"
+    style={
+      Object {
+        "display": "flex",
+        "flexDirection": "row",
+        "margin": 10,
+      }
+    }
+  >
+    <div
+      className="notes-list"
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
+      <div
+        className="NotesList"
+      >
+        <div
+          className="wrapper"
+          style={
+            Object {
+              "display": "flex",
+            }
+          }
+        >
+          <div
+            className="studentCard"
+            style={
+              Object {
+                "border": "1px solid #eee",
+                "marginBottom": 10,
+                "marginTop": 10,
+                "padding": 15,
+                "width": "25%",
+              }
+            }
+          >
+            <p>
+              <a
+                href="/students/79"
+                style={
+                  Object {
+                    "color": "#3177c9",
+                    "fontSize": "18px",
+                    "fontWeight": "bold",
+                    "marginBottom": "5%",
+                  }
+                }
+              >
+                White
+                , 
+                Elsa
+              </a>
+            </p>
+            <p>
+              <a
+                className="school-link"
+                href="/schools/9"
+              >
+                Somerville High
+              </a>
+            </p>
+            <p>
+              10
+              th Grade
+            </p>
+          </div>
+          <div
+            className="NoteCard"
+            style={
+              Object {
+                "border": "1px solid #eee",
+                "marginBottom": 10,
+                "marginTop": 10,
+                "padding": 15,
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "display": "flex",
+                  "justifyContent": "space-between",
+                }
+              }
+            >
+              <span
+                className="date"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "fontWeight": "bold",
+                    "paddingRight": 10,
+                    "width": "11em",
+                  }
+                }
+              >
+                August 23, 2018
+              </span>
+              <span
+                style={
+                  Object {
+                    "background": "#eee",
+                    "display": "inline-block",
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "outline": "3px solid #eee",
+                    "textAlign": "center",
+                    "width": "10em",
+                  }
+                }
+              >
+                SST Meeting
+              </span>
+              <span
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "paddingLeft": 5,
+                  }
+                }
+              >
+                <a
+                  className="Educator"
+                  href="mailto:uri@demo.studentinsights.org"
+                  style={Object {}}
+                >
+                  Uri Disney
+                </a>
+              </span>
+            </div>
+            <div
+              className="RestrictedNotePresence"
+            >
+              <div>
+                <div
+                  className="NoteText"
+                  style={
+                    Object {
+                      "border": "1px solid transparent",
+                      "color": "#999",
+                      "fontFamily": "'Open Sans', sans-serif",
+                      "fontSize": 14,
+                      "marginTop": 5,
+                      "overflowX": "hidden",
+                      "padding": 0,
+                      "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-word",
+                    }
+                  }
+                >
+                  To respect Elsa's privacy, Uri marked this note as restricted.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="wrapper"
+          style={
+            Object {
+              "display": "flex",
+            }
+          }
+        >
+          <div
+            className="studentCard"
+            style={
+              Object {
+                "border": "1px solid #eee",
+                "marginBottom": 10,
+                "marginTop": 10,
+                "padding": 15,
+                "width": "25%",
+              }
+            }
+          >
+            <p>
+              <a
+                href="/students/79"
+                style={
+                  Object {
+                    "color": "#3177c9",
+                    "fontSize": "18px",
+                    "fontWeight": "bold",
+                    "marginBottom": "5%",
+                  }
+                }
+              >
+                White
+                , 
+                Elsa
+              </a>
+            </p>
+            <p>
+              <a
+                className="school-link"
+                href="/schools/9"
+              >
+                Somerville High
+              </a>
+            </p>
+            <p>
+              10
+              th Grade
+            </p>
+          </div>
+          <div
+            className="NoteCard"
+            style={
+              Object {
+                "border": "1px solid #eee",
+                "marginBottom": 10,
+                "marginTop": 10,
+                "padding": 15,
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "display": "flex",
+                  "justifyContent": "space-between",
+                }
+              }
+            >
+              <span
+                className="date"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "fontWeight": "bold",
+                    "paddingRight": 10,
+                    "width": "11em",
+                  }
+                }
+              >
+                August 23, 2018
+              </span>
+              <span
+                style={
+                  Object {
+                    "background": "#eee",
+                    "display": "inline-block",
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "outline": "3px solid #eee",
+                    "textAlign": "center",
+                    "width": "10em",
+                  }
+                }
+              >
+                MTSS Meeting
+              </span>
+              <span
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "paddingLeft": 5,
+                  }
+                }
+              >
+                <a
+                  className="Educator"
+                  href="mailto:uri@demo.studentinsights.org"
+                  style={Object {}}
+                >
+                  Uri Disney
+                </a>
+              </span>
+            </div>
+            <div
+              className="RestrictedNotePresence"
+            >
+              <div>
+                <div
+                  className="NoteText"
+                  style={
+                    Object {
+                      "border": "1px solid transparent",
+                      "color": "#999",
+                      "fontFamily": "'Open Sans', sans-serif",
+                      "fontSize": 14,
+                      "marginTop": 5,
+                      "overflowX": "hidden",
+                      "padding": 0,
+                      "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-word",
+                    }
+                  }
+                >
+                  To respect Elsa's privacy, Uri marked this note as restricted.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="wrapper"
+          style={
+            Object {
+              "display": "flex",
+            }
+          }
+        >
+          <div
+            className="studentCard"
+            style={
+              Object {
+                "border": "1px solid #eee",
+                "marginBottom": 10,
+                "marginTop": 10,
+                "padding": 15,
+                "width": "25%",
+              }
+            }
+          >
+            <p>
+              <a
+                href="/students/79"
+                style={
+                  Object {
+                    "color": "#3177c9",
+                    "fontSize": "18px",
+                    "fontWeight": "bold",
+                    "marginBottom": "5%",
+                  }
+                }
+              >
+                White
+                , 
+                Elsa
+              </a>
+            </p>
+            <p>
+              <a
+                className="school-link"
+                href="/schools/9"
+              >
+                Somerville High
+              </a>
+            </p>
+            <p>
+              10
+              th Grade
+            </p>
+          </div>
+          <div
+            className="NoteCard"
+            style={
+              Object {
+                "border": "1px solid #eee",
+                "marginBottom": 10,
+                "marginTop": 10,
+                "padding": 15,
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "display": "flex",
+                  "justifyContent": "space-between",
+                }
+              }
+            >
+              <span
+                className="date"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "fontWeight": "bold",
+                    "paddingRight": 10,
+                    "width": "11em",
+                  }
+                }
+              >
+                August 23, 2018
+              </span>
+              <span
+                style={
+                  Object {
+                    "background": "#eee",
+                    "display": "inline-block",
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "outline": "3px solid #eee",
+                    "textAlign": "center",
+                    "width": "10em",
+                  }
+                }
+              >
+                MTSS Meeting
+              </span>
+              <span
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "paddingLeft": 5,
+                  }
+                }
+              >
+                <a
+                  className="Educator"
+                  href="mailto:uri@demo.studentinsights.org"
+                  style={Object {}}
+                >
+                  Uri Disney
+                </a>
+              </span>
+            </div>
+            <div
+              className="RestrictedNotePresence"
+            >
+              <div>
+                <div
+                  className="NoteText"
+                  style={
+                    Object {
+                      "border": "1px solid transparent",
+                      "color": "#999",
+                      "fontFamily": "'Open Sans', sans-serif",
+                      "fontSize": 14,
+                      "marginTop": 5,
+                      "overflowX": "hidden",
+                      "padding": 0,
+                      "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-word",
+                    }
+                  }
+                >
+                  To respect Elsa's privacy, Uri marked this note as restricted.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="wrapper"
+          style={
+            Object {
+              "display": "flex",
+            }
+          }
+        >
+          <div
+            className="studentCard"
+            style={
+              Object {
+                "border": "1px solid #eee",
+                "marginBottom": 10,
+                "marginTop": 10,
+                "padding": 15,
+                "width": "25%",
+              }
+            }
+          >
+            <p>
+              <a
+                href="/students/10"
+                style={
+                  Object {
+                    "color": "#3177c9",
+                    "fontSize": "18px",
+                    "fontWeight": "bold",
+                    "marginBottom": "5%",
+                  }
+                }
+              >
+                Disney
+                , 
+                Donald
+              </a>
+            </p>
+            <p>
+              <a
+                className="school-link"
+                href="/schools/2"
+              >
+                Arthur D Healey
+              </a>
+            </p>
+            <p>
+              <a
+                className="homeroom-link"
+                href="/homerooms/1"
+              >
+                Homeroom HEA 003
+              </a>
+            </p>
+          </div>
+          <div
+            className="NoteCard"
+            style={
+              Object {
+                "border": "1px solid #eee",
+                "marginBottom": 10,
+                "marginTop": 10,
+                "padding": 15,
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "display": "flex",
+                  "justifyContent": "space-between",
+                }
+              }
+            >
+              <span
+                className="date"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "fontWeight": "bold",
+                    "paddingRight": 10,
+                    "width": "11em",
+                  }
+                }
+              >
+                August 20, 2018
+              </span>
+              <span
+                style={
+                  Object {
+                    "background": "#eee",
+                    "display": "inline-block",
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "outline": "3px solid #eee",
+                    "textAlign": "center",
+                    "width": "10em",
+                  }
+                }
+              >
+                SST Meeting
+              </span>
+              <span
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "paddingLeft": 5,
+                  }
+                }
+              >
+                <a
+                  className="Educator"
+                  href="mailto:uri@demo.studentinsights.org"
+                  style={Object {}}
+                >
+                  Uri Disney
+                </a>
+              </span>
+            </div>
+            <div
+              className="RestrictedNotePresence"
+            >
+              <div>
+                <div
+                  className="NoteText"
+                  style={
+                    Object {
+                      "border": "1px solid transparent",
+                      "color": "#999",
+                      "fontFamily": "'Open Sans', sans-serif",
+                      "fontSize": 14,
+                      "marginTop": 5,
+                      "overflowX": "hidden",
+                      "padding": 0,
+                      "whiteSpace": "pre-wrap",
+                      "wordBreak": "break-word",
+                    }
+                  }
+                >
+                  To respect Donald's privacy, Uri marked this note as restricted.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="wrapper"
+          style={
+            Object {
+              "display": "flex",
+            }
+          }
+        >
+          <div
+            className="studentCard"
+            style={
+              Object {
+                "border": "1px solid #eee",
+                "marginBottom": 10,
+                "marginTop": 10,
+                "padding": 15,
+                "width": "25%",
+              }
+            }
+          >
+            <p>
+              <a
+                href="/students/10"
+                style={
+                  Object {
+                    "color": "#3177c9",
+                    "fontSize": "18px",
+                    "fontWeight": "bold",
+                    "marginBottom": "5%",
+                  }
+                }
+              >
+                Disney
+                , 
+                Donald
+              </a>
+            </p>
+            <p>
+              <a
+                className="school-link"
+                href="/schools/2"
+              >
+                Arthur D Healey
+              </a>
+            </p>
+            <p>
+              <a
+                className="homeroom-link"
+                href="/homerooms/1"
+              >
+                Homeroom HEA 003
+              </a>
+            </p>
+          </div>
+          <div
+            className="NoteCard"
+            style={
+              Object {
+                "border": "1px solid #eee",
+                "marginBottom": 10,
+                "marginTop": 10,
+                "padding": 15,
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "display": "flex",
+                  "justifyContent": "space-between",
+                }
+              }
+            >
+              <span
+                className="date"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "fontWeight": "bold",
+                    "paddingRight": 10,
+                    "width": "11em",
+                  }
+                }
+              >
+                July 23, 2018
+              </span>
+              <span
+                style={
+                  Object {
+                    "background": "#eee",
+                    "display": "inline-block",
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "outline": "3px solid #eee",
+                    "textAlign": "center",
+                    "width": "10em",
+                  }
+                }
+              >
+                BBST Meeting
+              </span>
+              <span
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "paddingLeft": 5,
+                  }
+                }
+              >
+                <a
+                  className="Educator"
+                  href="mailto:uri@demo.studentinsights.org"
+                  style={Object {}}
+                >
+                  Uri Disney
+                </a>
+              </span>
+            </div>
+            <div
+              className="NoteText"
+              style={
+                Object {
+                  "border": "1px solid transparent",
+                  "fontFamily": "'Open Sans', sans-serif",
+                  "fontSize": 14,
+                  "marginTop": 5,
+                  "overflowX": "hidden",
+                  "padding": 0,
+                  "whiteSpace": "pre-wrap",
+                  "wordBreak": "break-word",
+                }
+              }
+            >
+              Note
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      style={
+        Object {
+          "flex": 1,
+          "paddingLeft": 20,
+        }
+      }
+    >
+      <div>
+        <div
+          className="Card BoxCard "
+          style={
+            Object {
+              "border": "1px solid #ccc",
+              "borderRadius": 3,
+              "display": "flex",
+              "flexDirection": "column",
+              "margin": 20,
+              "padding": 0,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#eee",
+                "borderBottom": "1px solid #ccc",
+                "color": "black",
+                "display": "flex",
+                "justifyContent": "space-between",
+                "padding": 10,
+              }
+            }
+          >
+            Most common words
+          </div>
+          <canvas
+            className="WordCloud"
+            height={400}
+            style={
+              Object {
+                "cursor": "pointer",
+              }
+            }
+            width={400}
+          />
         </div>
       </div>
     </div>

--- a/app/assets/javascripts/search_notes/SearchNotesPage.js
+++ b/app/assets/javascripts/search_notes/SearchNotesPage.js
@@ -6,11 +6,12 @@ import {supportsHouse} from '../helpers/PerDistrict';
 import {ALL} from '../components/SimpleFilterSelect';
 import {TIME_RANGE_SCHOOL_YEAR} from '../components/SelectTimeRange';
 import SectionHeading from '../components/SectionHeading';
-import Card from '../components/Card';
+import BoxCard from '../components/BoxCard';
+import WordCloud from '../components/WordCloud';
 import MutableFeedView from '../feed/MutableFeedView';
 import SearchNotesBar from './SearchNotesBar';
 import SearchQueryFetcher from './SearchQueryFetcher';
-import WordCloud from './WordCloud';
+
 
 
 // Page for searching notes
@@ -122,14 +123,13 @@ export default class SearchNotesPage extends React.Component {
     const words = wordsFromEventNoteCards(feedCards);
     return (
       <div style={styles.flexVertical}>
-        <Card style={styles.card}>
-          <div style={styles.cardTitle}>Most common words</div>
+        <BoxCard title="Most common words">
           <WordCloud
             width={400}
             height={400}
             words={words}
           />
-        </Card>
+        </BoxCard>
       </div>
     );
   }
@@ -164,20 +164,6 @@ const styles = {
     paddingLeft: 10,
     paddingTop: 20,
     color: '#aaa'
-  },
-  card: {
-    margin: 20,
-    padding: 0,
-    flexDirection: 'column',
-    display: 'flex'
-  },
-  cardTitle: {
-    backgroundColor: '#eee',
-    padding: 10,
-    color: 'black',
-    borderBottom: '1px solid #ccc',
-    display: 'flex',
-    justifyContent: 'space-between'
   }
 };
 


### PR DESCRIPTION
# Who is this PR for?
educators

# What does this PR do?
This is a prototype, but adds in a wordcloud as reflection support on my notes page, shipped dark with querystring switch.

Factors out `<WordCloud />` from search page, as well as a `<BoxCard />` component for the sidebar style there and on the home page (not touched here).

# Screenshot (if adding a client-side feature)

# Checklists
*Which features or pages does this PR touch?*
+ [x] My Notes
+ [x] Search Notes

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here