### PR TITLE
Multifactor: Add private methods for provisioning manually

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'ipcat'
 gem 'dalli'
 gem 'rotp'
 gem 'twilio-ruby'
+gem 'rqrcode'
 
 gem 'administrate', '~> 0.10.0'
 gem 'authtrail'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
       rack-test (>= 0.6.3)
       xpath (~> 3.0)
     choice (0.2.0)
+    chunky_png (1.3.11)
     coderay (1.1.2)
     concurrent-ruby (1.1.3)
     crass (1.0.4)
@@ -250,6 +251,8 @@ GEM
       multi_json
     rotp (4.0.2)
       addressable (~> 2.5)
+    rqrcode (0.10.1)
+      chunky_png (~> 1.0)
     rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -373,6 +376,7 @@ DEPENDENCIES
   rails-erd
   rollbar
   rotp
+  rqrcode
   rspec-rails
   rubocop
   rubyzip (~> 1.2.2)

--- a/app/lib/multifactor_authenticator.rb
+++ b/app/lib/multifactor_authenticator.rb
@@ -91,7 +91,6 @@ class MultifactorAuthenticator
       rotp_secret: EducatorMultifactorConfig.new_rotp_secret,
       last_verification_at: nil
     })
-    nil
   end
 
   # private, for one-off console use only

--- a/spec/lib/multifactor_authenticator_spec.rb
+++ b/spec/lib/multifactor_authenticator_spec.rb
@@ -198,4 +198,32 @@ RSpec.describe 'MultifactorAuthenticator' do
       expect(secrets.uniq.size).to eq enabled_educators.size
     end
   end
+
+  describe '#enable_multifactor! (private)' do
+    it 'works' do
+      authenticator = MultifactorAuthenticator.new(pals.shs_sofia_counselor)
+      config = authenticator.send(:enable_multifactor!)
+      expect(config.valid?).to eq true
+    end
+
+    it 'raises if already enabled' do
+      authenticator = MultifactorAuthenticator.new(pals.rich_districtwide)
+      expect { authenticator.send(:enable_multifactor!) }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  describe '#provision (private)' do
+    it 'makes a pretty ansi QR code for the generated secret' do
+      authenticator = MultifactorAuthenticator.new(pals.rich_districtwide)
+      ansi_qr = authenticator.send(:provision)
+      expect(ansi_qr).to include("\033[47m")
+      expect(ansi_qr).to include("\033[40m")
+      expect(ansi_qr.size).to be >= 30000
+    end
+
+    it 'returns nil when not enabled' do
+      authenticator = MultifactorAuthenticator.new(pals.shs_sofia_counselor)
+      expect(authenticator.send(:provision)).to eq nil
+    end
+  end
 end


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Makes it simpler for developers to enable this and provision accounts manually with users to start.  Nothing self-serve yet.

# What does this PR do?
Adds `enable_multifactor!` and `provision` methods.  ANSI QR codes on the console.

# Checklists
+ [x] Manual testing made more sense here