### PR TITLE
Bedford: Adjust note types

### DIFF
--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -199,8 +199,8 @@ export function takeNotesChoices(districtKey) {
 
   if (districtKey === BEDFORD) {
     return {
-      leftEventNoteTypeIds: [500, 302, 304],
-      rightEventNoteTypeIds: [501, 502, 503]
+      leftEventNoteTypeIds: [300, 302, 304],
+      rightEventNoteTypeIds: []
     };
   }
 
@@ -217,7 +217,7 @@ export function takeNotesChoices(districtKey) {
 // In tables of students, what eventNoteTypeIds should be shown as columns with notes
 // about those students?
 export function studentTableEventNoteTypeIds(districtKey, schoolType) {
-  if (districtKey === BEDFORD) return [500, 501, 502, 503];
+  if (districtKey === BEDFORD) return [300, 302, 304];
   if (districtKey === NEW_BEDFORD) return [400];
   
   const isSomervilleOrDemo = (districtKey === SOMERVILLE || districtKey === DEMO);

--- a/app/assets/javascripts/helpers/PerDistrict.test.js
+++ b/app/assets/javascripts/helpers/PerDistrict.test.js
@@ -45,7 +45,7 @@ describe('#eventNoteTypeIdsForSearch', () => {
   });
 
   it('handles beford', () => {
-    expect(eventNoteTypeIdsForSearch('bedford')).toEqual([500, 302, 304, 501, 502, 503]);
+    expect(eventNoteTypeIdsForSearch('bedford')).toEqual([300, 302, 304]);
   });
 });
 

--- a/app/assets/javascripts/homeroom/HomeroomTable.test.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.test.js
@@ -96,10 +96,9 @@ describe('high-level integration test', () => {
     const {el} = testRender(props, context);
     expect(headerTexts(el)).toEqual([
       'Name',
-      'Last STAT',
-      'Last CAT',
-      'Last 504',
-      'Last SPED',
+      'Last SST',
+      'Last Parent',
+      'Last Other',
       'Program Assigned',
       'Disability',
       'Level of Need',

--- a/app/assets/javascripts/student_profile/TakeNotes.test.js
+++ b/app/assets/javascripts/student_profile/TakeNotes.test.js
@@ -82,12 +82,9 @@ describe('buttons for taking notes', () => {
   it('works for New Bedford', () => {
     const {el} = renderTestEl(testProps(), { districtKey: BEDFORD });
     expect(buttonTexts(el)).toEqual([
-      'STAT Meeting',
+      'SST Meeting',
       'Parent conversation',
-      'Something else',
-      'CAT Meeting',
-      '504 Meeting',
-      'SPED Meeting'
+      'Something else'
     ]);
   });
 });

--- a/app/models/event_note_type.rb
+++ b/app/models/event_note_type.rb
@@ -11,10 +11,10 @@ class EventNoteType < ApplicationRecord
       { id: 307, name: 'NEST' },
       { id: 308, name: 'Counselor Meeting' },
       { id: 400, name: 'BBST Meeting' },
-      { id: 500, name: 'STAT Meeting' },
-      { id: 501, name: 'CAT Meeting' },
-      { id: 502, name: '504 Meeting' },
-      { id: 503, name: 'SPED Meeting' }
+      { id: 500, name: 'STAT Meeting' }, # deprecated
+      { id: 501, name: 'CAT Meeting' }, # deprecated
+      { id: 502, name: '504 Meeting' }, # deprecated
+      { id: 503, name: 'SPED Meeting' } # deprecated
     ])
   end
 

--- a/db/migrate/20181214005810_bedford_note_types.rb
+++ b/db/migrate/20181214005810_bedford_note_types.rb
@@ -1,0 +1,15 @@
+class BedfordNoteTypes < ActiveRecord::Migration[5.2]
+  def change
+    return unless PerDistrict.new.district_key == PerDistrict::BEDFORD
+
+    # Effectively remove other notes types for Bedford, convert older
+    # types to "Something else" so it's not confusing for folks.
+    #
+    # Log the ids changed.
+    notes_with_other_types = EventNote.where.not(event_note_type_id: [300, 302, 304])
+    puts "Migrating event_note_type_id for #{notes_with_other_types.size} EventNote ids: [#{notes_with_other_types.join(',')}]"
+    notes_with_other_types.each do |note|
+      note.update!(event_note_type_id: 304)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_10_184301) do
+ActiveRecord::Schema.define(version: 2018_12_14_005810) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,8 +113,12 @@ ActiveRecord::Schema.define(version: 2018_12_10_184301) do
     t.integer "ed_plan_id", null: false
     t.text "iac_oid", null: false
     t.text "iac_sep_oid", null: false
+    t.text "iac_content_area"
+    t.text "iac_category"
+    t.text "iac_type"
     t.text "iac_description"
     t.text "iac_field"
+    t.text "iac_name"
     t.datetime "iac_last_modified"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
# Who is this PR for?
Bedford educators

# What problem does this PR fix?
Trying to simplify terms across schools that have slightly different support structures.

# What does this PR do?
Updates notes types to: SST Meeting, Parent conversation and Something else.  Separately, we can add in some hover text explaining the different kinds of SST meetings (eg, CPST).


# Checklists
*Which features or pages does this PR touch?*
+ [x] Home page
+ [x] Student Profile
+ [x] Homeroom
+ [x] My Notes
+ [x] School Overview
+ [x] Absences
+ [x] Tardies
+ [x] Discipline

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
