### PR TITLE
Mulitfactor: Update TestPals to use stable TOTP secret in development and demo

### DIFF
--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -101,7 +101,7 @@ class TestPals
     )
     EducatorMultifactorConfig.create!({
       educator: @uri,
-      rotp_secret: EducatorMultifactorConfig.new_rotp_secret
+      rotp_secret: '4444rrr2vwjqgua2umohlpuzobar4444' # so development and demo have a stable TOTP setup over deploys
     })
 
     # Rich works in the central office and has districwide access, but


### PR DESCRIPTION
# Who is this PR for?
test users, developers

# What problem does this PR fix?
The TOTP secret for test users are generated anew each time, but this is a pain for development and demo, where we want this to be stable across builds so that users can test it.

# What does this PR do?
Fixes the secret for the `TestPals` admin user.  This only impacts dev and demo.  The 444s are intended as a weak signal that it's an artificial value (`fake` isn't allowed in the format).
