### PR TITLE
Profile: Add missing context for IEP links

### DIFF
--- a/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
+++ b/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
@@ -280,7 +280,9 @@ export default class LightHeaderSupportBits extends React.Component {
 
   }
 }
-
+LightHeaderSupportBits.contextTypes = {
+  districtKey: PropTypes.string.isRequired
+};
 LightHeaderSupportBits.propTypes = {
   educatorLabels: PropTypes.arrayOf(PropTypes.string).isRequired,
   iepDocument: PropTypes.object,


### PR DESCRIPTION
# Who is this PR for?
Bedford educators

# What problem does this PR fix?
A bug in the profile page code meant that `shouldShowIepLink` wasn't getting called correctly, and these links were mistakenly appearing for Bedford users.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile
