### PR TITLE
Profile: Show "no data" for math and ELA

### DIFF
--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -240,8 +240,8 @@ export function isStudentActive(districtKey, student) {
 }
 
 
-// Should STAR be used instead of MCAS in K8 student profiles?
-export function useStarForProfileColumns(districtKey) {
+// Should STAR be used on student profiles at all?
+export function shouldUseStarData(districtKey) {
   if (districtKey === SOMERVILLE) return true;
   if (districtKey === DEMO) return true;
   if (districtKey === NEW_BEDFORD) return true;

--- a/app/assets/javascripts/student_profile/ElaDetails.js
+++ b/app/assets/javascripts/student_profile/ElaDetails.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import {toMomentFromRailsDate} from '../helpers/toMoment';
 import {high, medium, low} from '../helpers/colors';
+import {Email} from '../components/PublicLinks';
 import DetailsSection from './DetailsSection';
 import StarChart from './StarChart';
 import {McasNextGenChart, McasOldChart, McasSgpChart} from './McasChart';
@@ -18,15 +19,28 @@ range since interpolation lines will still be visible.
 export default class ElaDetails extends React.Component {
   render() {
     const {hideStar} = this.props;
+    const els = [
+      this.renderDibels(),
+      this.renderFAndPs(),
+      (!hideStar && this.renderStarReading()),
+      this.renderMCASELANextGenScores(),
+      this.renderMCASELAScores(),
+      this.renderMCASELAGrowth()
+    ];
+
     return (
       <div className="ElaDetails">
-        {this.renderDibels()}
-        {this.renderFAndPs()}
-        {!hideStar && this.renderStarReading()}
-        {this.renderMCASELANextGenScores()}
-        {this.renderMCASELAScores()}
-        {this.renderMCASELAGrowth()}
+        {_.compact(els).length > 0 ? els : this.renderNoData()}
       </div>
+    );
+  }
+
+  renderNoData() {
+    return (
+      <DetailsSection key="no-data" title="Reading data">
+        <div>No data has been synced.</div>
+        <div>Please reach out to your district lead or <Email /> if you have ideas for how to improve this!</div>
+      </DetailsSection>
     );
   }
 
@@ -35,7 +49,7 @@ export default class ElaDetails extends React.Component {
     if (dibels.length === 0) return null;
     const latestDibels = _.last(_.sortBy(dibels, 'date_taken'));
     return (
-      <DetailsSection title="DIBELS, latest score">
+      <DetailsSection key="dibels" title="DIBELS, latest score">
         <div>{this.renderDibelsScore(latestDibels.benchmark)} on {toMomentFromRailsDate(latestDibels.date_taken).format('M/D/YY')}</div>
       </DetailsSection>
     );
@@ -57,7 +71,7 @@ export default class ElaDetails extends React.Component {
     const maybeCode = (fAndP.f_and_p_code) ? ` with ${fAndP.f_and_p_code} code` : null;
     
     return (
-      <DetailsSection title="Fountas and Pinnell (F&P), latest score">
+      <DetailsSection key="f_and_ps" title="Fountas and Pinnell (F&P), latest score">
         <div>
           <span style={{padding: 5, backgroundColor: '#ccc', fontWeight: 'bold'}}>Level {fAndP.instructional_level}{maybeCode}</span>
           <span> on {toMomentFromRailsDate(fAndP.benchmark_date).format('M/D/YY')}</span>
@@ -69,7 +83,7 @@ export default class ElaDetails extends React.Component {
   renderStarReading() {
     const {chartData, studentGrade} = this.props;
     return (
-      <DetailsSection title="STAR Reading, last 4 years">
+      <DetailsSection key="star" title="STAR Reading, last 4 years">
         <StarChart
           starSeries={chartData.star_series_reading_percentile}
           studentGrade={studentGrade}
@@ -84,7 +98,7 @@ export default class ElaDetails extends React.Component {
     if (!mcasSeries || mcasSeries.length === 0) return null;
 
     return (
-      <DetailsSection title="MCAS ELA Scores (Next Gen), last 4 years">
+      <DetailsSection key="next-gen-mcas" title="MCAS ELA Scores (Next Gen), last 4 years">
         <McasNextGenChart
           mcasSeries={mcasSeries}
           studentGrade={studentGrade}
@@ -99,7 +113,7 @@ export default class ElaDetails extends React.Component {
     if (!mcasSeries || mcasSeries.length === 0) return null;
 
     return (
-      <DetailsSection title="MCAS ELA Scores, last 4 years">
+      <DetailsSection key="old-mcas" title="MCAS ELA Scores, last 4 years">
         <McasOldChart
           mcasSeries={mcasSeries}
           studentGrade={studentGrade}
@@ -114,7 +128,7 @@ export default class ElaDetails extends React.Component {
     if (!mcasSeries || mcasSeries.length === 0) return null;
     
     return (
-      <DetailsSection title="MCAS ELA growth percentile (SGP), last 4 years">
+      <DetailsSection key="mcas-sgp" title="MCAS ELA growth percentile (SGP), last 4 years">
         <McasSgpChart
           mcasSeries={mcasSeries}
           studentGrade={studentGrade}

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -6,7 +6,7 @@ import {updateGlobalStylesToRemoveHorizontalScrollbars, alwaysShowVerticalScroll
 import * as InsightsPropTypes from '../helpers/InsightsPropTypes';
 import {toMomentFromTimestamp} from '../helpers/toMoment';
 import * as FeedHelpers from '../helpers/FeedHelpers';
-import {isStudentActive, useStarForProfileColumns} from '../helpers/PerDistrict';
+import {isStudentActive, shouldUseStarData} from '../helpers/PerDistrict';
 import LightProfileHeader from './LightProfileHeader';
 import LightProfileTab, {LightShoutNumber} from './LightProfileTab';
 import LightAttendanceDetails from './LightAttendanceDetails';
@@ -222,7 +222,7 @@ export default class LightProfilePage extends React.Component {
 
   renderReadingColumn() {
     const {districtKey} = this.context;
-    return (useStarForProfileColumns(districtKey))
+    return (shouldUseStarData(districtKey))
       ? this.renderReadingColumnAsStar()
       : this.renderReadingColumnAsMcas();
   }
@@ -272,7 +272,7 @@ export default class LightProfilePage extends React.Component {
 
   renderMathColumn() {
     const {districtKey} = this.context;
-    return (useStarForProfileColumns(districtKey))
+    return (shouldUseStarData(districtKey))
       ? this.renderMathColumnAsStar()
       : this.renderMathColumnAsMcas();
   }
@@ -429,6 +429,7 @@ export default class LightProfilePage extends React.Component {
   }
 
   renderReading() {
+    const {districtKey} = this.context;
     const {student, chartData, currentEducator, dibels, fAndPs} = this.props.profileJson;
     const showMinimalReadingData = currentEducator.labels.indexOf('profile_enable_minimal_reading_data') !== -1;
     return (
@@ -436,6 +437,7 @@ export default class LightProfilePage extends React.Component {
         className="LightProfilePage-ela"
         chartData={chartData}
         studentGrade={student.grade}
+        hideStar={!shouldUseStarData(districtKey)}
         dibels={showMinimalReadingData ? dibels : []}
         fAndPs={showMinimalReadingData ? fAndPs : []}
       />
@@ -443,12 +445,15 @@ export default class LightProfilePage extends React.Component {
   }
 
   renderMath() {
+    const {districtKey} = this.context;
     const {student, chartData} = this.props.profileJson;
     return (
       <MathDetails
         className="LightProfilePage-math"
         chartData={chartData}
-        studentGrade={student.grade} />
+        studentGrade={student.grade}
+        hideStar={!shouldUseStarData(districtKey)}
+      />
     );
   }
 

--- a/app/assets/javascripts/student_profile/MathDetails.js
+++ b/app/assets/javascripts/student_profile/MathDetails.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from 'lodash';
+import {Email} from '../components/PublicLinks';
 import DetailsSection from './DetailsSection';
 import StarChart from './StarChart';
 import {McasNextGenChart, McasOldChart, McasSgpChart} from './McasChart';
@@ -13,24 +15,35 @@ area, and Highcharts hovers look a little strange because of that.  It shows a b
 historical context though, so we'll keep all data points, even those outside of the visible
 range since interpolation lines will still be visible.
 */
-
 export default class MathDetails extends React.Component {
   render() {
     const {hideStar} = this.props;
+    const els = [
+      (!hideStar && this.renderStarMath()),
+      this.renderMCASMathNextGenScores(),
+      this.renderMCASMathScores(),
+      this.renderMCASMathGrowth()
+    ];
     return (
       <div className="MathDetails">
-        {!hideStar && this.renderStarMath()}
-        {this.renderMCASMathNextGenScores()}
-        {this.renderMCASMathScores()}
-        {this.renderMCASMathGrowth()}
+        {_.compact(els).length > 0 ? els : this.renderNoData()}
       </div>
+    );
+  }
+
+  renderNoData() {
+    return (
+      <DetailsSection key="no-data" title="Math data">
+        <div>No data has been synced.</div>
+        <div>Please reach out to your district lead or <Email /> if you have ideas for how to improve this!</div>
+      </DetailsSection>
     );
   }
 
   renderStarMath() {
     const {chartData, studentGrade} = this.props;
     return (
-      <DetailsSection title="STAR Math, last 4 years">
+      <DetailsSection key="star" title="STAR Math, last 4 years">
         <StarChart
           starSeries={chartData.star_series_math_percentile}
           studentGrade={studentGrade}
@@ -45,7 +58,7 @@ export default class MathDetails extends React.Component {
     if (!mcasSeries || mcasSeries.length === 0) return null;
 
     return (
-      <DetailsSection title="MCAS Math Scores (Next Gen), last 4 years">
+      <DetailsSection key="next-gen-mcas" title="MCAS Math Scores (Next Gen), last 4 years">
         <McasNextGenChart
           mcasSeries={mcasSeries}
           studentGrade={studentGrade}
@@ -60,7 +73,7 @@ export default class MathDetails extends React.Component {
     if (!mcasSeries || mcasSeries.length === 0) return null;
 
     return (
-      <DetailsSection title="MCAS Math Scores, last 4 years">
+      <DetailsSection key="mcas-old" title="MCAS Math Scores, last 4 years">
         <McasOldChart
           mcasSeries={mcasSeries}
           studentGrade={studentGrade}
@@ -75,7 +88,7 @@ export default class MathDetails extends React.Component {
     if (!mcasSeries || mcasSeries.length === 0) return null;
 
     return (
-      <DetailsSection title="MCAS Math growth percentile (SGP), last 4 years">
+      <DetailsSection key="mcas-sgp" title="MCAS Math growth percentile (SGP), last 4 years">
         <McasSgpChart
           mcasSeries={mcasSeries}
           studentGrade={studentGrade}

--- a/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
@@ -3681,10 +3681,138 @@ exports[`snapshots works for aladdin testing 1`] = `
     >
       <div
         className="ElaDetails"
-      />
+      >
+        <div
+          className="DetailsSection"
+          style={
+            Object {
+              "border": "1px solid #ccc",
+              "marginLeft": "auto",
+              "marginRight": "auto",
+              "marginTop": 50,
+              "padding": "30px 30px 30px 30px",
+              "position": "relative",
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "bottom": 10,
+                "display": "flex",
+                "justifyContent": "space-between",
+                "position": "relative",
+              }
+            }
+          >
+            <h4
+              style={
+                Object {
+                  "color": "black",
+                  "fontSize": 24,
+                  "paddingBottom": 20,
+                }
+              }
+            >
+              Reading data
+            </h4>
+            <span
+              style={
+                Object {
+                  "textAlign": "right",
+                  "verticalAlign": "text-top",
+                }
+              }
+            >
+              <a
+                href="#"
+              >
+                Back to top
+              </a>
+            </span>
+          </div>
+          <div>
+            No data has been synced.
+          </div>
+          <div>
+            Please reach out to your district lead or 
+            <a
+              href="mailto://ideas@studentinsights.org"
+            >
+              ideas@studentinsights.org
+            </a>
+             if you have ideas for how to improve this!
+          </div>
+        </div>
+      </div>
       <div
         className="MathDetails"
-      />
+      >
+        <div
+          className="DetailsSection"
+          style={
+            Object {
+              "border": "1px solid #ccc",
+              "marginLeft": "auto",
+              "marginRight": "auto",
+              "marginTop": 50,
+              "padding": "30px 30px 30px 30px",
+              "position": "relative",
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "bottom": 10,
+                "display": "flex",
+                "justifyContent": "space-between",
+                "position": "relative",
+              }
+            }
+          >
+            <h4
+              style={
+                Object {
+                  "color": "black",
+                  "fontSize": 24,
+                  "paddingBottom": 20,
+                }
+              }
+            >
+              Math data
+            </h4>
+            <span
+              style={
+                Object {
+                  "textAlign": "right",
+                  "verticalAlign": "text-top",
+                }
+              }
+            >
+              <a
+                href="#"
+              >
+                Back to top
+              </a>
+            </span>
+          </div>
+          <div>
+            No data has been synced.
+          </div>
+          <div>
+            Please reach out to your district lead or 
+            <a
+              href="mailto://ideas@studentinsights.org"
+            >
+              ideas@studentinsights.org
+            </a>
+             if you have ideas for how to improve this!
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
# Who is this PR for?
Bedford educators in early grades

# What problem does this PR fix?
None of these data sources are available in Bedford, so this explicitly acknowledges that.

# Screenshot (if adding a client-side feature)
<img width="1051" alt="screen shot 2018-12-17 at 3 45 31 pm" src="https://user-images.githubusercontent.com/1056957/50114903-d99ba080-0213-11e9-96b4-cea434dd62c3.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here