### PR TITLE
Profile: Update educator contacts to respect PerDistrict setting for counselor field

### DIFF
--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -140,6 +140,7 @@ export function somervilleHouses() {
 export function supportsCounselor(districtKey) {
   if (districtKey === SOMERVILLE) return true;
   if (districtKey === DEMO) return true;
+  if (districtKey === BEDFORD) return false; // data is exported, but not meaningful for K8
   return false;
 }
 

--- a/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
+++ b/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
@@ -89,6 +89,9 @@ export default class LightHeaderSupportBits extends React.Component {
   }
 
   renderCounselor() {
+    const {districtKey} = this.context;
+    if (!supportsCounselor(districtKey)) return false;
+
     const {student} = this.props;
     const {counselor} = student;
     if (!counselor) return null;

--- a/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
+++ b/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
@@ -4,7 +4,8 @@ import _ from 'lodash';
 import {
   hasActive504Plan,
   supportsSpedLiaison,
-  shouldShowIepLink
+  shouldShowIepLink,
+  supportsCounselor
 } from '../helpers/PerDistrict';
 import {
   hasAnySpecialEducationData,
@@ -52,8 +53,13 @@ export default class LightHeaderSupportBits extends React.Component {
   }
 
   renderEducators() {
+    const {districtKey} = this.context;
     const {student} = this.props;
-    const hasAnyContacts = (student.counselor || student.sped_liaison || this.educatorNamesFromServices().length > 0);
+    const hasAnyContacts = (
+      (supportsCounselor(districtKey) && student.counselor) ||
+      student.sped_liaison ||
+      (this.educatorNamesFromServices().length > 0)
+    );
     if (!hasAnyContacts) return <span>No educator contacts</span>;
 
     return (

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -290,7 +290,7 @@ class PerDistrict
 
   def import_student_counselor?
     return true if @district_key == SOMERVILLE
-    return true if @district_key == BEDFORD
+    return true if @district_key == BEDFORD  # this data is in export, but not meaningful for K8
     return true if @district_key == DEMO
     false
   end


### PR DESCRIPTION
# Who is this PR for?
Bedford educators

# What problem does this PR fix?
Bedford exports this value, but the data is only administrative and not meaningful

# What does this PR do?
Updates the profile to respect the `PerDistrict.js` setting for this, and updates the server method with a note about this.

