### PR TITLE
Photos: Enable student photos for Bedford

### DIFF
--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -9,6 +9,7 @@ export const DEMO = 'demo';
 
 export function hasStudentPhotos(districtKey) {
   if (districtKey === SOMERVILLE) return true;
+  if (districtKey === BEDFORD) return true;
   if (districtKey === NEW_BEDFORD) return false;
   return false;
 }

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -330,7 +330,9 @@ class PerDistrict
   end
 
   def import_student_photos?
-    @district_key == SOMERVILLE
+    return true if @district_key == SOMERVILLE
+    return true if @district_key == BEDFORD
+    false
   end
 
   def import_dibels?

--- a/app/importers/photo_import/student_photo_importer.rb
+++ b/app/importers/photo_import/student_photo_importer.rb
@@ -7,7 +7,8 @@ class StudentPhotoImporter
   REQUIRED_KEYS = [
     'AWS_ACCESS_KEY_ID',
     'AWS_SECRET_ACCESS_KEY',
-    'AWS_S3_PHOTOS_BUCKET'
+    'AWS_S3_PHOTOS_BUCKET',
+    'AWS_REGION'
   ]
 
   def initialize
@@ -20,11 +21,11 @@ class StudentPhotoImporter
   def import
     FileUtils.mkdir_p('tmp/data_download/photos')
 
-    log('Downloading photos.zip from SFTP site...')
+    log('Downloading photos zipfile from SFTP site...')
 
     photos_zip_file = sftp_client.download_file(remote_filename)
 
-    log("Downloaded Photos ZIP file!")
+    log('Downloaded photos zipfile!')
 
     unzipped_count = 0
 

--- a/config/district_bedford.yml
+++ b/config/district_bedford.yml
@@ -5,6 +5,9 @@ sftp_filenames:
   FILENAME_FOR_ATTENDANCE_IMPORT:    /home/bedford/data/attendance.csv
   FILENAME_FOR_ASSESSMENT_IMPORT:    /home/bedford/data/Assessment.csv
 
+  # student photos snapshot
+  FILENAME_FOR_PHOTOS_ZIP:           /home/bedford/data/Photos.zip
+
 
 school_definitions_for_import:
   - name: Lane Elementary


### PR DESCRIPTION
# Who is this PR for?
Bedford users

# What problem does this PR fix?
Student photos aren't enabled for Bedford, but are now exported.

# What does this PR do?
Enables this for Bedford in the server and UI, updates some logging copy for the importer, and adds back a mistakenly missing ENV value that's needed.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile
+ [x] Homeroom

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here