### PR TITLE
Teams: Migration to store season

### DIFF
--- a/db/migrate/20190108202757_add_season_to_teams.rb
+++ b/db/migrate/20190108202757_add_season_to_teams.rb
@@ -1,0 +1,5 @@
+class AddSeasonToTeams < ActiveRecord::Migration[5.2]
+  def change
+    add_column :team_memberships, :season_key, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_21_171134) do
+ActiveRecord::Schema.define(version: 2019_01_08_202757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -609,6 +609,7 @@ ActiveRecord::Schema.define(version: 2018_12_21_171134) do
     t.text "school_year_text", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "season_key"
   end
 
   create_table "transition_notes", force: :cascade do |t|


### PR DESCRIPTION
# Who is this PR for?
HS students, educators, coaches

# What problem does this PR fix?
Allows tracking current season for sports teams, not just school year.

# What does this PR do?
Adds a `season_key` field.
