### PR TITLE
Fix bug with ed plan migration name

### DIFF
--- a/db/migrate/20181206152822_add_ed_plan.rb
+++ b/db/migrate/20181206152822_add_ed_plan.rb
@@ -1,4 +1,4 @@
-class EdPlan < ActiveRecord::Migration[5.2]
+class AddEdPlan < ActiveRecord::Migration[5.2]
   def change
     create_table :ed_plans do |t|
       t.text :sep_oid, null: false, unique: true


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Running migrations fails, because migration class names and model class names can't collide.

# What does this PR do?
Fixes the migration class name.
