### PR TITLE
Set profile heatmap width

### DIFF
--- a/app/assets/javascripts/student_profile/LightBehaviorDetails.js
+++ b/app/assets/javascripts/student_profile/LightBehaviorDetails.js
@@ -133,7 +133,7 @@ export default class LightBehaviorDetails extends React.Component {
             />
           ))}
         </div>
-        <div>
+        <div style={{width: '50%'}}>
           <IncidentHeatmap incidents={this.props.disciplineIncidents}/>
         </div>
       </div>


### PR DESCRIPTION
# Who is this PR for?

Educators

# What problem does this PR fix?
The student profile discipline incident heatmap isn't set at 50% width, causing it to compress the incident cards.

# What does this PR do?

Sets the chart width so it takes half the space.

*Which features or pages does this PR touch?*
+ [ ] Home page


*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [ ] Manual testing made more sense here