### PR TITLE
Reading: Remove download, send back empty JSON for client, improve notice on network failure

### DIFF
--- a/app/assets/javascripts/reading/ReadingEntryPage.js
+++ b/app/assets/javascripts/reading/ReadingEntryPage.js
@@ -14,7 +14,6 @@ import {ALL} from '../components/SimpleFilterSelect';
 import {describeEntryColumns, sortFnsMap} from './entryColumns';
 import DocumentContext from './DocumentContext';
 import Sortable from './Sortable';
-import LazyExportLink from './LazyExportLink';
 
 
 // Page for entering benchmark reading data for students in a grade.
@@ -106,15 +105,6 @@ export class ReadingEntryPageView extends React.Component {
     });
   }
 
-  exportCsvFn(columns, students) {
-    const {nowFn} = this.context;
-    const {school, grade} = this.props;
-    const now = nowFn();
-    const filename = `Reading-${school.slug.toUpperCase()}-${grade}-${now.format('YYYY-MM-DD')}.csv`;
-    const csvText = toCsvTextFromTable(columns, students);
-    return {csvText, filename};
-  }
-
   onSearchChanged(e) {
     this.setState({searchText: e.target.value});
   }
@@ -143,9 +133,8 @@ export class ReadingEntryPageView extends React.Component {
               <SectionHeading titleStyle={styles.title}>
                 <div>Benchmark Reading Data: {gradeText(grade)} at {school.name}</div>
                 <div style={{display: 'flex'}}>
-                  {pending.length > 0 ? '...' : null}
-                  {failed.length > 0 ? '!' : null}
-                  {this.renderDownloadLink(students, columns)}
+                  {pending.length > 0 ? <Pending /> : null}
+                  {failed.length > 0 ? <Failure /> : null}
                 </div>
               </SectionHeading>
               {this.renderFilters()}
@@ -155,10 +144,6 @@ export class ReadingEntryPageView extends React.Component {
         }}
       </DocumentContext>
     );
-  }
-
-  renderDownloadLink(students, columns) {
-    return <LazyExportLink exportCsvFn={() => this.exportCsvFn(students, columns)} />;
   }
 
   renderFilters() {
@@ -295,3 +280,34 @@ const styles = {
     width: 220
   }
 };
+
+
+
+function Pending() {
+  return <span style={{
+    width: '8em',
+    textAlign: 'center',
+    color: '#333',
+    fontSize: 14,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    marginRight: 10,
+    padding: 5}}>...</span>;
+}
+
+function Failure() {
+  return <span style={{
+    width: '8em',
+    textAlign: 'center',
+    backgroundColor: 'red',
+    color: 'white',
+    fontSize: 14,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 10,
+    padding: 5,
+    fontWeight: 'bold'
+  }}>network error</span>;
+}

--- a/app/assets/javascripts/reading/ReadingEntryPage.js
+++ b/app/assets/javascripts/reading/ReadingEntryPage.js
@@ -4,7 +4,6 @@ import _ from 'lodash';
 import {Table, Column, AutoSizer} from 'react-virtualized';
 import {apiFetchJson} from '../helpers/apiFetchJson';
 import {gradeText} from '../helpers/gradeText';
-import {toCsvTextFromTable} from '../helpers/toCsvFromTable';
 import {updateGlobalStylesToTakeFullHeight} from '../helpers/globalStylingWorkarounds';
 import GenericLoader from '../components/GenericLoader';
 import SectionHeading from '../components/SectionHeading';

--- a/app/controllers/reading_controller.rb
+++ b/app/controllers/reading_controller.rb
@@ -48,7 +48,7 @@ class ReadingController < ApplicationController
       educator_id: current_educator.id
     })
 
-    head :created
+    render json: {}, status: 201
   end
 
   private

--- a/spec/controllers/reading_controller_spec.rb
+++ b/spec/controllers/reading_controller_spec.rb
@@ -125,14 +125,14 @@ describe ReadingController, :type => :controller do
         value: 'phonological awareness, segmenting'
       })
       expect(response.status).to eq 201
-      expect(response.body).to eq ''
+      expect(response.body).to eq '{}'
 
       put_update_data_point_json({
         benchmark_assessment_key: 'dibels_dorf_acc',
         value: 'multisyllabic decoding'
       })
       expect(response.status).to eq 201
-      expect(response.body).to eq ''
+      expect(response.body).to eq '{}'
 
       # verify storage in database
       reading_benchmark_data_points = ReadingBenchmarkDataPoint.where(student_id: pals.healey_kindergarten_student.id)


### PR DESCRIPTION
From https://github.com/studentinsights/studentinsights/pull/2352

The client expects valid JSON, so an empty response body raises a clientside error.  This also makes the message on network failure more visible, so that if it does happen folks don't type in all the data without realizing.

Also, the approach to downloading CSV doesn't work with the state in the `doc` object, so this removes that for now.  