### PR TITLE
Profile: Update UI check for IEP to use student record field as authoritative if PDF conflicts

### DIFF
--- a/app/assets/javascripts/helpers/specialEducation.js
+++ b/app/assets/javascripts/helpers/specialEducation.js
@@ -1,8 +1,6 @@
 // This file contains functions that handle variations by district, so that they work
 // across all districts.
-export function hasAnySpecialEducationData(student, maybeIepDocument) {
-  if (maybeIepDocument) return true;
-  
+export function hasActiveIep(student) {
   const {program, placement, disability, levelOfNeed} = cleanSpecialEducationValues(student);
   if (program && isSpecialEducationProgram(program)) return true;
   if (placement) return true;

--- a/app/assets/javascripts/helpers/specialEducation.test.js
+++ b/app/assets/javascripts/helpers/specialEducation.test.js
@@ -1,27 +1,27 @@
 import {
-  hasAnySpecialEducationData,
+  hasActiveIep,
   prettyProgramOrPlacementText,
   prettyIepTextForSpecialEducationStudent
 } from './specialEducation';
 
-describe('#hasAnySpecialEducationData', () => {
+describe('#hasActiveIep', () => {
   it('excludes other programs', () => {
-    expect(hasAnySpecialEducationData({
+    expect(hasActiveIep({
       program_assigned: '2Way English',
       sped_placement: null,
       disability: null,
       sped_level_of_need: null,
-    }, null)).toEqual(false);
+    })).toEqual(false);
   });
 
   it('ignores sped_liaison value', () => {
-    expect(hasAnySpecialEducationData({
+    expect(hasActiveIep({
       program_assigned: 'Reg Ed',
       sped_placement: null,
       disability: null,
       sped_level_of_need: null,
       sped_liaison: 'Concepcion'
-    }, null)).toEqual(false);
+    })).toEqual(false);
   });
 });
 

--- a/app/assets/javascripts/reading/entryColumns.js
+++ b/app/assets/javascripts/reading/entryColumns.js
@@ -5,7 +5,7 @@ import {hasActive504Plan} from '../helpers/PerDistrict';
 import {toMomentFromRailsDate} from '../helpers/toMoment';
 import {toSchoolYear, firstDayOfSchool} from '../helpers/schoolYear';
 import {isEnglishLearner, accessLevelNumber} from '../helpers/language';
-import {hasAnySpecialEducationData} from '../helpers/specialEducation';
+import {hasActiveIep} from '../helpers/specialEducation';
 import HelpBubble, {
   modalFullScreenFlex,
   dialogFullScreenFlex
@@ -81,7 +81,7 @@ export function describeEntryColumns(params) {
     width: 50,
     style: styles.cell,
     cellRenderer({rowData}) {  // eslint-disable-line react/prop-types
-      if (!hasAnySpecialEducationData(rowData, rowData.latest_iep_document)) return null;
+      if (!hasActiveIep(rowData)) return null;
       return (
         <PerDistrictContainer districtKey={districtKey}>
           <IepDialog
@@ -191,7 +191,7 @@ export function sortFnsMap(doc, districtKey, nowMoment) {
     student_name(student) { return `${student.last_name}, ${student.first_name}`; },
     homeroom_educator_name(student) { return homeroomLastName(student); },
     plan_504(student) { return hasActive504Plan(student.plan_504) ? '504' : null; },
-    iep(student) { return hasAnySpecialEducationData(student, student.latest_iep_document) ? 'IEP' : null; },
+    iep(student) { return hasActiveIep(student) ? 'IEP' : null; },
     english_learner_level(student) { return englishLearnerLinkText(districtKey, student); },
     mtss(student) { return renderMtss(student.mtss, nowMoment); },
     [F_AND_P_ENGLISH](student) { return readDoc(doc, student.id, F_AND_P_ENGLISH) || 'a'; },

--- a/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
+++ b/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
@@ -8,7 +8,7 @@ import {
   supportsCounselor
 } from '../helpers/PerDistrict';
 import {
-  hasAnySpecialEducationData,
+  hasActiveIep,
   prettyProgramOrPlacementText,
   prettyLevelOfNeedText,
   prettyIepTextForSpecialEducationStudent,
@@ -152,8 +152,8 @@ export default class LightHeaderSupportBits extends React.Component {
 
   renderIEP() {
     const {districtKey} = this.context;
-    const {student, iepDocument} = this.props;
-    if (!hasAnySpecialEducationData(student, iepDocument)) return null;
+    const {student} = this.props;
+    if (!hasActiveIep(student)) return null;
     
     const specialEducationText = prettyIepTextForSpecialEducationStudent(student);
     if (!shouldShowIepLink(districtKey)) return specialEducationText;


### PR DESCRIPTION
# Who is this PR for?
educators, students, families

# What problem does this PR fix?
There are multiple bits of data about special education and IEPs - previously `hasAnySpecialEducationData` was used to decide whether to consider the student as having an active IEP, but this was overly inclusive.

# What does this PR do?
Changes `hasAnySpecialEducationData` to `hasActiveIep`, which uses the student record fields as authoritative, regardless of the IEP PDF document.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile
+ [x] Benchmark reading data

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
