### PR TITLE
Prevent scatterplot from displaying with too many data points

### DIFF
--- a/app/assets/javascripts/components/ScatterPlotOverloadMessage.js
+++ b/app/assets/javascripts/components/ScatterPlotOverloadMessage.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function ScatterPlotOverloadMessage() {
+  return (
+    <div style={styles.message}>
+      <span>There are too many students to display this data. You can select another chart type or try filtering the students.</span>
+    </div>
+  );
+}
+
+const styles = {
+  message: {
+    padding: 20
+  }
+};

--- a/app/assets/javascripts/school_administrator_dashboard/DashboardTestData.js
+++ b/app/assets/javascripts/school_administrator_dashboard/DashboardTestData.js
@@ -68,6 +68,15 @@ export function createStudents(nowMoment) {
     id: 1,
     absences: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo, testEvents.threeMonthsAgo],
     tardies: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo, testEvents.threeMonthsAgo],
+    discipline_incidents: [{
+      id:23,
+      incident_code:"Assault",
+      created_at: nowMoment.clone().subtract(30, 'days').format(),
+      incident_location:"Playground",
+      incident_description:"Description",
+      occurred_at: nowMoment.clone().subtract(30, 'days').format(),
+      has_exact_time:true,
+      student_id:1}],
     events: 3,
     latest_note: {
       event_note_type_id: 300,

--- a/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/SchoolDisciplineDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/SchoolDisciplineDashboard.js
@@ -382,7 +382,7 @@ export default class SchoolDisciplineDashboard extends React.Component {
                 />
               </div>
                 {this.state.selectedChart === "scatter"
-                  ? this.renderDisciplineScatterPlot(dashboardStudents, selectedChart)
+                  ? this.renderDisciplineScatterPlot(dashboardStudents)
                   : this.renderDisciplineBarChart(dashboardStudents, selectedChart)}
             </div>
           </div>
@@ -425,7 +425,7 @@ export default class SchoolDisciplineDashboard extends React.Component {
       onZoom: this.onZoom
     };
     return (
-      <DisciplineScatterPlot {...props}/>
+      seriesData.length > 500 ? <ScatterPlotOverloadMessage/> : <DisciplineScatterPlot {...props}/>
     );
   }
 

--- a/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/SchoolDisciplineDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/SchoolDisciplineDashboard.js
@@ -28,6 +28,7 @@ import EscapeListener from '../../components/EscapeListener';
 import StudentsTable from '../StudentsTable';
 import DashboardBarChart from '../DashboardBarChart';
 import DisciplineScatterPlot, {getincidentTimeAsMinutes} from '../../components/DisciplineScatterPlot';
+import ScatterPlotOverloadMessage from '../../components/ScatterPlotOverloadMessage';
 import * as dashboardStyles from '../dashboardStyles';
 
 
@@ -380,7 +381,9 @@ export default class SchoolDisciplineDashboard extends React.Component {
                   clearable={false}
                 />
               </div>
-             {this.renderDisciplineChart(dashboardStudents, selectedChart)}
+                {this.state.selectedChart === "scatter"
+                  ? this.renderDisciplineScatterPlot(dashboardStudents, selectedChart)
+                  : this.renderDisciplineBarChart(dashboardStudents, selectedChart)}
             </div>
           </div>
         </div>
@@ -388,35 +391,41 @@ export default class SchoolDisciplineDashboard extends React.Component {
     );
   }
 
-  renderDisciplineChart(students, selectedChart) {
+  renderDisciplineBarChart(students, selectedChart) {
     const selectedStudents = this.filterStudents(students, {shouldFilterSelectedCategory: false});
     const {categories, seriesData} = this.getChartData(selectedStudents, selectedChart);
-    const commonProps = {
+    const props = {
       id: "String",
       animation: false,
       categories: {categories: categories},
       seriesData: seriesData,
       titleText: null,
-      toolTipFormatter: this.toolTipFormatter
-    };
-    const barChartProps = {
-      ...commonProps,
+      toolTipFormatter: this.toolTipFormatter,
       measureText: "Number of Incidents",
       tooltip: {pointFormat: 'Total incidents: <b>{point.y}</b>'},
       onColumnClick: this.onColumnClick,
       onBackgroundClick: this.onResetStudentList
     };
-    const scatterPlotProps = {
-      ...commonProps,
+    return (
+      <DashboardBarChart {...props}/>
+    );
+  }
+
+  renderDisciplineScatterPlot(students) {
+    const selectedStudents = this.filterStudents(students, {shouldFilterSelectedCategory: false});
+    const {categories, seriesData} = this.getChartData(selectedStudents, "scatter");
+    const props = {
+      id: "String",
+      animation: false,
+      categories: {categories: categories},
+      seriesData: seriesData,
+      titleText: null,
+      toolTipFormatter: this.toolTipFormatter,
       measureText: "Time of Incident",
       onZoom: this.onZoom
     };
     return (
-      (selectedChart === 'scatter') ? (
-      <DisciplineScatterPlot {...scatterPlotProps}/>
-      ) : (
-      <DashboardBarChart {...barChartProps}/>
-      )
+      <DisciplineScatterPlot {...props}/>
     );
   }
 

--- a/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/SchoolDisciplineDashboard.test.js
+++ b/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/SchoolDisciplineDashboard.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount, shallow} from 'enzyme';
-import moment from 'moment';
 import renderer from 'react-test-renderer';
 import {toMomentFromTimestamp} from '../../helpers/toMoment';
 import {withNowMoment, withNowContext} from '../../testing/NowContainer';

--- a/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/SchoolDisciplineDashboard.test.js
+++ b/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/SchoolDisciplineDashboard.test.js
@@ -15,8 +15,12 @@ import SchoolDisciplineDashboard from './SchoolDisciplineDashboard';
 
 jest.mock('react-virtualized'); // doesn't work in test without a real DOM
 
+function setDate() {
+  return toMomentFromTimestamp('2018-09-22T17:03:06.123Z');
+}
+
 function testContext(context = {}) {
-  const nowMoment = toMomentFromTimestamp('2018-09-22T17:03:06.123Z');
+  const nowMoment = setDate();
   return {
     districtKey: 'somerville',
     nowFn() { return nowMoment; },
@@ -24,11 +28,7 @@ function testContext(context = {}) {
   };
 }
 
-function testEl(moreProps = {}) {
-  const props = {
-    dashboardStudents: createStudents(moment.utc()),
-    ...moreProps
-  };
+function testEl(props = {}) {
   return <SchoolDisciplineDashboard {...props} />;
 }
 
@@ -48,9 +48,35 @@ function renderShallow(props = {}) {
   return shallow(el, {context});
 }
 
+function create501Students() {
+  const now = setDate();
+  let students = [];
+  for (let i=0; i < 501; i++) {
+    const student = {
+      first_name: 'Pierrot',
+      last_name: 'Zanni',
+      homeroom_label: 'Test 1',
+      grade: '4',
+      id: 1,
+      discipline_incidents: [{
+        id:23,
+        incident_code:"Assault",
+        created_at: now.clone().subtract(30, 'days').format(),
+        incident_location:"Playground",
+        incident_description:"Description",
+        occurred_at: now.clone().subtract(30, 'days').format(),
+        has_exact_time:true,
+        student_id:1}],
+      events: 3
+    };
+    students.push(student);
+  }
+  return students;
+}
+
 it('displays house for SHS', () => {
   const context = testContext({districtKey: 'somerville'});
-  const props = {school: testHighSchool()};
+  const props = {school: testHighSchool(), dashboardStudents: createStudents(setDate())};
   const el = testEl(props);
   const dash = mount(elWrappedInContext(el, context));
   expect(dash.find('SelectHouse').length > 0).toEqual(true);
@@ -58,7 +84,7 @@ it('displays house for SHS', () => {
 
 it('does not display house for Healey', () => {
   const context = testContext({districtKey: 'somerville'});
-  const props = {school: testSchool()};
+  const props = {school: testSchool(), dashboardStudents: createStudents(setDate())};
   const el = testEl(props);
   const dash = mount(elWrappedInContext(el, context));
   expect(dash.find('SelectHouse').length > 0).toEqual(false);
@@ -66,7 +92,7 @@ it('does not display house for Healey', () => {
 
 it('displays counselor for SHS', () => {
   const context = testContext({districtKey: 'somerville'});
-  const props = {school: testHighSchool()};
+  const props = {school: testHighSchool(), dashboardStudents: createStudents(setDate())};
   const el = testEl(props);
   const dash = mount(elWrappedInContext(el, context));
   expect(dash.find('SelectCounselor').length > 0).toEqual(true);
@@ -74,7 +100,7 @@ it('displays counselor for SHS', () => {
 
 it('does not display counselor for Healey', () => {
   const context = testContext({districtKey: 'somerville'});
-  const props = {school: testSchool()};
+  const props = {school: testSchool(), dashboardStudents: createStudents(setDate())};
   const el = testEl(props);
   const dash = mount(elWrappedInContext(el, context));
   expect(dash.find('SelectCounselor').length > 0).toEqual(false);
@@ -82,7 +108,7 @@ it('does not display counselor for Healey', () => {
 
 it('displays grade for SHS', () => {
   const context = testContext({districtKey: 'somerville'});
-  const props = {school: testHighSchool()};
+  const props = {school: testHighSchool(), dashboardStudents: createStudents(setDate())};
   const el = testEl(props);
   const dash = mount(elWrappedInContext(el, context));
   expect(dash.find('SelectGrade').length > 0).toEqual(true);
@@ -90,7 +116,7 @@ it('displays grade for SHS', () => {
 
 it('displays grade for Healey', () => {
   const context = testContext({districtKey: 'somerville'});
-  const props = {school: testSchool()};
+  const props = {school: testSchool(), dashboardStudents: createStudents(setDate())};
   const el = testEl(props);
   const dash = mount(elWrappedInContext(el, context));
   expect(dash.find('SelectGrade').length > 0).toEqual(true);
@@ -98,15 +124,24 @@ it('displays grade for Healey', () => {
 
 it('renders a scatter plot', () => {
   const context = testContext({districtKey: 'somerville'});
-  const props = {school: testSchool()};
+  const props = {school: testSchool(), dashboardStudents: createStudents(setDate())};
   const el = testEl(props);
   const dash = mount(elWrappedInContext(el, context));
   expect(dash.find('DisciplineScatterPlot').length > 0).toEqual(true);
 });
 
+it('does not render a scatter plot when there are more than 500 incidents', () => {
+  const context = testContext({districtKey: 'somerville'});
+  const props = {school: testSchool(), dashboardStudents: create501Students(setDate())};
+  const el = testEl(props);
+  const dash = mount(elWrappedInContext(el, context));
+  expect(dash.find('DisciplineScatterPlot').length === 0).toEqual(true);
+  expect(dash.find('ScatterPlotOverloadMessage').length > 0).toEqual(true);
+});
+
 it('renders a student list', () => {
   const context = testContext({districtKey: 'somerville'});
-  const props = {school: testSchool()};
+  const props = {school: testSchool(), dashboardStudents: createStudents(setDate())};
   const el = testEl(props);
   const dash = mount(elWrappedInContext(el, context));
   expect(dash.find('StudentsTable').length > 0).toEqual(true);
@@ -114,14 +149,14 @@ it('renders a student list', () => {
 
 it('renders a date range selector', () => {
   const context = testContext({districtKey: 'somerville'});
-  const props = {school: testSchool()};
+  const props = {school: testSchool(), dashboardStudents: createStudents(setDate())};
   const el = testEl(props);
   const dash = mount(elWrappedInContext(el, context));
   expect(dash.find('SelectTimeRange').length > 0).toEqual(true);
 });
 
 it('can render a bar chart', () => {
-  const dash = renderShallow({school: testSchool()});
+  const dash = renderShallow({school: testSchool(), dashboardStudents: createStudents(setDate())});
   dash.setState({selectedChart: 'grade'});
   expect(dash.find('DashboardBarChart').length > 0).toEqual(true);
 });
@@ -130,7 +165,7 @@ function snapshotJson(districtKey) {
   return renderer.create(
     withNowContext('2018-09-22T17:03:06.123Z',
       <PerDistrictContainer districtKey={districtKey}>
-        {pageSizeFrame(testEl({school: testSchool()}))}
+        {pageSizeFrame(testEl({school: testSchool(), dashboardStudents: createStudents(setDate())}))}
       </PerDistrictContainer>
   ));
 }

--- a/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/__snapshots__/SchoolDisciplineDashboard.test.js.snap
+++ b/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/__snapshots__/SchoolDisciplineDashboard.test.js.snap
@@ -158,7 +158,7 @@ exports[`snapshots works for bedford 1`] = `
                 >
                   <span
                     className="Select-multi-value-wrapper"
-                    id="react-select-56--value"
+                    id="react-select-60--value"
                   >
                     <div
                       className="Select-placeholder"
@@ -174,7 +174,7 @@ exports[`snapshots works for bedford 1`] = `
                       }
                     >
                       <input
-                        aria-activedescendant="react-select-56--value"
+                        aria-activedescendant="react-select-60--value"
                         aria-expanded="false"
                         aria-haspopup="false"
                         aria-owns=""
@@ -238,7 +238,7 @@ exports[`snapshots works for bedford 1`] = `
                 >
                   <span
                     className="Select-multi-value-wrapper"
-                    id="react-select-57--value"
+                    id="react-select-61--value"
                   >
                     <div
                       className="Select-placeholder"
@@ -254,7 +254,7 @@ exports[`snapshots works for bedford 1`] = `
                       }
                     >
                       <input
-                        aria-activedescendant="react-select-57--value"
+                        aria-activedescendant="react-select-61--value"
                         aria-expanded="false"
                         aria-haspopup="false"
                         aria-owns=""
@@ -347,7 +347,7 @@ exports[`snapshots works for bedford 1`] = `
                 >
                   <span
                     className="Select-multi-value-wrapper"
-                    id="react-select-58--value"
+                    id="react-select-62--value"
                   >
                     <div
                       className="Select-value"
@@ -355,14 +355,14 @@ exports[`snapshots works for bedford 1`] = `
                       <span
                         aria-selected="true"
                         className="Select-value-label"
-                        id="react-select-58--value-item"
+                        id="react-select-62--value-item"
                         role="option"
                       >
                         Last 45 days
                       </span>
                     </div>
                     <div
-                      aria-activedescendant="react-select-58--value"
+                      aria-activedescendant="react-select-62--value"
                       aria-disabled="false"
                       aria-expanded={false}
                       aria-owns=""
@@ -438,7 +438,7 @@ exports[`snapshots works for bedford 1`] = `
                   }
                 }
               >
-                Total Incidents:  0
+                Total Incidents:  1
               </div>
             </div>
           </div>
@@ -490,7 +490,7 @@ exports[`snapshots works for bedford 1`] = `
                 >
                   <span
                     className="Select-multi-value-wrapper"
-                    id="react-select-59--value"
+                    id="react-select-63--value"
                   >
                     <div
                       className="Select-value"
@@ -498,7 +498,7 @@ exports[`snapshots works for bedford 1`] = `
                       <span
                         aria-selected="true"
                         className="Select-value-label"
-                        id="react-select-59--value-item"
+                        id="react-select-63--value-item"
                         role="option"
                       >
                         Day & Time
@@ -513,7 +513,7 @@ exports[`snapshots works for bedford 1`] = `
                       }
                     >
                       <input
-                        aria-activedescendant="react-select-59--value"
+                        aria-activedescendant="react-select-63--value"
                         aria-expanded="false"
                         aria-haspopup="false"
                         aria-owns=""
@@ -589,1182 +589,6 @@ exports[`snapshots works for bedford 1`] = `
 `;
 
 exports[`snapshots works for demo 1`] = `
-<div
-  style={
-    Object {
-      "background": "#333",
-      "width": "100%",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "background": "white",
-        "border": "5px solid #333",
-        "display": "flex",
-        "flexDirection": "column",
-        "height": 768,
-        "width": 1024,
-      }
-    }
-  >
-    <div
-      className="SchoolDisciplineDashboard EscapeListener"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "display": "flex",
-          "flex": 1,
-          "flexDirection": "column",
-          "width": "100%",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "background": "red",
-            "color": "white",
-            "fontWeight": "bold",
-            "padding": 20,
-          }
-        }
-      >
-        <span>
-          This is an experimental prototype!
-        </span>
-        <span
-          style={
-            Object {
-              "marginLeft": 10,
-            }
-          }
-        >
-          Please share your feedback with 
-          <a
-            href="mailto://ideas@studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            ideas@studentinsights.org
-          </a>
-          .
-        </span>
-      </div>
-      <div
-        style={
-          Object {
-            "display": "flex",
-            "flex": 1,
-            "flexDirection": "column",
-            "paddingLeft": 10,
-            "paddingRight": 10,
-            "width": "100%",
-          }
-        }
-      >
-        <div
-          className="SectionHeading"
-          style={
-            Object {
-              "borderBottom": "1px solid #333",
-              "padding": 10,
-            }
-          }
-        >
-          <h4
-            style={
-              Object {
-                "color": "black",
-                "display": "inline",
-              }
-            }
-          >
-            Recent Discipline incidents at 
-            Arthur D. Healey
-          </h4>
-        </div>
-        <div
-          style={
-            Object {
-              "borderBottom": "1px solid #ccc",
-              "display": "flex",
-              "flexDirection": "row",
-              "justifyContent": "space-between",
-              "padding": 10,
-              "width": "100%",
-            }
-          }
-        >
-          <div
-            className="FilterBar"
-            style={
-              Object {
-                "display": "flex",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                }
-              }
-            >
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "marginRight": 10,
-                  }
-                }
-              >
-                Filter by
-              </span>
-              <div
-                className="Select is-searchable Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 10,
-                      "width": "10em",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-44--value"
-                  >
-                    <div
-                      className="Select-placeholder"
-                    >
-                      Incident Type...
-                    </div>
-                    <div
-                      className="Select-input"
-                      style={
-                        Object {
-                          "display": "inline-block",
-                        }
-                      }
-                    >
-                      <input
-                        aria-activedescendant="react-select-44--value"
-                        aria-expanded="false"
-                        aria-haspopup="false"
-                        aria-owns=""
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={false}
-                        role="combobox"
-                        style={
-                          Object {
-                            "boxSizing": "content-box",
-                            "width": "5px",
-                          }
-                        }
-                        value=""
-                      />
-                      <div
-                        style={
-                          Object {
-                            "height": 0,
-                            "left": 0,
-                            "overflow": "scroll",
-                            "position": "absolute",
-                            "top": 0,
-                            "visibility": "hidden",
-                            "whiteSpace": "pre",
-                          }
-                        }
-                      >
-                        
-                      </div>
-                    </div>
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-              <div
-                className="Select is-searchable Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 10,
-                      "width": "8em",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-45--value"
-                  >
-                    <div
-                      className="Select-placeholder"
-                    >
-                      Grade...
-                    </div>
-                    <div
-                      className="Select-input"
-                      style={
-                        Object {
-                          "display": "inline-block",
-                        }
-                      }
-                    >
-                      <input
-                        aria-activedescendant="react-select-45--value"
-                        aria-expanded="false"
-                        aria-haspopup="false"
-                        aria-owns=""
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={false}
-                        role="combobox"
-                        style={
-                          Object {
-                            "boxSizing": "content-box",
-                            "width": "5px",
-                          }
-                        }
-                        value=""
-                      />
-                      <div
-                        style={
-                          Object {
-                            "height": 0,
-                            "left": 0,
-                            "overflow": "scroll",
-                            "position": "absolute",
-                            "top": 0,
-                            "visibility": "hidden",
-                            "whiteSpace": "pre",
-                          }
-                        }
-                      >
-                        
-                      </div>
-                    </div>
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="FilterBar"
-            style={
-              Object {
-                "display": "flex",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                }
-              }
-            >
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "marginRight": 10,
-                  }
-                }
-              >
-                Filter by
-              </span>
-              <div
-                className="Select has-value Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 10,
-                      "width": "10em",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-46--value"
-                  >
-                    <div
-                      className="Select-value"
-                    >
-                      <span
-                        aria-selected="true"
-                        className="Select-value-label"
-                        id="react-select-46--value-item"
-                        role="option"
-                      >
-                        Last 45 days
-                      </span>
-                    </div>
-                    <div
-                      aria-activedescendant="react-select-46--value"
-                      aria-disabled="false"
-                      aria-expanded={false}
-                      aria-owns=""
-                      className="Select-input"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      role="combobox"
-                      style={
-                        Object {
-                          "border": 0,
-                          "display": "inline-block",
-                          "width": 1,
-                        }
-                      }
-                      tabIndex={0}
-                    />
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          style={
-            Object {
-              "display": "flex",
-              "flex": "1",
-              "padding": 10,
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "alignContent": "flex-start",
-                "display": "flex",
-                "width": 450,
-              }
-            }
-          >
-            <div
-              className="StudentsTable"
-              style={
-                Object {
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "column",
-                  "marginBottom": 10,
-                  "marginTop": 10,
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "flex": 1,
-                  }
-                }
-              />
-              <div
-                style={
-                  Object {
-                    "paddingTop": 10,
-                  }
-                }
-              >
-                Total Incidents:  0
-              </div>
-            </div>
-          </div>
-          <div
-            style={
-              Object {
-                "display": "flex",
-                "flex": "1",
-                "flexDirection": "column",
-                "paddingLeft": 20,
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "display": "flex",
-                  "justifyContent": "center",
-                  "marginTop": "20px",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "fontSize": "18px",
-                    "marginRight": "10px",
-                  }
-                }
-              >
-                Break down by:
-              </div>
-              <div
-                className="Select has-value is-searchable Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "width": "200px",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-47--value"
-                  >
-                    <div
-                      className="Select-value"
-                    >
-                      <span
-                        aria-selected="true"
-                        className="Select-value-label"
-                        id="react-select-47--value-item"
-                        role="option"
-                      >
-                        Day & Time
-                      </span>
-                    </div>
-                    <div
-                      className="Select-input"
-                      style={
-                        Object {
-                          "display": "inline-block",
-                        }
-                      }
-                    >
-                      <input
-                        aria-activedescendant="react-select-47--value"
-                        aria-expanded="false"
-                        aria-haspopup="false"
-                        aria-owns=""
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={false}
-                        role="combobox"
-                        style={
-                          Object {
-                            "boxSizing": "content-box",
-                            "width": "5px",
-                          }
-                        }
-                        value=""
-                      />
-                      <div
-                        style={
-                          Object {
-                            "height": 0,
-                            "left": 0,
-                            "overflow": "scroll",
-                            "position": "absolute",
-                            "top": 0,
-                            "visibility": "hidden",
-                            "whiteSpace": "pre",
-                          }
-                        }
-                      >
-                        
-                      </div>
-                    </div>
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-            <div
-              className="DisciplineScatterPlot"
-              id="String"
-              style={
-                Object {
-                  "display": "flex",
-                  "flex": 1,
-                  "padding": 10,
-                  "width": "100%",
-                }
-              }
-            >
-              <div
-                className="HighchartsWrapper"
-                style={
-                  Object {
-                    "flex": 1,
-                  }
-                }
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`snapshots works for new_bedford 1`] = `
-<div
-  style={
-    Object {
-      "background": "#333",
-      "width": "100%",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "background": "white",
-        "border": "5px solid #333",
-        "display": "flex",
-        "flexDirection": "column",
-        "height": 768,
-        "width": 1024,
-      }
-    }
-  >
-    <div
-      className="SchoolDisciplineDashboard EscapeListener"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "display": "flex",
-          "flex": 1,
-          "flexDirection": "column",
-          "width": "100%",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "background": "red",
-            "color": "white",
-            "fontWeight": "bold",
-            "padding": 20,
-          }
-        }
-      >
-        <span>
-          This is an experimental prototype!
-        </span>
-        <span
-          style={
-            Object {
-              "marginLeft": 10,
-            }
-          }
-        >
-          Please share your feedback with 
-          <a
-            href="mailto://ideas@studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            ideas@studentinsights.org
-          </a>
-          .
-        </span>
-      </div>
-      <div
-        style={
-          Object {
-            "display": "flex",
-            "flex": 1,
-            "flexDirection": "column",
-            "paddingLeft": 10,
-            "paddingRight": 10,
-            "width": "100%",
-          }
-        }
-      >
-        <div
-          className="SectionHeading"
-          style={
-            Object {
-              "borderBottom": "1px solid #333",
-              "padding": 10,
-            }
-          }
-        >
-          <h4
-            style={
-              Object {
-                "color": "black",
-                "display": "inline",
-              }
-            }
-          >
-            Recent Discipline incidents at 
-            Arthur D. Healey
-          </h4>
-        </div>
-        <div
-          style={
-            Object {
-              "borderBottom": "1px solid #ccc",
-              "display": "flex",
-              "flexDirection": "row",
-              "justifyContent": "space-between",
-              "padding": 10,
-              "width": "100%",
-            }
-          }
-        >
-          <div
-            className="FilterBar"
-            style={
-              Object {
-                "display": "flex",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                }
-              }
-            >
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "marginRight": 10,
-                  }
-                }
-              >
-                Filter by
-              </span>
-              <div
-                className="Select is-searchable Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 10,
-                      "width": "10em",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-52--value"
-                  >
-                    <div
-                      className="Select-placeholder"
-                    >
-                      Incident Type...
-                    </div>
-                    <div
-                      className="Select-input"
-                      style={
-                        Object {
-                          "display": "inline-block",
-                        }
-                      }
-                    >
-                      <input
-                        aria-activedescendant="react-select-52--value"
-                        aria-expanded="false"
-                        aria-haspopup="false"
-                        aria-owns=""
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={false}
-                        role="combobox"
-                        style={
-                          Object {
-                            "boxSizing": "content-box",
-                            "width": "5px",
-                          }
-                        }
-                        value=""
-                      />
-                      <div
-                        style={
-                          Object {
-                            "height": 0,
-                            "left": 0,
-                            "overflow": "scroll",
-                            "position": "absolute",
-                            "top": 0,
-                            "visibility": "hidden",
-                            "whiteSpace": "pre",
-                          }
-                        }
-                      >
-                        
-                      </div>
-                    </div>
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-              <div
-                className="Select is-searchable Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 10,
-                      "width": "8em",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-53--value"
-                  >
-                    <div
-                      className="Select-placeholder"
-                    >
-                      Grade...
-                    </div>
-                    <div
-                      className="Select-input"
-                      style={
-                        Object {
-                          "display": "inline-block",
-                        }
-                      }
-                    >
-                      <input
-                        aria-activedescendant="react-select-53--value"
-                        aria-expanded="false"
-                        aria-haspopup="false"
-                        aria-owns=""
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={false}
-                        role="combobox"
-                        style={
-                          Object {
-                            "boxSizing": "content-box",
-                            "width": "5px",
-                          }
-                        }
-                        value=""
-                      />
-                      <div
-                        style={
-                          Object {
-                            "height": 0,
-                            "left": 0,
-                            "overflow": "scroll",
-                            "position": "absolute",
-                            "top": 0,
-                            "visibility": "hidden",
-                            "whiteSpace": "pre",
-                          }
-                        }
-                      >
-                        
-                      </div>
-                    </div>
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="FilterBar"
-            style={
-              Object {
-                "display": "flex",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                }
-              }
-            >
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "marginRight": 10,
-                  }
-                }
-              >
-                Filter by
-              </span>
-              <div
-                className="Select has-value Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 10,
-                      "width": "10em",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-54--value"
-                  >
-                    <div
-                      className="Select-value"
-                    >
-                      <span
-                        aria-selected="true"
-                        className="Select-value-label"
-                        id="react-select-54--value-item"
-                        role="option"
-                      >
-                        Last 45 days
-                      </span>
-                    </div>
-                    <div
-                      aria-activedescendant="react-select-54--value"
-                      aria-disabled="false"
-                      aria-expanded={false}
-                      aria-owns=""
-                      className="Select-input"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      role="combobox"
-                      style={
-                        Object {
-                          "border": 0,
-                          "display": "inline-block",
-                          "width": 1,
-                        }
-                      }
-                      tabIndex={0}
-                    />
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          style={
-            Object {
-              "display": "flex",
-              "flex": "1",
-              "padding": 10,
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "alignContent": "flex-start",
-                "display": "flex",
-                "width": 450,
-              }
-            }
-          >
-            <div
-              className="StudentsTable"
-              style={
-                Object {
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "column",
-                  "marginBottom": 10,
-                  "marginTop": 10,
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "flex": 1,
-                  }
-                }
-              />
-              <div
-                style={
-                  Object {
-                    "paddingTop": 10,
-                  }
-                }
-              >
-                Total Incidents:  0
-              </div>
-            </div>
-          </div>
-          <div
-            style={
-              Object {
-                "display": "flex",
-                "flex": "1",
-                "flexDirection": "column",
-                "paddingLeft": 20,
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "display": "flex",
-                  "justifyContent": "center",
-                  "marginTop": "20px",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "fontSize": "18px",
-                    "marginRight": "10px",
-                  }
-                }
-              >
-                Break down by:
-              </div>
-              <div
-                className="Select has-value is-searchable Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "width": "200px",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-55--value"
-                  >
-                    <div
-                      className="Select-value"
-                    >
-                      <span
-                        aria-selected="true"
-                        className="Select-value-label"
-                        id="react-select-55--value-item"
-                        role="option"
-                      >
-                        Day & Time
-                      </span>
-                    </div>
-                    <div
-                      className="Select-input"
-                      style={
-                        Object {
-                          "display": "inline-block",
-                        }
-                      }
-                    >
-                      <input
-                        aria-activedescendant="react-select-55--value"
-                        aria-expanded="false"
-                        aria-haspopup="false"
-                        aria-owns=""
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={false}
-                        role="combobox"
-                        style={
-                          Object {
-                            "boxSizing": "content-box",
-                            "width": "5px",
-                          }
-                        }
-                        value=""
-                      />
-                      <div
-                        style={
-                          Object {
-                            "height": 0,
-                            "left": 0,
-                            "overflow": "scroll",
-                            "position": "absolute",
-                            "top": 0,
-                            "visibility": "hidden",
-                            "whiteSpace": "pre",
-                          }
-                        }
-                      >
-                        
-                      </div>
-                    </div>
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-            <div
-              className="DisciplineScatterPlot"
-              id="String"
-              style={
-                Object {
-                  "display": "flex",
-                  "flex": 1,
-                  "padding": 10,
-                  "width": "100%",
-                }
-              }
-            >
-              <div
-                className="HighchartsWrapper"
-                style={
-                  Object {
-                    "flex": 1,
-                  }
-                }
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`snapshots works for somerville 1`] = `
 <div
   style={
     Object {
@@ -2202,7 +1026,7 @@ exports[`snapshots works for somerville 1`] = `
                   }
                 }
               >
-                Total Incidents:  0
+                Total Incidents:  1
               </div>
             </div>
           </div>
@@ -2278,6 +1102,1182 @@ exports[`snapshots works for somerville 1`] = `
                     >
                       <input
                         aria-activedescendant="react-select-51--value"
+                        aria-expanded="false"
+                        aria-haspopup="false"
+                        aria-owns=""
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        required={false}
+                        role="combobox"
+                        style={
+                          Object {
+                            "boxSizing": "content-box",
+                            "width": "5px",
+                          }
+                        }
+                        value=""
+                      />
+                      <div
+                        style={
+                          Object {
+                            "height": 0,
+                            "left": 0,
+                            "overflow": "scroll",
+                            "position": "absolute",
+                            "top": 0,
+                            "visibility": "hidden",
+                            "whiteSpace": "pre",
+                          }
+                        }
+                      >
+                        
+                      </div>
+                    </div>
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              className="DisciplineScatterPlot"
+              id="String"
+              style={
+                Object {
+                  "display": "flex",
+                  "flex": 1,
+                  "padding": 10,
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                className="HighchartsWrapper"
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`snapshots works for new_bedford 1`] = `
+<div
+  style={
+    Object {
+      "background": "#333",
+      "width": "100%",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "background": "white",
+        "border": "5px solid #333",
+        "display": "flex",
+        "flexDirection": "column",
+        "height": 768,
+        "width": 1024,
+      }
+    }
+  >
+    <div
+      className="SchoolDisciplineDashboard EscapeListener"
+      onKeyDown={[Function]}
+      style={
+        Object {
+          "display": "flex",
+          "flex": 1,
+          "flexDirection": "column",
+          "width": "100%",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "background": "red",
+            "color": "white",
+            "fontWeight": "bold",
+            "padding": 20,
+          }
+        }
+      >
+        <span>
+          This is an experimental prototype!
+        </span>
+        <span
+          style={
+            Object {
+              "marginLeft": 10,
+            }
+          }
+        >
+          Please share your feedback with 
+          <a
+            href="mailto://ideas@studentinsights.org"
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            ideas@studentinsights.org
+          </a>
+          .
+        </span>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "flex": 1,
+            "flexDirection": "column",
+            "paddingLeft": 10,
+            "paddingRight": 10,
+            "width": "100%",
+          }
+        }
+      >
+        <div
+          className="SectionHeading"
+          style={
+            Object {
+              "borderBottom": "1px solid #333",
+              "padding": 10,
+            }
+          }
+        >
+          <h4
+            style={
+              Object {
+                "color": "black",
+                "display": "inline",
+              }
+            }
+          >
+            Recent Discipline incidents at 
+            Arthur D. Healey
+          </h4>
+        </div>
+        <div
+          style={
+            Object {
+              "borderBottom": "1px solid #ccc",
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "padding": 10,
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            className="FilterBar"
+            style={
+              Object {
+                "display": "flex",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Filter by
+              </span>
+              <div
+                className="Select is-searchable Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "marginLeft": 10,
+                      "width": "10em",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-56--value"
+                  >
+                    <div
+                      className="Select-placeholder"
+                    >
+                      Incident Type...
+                    </div>
+                    <div
+                      className="Select-input"
+                      style={
+                        Object {
+                          "display": "inline-block",
+                        }
+                      }
+                    >
+                      <input
+                        aria-activedescendant="react-select-56--value"
+                        aria-expanded="false"
+                        aria-haspopup="false"
+                        aria-owns=""
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        required={false}
+                        role="combobox"
+                        style={
+                          Object {
+                            "boxSizing": "content-box",
+                            "width": "5px",
+                          }
+                        }
+                        value=""
+                      />
+                      <div
+                        style={
+                          Object {
+                            "height": 0,
+                            "left": 0,
+                            "overflow": "scroll",
+                            "position": "absolute",
+                            "top": 0,
+                            "visibility": "hidden",
+                            "whiteSpace": "pre",
+                          }
+                        }
+                      >
+                        
+                      </div>
+                    </div>
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+              <div
+                className="Select is-searchable Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "marginLeft": 10,
+                      "width": "8em",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-57--value"
+                  >
+                    <div
+                      className="Select-placeholder"
+                    >
+                      Grade...
+                    </div>
+                    <div
+                      className="Select-input"
+                      style={
+                        Object {
+                          "display": "inline-block",
+                        }
+                      }
+                    >
+                      <input
+                        aria-activedescendant="react-select-57--value"
+                        aria-expanded="false"
+                        aria-haspopup="false"
+                        aria-owns=""
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        required={false}
+                        role="combobox"
+                        style={
+                          Object {
+                            "boxSizing": "content-box",
+                            "width": "5px",
+                          }
+                        }
+                        value=""
+                      />
+                      <div
+                        style={
+                          Object {
+                            "height": 0,
+                            "left": 0,
+                            "overflow": "scroll",
+                            "position": "absolute",
+                            "top": 0,
+                            "visibility": "hidden",
+                            "whiteSpace": "pre",
+                          }
+                        }
+                      >
+                        
+                      </div>
+                    </div>
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="FilterBar"
+            style={
+              Object {
+                "display": "flex",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Filter by
+              </span>
+              <div
+                className="Select has-value Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "marginLeft": 10,
+                      "width": "10em",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-58--value"
+                  >
+                    <div
+                      className="Select-value"
+                    >
+                      <span
+                        aria-selected="true"
+                        className="Select-value-label"
+                        id="react-select-58--value-item"
+                        role="option"
+                      >
+                        Last 45 days
+                      </span>
+                    </div>
+                    <div
+                      aria-activedescendant="react-select-58--value"
+                      aria-disabled="false"
+                      aria-expanded={false}
+                      aria-owns=""
+                      className="Select-input"
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      role="combobox"
+                      style={
+                        Object {
+                          "border": 0,
+                          "display": "inline-block",
+                          "width": 1,
+                        }
+                      }
+                      tabIndex={0}
+                    />
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "flex": "1",
+              "padding": 10,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "alignContent": "flex-start",
+                "display": "flex",
+                "width": 450,
+              }
+            }
+          >
+            <div
+              className="StudentsTable"
+              style={
+                Object {
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "column",
+                  "marginBottom": 10,
+                  "marginTop": 10,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "paddingTop": 10,
+                  }
+                }
+              >
+                Total Incidents:  1
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "display": "flex",
+                "flex": "1",
+                "flexDirection": "column",
+                "paddingLeft": 20,
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "display": "flex",
+                  "justifyContent": "center",
+                  "marginTop": "20px",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "fontSize": "18px",
+                    "marginRight": "10px",
+                  }
+                }
+              >
+                Break down by:
+              </div>
+              <div
+                className="Select has-value is-searchable Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "width": "200px",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-59--value"
+                  >
+                    <div
+                      className="Select-value"
+                    >
+                      <span
+                        aria-selected="true"
+                        className="Select-value-label"
+                        id="react-select-59--value-item"
+                        role="option"
+                      >
+                        Day & Time
+                      </span>
+                    </div>
+                    <div
+                      className="Select-input"
+                      style={
+                        Object {
+                          "display": "inline-block",
+                        }
+                      }
+                    >
+                      <input
+                        aria-activedescendant="react-select-59--value"
+                        aria-expanded="false"
+                        aria-haspopup="false"
+                        aria-owns=""
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        required={false}
+                        role="combobox"
+                        style={
+                          Object {
+                            "boxSizing": "content-box",
+                            "width": "5px",
+                          }
+                        }
+                        value=""
+                      />
+                      <div
+                        style={
+                          Object {
+                            "height": 0,
+                            "left": 0,
+                            "overflow": "scroll",
+                            "position": "absolute",
+                            "top": 0,
+                            "visibility": "hidden",
+                            "whiteSpace": "pre",
+                          }
+                        }
+                      >
+                        
+                      </div>
+                    </div>
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              className="DisciplineScatterPlot"
+              id="String"
+              style={
+                Object {
+                  "display": "flex",
+                  "flex": 1,
+                  "padding": 10,
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                className="HighchartsWrapper"
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`snapshots works for somerville 1`] = `
+<div
+  style={
+    Object {
+      "background": "#333",
+      "width": "100%",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "background": "white",
+        "border": "5px solid #333",
+        "display": "flex",
+        "flexDirection": "column",
+        "height": 768,
+        "width": 1024,
+      }
+    }
+  >
+    <div
+      className="SchoolDisciplineDashboard EscapeListener"
+      onKeyDown={[Function]}
+      style={
+        Object {
+          "display": "flex",
+          "flex": 1,
+          "flexDirection": "column",
+          "width": "100%",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "background": "red",
+            "color": "white",
+            "fontWeight": "bold",
+            "padding": 20,
+          }
+        }
+      >
+        <span>
+          This is an experimental prototype!
+        </span>
+        <span
+          style={
+            Object {
+              "marginLeft": 10,
+            }
+          }
+        >
+          Please share your feedback with 
+          <a
+            href="mailto://ideas@studentinsights.org"
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            ideas@studentinsights.org
+          </a>
+          .
+        </span>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "flex": 1,
+            "flexDirection": "column",
+            "paddingLeft": 10,
+            "paddingRight": 10,
+            "width": "100%",
+          }
+        }
+      >
+        <div
+          className="SectionHeading"
+          style={
+            Object {
+              "borderBottom": "1px solid #333",
+              "padding": 10,
+            }
+          }
+        >
+          <h4
+            style={
+              Object {
+                "color": "black",
+                "display": "inline",
+              }
+            }
+          >
+            Recent Discipline incidents at 
+            Arthur D. Healey
+          </h4>
+        </div>
+        <div
+          style={
+            Object {
+              "borderBottom": "1px solid #ccc",
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "padding": 10,
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            className="FilterBar"
+            style={
+              Object {
+                "display": "flex",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Filter by
+              </span>
+              <div
+                className="Select is-searchable Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "marginLeft": 10,
+                      "width": "10em",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-52--value"
+                  >
+                    <div
+                      className="Select-placeholder"
+                    >
+                      Incident Type...
+                    </div>
+                    <div
+                      className="Select-input"
+                      style={
+                        Object {
+                          "display": "inline-block",
+                        }
+                      }
+                    >
+                      <input
+                        aria-activedescendant="react-select-52--value"
+                        aria-expanded="false"
+                        aria-haspopup="false"
+                        aria-owns=""
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        required={false}
+                        role="combobox"
+                        style={
+                          Object {
+                            "boxSizing": "content-box",
+                            "width": "5px",
+                          }
+                        }
+                        value=""
+                      />
+                      <div
+                        style={
+                          Object {
+                            "height": 0,
+                            "left": 0,
+                            "overflow": "scroll",
+                            "position": "absolute",
+                            "top": 0,
+                            "visibility": "hidden",
+                            "whiteSpace": "pre",
+                          }
+                        }
+                      >
+                        
+                      </div>
+                    </div>
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+              <div
+                className="Select is-searchable Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "marginLeft": 10,
+                      "width": "8em",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-53--value"
+                  >
+                    <div
+                      className="Select-placeholder"
+                    >
+                      Grade...
+                    </div>
+                    <div
+                      className="Select-input"
+                      style={
+                        Object {
+                          "display": "inline-block",
+                        }
+                      }
+                    >
+                      <input
+                        aria-activedescendant="react-select-53--value"
+                        aria-expanded="false"
+                        aria-haspopup="false"
+                        aria-owns=""
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        required={false}
+                        role="combobox"
+                        style={
+                          Object {
+                            "boxSizing": "content-box",
+                            "width": "5px",
+                          }
+                        }
+                        value=""
+                      />
+                      <div
+                        style={
+                          Object {
+                            "height": 0,
+                            "left": 0,
+                            "overflow": "scroll",
+                            "position": "absolute",
+                            "top": 0,
+                            "visibility": "hidden",
+                            "whiteSpace": "pre",
+                          }
+                        }
+                      >
+                        
+                      </div>
+                    </div>
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="FilterBar"
+            style={
+              Object {
+                "display": "flex",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Filter by
+              </span>
+              <div
+                className="Select has-value Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "marginLeft": 10,
+                      "width": "10em",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-54--value"
+                  >
+                    <div
+                      className="Select-value"
+                    >
+                      <span
+                        aria-selected="true"
+                        className="Select-value-label"
+                        id="react-select-54--value-item"
+                        role="option"
+                      >
+                        Last 45 days
+                      </span>
+                    </div>
+                    <div
+                      aria-activedescendant="react-select-54--value"
+                      aria-disabled="false"
+                      aria-expanded={false}
+                      aria-owns=""
+                      className="Select-input"
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      role="combobox"
+                      style={
+                        Object {
+                          "border": 0,
+                          "display": "inline-block",
+                          "width": 1,
+                        }
+                      }
+                      tabIndex={0}
+                    />
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "flex": "1",
+              "padding": 10,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "alignContent": "flex-start",
+                "display": "flex",
+                "width": 450,
+              }
+            }
+          >
+            <div
+              className="StudentsTable"
+              style={
+                Object {
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "column",
+                  "marginBottom": 10,
+                  "marginTop": 10,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "paddingTop": 10,
+                  }
+                }
+              >
+                Total Incidents:  1
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "display": "flex",
+                "flex": "1",
+                "flexDirection": "column",
+                "paddingLeft": 20,
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "display": "flex",
+                  "justifyContent": "center",
+                  "marginTop": "20px",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "fontSize": "18px",
+                    "marginRight": "10px",
+                  }
+                }
+              >
+                Break down by:
+              </div>
+              <div
+                className="Select has-value is-searchable Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "width": "200px",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-55--value"
+                  >
+                    <div
+                      className="Select-value"
+                    >
+                      <span
+                        aria-selected="true"
+                        className="Select-value-label"
+                        id="react-select-55--value-item"
+                        role="option"
+                      >
+                        Day & Time
+                      </span>
+                    </div>
+                    <div
+                      className="Select-input"
+                      style={
+                        Object {
+                          "display": "inline-block",
+                        }
+                      }
+                    >
+                      <input
+                        aria-activedescendant="react-select-55--value"
                         aria-expanded="false"
                         aria-haspopup="false"
                         aria-owns=""


### PR DESCRIPTION
# Who is this PR for?
Educators

# What problem does this PR fix?

When there are hundreds of discipline incidents, the scatterplot will have too many data points to show useful information.

# What does this PR do?

Prevents the scatterplot from displaying when there are more than 500 incidents

# Screenshot (if adding a client-side feature)
![limit_heatmap](https://user-images.githubusercontent.com/638809/51343063-75af0680-1a63-11e9-861d-af5d812b4507.gif)

# Checklists
*Which features or pages does this PR touch?*
+ [x] Discipline

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here