### PR TITLE
Hide scatterplot for large schools

### DIFF
--- a/app/assets/javascripts/school_administrator_dashboard/DashboardTestData.js
+++ b/app/assets/javascripts/school_administrator_dashboard/DashboardTestData.js
@@ -68,6 +68,15 @@ export function createStudents(nowMoment) {
     id: 1,
     absences: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo, testEvents.threeMonthsAgo],
     tardies: [testEvents.oneMonthAgo, testEvents.twoMonthsAgo, testEvents.threeMonthsAgo],
+    discipline_incidents: [{
+      id:23,
+      incident_code:"Assault",
+      created_at: nowMoment.clone().subtract(30, 'days').format(),
+      incident_location:"Playground",
+      incident_description:"Description",
+      occurred_at: nowMoment.clone().subtract(30, 'days').format(),
+      has_exact_time:true,
+      student_id:1}],
     events: 3,
     latest_note: {
       event_note_type_id: 300,

--- a/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/SchoolDisciplineDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/SchoolDisciplineDashboard.js
@@ -49,6 +49,13 @@ export default class SchoolDisciplineDashboard extends React.Component {
     this.memoize = memoizer();
   }
 
+  //Remove scatter plot option when there are too many incidents to show patterns
+  componentDidMount() {
+    if (this.getIncidentsFromStudents(this.props.dashboardStudents).length > 500) {
+      this.setState({selectedChart: 'incident_location', scatterPlotAvailable: false});
+    }
+  }
+
   filterIncidents(disciplineIncidents, options = {}) {
     return this.memoize(['filteredIncidents', this.state, arguments], () => {
       if (!disciplineIncidents) return [];
@@ -315,10 +322,10 @@ export default class SchoolDisciplineDashboard extends React.Component {
 
   render() {
     const {districtKey} = this.context;
-    const {timeRangeKey, selectedChart, grade, house, counselor} = this.state;
+    const {scatterPlotAvailable, timeRangeKey, selectedChart, grade, house, counselor} = this.state;
     const {school, dashboardStudents} = this.props;
     const chartOptions = [
-      {value: 'scatter', label: 'Day & Time'},
+      ... scatterPlotAvailable ? [{value: 'scatter', label: 'Day & Time'}] : [],
       {value: 'incident_location', label: 'Location'},
       {value: 'time', label: 'Time'},
       {value: 'homeroom_label', label: 'Classroom'},
@@ -481,6 +488,7 @@ const styles = {
 function initialState() {
   return {
     timeRangeKey: TIME_RANGE_45_DAYS_AGO,
+    scatterPlotAvailable: true,
     selectedChart: 'scatter',
     selectedIncidentCode: ALL,
     selectedCategory: null,

--- a/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/__snapshots__/SchoolDisciplineDashboard.test.js.snap
+++ b/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/__snapshots__/SchoolDisciplineDashboard.test.js.snap
@@ -158,7 +158,7 @@ exports[`snapshots works for bedford 1`] = `
                 >
                   <span
                     className="Select-multi-value-wrapper"
-                    id="react-select-56--value"
+                    id="react-select-60--value"
                   >
                     <div
                       className="Select-placeholder"
@@ -174,7 +174,7 @@ exports[`snapshots works for bedford 1`] = `
                       }
                     >
                       <input
-                        aria-activedescendant="react-select-56--value"
+                        aria-activedescendant="react-select-60--value"
                         aria-expanded="false"
                         aria-haspopup="false"
                         aria-owns=""
@@ -238,7 +238,7 @@ exports[`snapshots works for bedford 1`] = `
                 >
                   <span
                     className="Select-multi-value-wrapper"
-                    id="react-select-57--value"
+                    id="react-select-61--value"
                   >
                     <div
                       className="Select-placeholder"
@@ -254,7 +254,7 @@ exports[`snapshots works for bedford 1`] = `
                       }
                     >
                       <input
-                        aria-activedescendant="react-select-57--value"
+                        aria-activedescendant="react-select-61--value"
                         aria-expanded="false"
                         aria-haspopup="false"
                         aria-owns=""
@@ -347,7 +347,7 @@ exports[`snapshots works for bedford 1`] = `
                 >
                   <span
                     className="Select-multi-value-wrapper"
-                    id="react-select-58--value"
+                    id="react-select-62--value"
                   >
                     <div
                       className="Select-value"
@@ -355,14 +355,14 @@ exports[`snapshots works for bedford 1`] = `
                       <span
                         aria-selected="true"
                         className="Select-value-label"
-                        id="react-select-58--value-item"
+                        id="react-select-62--value-item"
                         role="option"
                       >
                         Last 45 days
                       </span>
                     </div>
                     <div
-                      aria-activedescendant="react-select-58--value"
+                      aria-activedescendant="react-select-62--value"
                       aria-disabled="false"
                       aria-expanded={false}
                       aria-owns=""
@@ -438,7 +438,7 @@ exports[`snapshots works for bedford 1`] = `
                   }
                 }
               >
-                Total Incidents:  0
+                Total Incidents:  1
               </div>
             </div>
           </div>
@@ -490,7 +490,7 @@ exports[`snapshots works for bedford 1`] = `
                 >
                   <span
                     className="Select-multi-value-wrapper"
-                    id="react-select-59--value"
+                    id="react-select-63--value"
                   >
                     <div
                       className="Select-value"
@@ -498,7 +498,7 @@ exports[`snapshots works for bedford 1`] = `
                       <span
                         aria-selected="true"
                         className="Select-value-label"
-                        id="react-select-59--value-item"
+                        id="react-select-63--value-item"
                         role="option"
                       >
                         Day & Time
@@ -513,7 +513,7 @@ exports[`snapshots works for bedford 1`] = `
                       }
                     >
                       <input
-                        aria-activedescendant="react-select-59--value"
+                        aria-activedescendant="react-select-63--value"
                         aria-expanded="false"
                         aria-haspopup="false"
                         aria-owns=""
@@ -589,1182 +589,6 @@ exports[`snapshots works for bedford 1`] = `
 `;
 
 exports[`snapshots works for demo 1`] = `
-<div
-  style={
-    Object {
-      "background": "#333",
-      "width": "100%",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "background": "white",
-        "border": "5px solid #333",
-        "display": "flex",
-        "flexDirection": "column",
-        "height": 768,
-        "width": 1024,
-      }
-    }
-  >
-    <div
-      className="SchoolDisciplineDashboard EscapeListener"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "display": "flex",
-          "flex": 1,
-          "flexDirection": "column",
-          "width": "100%",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "background": "red",
-            "color": "white",
-            "fontWeight": "bold",
-            "padding": 20,
-          }
-        }
-      >
-        <span>
-          This is an experimental prototype!
-        </span>
-        <span
-          style={
-            Object {
-              "marginLeft": 10,
-            }
-          }
-        >
-          Please share your feedback with 
-          <a
-            href="mailto://ideas@studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            ideas@studentinsights.org
-          </a>
-          .
-        </span>
-      </div>
-      <div
-        style={
-          Object {
-            "display": "flex",
-            "flex": 1,
-            "flexDirection": "column",
-            "paddingLeft": 10,
-            "paddingRight": 10,
-            "width": "100%",
-          }
-        }
-      >
-        <div
-          className="SectionHeading"
-          style={
-            Object {
-              "borderBottom": "1px solid #333",
-              "padding": 10,
-            }
-          }
-        >
-          <h4
-            style={
-              Object {
-                "color": "black",
-                "display": "inline",
-              }
-            }
-          >
-            Recent Discipline incidents at 
-            Arthur D. Healey
-          </h4>
-        </div>
-        <div
-          style={
-            Object {
-              "borderBottom": "1px solid #ccc",
-              "display": "flex",
-              "flexDirection": "row",
-              "justifyContent": "space-between",
-              "padding": 10,
-              "width": "100%",
-            }
-          }
-        >
-          <div
-            className="FilterBar"
-            style={
-              Object {
-                "display": "flex",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                }
-              }
-            >
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "marginRight": 10,
-                  }
-                }
-              >
-                Filter by
-              </span>
-              <div
-                className="Select is-searchable Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 10,
-                      "width": "10em",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-44--value"
-                  >
-                    <div
-                      className="Select-placeholder"
-                    >
-                      Incident Type...
-                    </div>
-                    <div
-                      className="Select-input"
-                      style={
-                        Object {
-                          "display": "inline-block",
-                        }
-                      }
-                    >
-                      <input
-                        aria-activedescendant="react-select-44--value"
-                        aria-expanded="false"
-                        aria-haspopup="false"
-                        aria-owns=""
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={false}
-                        role="combobox"
-                        style={
-                          Object {
-                            "boxSizing": "content-box",
-                            "width": "5px",
-                          }
-                        }
-                        value=""
-                      />
-                      <div
-                        style={
-                          Object {
-                            "height": 0,
-                            "left": 0,
-                            "overflow": "scroll",
-                            "position": "absolute",
-                            "top": 0,
-                            "visibility": "hidden",
-                            "whiteSpace": "pre",
-                          }
-                        }
-                      >
-                        
-                      </div>
-                    </div>
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-              <div
-                className="Select is-searchable Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 10,
-                      "width": "8em",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-45--value"
-                  >
-                    <div
-                      className="Select-placeholder"
-                    >
-                      Grade...
-                    </div>
-                    <div
-                      className="Select-input"
-                      style={
-                        Object {
-                          "display": "inline-block",
-                        }
-                      }
-                    >
-                      <input
-                        aria-activedescendant="react-select-45--value"
-                        aria-expanded="false"
-                        aria-haspopup="false"
-                        aria-owns=""
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={false}
-                        role="combobox"
-                        style={
-                          Object {
-                            "boxSizing": "content-box",
-                            "width": "5px",
-                          }
-                        }
-                        value=""
-                      />
-                      <div
-                        style={
-                          Object {
-                            "height": 0,
-                            "left": 0,
-                            "overflow": "scroll",
-                            "position": "absolute",
-                            "top": 0,
-                            "visibility": "hidden",
-                            "whiteSpace": "pre",
-                          }
-                        }
-                      >
-                        
-                      </div>
-                    </div>
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="FilterBar"
-            style={
-              Object {
-                "display": "flex",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                }
-              }
-            >
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "marginRight": 10,
-                  }
-                }
-              >
-                Filter by
-              </span>
-              <div
-                className="Select has-value Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 10,
-                      "width": "10em",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-46--value"
-                  >
-                    <div
-                      className="Select-value"
-                    >
-                      <span
-                        aria-selected="true"
-                        className="Select-value-label"
-                        id="react-select-46--value-item"
-                        role="option"
-                      >
-                        Last 45 days
-                      </span>
-                    </div>
-                    <div
-                      aria-activedescendant="react-select-46--value"
-                      aria-disabled="false"
-                      aria-expanded={false}
-                      aria-owns=""
-                      className="Select-input"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      role="combobox"
-                      style={
-                        Object {
-                          "border": 0,
-                          "display": "inline-block",
-                          "width": 1,
-                        }
-                      }
-                      tabIndex={0}
-                    />
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          style={
-            Object {
-              "display": "flex",
-              "flex": "1",
-              "padding": 10,
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "alignContent": "flex-start",
-                "display": "flex",
-                "width": 450,
-              }
-            }
-          >
-            <div
-              className="StudentsTable"
-              style={
-                Object {
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "column",
-                  "marginBottom": 10,
-                  "marginTop": 10,
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "flex": 1,
-                  }
-                }
-              />
-              <div
-                style={
-                  Object {
-                    "paddingTop": 10,
-                  }
-                }
-              >
-                Total Incidents:  0
-              </div>
-            </div>
-          </div>
-          <div
-            style={
-              Object {
-                "display": "flex",
-                "flex": "1",
-                "flexDirection": "column",
-                "paddingLeft": 20,
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "display": "flex",
-                  "justifyContent": "center",
-                  "marginTop": "20px",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "fontSize": "18px",
-                    "marginRight": "10px",
-                  }
-                }
-              >
-                Break down by:
-              </div>
-              <div
-                className="Select has-value is-searchable Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "width": "200px",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-47--value"
-                  >
-                    <div
-                      className="Select-value"
-                    >
-                      <span
-                        aria-selected="true"
-                        className="Select-value-label"
-                        id="react-select-47--value-item"
-                        role="option"
-                      >
-                        Day & Time
-                      </span>
-                    </div>
-                    <div
-                      className="Select-input"
-                      style={
-                        Object {
-                          "display": "inline-block",
-                        }
-                      }
-                    >
-                      <input
-                        aria-activedescendant="react-select-47--value"
-                        aria-expanded="false"
-                        aria-haspopup="false"
-                        aria-owns=""
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={false}
-                        role="combobox"
-                        style={
-                          Object {
-                            "boxSizing": "content-box",
-                            "width": "5px",
-                          }
-                        }
-                        value=""
-                      />
-                      <div
-                        style={
-                          Object {
-                            "height": 0,
-                            "left": 0,
-                            "overflow": "scroll",
-                            "position": "absolute",
-                            "top": 0,
-                            "visibility": "hidden",
-                            "whiteSpace": "pre",
-                          }
-                        }
-                      >
-                        
-                      </div>
-                    </div>
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-            <div
-              className="DisciplineScatterPlot"
-              id="String"
-              style={
-                Object {
-                  "display": "flex",
-                  "flex": 1,
-                  "padding": 10,
-                  "width": "100%",
-                }
-              }
-            >
-              <div
-                className="HighchartsWrapper"
-                style={
-                  Object {
-                    "flex": 1,
-                  }
-                }
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`snapshots works for new_bedford 1`] = `
-<div
-  style={
-    Object {
-      "background": "#333",
-      "width": "100%",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "background": "white",
-        "border": "5px solid #333",
-        "display": "flex",
-        "flexDirection": "column",
-        "height": 768,
-        "width": 1024,
-      }
-    }
-  >
-    <div
-      className="SchoolDisciplineDashboard EscapeListener"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "display": "flex",
-          "flex": 1,
-          "flexDirection": "column",
-          "width": "100%",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "background": "red",
-            "color": "white",
-            "fontWeight": "bold",
-            "padding": 20,
-          }
-        }
-      >
-        <span>
-          This is an experimental prototype!
-        </span>
-        <span
-          style={
-            Object {
-              "marginLeft": 10,
-            }
-          }
-        >
-          Please share your feedback with 
-          <a
-            href="mailto://ideas@studentinsights.org"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            ideas@studentinsights.org
-          </a>
-          .
-        </span>
-      </div>
-      <div
-        style={
-          Object {
-            "display": "flex",
-            "flex": 1,
-            "flexDirection": "column",
-            "paddingLeft": 10,
-            "paddingRight": 10,
-            "width": "100%",
-          }
-        }
-      >
-        <div
-          className="SectionHeading"
-          style={
-            Object {
-              "borderBottom": "1px solid #333",
-              "padding": 10,
-            }
-          }
-        >
-          <h4
-            style={
-              Object {
-                "color": "black",
-                "display": "inline",
-              }
-            }
-          >
-            Recent Discipline incidents at 
-            Arthur D. Healey
-          </h4>
-        </div>
-        <div
-          style={
-            Object {
-              "borderBottom": "1px solid #ccc",
-              "display": "flex",
-              "flexDirection": "row",
-              "justifyContent": "space-between",
-              "padding": 10,
-              "width": "100%",
-            }
-          }
-        >
-          <div
-            className="FilterBar"
-            style={
-              Object {
-                "display": "flex",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                }
-              }
-            >
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "marginRight": 10,
-                  }
-                }
-              >
-                Filter by
-              </span>
-              <div
-                className="Select is-searchable Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 10,
-                      "width": "10em",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-52--value"
-                  >
-                    <div
-                      className="Select-placeholder"
-                    >
-                      Incident Type...
-                    </div>
-                    <div
-                      className="Select-input"
-                      style={
-                        Object {
-                          "display": "inline-block",
-                        }
-                      }
-                    >
-                      <input
-                        aria-activedescendant="react-select-52--value"
-                        aria-expanded="false"
-                        aria-haspopup="false"
-                        aria-owns=""
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={false}
-                        role="combobox"
-                        style={
-                          Object {
-                            "boxSizing": "content-box",
-                            "width": "5px",
-                          }
-                        }
-                        value=""
-                      />
-                      <div
-                        style={
-                          Object {
-                            "height": 0,
-                            "left": 0,
-                            "overflow": "scroll",
-                            "position": "absolute",
-                            "top": 0,
-                            "visibility": "hidden",
-                            "whiteSpace": "pre",
-                          }
-                        }
-                      >
-                        
-                      </div>
-                    </div>
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-              <div
-                className="Select is-searchable Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 10,
-                      "width": "8em",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-53--value"
-                  >
-                    <div
-                      className="Select-placeholder"
-                    >
-                      Grade...
-                    </div>
-                    <div
-                      className="Select-input"
-                      style={
-                        Object {
-                          "display": "inline-block",
-                        }
-                      }
-                    >
-                      <input
-                        aria-activedescendant="react-select-53--value"
-                        aria-expanded="false"
-                        aria-haspopup="false"
-                        aria-owns=""
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={false}
-                        role="combobox"
-                        style={
-                          Object {
-                            "boxSizing": "content-box",
-                            "width": "5px",
-                          }
-                        }
-                        value=""
-                      />
-                      <div
-                        style={
-                          Object {
-                            "height": 0,
-                            "left": 0,
-                            "overflow": "scroll",
-                            "position": "absolute",
-                            "top": 0,
-                            "visibility": "hidden",
-                            "whiteSpace": "pre",
-                          }
-                        }
-                      >
-                        
-                      </div>
-                    </div>
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="FilterBar"
-            style={
-              Object {
-                "display": "flex",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                }
-              }
-            >
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "marginRight": 10,
-                  }
-                }
-              >
-                Filter by
-              </span>
-              <div
-                className="Select has-value Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 10,
-                      "width": "10em",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-54--value"
-                  >
-                    <div
-                      className="Select-value"
-                    >
-                      <span
-                        aria-selected="true"
-                        className="Select-value-label"
-                        id="react-select-54--value-item"
-                        role="option"
-                      >
-                        Last 45 days
-                      </span>
-                    </div>
-                    <div
-                      aria-activedescendant="react-select-54--value"
-                      aria-disabled="false"
-                      aria-expanded={false}
-                      aria-owns=""
-                      className="Select-input"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      role="combobox"
-                      style={
-                        Object {
-                          "border": 0,
-                          "display": "inline-block",
-                          "width": 1,
-                        }
-                      }
-                      tabIndex={0}
-                    />
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          style={
-            Object {
-              "display": "flex",
-              "flex": "1",
-              "padding": 10,
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "alignContent": "flex-start",
-                "display": "flex",
-                "width": 450,
-              }
-            }
-          >
-            <div
-              className="StudentsTable"
-              style={
-                Object {
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "column",
-                  "marginBottom": 10,
-                  "marginTop": 10,
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "flex": 1,
-                  }
-                }
-              />
-              <div
-                style={
-                  Object {
-                    "paddingTop": 10,
-                  }
-                }
-              >
-                Total Incidents:  0
-              </div>
-            </div>
-          </div>
-          <div
-            style={
-              Object {
-                "display": "flex",
-                "flex": "1",
-                "flexDirection": "column",
-                "paddingLeft": 20,
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "display": "flex",
-                  "justifyContent": "center",
-                  "marginTop": "20px",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "fontSize": "18px",
-                    "marginRight": "10px",
-                  }
-                }
-              >
-                Break down by:
-              </div>
-              <div
-                className="Select has-value is-searchable Select--single"
-              >
-                <div
-                  className="Select-control"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    Object {
-                      "width": "200px",
-                    }
-                  }
-                >
-                  <span
-                    className="Select-multi-value-wrapper"
-                    id="react-select-55--value"
-                  >
-                    <div
-                      className="Select-value"
-                    >
-                      <span
-                        aria-selected="true"
-                        className="Select-value-label"
-                        id="react-select-55--value-item"
-                        role="option"
-                      >
-                        Day & Time
-                      </span>
-                    </div>
-                    <div
-                      className="Select-input"
-                      style={
-                        Object {
-                          "display": "inline-block",
-                        }
-                      }
-                    >
-                      <input
-                        aria-activedescendant="react-select-55--value"
-                        aria-expanded="false"
-                        aria-haspopup="false"
-                        aria-owns=""
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={false}
-                        role="combobox"
-                        style={
-                          Object {
-                            "boxSizing": "content-box",
-                            "width": "5px",
-                          }
-                        }
-                        value=""
-                      />
-                      <div
-                        style={
-                          Object {
-                            "height": 0,
-                            "left": 0,
-                            "overflow": "scroll",
-                            "position": "absolute",
-                            "top": 0,
-                            "visibility": "hidden",
-                            "whiteSpace": "pre",
-                          }
-                        }
-                      >
-                        
-                      </div>
-                    </div>
-                  </span>
-                  <span
-                    className="Select-arrow-zone"
-                    onMouseDown={[Function]}
-                  >
-                    <span
-                      className="Select-arrow"
-                      onMouseDown={[Function]}
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-            <div
-              className="DisciplineScatterPlot"
-              id="String"
-              style={
-                Object {
-                  "display": "flex",
-                  "flex": 1,
-                  "padding": 10,
-                  "width": "100%",
-                }
-              }
-            >
-              <div
-                className="HighchartsWrapper"
-                style={
-                  Object {
-                    "flex": 1,
-                  }
-                }
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`snapshots works for somerville 1`] = `
 <div
   style={
     Object {
@@ -2202,7 +1026,7 @@ exports[`snapshots works for somerville 1`] = `
                   }
                 }
               >
-                Total Incidents:  0
+                Total Incidents:  1
               </div>
             </div>
           </div>
@@ -2278,6 +1102,1182 @@ exports[`snapshots works for somerville 1`] = `
                     >
                       <input
                         aria-activedescendant="react-select-51--value"
+                        aria-expanded="false"
+                        aria-haspopup="false"
+                        aria-owns=""
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        required={false}
+                        role="combobox"
+                        style={
+                          Object {
+                            "boxSizing": "content-box",
+                            "width": "5px",
+                          }
+                        }
+                        value=""
+                      />
+                      <div
+                        style={
+                          Object {
+                            "height": 0,
+                            "left": 0,
+                            "overflow": "scroll",
+                            "position": "absolute",
+                            "top": 0,
+                            "visibility": "hidden",
+                            "whiteSpace": "pre",
+                          }
+                        }
+                      >
+                        
+                      </div>
+                    </div>
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              className="DisciplineScatterPlot"
+              id="String"
+              style={
+                Object {
+                  "display": "flex",
+                  "flex": 1,
+                  "padding": 10,
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                className="HighchartsWrapper"
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`snapshots works for new_bedford 1`] = `
+<div
+  style={
+    Object {
+      "background": "#333",
+      "width": "100%",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "background": "white",
+        "border": "5px solid #333",
+        "display": "flex",
+        "flexDirection": "column",
+        "height": 768,
+        "width": 1024,
+      }
+    }
+  >
+    <div
+      className="SchoolDisciplineDashboard EscapeListener"
+      onKeyDown={[Function]}
+      style={
+        Object {
+          "display": "flex",
+          "flex": 1,
+          "flexDirection": "column",
+          "width": "100%",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "background": "red",
+            "color": "white",
+            "fontWeight": "bold",
+            "padding": 20,
+          }
+        }
+      >
+        <span>
+          This is an experimental prototype!
+        </span>
+        <span
+          style={
+            Object {
+              "marginLeft": 10,
+            }
+          }
+        >
+          Please share your feedback with 
+          <a
+            href="mailto://ideas@studentinsights.org"
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            ideas@studentinsights.org
+          </a>
+          .
+        </span>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "flex": 1,
+            "flexDirection": "column",
+            "paddingLeft": 10,
+            "paddingRight": 10,
+            "width": "100%",
+          }
+        }
+      >
+        <div
+          className="SectionHeading"
+          style={
+            Object {
+              "borderBottom": "1px solid #333",
+              "padding": 10,
+            }
+          }
+        >
+          <h4
+            style={
+              Object {
+                "color": "black",
+                "display": "inline",
+              }
+            }
+          >
+            Recent Discipline incidents at 
+            Arthur D. Healey
+          </h4>
+        </div>
+        <div
+          style={
+            Object {
+              "borderBottom": "1px solid #ccc",
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "padding": 10,
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            className="FilterBar"
+            style={
+              Object {
+                "display": "flex",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Filter by
+              </span>
+              <div
+                className="Select is-searchable Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "marginLeft": 10,
+                      "width": "10em",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-56--value"
+                  >
+                    <div
+                      className="Select-placeholder"
+                    >
+                      Incident Type...
+                    </div>
+                    <div
+                      className="Select-input"
+                      style={
+                        Object {
+                          "display": "inline-block",
+                        }
+                      }
+                    >
+                      <input
+                        aria-activedescendant="react-select-56--value"
+                        aria-expanded="false"
+                        aria-haspopup="false"
+                        aria-owns=""
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        required={false}
+                        role="combobox"
+                        style={
+                          Object {
+                            "boxSizing": "content-box",
+                            "width": "5px",
+                          }
+                        }
+                        value=""
+                      />
+                      <div
+                        style={
+                          Object {
+                            "height": 0,
+                            "left": 0,
+                            "overflow": "scroll",
+                            "position": "absolute",
+                            "top": 0,
+                            "visibility": "hidden",
+                            "whiteSpace": "pre",
+                          }
+                        }
+                      >
+                        
+                      </div>
+                    </div>
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+              <div
+                className="Select is-searchable Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "marginLeft": 10,
+                      "width": "8em",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-57--value"
+                  >
+                    <div
+                      className="Select-placeholder"
+                    >
+                      Grade...
+                    </div>
+                    <div
+                      className="Select-input"
+                      style={
+                        Object {
+                          "display": "inline-block",
+                        }
+                      }
+                    >
+                      <input
+                        aria-activedescendant="react-select-57--value"
+                        aria-expanded="false"
+                        aria-haspopup="false"
+                        aria-owns=""
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        required={false}
+                        role="combobox"
+                        style={
+                          Object {
+                            "boxSizing": "content-box",
+                            "width": "5px",
+                          }
+                        }
+                        value=""
+                      />
+                      <div
+                        style={
+                          Object {
+                            "height": 0,
+                            "left": 0,
+                            "overflow": "scroll",
+                            "position": "absolute",
+                            "top": 0,
+                            "visibility": "hidden",
+                            "whiteSpace": "pre",
+                          }
+                        }
+                      >
+                        
+                      </div>
+                    </div>
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="FilterBar"
+            style={
+              Object {
+                "display": "flex",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Filter by
+              </span>
+              <div
+                className="Select has-value Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "marginLeft": 10,
+                      "width": "10em",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-58--value"
+                  >
+                    <div
+                      className="Select-value"
+                    >
+                      <span
+                        aria-selected="true"
+                        className="Select-value-label"
+                        id="react-select-58--value-item"
+                        role="option"
+                      >
+                        Last 45 days
+                      </span>
+                    </div>
+                    <div
+                      aria-activedescendant="react-select-58--value"
+                      aria-disabled="false"
+                      aria-expanded={false}
+                      aria-owns=""
+                      className="Select-input"
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      role="combobox"
+                      style={
+                        Object {
+                          "border": 0,
+                          "display": "inline-block",
+                          "width": 1,
+                        }
+                      }
+                      tabIndex={0}
+                    />
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "flex": "1",
+              "padding": 10,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "alignContent": "flex-start",
+                "display": "flex",
+                "width": 450,
+              }
+            }
+          >
+            <div
+              className="StudentsTable"
+              style={
+                Object {
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "column",
+                  "marginBottom": 10,
+                  "marginTop": 10,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "paddingTop": 10,
+                  }
+                }
+              >
+                Total Incidents:  1
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "display": "flex",
+                "flex": "1",
+                "flexDirection": "column",
+                "paddingLeft": 20,
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "display": "flex",
+                  "justifyContent": "center",
+                  "marginTop": "20px",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "fontSize": "18px",
+                    "marginRight": "10px",
+                  }
+                }
+              >
+                Break down by:
+              </div>
+              <div
+                className="Select has-value is-searchable Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "width": "200px",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-59--value"
+                  >
+                    <div
+                      className="Select-value"
+                    >
+                      <span
+                        aria-selected="true"
+                        className="Select-value-label"
+                        id="react-select-59--value-item"
+                        role="option"
+                      >
+                        Day & Time
+                      </span>
+                    </div>
+                    <div
+                      className="Select-input"
+                      style={
+                        Object {
+                          "display": "inline-block",
+                        }
+                      }
+                    >
+                      <input
+                        aria-activedescendant="react-select-59--value"
+                        aria-expanded="false"
+                        aria-haspopup="false"
+                        aria-owns=""
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        required={false}
+                        role="combobox"
+                        style={
+                          Object {
+                            "boxSizing": "content-box",
+                            "width": "5px",
+                          }
+                        }
+                        value=""
+                      />
+                      <div
+                        style={
+                          Object {
+                            "height": 0,
+                            "left": 0,
+                            "overflow": "scroll",
+                            "position": "absolute",
+                            "top": 0,
+                            "visibility": "hidden",
+                            "whiteSpace": "pre",
+                          }
+                        }
+                      >
+                        
+                      </div>
+                    </div>
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              className="DisciplineScatterPlot"
+              id="String"
+              style={
+                Object {
+                  "display": "flex",
+                  "flex": 1,
+                  "padding": 10,
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                className="HighchartsWrapper"
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`snapshots works for somerville 1`] = `
+<div
+  style={
+    Object {
+      "background": "#333",
+      "width": "100%",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "background": "white",
+        "border": "5px solid #333",
+        "display": "flex",
+        "flexDirection": "column",
+        "height": 768,
+        "width": 1024,
+      }
+    }
+  >
+    <div
+      className="SchoolDisciplineDashboard EscapeListener"
+      onKeyDown={[Function]}
+      style={
+        Object {
+          "display": "flex",
+          "flex": 1,
+          "flexDirection": "column",
+          "width": "100%",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "background": "red",
+            "color": "white",
+            "fontWeight": "bold",
+            "padding": 20,
+          }
+        }
+      >
+        <span>
+          This is an experimental prototype!
+        </span>
+        <span
+          style={
+            Object {
+              "marginLeft": 10,
+            }
+          }
+        >
+          Please share your feedback with 
+          <a
+            href="mailto://ideas@studentinsights.org"
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            ideas@studentinsights.org
+          </a>
+          .
+        </span>
+      </div>
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "flex": 1,
+            "flexDirection": "column",
+            "paddingLeft": 10,
+            "paddingRight": 10,
+            "width": "100%",
+          }
+        }
+      >
+        <div
+          className="SectionHeading"
+          style={
+            Object {
+              "borderBottom": "1px solid #333",
+              "padding": 10,
+            }
+          }
+        >
+          <h4
+            style={
+              Object {
+                "color": "black",
+                "display": "inline",
+              }
+            }
+          >
+            Recent Discipline incidents at 
+            Arthur D. Healey
+          </h4>
+        </div>
+        <div
+          style={
+            Object {
+              "borderBottom": "1px solid #ccc",
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "padding": 10,
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            className="FilterBar"
+            style={
+              Object {
+                "display": "flex",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Filter by
+              </span>
+              <div
+                className="Select is-searchable Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "marginLeft": 10,
+                      "width": "10em",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-52--value"
+                  >
+                    <div
+                      className="Select-placeholder"
+                    >
+                      Incident Type...
+                    </div>
+                    <div
+                      className="Select-input"
+                      style={
+                        Object {
+                          "display": "inline-block",
+                        }
+                      }
+                    >
+                      <input
+                        aria-activedescendant="react-select-52--value"
+                        aria-expanded="false"
+                        aria-haspopup="false"
+                        aria-owns=""
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        required={false}
+                        role="combobox"
+                        style={
+                          Object {
+                            "boxSizing": "content-box",
+                            "width": "5px",
+                          }
+                        }
+                        value=""
+                      />
+                      <div
+                        style={
+                          Object {
+                            "height": 0,
+                            "left": 0,
+                            "overflow": "scroll",
+                            "position": "absolute",
+                            "top": 0,
+                            "visibility": "hidden",
+                            "whiteSpace": "pre",
+                          }
+                        }
+                      >
+                        
+                      </div>
+                    </div>
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+              <div
+                className="Select is-searchable Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "marginLeft": 10,
+                      "width": "8em",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-53--value"
+                  >
+                    <div
+                      className="Select-placeholder"
+                    >
+                      Grade...
+                    </div>
+                    <div
+                      className="Select-input"
+                      style={
+                        Object {
+                          "display": "inline-block",
+                        }
+                      }
+                    >
+                      <input
+                        aria-activedescendant="react-select-53--value"
+                        aria-expanded="false"
+                        aria-haspopup="false"
+                        aria-owns=""
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        required={false}
+                        role="combobox"
+                        style={
+                          Object {
+                            "boxSizing": "content-box",
+                            "width": "5px",
+                          }
+                        }
+                        value=""
+                      />
+                      <div
+                        style={
+                          Object {
+                            "height": 0,
+                            "left": 0,
+                            "overflow": "scroll",
+                            "position": "absolute",
+                            "top": 0,
+                            "visibility": "hidden",
+                            "whiteSpace": "pre",
+                          }
+                        }
+                      >
+                        
+                      </div>
+                    </div>
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="FilterBar"
+            style={
+              Object {
+                "display": "flex",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Filter by
+              </span>
+              <div
+                className="Select has-value Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "marginLeft": 10,
+                      "width": "10em",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-54--value"
+                  >
+                    <div
+                      className="Select-value"
+                    >
+                      <span
+                        aria-selected="true"
+                        className="Select-value-label"
+                        id="react-select-54--value-item"
+                        role="option"
+                      >
+                        Last 45 days
+                      </span>
+                    </div>
+                    <div
+                      aria-activedescendant="react-select-54--value"
+                      aria-disabled="false"
+                      aria-expanded={false}
+                      aria-owns=""
+                      className="Select-input"
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      role="combobox"
+                      style={
+                        Object {
+                          "border": 0,
+                          "display": "inline-block",
+                          "width": 1,
+                        }
+                      }
+                      tabIndex={0}
+                    />
+                  </span>
+                  <span
+                    className="Select-arrow-zone"
+                    onMouseDown={[Function]}
+                  >
+                    <span
+                      className="Select-arrow"
+                      onMouseDown={[Function]}
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "flex": "1",
+              "padding": 10,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "alignContent": "flex-start",
+                "display": "flex",
+                "width": 450,
+              }
+            }
+          >
+            <div
+              className="StudentsTable"
+              style={
+                Object {
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "column",
+                  "marginBottom": 10,
+                  "marginTop": 10,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "paddingTop": 10,
+                  }
+                }
+              >
+                Total Incidents:  1
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "display": "flex",
+                "flex": "1",
+                "flexDirection": "column",
+                "paddingLeft": 20,
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "display": "flex",
+                  "justifyContent": "center",
+                  "marginTop": "20px",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "fontSize": "18px",
+                    "marginRight": "10px",
+                  }
+                }
+              >
+                Break down by:
+              </div>
+              <div
+                className="Select has-value is-searchable Select--single"
+              >
+                <div
+                  className="Select-control"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "width": "200px",
+                    }
+                  }
+                >
+                  <span
+                    className="Select-multi-value-wrapper"
+                    id="react-select-55--value"
+                  >
+                    <div
+                      className="Select-value"
+                    >
+                      <span
+                        aria-selected="true"
+                        className="Select-value-label"
+                        id="react-select-55--value-item"
+                        role="option"
+                      >
+                        Day & Time
+                      </span>
+                    </div>
+                    <div
+                      className="Select-input"
+                      style={
+                        Object {
+                          "display": "inline-block",
+                        }
+                      }
+                    >
+                      <input
+                        aria-activedescendant="react-select-55--value"
                         aria-expanded="false"
                         aria-haspopup="false"
                         aria-owns=""


### PR DESCRIPTION
# Who is this PR for?
Educators 

# What problem does this PR fix?
For large schools, the scatterplot in the discipline dashboard has too many datapoints to show useful information.

# What does this PR do?
Removes the scatterplot feature when there are more than 500 discipline incidents to display when first loading

# Checklists
*Which features or pages does this PR touch?*
+ [x] Discipline

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here