### PR TITLE
Add discipline code back to filter

### DIFF
--- a/app/assets/javascripts/components/SelectDisciplineIncidentType.js
+++ b/app/assets/javascripts/components/SelectDisciplineIncidentType.js
@@ -12,7 +12,7 @@ export default function SelectDisciplineIncidentType({type, onChange, types, sty
   return (
     <SimpleFilterSelect
       style={style}
-      placeholder="Incident Type..."
+      placeholder="Incident Code..."
       value={type}
       onChange={onChange}
       options={typeOptions} />

--- a/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/SchoolDisciplineDashboard.js
+++ b/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/SchoolDisciplineDashboard.js
@@ -142,7 +142,7 @@ export default class SchoolDisciplineDashboard extends React.Component {
       });
       return {categories, seriesData};
     }
-    case 'incident_location': {
+    case 'incident_location': case 'incident_code': {
       const incidents = this.getIncidentsFromStudents(students);
       const groupedIncidents = _.groupBy(incidents, selectedChart);
       const categories = this.sortedByIncidents(groupedIncidents);
@@ -330,7 +330,8 @@ export default class SchoolDisciplineDashboard extends React.Component {
       {value: 'time', label: 'Time'},
       {value: 'homeroom_label', label: 'Classroom'},
       {value: 'grade', label: 'Grade'},
-      {value: 'day', label: 'Day'}
+      {value: 'day', label: 'Day'},
+      {value: 'incident_code', label: 'Incident Code'}
     ];
     const incidentTypes = this.allIncidentTypes(dashboardStudents);
 

--- a/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/__snapshots__/SchoolDisciplineDashboard.test.js.snap
+++ b/app/assets/javascripts/school_administrator_dashboard/discipline_dashboard/__snapshots__/SchoolDisciplineDashboard.test.js.snap
@@ -163,7 +163,7 @@ exports[`snapshots works for bedford 1`] = `
                     <div
                       className="Select-placeholder"
                     >
-                      Incident Type...
+                      Incident Code...
                     </div>
                     <div
                       className="Select-input"
@@ -751,7 +751,7 @@ exports[`snapshots works for demo 1`] = `
                     <div
                       className="Select-placeholder"
                     >
-                      Incident Type...
+                      Incident Code...
                     </div>
                     <div
                       className="Select-input"
@@ -1339,7 +1339,7 @@ exports[`snapshots works for new_bedford 1`] = `
                     <div
                       className="Select-placeholder"
                     >
-                      Incident Type...
+                      Incident Code...
                     </div>
                     <div
                       className="Select-input"
@@ -1927,7 +1927,7 @@ exports[`snapshots works for somerville 1`] = `
                     <div
                       className="Select-placeholder"
                     >
-                      Incident Type...
+                      Incident Code...
                     </div>
                     <div
                       className="Select-input"


### PR DESCRIPTION
# Who is this PR for?
Educators

# What problem does this PR fix?
Schools have many different codes for discipline incidents, but there is no easy way to see how many of each type they have across the school.

# What does this PR do?
Adds an option to the discipline dashboard to view discipline incidents broken down by code.

# Screenshot (if adding a client-side feature)
![incident_codes](https://user-images.githubusercontent.com/638809/51567596-94e3d480-1e65-11e9-883d-6d6e79ad4224.gif)

# Checklists
*Which features or pages does this PR touch?*
+ [x] Discipline

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here