### PR TITLE
Revise timing for SessionRenewal to actually enable renewing

### DIFF
--- a/app/assets/javascripts/components/SessionRenewal.js
+++ b/app/assets/javascripts/components/SessionRenewal.js
@@ -68,7 +68,8 @@ export default class SessionRenewal extends React.Component {
     this.forceReload();
   }
 
-  onRenewClicked() {
+  onRenewClicked(e) {
+    e.preventDefault();
     apiFetchJson('/educators/reset').then(this.onRenewCompleted);
   }
 
@@ -83,7 +84,6 @@ export default class SessionRenewal extends React.Component {
 
   render() {
     const {status} = this.state;
-
     if (status === States.ACTIVE) return null;
     
     if (status === States.WARNING) return (

--- a/ui/App.js
+++ b/ui/App.js
@@ -65,7 +65,7 @@ export default class App extends React.Component {
     return (
       <SessionRenewal
         sessionTimeoutInSeconds={sessionTimeoutInSeconds}
-        warningTimeoutInSeconds={sessionTimeoutInSeconds - 1} />
+        warningTimeoutInSeconds={sessionTimeoutInSeconds - 60} />
     );
   }
 


### PR DESCRIPTION
# Who is this PR for?
educators, particularly folks facilitating MTSS or longer discussions

# What problem does this PR fix?
`SessionRenewal` uses a rough heuristic to warn users if their session is about to expire.  But there's a bug at the call site that means it only shows the warning for one second before forcing a reload.  This can lead to folks actively working with a page open for a long time to lose their work (eg, taking notes on the profile page during a long MTSS meeting, and the page just reloads without saving or warning).

# What does this PR do?
Sets the warning to show for 60 seconds.  Longer term we should revisit this altogether, but this improves things immediately today.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Core UI

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
ed of better test coverage
+ [x] Manual testing made more sense here