### PR TITLE
Reading: store grouping state locally, snapshot grouping state and post to server

### DIFF
--- a/app/assets/javascripts/components/Lifecycle.js
+++ b/app/assets/javascripts/components/Lifecycle.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Wraps lifecycle events, so that a caller can
+// describe imperative side-effecting actions based on when something
+// is rendered, without having to put that inside the
+// component definition.
+//
+// Example:
+//   <Lifecycle componentWillMount={this.prefetchScreenTwoData}>
+//     <ScreenOne />
+//   </Lifecycle>
+export default class Lifecycle extends React.Component {
+  componentWillMount(nextProps, nextState) {
+    const {componentWillMount} = this.props;
+    if (componentWillMount) componentWillMount(nextProps, nextState);
+  }
+
+  render() {
+    const {children} = this.props;
+    return children;
+  }  
+}
+
+Lifecycle.propTypes = {
+  children: PropTypes.node.isRequired,
+  componentWillMount: PropTypes.func
+};

--- a/app/assets/javascripts/components/Lifecycle.test.js
+++ b/app/assets/javascripts/components/Lifecycle.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Lifecycle from './Lifecycle.js';
+
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<Lifecycle><div>hello</div></Lifecycle>, div);
+});
+
+
+it('calls componentWillMount', () => {
+  const div = document.createElement('div');
+  const props = {
+    componentWillMount: jest.fn()
+  };
+  ReactDOM.render(<Lifecycle {...props}><div>hello</div></Lifecycle>, div);
+  expect(props.componentWillMount).toHaveBeenCalled();
+});

--- a/app/assets/javascripts/reading/Autosaver.js
+++ b/app/assets/javascripts/reading/Autosaver.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+
+
+export default class Autosaver extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      lastSavedSnapshot: null
+    };
+
+    this.doAutoSaveChanges = _.throttle(this.doAutoSaveChanges, props.autoSaveIntervalMs);
+  }
+
+  componentDidUpdate() {
+    console.log('componentDidUpdate');
+    this.doAutoSaveChanges();
+  }
+
+  componentWillUnmount() {
+    if (this.doAutoSaveChanges.flush) this.doAutoSaveChanges.flush(); // flush any queued changes
+  }
+
+  isDirty() {
+    const {readSnapshotFn} = this.props;
+    const {lastSavedSnapshot} = this.state;
+    return !_.isEqual(lastSavedSnapshot, readSnapshotFn());
+  }
+
+  // This method is throttled.
+  doAutoSaveChanges() {
+    const {doSaveFn} = this.props;
+    if (!this.isDirty()) return;
+
+    doSaveFn()
+      .then(this.onPostDone)
+      .catch(this.onPostError);
+  }
+
+  onPostDone(snapshotForSaving) {
+    this.setState({lastSavedSnapshot: snapshotForSaving});
+  }
+
+  onPostError(error) {
+    window.Rollbar.error('Autosaver#onPostError', error);
+  }
+
+  render() {
+    const {children} = this.props;
+    return children;
+  }
+}
+Autosaver.propTypes = {
+  readSnapshotFn: PropTypes.func.isRequired,
+  doSaveFn: PropTypes.func.isRequired,
+  children: PropTypes.node.isRequired,
+  autoSaveIntervalMs: PropTypes.number.isRequired
+};

--- a/app/assets/javascripts/reading/Autosaver.js
+++ b/app/assets/javascripts/reading/Autosaver.js
@@ -24,7 +24,9 @@ export default class Autosaver extends React.Component {
   isDirty() {
     const {readSnapshotFn} = this.props;
     const {lastSavedSnapshot} = this.state;
-    return !_.isEqual(lastSavedSnapshot, readSnapshotFn());
+    const snapshot = readSnapshotFn();
+    if (snapshot === undefined || snapshot === null) return false;
+    return !_.isEqual(lastSavedSnapshot, snapshot);
   }
 
   // This method is throttled.
@@ -42,7 +44,7 @@ export default class Autosaver extends React.Component {
   }
 
   onPostError(error) {
-    window.Rollbar.error('Autosaver#onPostError', error);
+    window.Rollbar.error && window.Rollbar.error('Autosaver#onPostError', error);
   }
 
   render() {

--- a/app/assets/javascripts/reading/Autosaver.js
+++ b/app/assets/javascripts/reading/Autosaver.js
@@ -14,7 +14,6 @@ export default class Autosaver extends React.Component {
   }
 
   componentDidUpdate() {
-    console.log('componentDidUpdate');
     this.doAutoSaveChanges();
   }
 

--- a/app/assets/javascripts/reading/Autosaver.js
+++ b/app/assets/javascripts/reading/Autosaver.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 
-
+// Autosaves on a throttled interval, calling `doSaveFn` whenever `readSnapshotFn`
+// has changed (using _.isEqual).
 export default class Autosaver extends React.Component {
   constructor(props) {
     super(props);
@@ -11,6 +12,8 @@ export default class Autosaver extends React.Component {
     };
 
     this.doAutoSaveChanges = _.throttle(this.doAutoSaveChanges, props.autoSaveIntervalMs);
+    this.onPostDone = this.onPostDone.bind(this);
+    this.onPostError = this.onPostError.bind(this);
   }
 
   componentDidUpdate() {

--- a/app/assets/javascripts/reading/Autosaver.test.js
+++ b/app/assets/javascripts/reading/Autosaver.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Autosaver from './Autosaver';
+
+
+export function testProps(props) {
+  return {
+    readSnapshotFn() {
+      return { foo: 'bar' };
+    },
+    doSaveFn() {
+      return Promise.resolve({ foo: 'bazzzzz-updated'});
+    },
+    autoSaveIntervalMs: 300,
+    ...props
+  };
+}
+
+
+it('renders without crashing', () => {
+  const el = document.createElement('div');
+  const props = testProps();
+  ReactDOM.render(
+    <Autosaver {...props}>
+      <div>hello!</div>
+    </Autosaver>
+  , el);
+});

--- a/app/assets/javascripts/reading/CreateGroups.js
+++ b/app/assets/javascripts/reading/CreateGroups.js
@@ -89,12 +89,7 @@ export default class CreateGroups extends React.Component {
   renderRow(group, groupIndex, studentsInGroup) {
     const {text, groupKey} = group;
     return (
-      <div key={groupKey} style={{
-        flex: 1,
-        display: 'flex',
-        flexDirection: 'row',
-        margin: 5
-      }}>
+      <div key={groupKey} style={styles.rowContainer}>
         {this.renderGroupName(groupKey, groupIndex, text, studentsInGroup)}
         <Droppable
           droppableId={groupKey}
@@ -244,10 +239,16 @@ const styles = {
   root: {
     position: 'relative'
   },
+  rowContainer: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'row',
+    margin: 5,
+    marginBottom: 10
+  },
   row: {
     display: 'flex',
     fontSize: 12,
-    marginBottom: 5,
     marginRight: 5,
     height: ROW_HEIGHT,
     background: '#f8f8f8',

--- a/app/assets/javascripts/reading/CreateGroups.js
+++ b/app/assets/javascripts/reading/CreateGroups.js
@@ -16,15 +16,11 @@ import {
   readDoc,
   somervilleDibelsThresholdsFor
 } from './readingData';
-
-
-// TODO(kr) import path
 import {
   reordered,
   insertedInto,
-  UNPLACED_ROOM_KEY,
-  initialStudentIdsByRoom
-} from '../class_lists/studentIdsByRoomFunctions';
+  UNPLACED_ROOM_KEY
+} from './studentIdsByRoomFunctions';
 
 
 // For making and reviewing reading groups.
@@ -33,8 +29,7 @@ export default class CreateGroups extends React.Component {
     super(props);
 
     this.state = {
-      dialogForStudentId: null,
-      studentIdsByRoom: initialStudentIdsByRoom(groups(props.classrooms).length, props.readingStudents)
+      dialogForStudentId: null
     };
     this.onDragEnd = this.onDragEnd.bind(this);
   }
@@ -47,21 +42,21 @@ export default class CreateGroups extends React.Component {
   }
 
   onDragEnd(dragEndResult) {
-    const {studentIdsByRoom} = this.state;
+    const {studentIdsByRoom, onStudentIdsByRoomChanged} = this.props;
     const updatedStudentIdsByRoom = studentIdsByRoomAfterDrag(studentIdsByRoom, dragEndResult);
-    this.setState({studentIdsByRoom: updatedStudentIdsByRoom});
+    onStudentIdsByRoomChanged({studentIdsByRoom: updatedStudentIdsByRoom});
   }
 
   render() {
-    const {readingStudents, classrooms} = this.props;
-    const {dialogForStudentId, studentIdsByRoom} = this.state;
+    const {readingStudents, studentIdsByRoom, classrooms} = this.props;
+    const {dialogForStudentId} = this.state;
     return (
       <div className="CreateGroups" style={styles.root}>
         <SectionHeading>Reading Groups: 3rd grade at Arthur D. Healey</SectionHeading>
         {dialogForStudentId && this.renderDialog(dialogForStudentId)}
         <DragDropContext onDragEnd={this.onDragEnd}>
           <div>
-            {groups(classrooms).map((group, groupIndex) => {
+            {createGroups(classrooms).map((group, groupIndex) => {
               const {groupKey} = group;
               const studentsInRoom = studentIdsByRoom[groupKey].map(studentId => {
                 return _.find(readingStudents, { id: studentId });
@@ -223,6 +218,8 @@ CreateGroups.contextTypes = {
   nowFn: PropTypes.func.isRequired
 };
 CreateGroups.propTypes = {
+  studentIdsByRoom: PropTypes.object.isRequired,
+  onStudentIdsByRoomChanged: PropTypes.func.isRequired,
   schoolName: PropTypes.string.isRequired,
   grade: PropTypes.string.isRequired,
   benchmarkPeriodKey: PropTypes.string.isRequired,
@@ -377,7 +374,7 @@ function fAndPRange(fAndPs) {
   return [_.first(sortedValidValues), _.last(sortedValidValues)].join(' to ');
 }
 
-function groups(classrooms) {
+export function createGroups(classrooms) {
   const unplacedGroup = {
     groupKey: UNPLACED_ROOM_KEY,
     text: 'Not placed'

--- a/app/assets/javascripts/reading/CreateGroups.story.js
+++ b/app/assets/javascripts/reading/CreateGroups.story.js
@@ -1,8 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
 import {storiesOf} from '@storybook/react';
+import {action} from '@storybook/addon-actions';
 import {testProps, testEl} from './CreateGroups.test';
 
 
+function storyProps(props = {}) {
+  return {
+    ...testProps(),
+    onStudentIdsByRoomChanged: action('onStudentIdsByRoomChanged'),
+    ...props
+  };
+}
+
 storiesOf('reading/CreateGroups', module) // eslint-disable-line no-undef
-  .add('mock photo', () => testEl(testProps()))
-  .add('fallback photo', () => testEl(testProps({useMockPhoto: true})));
+  .add('with state container', () => (
+    <StateContainer defaultStudentIdsByRoom={storyProps().studentIdsByRoom}>
+      {({studentIdsByRoom, onStudentIdsByRoomChanged}) => (
+        testEl(storyProps({
+          studentIdsByRoom,
+          onStudentIdsByRoomChanged,
+          useMockPhoto: true
+        }))
+      )}
+    </StateContainer>
+  ))
+  .add('mock photo', () => testEl(storyProps()))
+  .add('fallback photo', () => testEl(storyProps({useMockPhoto: true})));
   
+
+class StateContainer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      studentIdsByRoom: props.defaultStudentIdsByRoom
+    };
+
+    this.onStudentIdsByRoomChanged = this.onStudentIdsByRoomChanged.bind(this);
+  }
+
+  onStudentIdsByRoomChanged({studentIdsByRoom}) {
+    this.setState({studentIdsByRoom});
+  }
+
+  render() {
+    const {children} = this.props;
+    const {studentIdsByRoom} = this.state;
+    return children({
+      studentIdsByRoom,
+      onStudentIdsByRoomChanged: this.onStudentIdsByRoomChanged
+    });
+  }
+}
+StateContainer.propTypes = {
+  defaultStudentIdsByRoom: PropTypes.any,
+  children: PropTypes.func.isRequired
+};

--- a/app/assets/javascripts/reading/CreateGroups.test.js
+++ b/app/assets/javascripts/reading/CreateGroups.test.js
@@ -3,12 +3,15 @@ import ReactDOM from 'react-dom';
 import renderer from 'react-test-renderer';
 import {withNowContext} from '../testing/NowContainer';
 import PerDistrictContainer from '../components/PerDistrictContainer';
-import CreateGroups from './CreateGroups';
+import CreateGroups, {createGroups} from './CreateGroups';
 import propsFixture from './CreateGroups.fixture';
+import {initialStudentIdsByRoom} from './studentIdsByRoomFunctions';
 
-
-export function testProps(props) {
+export function testProps(props = {}) {
+  const {classrooms, readingStudents} = propsFixture;
   return {
+    studentIdsByRoom: initialStudentIdsByRoom(createGroups(classrooms).length, readingStudents),
+    onStudentIdsByRoomChanged: jest.fn(),
     ...propsFixture,
     ...props
   };

--- a/app/assets/javascripts/reading/ReadingGroupingWorkflow.js
+++ b/app/assets/javascripts/reading/ReadingGroupingWorkflow.js
@@ -42,15 +42,17 @@ export default class ReadingGroupingWorkflow extends React.Component {
 
       // CreateGroups
       primaryStudentIdsByRoom: null,
-      secondaryStudentIdsByRoom: null,
+      additionalStudentIdsByRoom: null,
 
       // data on students, from the server
       json: null
     };
 
-    this.readSnapshot = this.readSnapshot.bind(this);
+    this.isPhaseEditable = this.isPhaseEditable.bind(this);
+    this.readSnapshotForSaving = this.readSnapshotForSaving.bind(this);
     this.doSave = this.doSave.bind(this);
     this.fetchReadingDataJson = this.fetchReadingDataJson.bind(this);
+    this.onReadingDataLoaded = this.onReadingDataLoaded.bind(this);
   }
 
   isPhaseEditable(phaseKey) {
@@ -59,6 +61,9 @@ export default class ReadingGroupingWorkflow extends React.Component {
   }
 
   readSnapshotForSaving() {
+    const {groupingWorkspaceId} = this.state;
+    if (!groupingWorkspaceId) return null;
+
     return _.omit(this.state, ['selectedPhaseKey', 'json']);
   }
 
@@ -68,8 +73,7 @@ export default class ReadingGroupingWorkflow extends React.Component {
     const now = nowFn();
     const snapshotForSaving = this.readSnapshotForSaving();
     const {groupingWorkspaceId} = snapshotForSaving;
-    if (!groupingWorkspaceId) return;
-    
+
     const payload = {
       school_id: snapshotForSaving.team.schoolId,
       grade: snapshotForSaving.team.grade,
@@ -81,7 +85,9 @@ export default class ReadingGroupingWorkflow extends React.Component {
       }
     };
     const url = `/api/reading/grouping_snapshot_json/${groupingWorkspaceId}`;
-    return apiPostJson(url, payload).then(() => Promise.resolve(snapshotForSaving));
+    return apiPostJson(url, payload).then(() => {
+      return Promise.resolve(snapshotForSaving);
+    });
   }
 
   // Requires team to be picked (not enforced)
@@ -110,7 +116,7 @@ export default class ReadingGroupingWorkflow extends React.Component {
     return (
       <div style={styles.root}>
         <Autosaver
-          readSnapshotFn={this.readSnapshot}
+          readSnapshotFn={this.readSnapshotForSaving}
           doSaveFn={this.doSave}
           autoSaveIntervalMs={2000}
         >

--- a/app/assets/javascripts/reading/__snapshots__/CreateGroups.test.js.snap
+++ b/app/assets/javascripts/reading/__snapshots__/CreateGroups.test.js.snap
@@ -37,6 +37,7 @@ exports[`snapshots 1`] = `
           "flex": 1,
           "flexDirection": "row",
           "margin": 5,
+          "marginBottom": 10,
         }
       }
     >
@@ -49,7 +50,6 @@ exports[`snapshots 1`] = `
             "display": "flex",
             "fontSize": 12,
             "height": 100,
-            "marginBottom": 5,
             "marginRight": 5,
           }
         }
@@ -877,6 +877,7 @@ exports[`snapshots 1`] = `
           "flex": 1,
           "flexDirection": "row",
           "margin": 5,
+          "marginBottom": 10,
         }
       }
     >
@@ -889,7 +890,6 @@ exports[`snapshots 1`] = `
             "display": "flex",
             "fontSize": 12,
             "height": 100,
-            "marginBottom": 5,
             "marginRight": 5,
           }
         }
@@ -1122,6 +1122,7 @@ exports[`snapshots 1`] = `
           "flex": 1,
           "flexDirection": "row",
           "margin": 5,
+          "marginBottom": 10,
         }
       }
     >
@@ -1134,7 +1135,6 @@ exports[`snapshots 1`] = `
             "display": "flex",
             "fontSize": 12,
             "height": 100,
-            "marginBottom": 5,
             "marginRight": 5,
           }
         }

--- a/app/assets/javascripts/reading/studentIdsByRoomFunctions.js
+++ b/app/assets/javascripts/reading/studentIdsByRoomFunctions.js
@@ -1,0 +1,60 @@
+import _ from 'lodash';
+
+
+// Place the students into their initial state (eg, all unplaced, sorted alphabetically).
+// {[roomKey]: [studentId]}
+// Allow another placementFn to be passed.
+export function initialStudentIdsByRoom(roomsCount, students, options = {}) {
+  const initialMap = {
+    [UNPLACED_ROOM_KEY]: []
+  };
+  const studentIdsByRoom = _.range(0, roomsCount).reduce((map, roomIndex) => {
+    return {
+      ...map,
+      [roomKeyFromIndex(roomIndex)]: []
+    };
+  }, initialMap);
+
+  const sortedStudents = _.sortBy(students, student => `${student.last_name}, ${student.first_name}`);
+  sortedStudents.forEach(student => {
+    const roomKey = (options.placementFn)
+      ? options.placementFn(studentIdsByRoom, student)
+      : UNPLACED_ROOM_KEY;
+
+    studentIdsByRoom[roomKey].push(student.id);
+  });
+
+  return studentIdsByRoom;
+}
+
+// For testing and stories
+export function consistentlyPlacedInitialStudentIdsByRoom(classroomsCount, students) {
+  return initialStudentIdsByRoom(classroomsCount, students, {
+    placementFn(studentIdsByRoom, student) {
+      return roomKeyFromIndex(JSON.stringify(student).length % classroomsCount);
+    }
+  });
+}
+
+export const UNPLACED_ROOM_KEY = 'room:unplaced';
+
+// Helper functions related to moving students around.
+function roomKeyFromIndex(roomIndex) {
+  return `room:${roomIndex}`;
+}
+
+
+// Returns array with item inserted.
+export function insertedInto(items, insertIndex, itemToInsert) {
+  const itemsCopy = items.slice();
+  itemsCopy.splice(insertIndex, 0, itemToInsert);
+  return itemsCopy;
+}
+
+// Returns array with items swapped locations.
+export function reordered(items, fromIndex, toIndex) {
+  const result = items.slice();
+  const [removed] = result.splice(fromIndex, 1);
+  result.splice(toIndex, 0, removed);
+  return result;
+}

--- a/app/controllers/reading_controller.rb
+++ b/app/controllers/reading_controller.rb
@@ -45,7 +45,6 @@ class ReadingController < ApplicationController
     render json: {}, status: 201
   end
 
-
   # Used for multiple pages (eg, entry, grouping)
   def reading_json
     safe_params = params.permit(:school_slug, :grade)

--- a/app/controllers/reading_controller.rb
+++ b/app/controllers/reading_controller.rb
@@ -24,23 +24,22 @@ class ReadingController < ApplicationController
 
   # Snapshot of state when grouping
   def grouping_snapshot_json
-    safe_params = params.permit(*[
-      :school_id,
-      :grade,
-      :grouping_workspace_id,
-      :benchmark_school_year,
-      :benchmark_period_key,
-      :snapshot_json
-    ])
-    raise Exceptions::EducatorNotAuthorized unless is_authorized_for_grade_level?(safe_params[:school_id], safe_params[:grade])
-    raise Exceptions::EducatorNotAuthorized unless is_open_for_writing?(safe_params[:benchmark_school_year], safe_params[:benchmark_period_key])
+    params.require(:school_id)
+    params.require(:grade)
+    params.require(:grouping_workspace_id)
+    params.require(:benchmark_school_year)
+    params.require(:benchmark_period_key)
+    params.require(:snapshot_json)
+    raise Exceptions::EducatorNotAuthorized unless is_authorized_for_grade_level?(params[:school_id], params[:grade])
+    raise Exceptions::EducatorNotAuthorized unless is_open_for_writing?(params[:benchmark_school_year], params[:benchmark_period_key])
     ReadingGroupingSnapshot.create!({
-      grouping_workspace_id: safe_params[:grouping_workspace_id],
-      snapshot_json: safe_params[:snapshot_json],
-      school_id: safe_params[:school_id],
-      grade: safe_params[:grade],
-      benchmark_school_year: safe_params[:benchmark_school_year],
-      benchmark_period_key: safe_params[:benchmark_period_key]
+      grouping_workspace_id: params[:grouping_workspace_id],
+      school_id: params[:school_id],
+      grade: params[:grade],
+      benchmark_school_year: params[:benchmark_school_year],
+      benchmark_period_key: params[:benchmark_period_key],
+      snapshot_json: params[:snapshot_json],
+      educator_id: current_educator.id
     })
 
     render json: {}, status: 201

--- a/app/controllers/reading_controller.rb
+++ b/app/controllers/reading_controller.rb
@@ -22,6 +22,31 @@ class ReadingController < ApplicationController
     }
   end
 
+  # Snapshot of state when grouping
+  def grouping_snapshot_json
+    safe_params = params.permit(*[
+      :school_id,
+      :grade,
+      :grouping_workspace_id,
+      :benchmark_school_year,
+      :benchmark_period_key,
+      :snapshot_json
+    ])
+    raise Exceptions::EducatorNotAuthorized unless is_authorized_for_grade_level?(safe_params[:school_id], safe_params[:grade])
+    raise Exceptions::EducatorNotAuthorized unless is_open_for_writing?(safe_params[:benchmark_school_year], safe_params[:benchmark_period_key])
+    ReadingGroupingSnapshot.create!({
+      grouping_workspace_id: safe_params[:grouping_workspace_id],
+      snapshot_json: safe_params[:snapshot_json],
+      school_id: safe_params[:school_id],
+      grade: safe_params[:grade],
+      benchmark_school_year: safe_params[:benchmark_school_year],
+      benchmark_period_key: safe_params[:benchmark_period_key]
+    })
+
+    render json: {}, status: 201
+  end
+
+
   # Used for multiple pages (eg, entry, grouping)
   def reading_json
     safe_params = params.permit(:school_slug, :grade)

--- a/app/models/reading_grouping_snapshot.rb
+++ b/app/models/reading_grouping_snapshot.rb
@@ -1,0 +1,18 @@
+class ReadingGroupingSnapshot < ApplicationRecord
+  VALID_BENCHMARK_PERIOD_KEYS = ['fall', 'winter', 'spring']
+
+  belongs_to :school
+  belongs_to :educator # recorded by
+
+  validates :educator, presence: true
+  validates :school, presence: true
+  validates :grade, inclusion: { in: GradeLevels::ORDERED_GRADE_LEVELS }
+  validates :benchmark_school_year, presence: true
+  validates :benchmark_period_key, inclusion: {
+    in: VALID_BENCHMARK_PERIOD_KEYS,
+    message: "%{value} is not one of: #{VALID_BENCHMARK_PERIOD_KEYS.join(', ')}"
+  }
+
+  validates :grouping_workspace_id, presence: true
+  validates :snapshot_json, presence: true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
   get '/api/schools/:school_slug/reading/:grade/reading_json' => 'reading#reading_json'
   put '/api/reading/update_data_point_json' => 'reading#update_data_point_json'
   get '/api/reading/teams_json' => 'reading#teams_json'
+  post '/api/reading/grouping_snapshot_json/:grouping_workspace_id' => 'reading#grouping_snapshot_json'
 
   # classroom list creator
   get '/api/class_lists/workspaces_json' => 'class_lists#workspaces_json'

--- a/db/migrate/20190122235338_add_reading_grouping_snapshot.rb
+++ b/db/migrate/20190122235338_add_reading_grouping_snapshot.rb
@@ -1,0 +1,16 @@
+class AddReadingGroupingSnapshot < ActiveRecord::Migration[5.2]
+  def change
+    create_table :reading_grouping_snapshots do |t|
+      t.text :grouping_workspace_id, null: false
+      t.integer :school_id, null: false
+      t.text :grade, null: false
+      t.integer :benchmark_school_year, null: false
+      t.text :benchmark_period_key, null: false
+      t.json :snapshot_json, null: false
+      t.integer :educator_id, null: false
+      t.timestamps
+    end
+    add_foreign_key :reading_grouping_snapshots, :schools
+    add_foreign_key :reading_grouping_snapshots, :educators
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_14_171111) do
+ActiveRecord::Schema.define(version: 2019_01_22_235338) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,8 +113,12 @@ ActiveRecord::Schema.define(version: 2019_01_14_171111) do
     t.integer "ed_plan_id", null: false
     t.text "iac_oid", null: false
     t.text "iac_sep_oid", null: false
+    t.text "iac_content_area"
+    t.text "iac_category"
+    t.text "iac_type"
     t.text "iac_description"
     t.text "iac_field"
+    t.text "iac_name"
     t.datetime "iac_last_modified"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -415,6 +419,18 @@ ActiveRecord::Schema.define(version: 2019_01_14_171111) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "reading_grouping_snapshots", force: :cascade do |t|
+    t.text "grouping_workspace_id", null: false
+    t.integer "school_id", null: false
+    t.text "grade", null: false
+    t.integer "benchmark_school_year", null: false
+    t.text "benchmark_period_key", null: false
+    t.json "snapshot_json", null: false
+    t.integer "educator_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "schools", id: :serial, force: :cascade do |t|
     t.string "school_type", null: false
     t.string "name", null: false
@@ -676,6 +692,8 @@ ActiveRecord::Schema.define(version: 2019_01_14_171111) do
   add_foreign_key "masquerading_logs", "educators", column: "masquerading_as_educator_id"
   add_foreign_key "reading_benchmark_data_points", "educators"
   add_foreign_key "reading_benchmark_data_points", "students"
+  add_foreign_key "reading_grouping_snapshots", "educators"
+  add_foreign_key "reading_grouping_snapshots", "schools"
   add_foreign_key "sections", "courses", name: "sections_course_id_fk"
   add_foreign_key "service_uploads", "educators", column: "uploaded_by_educator_id", name: "service_uploads_uploaded_by_educator_id_fk"
   add_foreign_key "services", "educators", column: "recorded_by_educator_id", name: "services_recorded_by_educator_id_fk"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -113,12 +113,8 @@ ActiveRecord::Schema.define(version: 2019_01_22_235338) do
     t.integer "ed_plan_id", null: false
     t.text "iac_oid", null: false
     t.text "iac_sep_oid", null: false
-    t.text "iac_content_area"
-    t.text "iac_category"
-    t.text "iac_type"
     t.text "iac_description"
     t.text "iac_field"
-    t.text "iac_name"
     t.datetime "iac_last_modified"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/controllers/reading_controller_spec.rb
+++ b/spec/controllers/reading_controller_spec.rb
@@ -101,7 +101,7 @@ describe ReadingController, :type => :controller do
         "grade"=>"KF",
         "benchmark_school_year"=>2018,
         "benchmark_period_key"=>"winter",
-        "snapshot_json"=>{"opaque_key"=>"opaque_value"}        
+        "snapshot_json"=>{"opaque_key"=>"opaque_value"}
       }])
     end
   end


### PR DESCRIPTION
Builds on https://github.com/studentinsights/studentinsights/pull/2367

# Who is this PR for?
K5 reading teams

# What does this PR do?
This adds the "additional groups" grouping UI, and lifts state of groupings up to maintain it across navigating between groups.  It adds an `Autosaver` components that tracks changes and autosaves posting to the server to store that work in the database.  The schema is minimal and not intended as final; this is just enabling saving during the first pilot (and not yet even reading these into the UI yet).

# Screenshot (if adding a client-side feature)
(no visual feedback)

# Checklists
*Which features or pages does this PR touch?*
+ [X] Reading grouping page

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here