### PR TITLE
Removing n+1 queries in discipline dashboard

### DIFF
--- a/app/lib/dashboard_queries.rb
+++ b/app/lib/dashboard_queries.rb
@@ -66,14 +66,45 @@ class DashboardQueries
   end
 
   def discipline_dashboard_data(school)
-    student_discipline_data = authorized_students_for_dashboard(school) do |students_relation|
-      students_relation
-        .includes([homeroom: :educator], :discipline_incidents, :event_notes)
-        .where('occurred_at >= ?', @cutoff_time)
-        .references(:discipline_incidents)
+    students = authorized_students_for_dashboard(school) do |students_relation|
+      students_relation.includes([homeroom: :educator])
     end
-    students_with_events = student_discipline_data.map do |student|
-      individual_student_discipline_data(student)
+    student_ids = students.map(&:id)
+    discipline_incidents = DisciplineIncident
+      .where(student_id: student_ids)
+      .where('occurred_at >= ?', @cutoff_time)
+    latest_event_notes = EventNote
+      .where(student_id: student_ids)
+      .where('recorded_at >= ?', @cutoff_time)
+
+    # serialize
+    all_discipline_incidents_json = discipline_incidents.as_json
+    all_event_notes_json = latest_event_notes.as_json(only: [
+      :student_id,
+      :event_note_type_id,
+      :recorded_at
+    ])
+    students_json = students.as_json(only: [
+      :first_name,
+      :last_name,
+      :grade,
+      :house,
+      :counselor,
+      :id,
+      :local_id
+    ])
+
+     # merge
+    discipline_incidents_json_by_student_id = all_discipline_incidents_json.group_by {|json| json['student_id'] }
+    latest_event_notes_json_by_student_id = all_event_notes_json.group_by {|json| json['student_id'] }
+    students_with_events = students_json.map do |student_json|
+      student_id = student_json['id']
+      student = students.find {|s| s.id == student_id }
+      student_json.merge({
+        homeroom_label: homeroom_label(student.homeroom),
+        latest_note: latest_event_notes_json_by_student_id[student_id].try(:last),
+        discipline_incidents: discipline_incidents_json_by_student_id[student_id] || []
+      })
     end
     return_json(students_with_events, school)
   end


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
Discipline data loads slowly as a result of some inefficient queries

# What does this PR do?
improves the queries for discipline dashboard data to speed up load time

# Checklists
*Which features or pages does this PR touch?*
+ [x] Discipline

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here