### PR TITLE
Profile: Fix bug with rendering IepDialog in Bedford

### DIFF
--- a/app/assets/javascripts/reading/chips.js
+++ b/app/assets/javascripts/reading/chips.js
@@ -10,7 +10,7 @@ import {toMomentFromRailsDate} from '../helpers/toMoment';
 import {toSchoolYear, firstDayOfSchool} from '../helpers/schoolYear';
 import {hasActiveIep} from '../helpers/specialEducation';
 import PerDistrictContainer from '../components/PerDistrictContainer';
-import IepDialog from '../student_profile/IepDialog';
+import IepDialogLink from '../student_profile/IepDialogLink';
 import LanguageStatusLink from '../student_profile/LanguageStatusLink'; 
 import EdPlansPanel from '../student_profile/EdPlansPanel';
 
@@ -54,7 +54,7 @@ export function renderIepChip(districtKey, student, props = {}) {
   if (!hasActiveIep(student)) return null;
   return (
     <PerDistrictContainer districtKey={districtKey}>
-      <IepDialog
+      <IepDialogLink
         student={student}
         iepDocument={student.latest_iep_document}
         linkEl="IEP"

--- a/app/assets/javascripts/student_profile/IepDialogLink.js
+++ b/app/assets/javascripts/student_profile/IepDialogLink.js
@@ -5,6 +5,7 @@ import {
   shouldShowIepLink
 } from '../helpers/PerDistrict';
 import {
+  hasActiveIep,
   prettyLevelOfNeedText,
   prettyIepTextForSpecialEducationStudent,
   cleanSpecialEducationValues
@@ -15,15 +16,21 @@ import HelpBubble, {
 } from '../components/HelpBubble';
 import Pdf from '../student_profile/Pdf'; // TODO
 
-
-export default class IepDialog extends React.Component {
+// For students who have an IEP, render a link that describes the IEP
+// and lets educators click to open a dialog and see more.
+export default class IepDialogLink extends React.Component {
   render() {
     const {districtKey} = this.context;
     const {student, linkEl} = this.props;
-    const specialEducationText = (linkEl !== undefined)
-      ? linkEl
-      : prettyIepTextForSpecialEducationStudent(student);
-    if (!shouldShowIepLink(districtKey)) return specialEducationText;
+    if (!hasActiveIep(student)) return null;
+
+    // Enable different text (eg, shorted) and disabling links
+    const specialEducationText = (linkEl === undefined || linkEl === null)
+      ? prettyIepTextForSpecialEducationStudent(student)
+      : linkEl;
+    if (!shouldShowIepLink(districtKey)) {
+      return <span>{specialEducationText}</span>;
+    }
     
     return (
       <HelpBubble
@@ -105,10 +112,10 @@ export default class IepDialog extends React.Component {
   }
 
 }
-IepDialog.contextTypes = {
+IepDialogLink.contextTypes = {
   districtKey: PropTypes.string.isRequired
 };
-IepDialog.propTypes = {
+IepDialogLink.propTypes = {
   student: PropTypes.object.isRequired,
   iepDocument: PropTypes.object,
   linkEl: PropTypes.node

--- a/app/assets/javascripts/student_profile/IepDialogLink.story.js
+++ b/app/assets/javascripts/student_profile/IepDialogLink.story.js
@@ -1,0 +1,5 @@
+import {storiesOf} from '@storybook/react';
+import {renderAcrossAllCombinations} from './IepDialogLink.test';
+
+storiesOf('profile/IepDialogLink', module) // eslint-disable-line no-undef
+  .add('all combinations', () => renderAcrossAllCombinations());

--- a/app/assets/javascripts/student_profile/IepDialogLink.test.js
+++ b/app/assets/javascripts/student_profile/IepDialogLink.test.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import renderer from 'react-test-renderer';
+import {withDefaultNowContext} from '../testing/NowContainer';
+import PerDistrictContainer from '../components/PerDistrictContainer';
+import IepDialogLink from './IepDialogLink';
+import serializedDataForPlutoPoppins from './fixtures/serializedDataForPlutoPoppins.fixture';
+
+function testProps(props = {}) {
+  return {
+    student: serializedDataForPlutoPoppins.student,
+    iepDocument: {
+      id: 789
+    },
+    linkEl: null,
+    ...props
+  };
+}
+
+function testEl(props, context = {}) {
+  const districtKey = context.districtKey || 'somerville';
+  return withDefaultNowContext(
+    <PerDistrictContainer districtKey={districtKey}>
+      <IepDialogLink {...props} />
+    </PerDistrictContainer>
+  );
+}
+
+export function renderAcrossAllCombinations() {
+  const props = testProps();
+  const districtKeys = [
+    'somerville',
+    'bedford',
+    'new_bedford'
+  ];
+
+  const els = districtKeys.map(districtKey => (
+    <div key={districtKey} style={{margin: 10}}>
+      <div>{districtKey}</div>
+      <div style={{border: '1px solid #ccc'}}>{testEl(props, {districtKey})}</div>
+    </div>
+  ));
+  return <div>{els}</div>;
+}
+
+function snapshotTree(districtKey, props = {}) {
+  return renderer
+    .create(testEl(testProps(props), {districtKey}))
+    .toJSON();
+}
+
+it('renders without crashing', () => {
+  const el = document.createElement('div');
+  const props = testProps();
+  ReactDOM.render(testEl(props), el);
+});
+
+describe('snapshots', () => {
+  it('works for Somerville', () => expect(snapshotTree('somerville')).toMatchSnapshot());
+  it('works for Bedford', () => expect(snapshotTree('bedford')).toMatchSnapshot());
+  it('works for New Bedford', () => expect(snapshotTree('new_bedford')).toMatchSnapshot());
+});

--- a/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
+++ b/app/assets/javascripts/student_profile/LightHeaderSupportBits.js
@@ -17,7 +17,7 @@ import HelpBubble, {
   dialogFullScreenFlex
 } from '../components/HelpBubble';
 import Team from '../components/Team';
-import IepDialog from './IepDialog';
+import IepDialogLink from './IepDialogLink';
 import EdPlansPanel from './EdPlansPanel';
 import LanguageStatusLink from './LanguageStatusLink';
 
@@ -151,7 +151,7 @@ export default class LightHeaderSupportBits extends React.Component {
     if (!hasActiveIep(student)) return null;
 
     return (
-      <IepDialog
+      <IepDialogLink
         student={student}
         iepDocument={iepDocument}
       />

--- a/app/assets/javascripts/student_profile/__snapshots__/IepDialogLink.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/IepDialogLink.test.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshots works for Bedford 1`] = `
+<span>
+  IEP for Communication
+</span>
+`;
+
+exports[`snapshots works for New Bedford 1`] = `
+<div
+  style={
+    Object {
+      "display": "block",
+      "marginLeft": 0,
+    }
+  }
+>
+  <a
+    href="#"
+    onClick={[Function]}
+    style={
+      Object {
+        "display": "inline-block",
+        "fontSize": 14,
+        "outline": "none",
+      }
+    }
+  >
+    IEP for Communication
+  </a>
+</div>
+`;
+
+exports[`snapshots works for Somerville 1`] = `
+<div
+  style={
+    Object {
+      "display": "block",
+      "marginLeft": 0,
+    }
+  }
+>
+  <a
+    href="#"
+    onClick={[Function]}
+    style={
+      Object {
+        "display": "inline-block",
+        "fontSize": 14,
+        "outline": "none",
+      }
+    }
+  >
+    IEP for Communication
+  </a>
+</div>
+`;

--- a/ui/config/.storybook/config.js
+++ b/ui/config/.storybook/config.js
@@ -27,6 +27,7 @@ function loadStories() {
   require('../../../app/assets/javascripts/student_profile/LightProfilePage.story');
   require('../../../app/assets/javascripts/student_profile/RestrictedNotePresence.story');
   require('../../../app/assets/javascripts/student_profile/LanguageStatusLink.story');
+  require('../../../app/assets/javascripts/student_profile/IepDialogLink.story');
 
   // my notes
   require('../../../app/assets/javascripts/my_notes/NotesFeed.story');


### PR DESCRIPTION
# Who is this PR for?
Bedford educators

# What problem does this PR fix?
https://github.com/studentinsights/studentinsights/pull/2359 introduced a regression to the profile page for Bedford only.  This led to the profile page not loading, and Rollbar errors were ambiguous (which would be improved with React 16 error boundaries), so I mistakenly thought this was related to trying to interact after session expiration.

# What does this PR do?
Fixes the bug; wraps the return value from `<IepDialog />` in an element rather than a plain string (https://reactjs.org/docs/error-decoder.html/?invariant=109&args[]=t) and renames it to `<IepDialogLink />` to clarify and add tests and stories.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile
+ [x] Reading entry
+ [x] Reading grouping

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here