### PR TITLE
SessionRenewal: Rework to probe server to warn about session expiration instead of using heuristic

### DIFF
--- a/app/assets/javascripts/components/SessionRenewal-One.test.js
+++ b/app/assets/javascripts/components/SessionRenewal-One.test.js
@@ -1,60 +1,52 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import {withDefaultNowContext} from '../testing/NowContainer';
 import fetchMock from 'fetch-mock/es5/client';
-import SessionRenewal from './SessionRenewal';
-
-
-export function testProps(props = {}) {
-  return {
-    sessionTimeoutInSeconds: 2,
-    warningTimeoutInSeconds: 1,
-    forceReload: jest.fn(),
-    ...props
-  };
-}
-
-export function testRender(props = {}) {
-  const el = document.createElement('div');
-  ReactDOM.render(withDefaultNowContext(<SessionRenewal {...props} />), el);
-  return el;
-}
-
-export function resetFetchMock() {
-  fetchMock.reset();
-  fetchMock.restore();
-  fetchMock.get('/educators/reset', {});
-}
-
-export function callUrls() {
-  const callUrls = fetchMock.calls().map(call => call[0]);
-  return callUrls;
-}
+import {TEST_DELAY, testProps, testRender} from './SessionRenewal-testHelpers';
+import {shouldWarn} from './SessionRenewal';
 
 
 // These tests are split across files, since using fetchMock in the same file leads to pollution
 // across tests that are run in parallel.
-beforeEach(resetFetchMock);
+beforeEach(() => {
+  fetchMock.reset();
+  fetchMock.restore();
+  fetchMock.get('/educators/reset', {});
+});
 
 it('renders without crashing', () => {
   testRender(testProps());
 });
 
-it('when ACTIVE, renders nothing', () => {
+it('normally renders nothing', () => {
   const props = testProps();
   const el = testRender(props);
   expect($(el).text()).toEqual('');
 });
 
-// TODO(kr)
-function disabledTests() { // eslint-disable-line
-  it('after WARNING timeout, shows message', done => {
-    const props = testProps();
-    const el = testRender(props);
+it('shows warning message', done => {
+  fetchMock.get('/educators/probe', { remaining_seconds: 3 });
+  const props = testProps();
+  const el = testRender(props);
 
-    setTimeout(() => {
-      expect($(el).text()).toEqual('Please click this link or your session will timeout due to inactivity.');
-      done();
-    }, 1500);
-  });
-}
+  setTimeout(() => {
+    expect($(el).text()).toEqual('Please click this link or your session will timeout due to inactivity.');
+    done();
+  }, TEST_DELAY);
+});
+
+it('does not show warning message', done => {
+  fetchMock.get('/educators/probe', { remaining_seconds: 7 });
+  const props = testProps();
+  const el = testRender(props);
+
+  setTimeout(() => {
+    expect($(el).text()).toEqual('');
+    done();
+  }, TEST_DELAY);
+});
+
+it('shouldWarn', () => {
+  expect(shouldWarn(120, 60, 30)).toEqual(false);
+  expect(shouldWarn(91, 60, 30)).toEqual(false);
+  expect(shouldWarn(90, 60, 30)).toEqual(true);
+  expect(shouldWarn(60, 60, 30)).toEqual(true);
+  expect(shouldWarn(30, 60, 30)).toEqual(true);
+});

--- a/app/assets/javascripts/components/SessionRenewal-Three.test.js
+++ b/app/assets/javascripts/components/SessionRenewal-Three.test.js
@@ -1,17 +1,24 @@
-import {testProps, testRender, resetFetchMock} from './SessionRenewal-One.test';
+import fetchMock from 'fetch-mock/es5/client';
+import {TEST_DELAY, testProps, testRender} from './SessionRenewal-testHelpers';
 
-// TODO(kr)
-function disabledTests() { // eslint-disable-line
-  beforeEach(resetFetchMock);
+beforeEach(() => {
+  fetchMock.reset();
+  fetchMock.restore();
+  fetchMock.get('/educators/reset', {});
+  fetchMock.get('/educators/probe', new Response('{}', {
+    status: 302,
+    redirectUrl: '/educators/probe'
+  }));
+});
 
-  it('after TIMED_OUT, shows message, signs out, and calls forceReload', done => {
-    const props = testProps();
-    const el = testRender(props);
+it('if probe fails, calls forciblyClearPage', done => {
+  const props = testProps();
+  const el = testRender(props);
 
-    setTimeout(() => {
-      expect($(el).text()).toEqual('Your session has timed out due to inactivity.');
-      expect(props.forceReload).toHaveBeenCalled();
-      done();
-    }, 2500);
-  });
-}
+  setTimeout(() => {
+    expect(props.forciblyClearPage).toHaveBeenCalled();
+    expect(props.warnFn).toHaveBeenCalledWith('SessionRenewal#onProbed-TIMED_OUT');
+    expect($(el).text()).toEqual('');
+    done();
+  }, TEST_DELAY);
+});

--- a/app/assets/javascripts/components/SessionRenewal-Two.test.js
+++ b/app/assets/javascripts/components/SessionRenewal-Two.test.js
@@ -1,19 +1,24 @@
 import ReactTestUtils from 'react-addons-test-utils';
-import {testProps, testRender, resetFetchMock, callUrls} from './SessionRenewal-One.test';
+import fetchMock from 'fetch-mock/es5/client';
+import {TEST_DELAY, testProps, testRender, callUrls} from './SessionRenewal-testHelpers';
 
-// TODO(kr)
-function disabledTests() { // eslint-disable-line
-  // This is split out as a separate file, since using fetchMock in the same file leads to pollution
-  // across tests that are run in parallel.
-  it('when renew is clicked, makes HTTP request to renew', done => {
-    resetFetchMock();
-    const props = testProps();
-    const el = testRender(props);
-    setTimeout(() => {
-      expect($(el).text()).toEqual('Please click this link or your session will timeout due to inactivity.');
-      ReactTestUtils.Simulate.click($(el).find('a').get(0));
-      expect(callUrls(props.fetch)).toContain('/educators/reset');
-      done();
-    }, 1500);  
-  }); 
-}
+// This is split out as a separate file, since using fetchMock in the same file leads to pollution
+// across tests that are run in parallel.
+beforeEach(() => {
+  fetchMock.reset();
+  fetchMock.restore();
+  fetchMock.get('/educators/reset', {});
+  fetchMock.get('/educators/probe', { remaining_seconds: 3 });
+});
+
+it('when renew is clicked, makes HTTP request to renew', done => {  
+  const props = testProps();
+  const el = testRender(props);
+  setTimeout(() => {
+    expect($(el).text()).toEqual('Please click this link or your session will timeout due to inactivity.');
+    ReactTestUtils.Simulate.click($(el).find('a').get(0));
+    expect(callUrls(fetchMock)).toContain('/educators/reset');
+    expect(props.warnFn).toHaveBeenCalledWith('SessionRenewal#onRenewClicked');
+    done();
+  }, TEST_DELAY);  
+}); 

--- a/app/assets/javascripts/components/SessionRenewal-testHelpers.js
+++ b/app/assets/javascripts/components/SessionRenewal-testHelpers.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {withDefaultNowContext} from '../testing/NowContainer';
+import SessionRenewal from './SessionRenewal';
+
+export const TEST_DELAY = 300;
+
+export function testProps(props = {}) {
+  return {
+    probeIntervalInSeconds: 0.1,
+    warningDurationInSeconds: 5,
+    forciblyClearPage: jest.fn(),
+    warnFn: jest.fn(),
+    ...props
+  };
+}
+
+export function testRender(props = {}) {
+  const el = document.createElement('div');
+  ReactDOM.render(withDefaultNowContext(<SessionRenewal {...props} />), el);
+  return el;
+}
+
+export function callUrls(fetchMock) {
+  const callUrls = fetchMock.calls().map(call => call[0]);
+  return callUrls;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,6 +36,17 @@ class ApplicationController < ActionController::Base
   include MasqueradeHelpers
   helper_method :masquerade
 
+  # This is a hook that Devise looks for.  We add it here to override
+  # Devise's default behavior of storing the last page the user visited,
+  # and redirecting them back there after their next sign in.
+  # We use our own code here and always navigate to the same page after
+  # sign-in.
+  #
+  # For Devise docs, see https://github.com/plataformatec/devise/blob/40f02ae69baf7e9b0449aaab2aba0d0e166f77a3/lib/devise/controllers/helpers.rb#L188
+  def after_sign_in_path_for(educator)
+    homepage_path_for_role(educator)
+  end
+
   def homepage_path_for_role(educator)
     home_path # /home
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,7 @@ Rails.application.routes.draw do
   get '/educators/my_sections'=> 'ui#ui'
   get '/educators/my_notes'=> 'ui#ui'
   get '/educators/reset'=> 'educators#reset_session_clock'
+  get '/educators/probe'=> 'educators#probe'
   get '/educators/services_dropdown/:id' => 'educators#names_for_dropdown'
 
   # error pages

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -125,4 +125,14 @@ RSpec.describe ApplicationController, :type => :controller do
       end
     end
   end
+
+  describe '#after_sign_in_path_for' do
+    it 'works' do
+      Educator.all.each do |educator|
+        sign_in(educator)
+        expect(controller.after_sign_in_path_for(educator)).to eq '/home'
+        sign_out(educator)
+      end
+    end
+  end
 end

--- a/ui/App.js
+++ b/ui/App.js
@@ -64,8 +64,8 @@ export default class App extends React.Component {
   renderSessionRenewal(sessionTimeoutInSeconds) {
     return (
       <SessionRenewal
-        sessionTimeoutInSeconds={sessionTimeoutInSeconds}
-        warningTimeoutInSeconds={sessionTimeoutInSeconds - 60} />
+        probeIntervalInSeconds={60}
+        warningDurationInSeconds={30} />
     );
   }
 


### PR DESCRIPTION
Follow-on to https://github.com/studentinsights/studentinsights/pull/2370 and https://github.com/studentinsights/studentinsights/pull/2366.

# Who is this PR for?
educators

# What problem does this PR fix?
There were some user reports of being signed out unexpectedly, and in investigating and in looking at Rollbar errors related to `.slice` in parsing dates, this looks like it's coming from users interacting with the server (eg, to save a note) after the session has expired.  In that case, it means the educators loses what they just typed in.

# What does this PR do?
Reworks `<SessionRenewal />`.  The core loop is probing the server to see if the user is still signed in.  This is with a new `/educators/probe` endpoint that skips the normal Devise Timeoutable behavior of keeping the session alive.  This endpoint returns how much time is left in the session, and then `<SessionRenewal />` shows an expiration notice if it's within the warning window.  Renewing the session makes the same request to the server as before.

This works better than the previous approach because it avoids UI-side heuristics, and just checks with the server.  If the session has already expired, the UI redirects to close the page, since any data from interactions would be lost anyway.  The expiration message should make it clear to users this would happen beforehand, and this PR changes the background color to a warning orange instead of blue.

This revises the Rollbar instrumentation and keeps it in place, so we can verify this is working as expected.

# Checklists
*Which features or pages does this PR touch?*
+ [X] Core 

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [X] Included specs for changes
+ [X] Manual testing made more sense here