### PR TITLE
Student voice: Highlight new student voice surveys in home feed

### DIFF
--- a/app/assets/javascripts/feed/FeedView.js
+++ b/app/assets/javascripts/feed/FeedView.js
@@ -3,6 +3,7 @@ import React from 'react';
 import EventNoteCard from './EventNoteCard';
 import BirthdayCard from './BirthdayCard';
 import IncidentCard from './IncidentCard';
+import StudentVoiceCard from './StudentVoiceCard';
 
 
 // Pure UI component for rendering feed cards (eg, on the home page)
@@ -16,7 +17,8 @@ export default class FeedView extends React.Component {
           const cardProps = cardPropsFn ? cardPropsFn(type, json) : {};
           if (type === 'event_note_card') return this.renderEventNoteCard(json, cardProps);
           if (type === 'birthday_card') return this.renderBirthdayCard(json, cardProps);
-          if (type === 'incident_card') return this.renderIncidenCard(json, cardProps);
+          if (type === 'incident_card') return this.renderIncidentCard(json, cardProps);
+          if (type === 'student_voice') return this.renderStudentVoiceCard(json, cardProps);
           console.warn('Unexpected card type: ', type); // eslint-disable-line no-console
         })}
       </div>
@@ -41,14 +43,23 @@ export default class FeedView extends React.Component {
     />;
   }
 
-  renderIncidenCard(json, cardProps = {}) {
+  renderIncidentCard(json, cardProps = {}) {
     return <IncidentCard
       key={json.id}
       style={styles.card}
       incidentCard={json}
       {...cardProps}
     />;
-  }    
+  }
+
+  renderStudentVoiceCard(json, cardProps = {}) {
+    return <StudentVoiceCard
+      key={json.latest_form_timestamp}
+      style={styles.card}
+      studentVoiceCardJson={json}
+      {...cardProps}
+    />;
+  }
 }
 FeedView.propTypes = {
   feedCards: PropTypes.arrayOf(PropTypes.shape({

--- a/app/assets/javascripts/feed/IncidentCard.story.js
+++ b/app/assets/javascripts/feed/IncidentCard.story.js
@@ -4,5 +4,5 @@ import {withDefaultNowContext} from '../testing/NowContainer';
 import IncidentCard from './IncidentCard';
 import {testProps} from './IncidentCard.test';
 
-storiesOf('home/IncidentCard', module) // eslint-disable-line no-undef
+storiesOf('feed/IncidentCard', module) // eslint-disable-line no-undef
   .add('all', () => withDefaultNowContext(<IncidentCard {...testProps()} />));

--- a/app/assets/javascripts/feed/StudentVoiceCard.js
+++ b/app/assets/javascripts/feed/StudentVoiceCard.js
@@ -1,0 +1,83 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import Card from '../components/Card';
+import {toMomentFromTimestamp} from '../helpers/toMoment';
+
+
+// Render a card in the feed showing there are new student voice surveys in,
+// and allow clicking to see list of students and then jump to their profiles.
+export default class StudentVoiceCard extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isExpanded: false
+    };
+  }
+
+  onExpand(e) {
+    e.preventDefault();
+    this.setState({isExpanded: true});
+  }
+
+  render() {
+    const {style = {}} = this.props;
+    // const {isExpanded} = this.state;
+    // const now = this.context.nowFn();
+    // const thisYearBirthdateMoment = toMomentFromTimestamp(studentBirthdayCard.date_of_birth).year(now.year());
+    // const isWas = (thisYearBirthdateMoment.isBefore(now.clone().startOf('day'))) ? 'was' : 'is';
+    return (
+      <Card className="StudentVoiceCard" style={style}>
+        
+      </Card>
+    );
+  }
+
+  renderStudentsAndCount() {
+    const {studentVoiceCardJson} = this.props;
+    const {students} = studentVoiceCardJson;
+
+    // if it's <=3 students, just show them each with links
+    // if it's more, list two with links and then +n more, which expands
+    if (students.length === 0) {
+      return null; // shouldn't happen, but guard
+    } else if (students.length === 1) {
+      return <div>New student voice surveys are in for {this.renderShortList(students)}.</div>;
+    } else if (students.length === 2) {
+      return <div>New student voice surveys are in for {this.renderShortList(students)}.</div>;
+    } else if (students.length === 3) {
+      return <div>New student voice surveys are in for {this.renderShortList(students)}.</div>;
+    } else {
+      return <div>New student voice surveys are in for {this.renderExpandableList(students)}.</div>;
+    }
+  }
+
+  renderShortList(students) {
+    // const nStudentsText = (count === 1) ? 'one student' : `${count} students`;
+  }
+
+  renderExpandableList() {
+    // } href={`/students/${studentStudentVoiceCard.id}`}>{studentStudentVoiceCard.first_name} {studentStudentVoiceCard.last_name}
+  }
+}
+StudentVoiceCard.contextTypes = {
+  nowFn: PropTypes.func.isRequired
+};
+StudentVoiceCard.propTypes = {
+  studentVoiceCardJson: PropTypes.shape({
+    latest_form_timestamp: PropTypes.string.isRequired,
+    imported_forms_for_date_count: PropTypes.number.isRequired,
+    students: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      first_name: PropTypes.string.isRequired,
+      last_name: PropTypes.string.isRequired
+    })).isRequired
+  }).isRequired,
+  style: PropTypes.object
+};
+
+
+const styles = {
+  person: {
+    fontWeight: 'bold'
+  }
+};

--- a/app/assets/javascripts/feed/StudentVoiceCard.story.js
+++ b/app/assets/javascripts/feed/StudentVoiceCard.story.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {testEl, propsWithNStudents} from './StudentVoiceCard.test';
+
+storiesOf('feed/StudentVoiceCard', module) // eslint-disable-line no-undef
+  .add('combinations', () => (
+    <div>
+      {testEl(propsWithNStudents(1))}
+      {testEl(propsWithNStudents(2))}
+      {testEl(propsWithNStudents(3))}
+      {testEl(propsWithNStudents(4))}
+      {testEl({...propsWithNStudents(4), shuffleSeed: 100})}
+      {testEl({...propsWithNStudents(4), shuffleSeed: 200})}
+    </div>
+  ));

--- a/app/assets/javascripts/feed/StudentVoiceCard.test.js
+++ b/app/assets/javascripts/feed/StudentVoiceCard.test.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import renderer from 'react-test-renderer';
+import StudentVoiceCard from './StudentVoiceCard';
+import {withDefaultNowContext} from '../testing/NowContainer';
+
+function testStudents() {
+  return [{
+    id: 4,
+    first_name: 'Luke',
+    last_name: 'Skywalker'
+  }, {
+    id: 5,
+    first_name: 'Mari',
+    last_name: 'Kenobi'
+  }, {
+    id: 6,
+    first_name: 'Kylo',
+    last_name: 'Ren'
+  }, {
+    id: 7,
+    first_name: 'Darth',
+    last_name: 'Tater'
+  }];
+}
+
+export function testProps(props = {}) {
+  return {
+    shuffleSeed: 42,
+    studentVoiceCardJson: {
+      latest_form_timestamp: '2018-03-11T11:03:00.000Z',
+      imported_forms_for_date_count: 2,
+      students: testStudents()
+    },
+    ...props
+  };
+}
+
+export function propsWithNStudents(n) {
+  const props = testProps();
+  return {
+    ...props,
+    studentVoiceCardJson: {
+      ...props.studentVoiceCardJson,
+      students: testStudents().slice(0, n)
+    }
+  };
+}
+
+
+export function testEl(props) {
+  return withDefaultNowContext(<StudentVoiceCard {...props} />);
+}
+
+it('renders without crashing', () => {
+  const el = document.createElement('div');
+  ReactDOM.render(testEl(testProps()), el);
+  expect($(el).text()).toContain('💬 Darth Tater, Kylo Ren and 2 more students shared new student voice surveys.');
+  expect($(el).find('a').toArray().map(el => $(el).attr('href'))).toEqual([
+    '/students/7',
+    '/students/6',
+    '#'
+  ]);
+});
+
+describe('snapshots', () => {
+  it('works with one student', () => {
+    const tree = renderer.create(testEl(propsWithNStudents(1))).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('works with two students', () => {
+    const tree = renderer.create(testEl(propsWithNStudents(2))).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('works with three students', () => {
+    const tree = renderer.create(testEl(propsWithNStudents(3))).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('works with four students', () => {
+    const tree = renderer.create(testEl(propsWithNStudents(4))).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/app/assets/javascripts/feed/__snapshots__/StudentVoiceCard.test.js.snap
+++ b/app/assets/javascripts/feed/__snapshots__/StudentVoiceCard.test.js.snap
@@ -1,0 +1,220 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshots works with four students 1`] = `
+<div
+  className="Card StudentVoiceCard"
+  style={
+    Object {
+      "border": "1px solid #ccc",
+      "borderRadius": 3,
+      "padding": 10,
+    }
+  }
+>
+  <div>
+    <span
+      style={
+        Object {
+          "position": "relative",
+          "top": 1,
+        }
+      }
+    >
+      💬
+    </span>
+     
+    <a
+      href="/students/7"
+      style={
+        Object {
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Darth
+       
+      Tater
+    </a>
+    , 
+    <a
+      href="/students/6"
+      style={
+        Object {
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Kylo
+       
+      Ren
+    </a>
+     and 
+    <a
+      href="#"
+      onClick={[Function]}
+    >
+      2 more students
+    </a>
+     shared new student voice surveys.
+  </div>
+</div>
+`;
+
+exports[`snapshots works with one student 1`] = `
+<div
+  className="Card StudentVoiceCard"
+  style={
+    Object {
+      "border": "1px solid #ccc",
+      "borderRadius": 3,
+      "padding": 10,
+    }
+  }
+>
+  <div>
+    <span
+      style={
+        Object {
+          "position": "relative",
+          "top": 1,
+        }
+      }
+    >
+      💬
+    </span>
+     
+    <a
+      href="/students/4"
+      style={
+        Object {
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Luke
+       
+      Skywalker
+    </a>
+     shared a new student voice survey.
+  </div>
+</div>
+`;
+
+exports[`snapshots works with three students 1`] = `
+<div
+  className="Card StudentVoiceCard"
+  style={
+    Object {
+      "border": "1px solid #ccc",
+      "borderRadius": 3,
+      "padding": 10,
+    }
+  }
+>
+  <div>
+    <span
+      style={
+        Object {
+          "position": "relative",
+          "top": 1,
+        }
+      }
+    >
+      💬
+    </span>
+     
+    <a
+      href="/students/4"
+      style={
+        Object {
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Luke
+       
+      Skywalker
+    </a>
+    , 
+    <a
+      href="/students/5"
+      style={
+        Object {
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Mari
+       
+      Kenobi
+    </a>
+     and 
+    <a
+      href="/students/6"
+      style={
+        Object {
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Kylo
+       
+      Ren
+    </a>
+     shared new student voice surveys.
+  </div>
+</div>
+`;
+
+exports[`snapshots works with two students 1`] = `
+<div
+  className="Card StudentVoiceCard"
+  style={
+    Object {
+      "border": "1px solid #ccc",
+      "borderRadius": 3,
+      "padding": 10,
+    }
+  }
+>
+  <div>
+    <span
+      style={
+        Object {
+          "position": "relative",
+          "top": 1,
+        }
+      }
+    >
+      💬
+    </span>
+     
+    <a
+      href="/students/4"
+      style={
+        Object {
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Luke
+       
+      Skywalker
+    </a>
+     and 
+    <a
+      href="/students/5"
+      style={
+        Object {
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Mari
+       
+      Kenobi
+    </a>
+     shared new student voice surveys.
+  </div>
+</div>
+`;

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -114,6 +114,10 @@ class PerDistrict
     EnvironmentVariable.is_true('FEED_INCLUDE_INCIDENT_CARDS') || false
   end
 
+  def include_student_voice_cards?
+    EnvironmentVariable.is_true('FEED_INCLUDE_STUDENT_VOICE_CARDS') || false
+  end
+
   def high_school_enabled?
     @district_key == SOMERVILLE
   end

--- a/app/lib/feed.rb
+++ b/app/lib/feed.rb
@@ -37,7 +37,7 @@ class Feed
     else
       []
     end
-    student_voice_cards = if PerDistrict.new.include_student_voice_cards?
+    student_voice_cards = if PerDistrict.new.include_student_voice_cards? && current_educator.labels.include?('enable_student_voice_cards_in_feed')
       self.student_voice_cards(time_now)
     else
       []

--- a/app/lib/feed.rb
+++ b/app/lib/feed.rb
@@ -99,6 +99,8 @@ class Feed
       students = imported_forms_for_date.map(&:student).uniq
       latest_form_timestamp = imported_forms_for_date.map(&:form_timestamp).max
       json = {
+        latest_form_timestamp: latest_form_timestamp,
+        imported_forms_for_date_count: imported_forms_for_date.size,
         students: students.as_json(only: [:id, :first_name, :last_name])
       }
       FeedCard.new(:student_voice, latest_form_timestamp, json)

--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -8,25 +8,31 @@ class EducatorLabel < ApplicationRecord
     uniqueness: { scope: [:label_key, :educator] },
     inclusion: {
       in: [
+        # deprecated
         'shs_experience_team', # deprecated
-        'k8_counselor',
-        'high_school_house_master',
-        'class_list_maker_finalizer_principal',
+        'enable_viewing_504_data_in_profile', # deprecated
+
+        # feed
         'use_counselor_based_feed',
         'use_housemaster_based_feed',
         'use_section_based_feed',
         'use_ell_based_feed',
         'use_community_school_based_feed',
+        'enable_student_voice_cards_in_feed',
+
+        # reading
+        'profile_enable_minimal_reading_data',
+        'enable_reading_benchmark_data_entry',
+
+        # other
+        'k8_counselor',
+        'high_school_house_master',
+        'class_list_maker_finalizer_principal',
         'enable_class_lists_override',
         'can_upload_student_voice_surveys',
         'should_show_levels_shs_link',
         'enable_searching_notes',
-        'enable_viewing_504_data_in_profile', # deprecated
-        'can_mark_notes_as_restricted',
-
-        # reading
-        'profile_enable_minimal_reading_data',
-        'enable_reading_benchmark_data_entry'
+        'can_mark_notes_as_restricted'
       ]
     }
   }

--- a/spec/importers/student_voice_surveys/mid_year_survey_importer_spec.rb
+++ b/spec/importers/student_voice_surveys/mid_year_survey_importer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MidYearSurveyImporter do
   end
 
   describe 'integration test' do
-    let!(:pals) { TestPals.create! }
+    let!(:pals) { TestPals.create!(skip_imported_forms: true) }
 
     it 'works for importing notes' do
       log = LogHelper::FakeLog.new

--- a/spec/importers/student_voice_surveys/q2_self_reflection_importer_spec.rb
+++ b/spec/importers/student_voice_surveys/q2_self_reflection_importer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Q2SelfReflectionImporter do
   end
 
   describe 'integration test' do
-    let!(:pals) { TestPals.create! }
+    let!(:pals) { TestPals.create!(skip_imported_forms: true) }
 
     it 'works for importing notes' do
       log = LogHelper::FakeLog.new

--- a/spec/lib/feed_spec.rb
+++ b/spec/lib/feed_spec.rb
@@ -97,6 +97,8 @@ RSpec.describe Feed do
         "type"=>"student_voice",
         "timestamp"=>"2018-03-11T11:03:00.000Z",
         "json"=>{
+          "latest_form_timestamp"=>"2018-03-11T11:03:00.000Z",
+          "imported_forms_for_date_count"=>2,
           "students"=>[{
             "id"=>pals.shs_freshman_mari.id,
             "first_name"=>"Mari",
@@ -269,6 +271,8 @@ RSpec.describe Feed do
         'type' => "student_voice",
         'timestamp' => "2018-03-11T11:03:00.000Z",
         'json' => {
+          "latest_form_timestamp"=>"2018-03-11T11:03:00.000Z",
+          "imported_forms_for_date_count"=>2,
           'students' => [{
             'id' => pals.shs_freshman_mari.id,
             'first_name' => "Mari",

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -76,6 +76,7 @@ class TestPals
 
     email_domain = options.fetch(:email_domain, 'demo.studentinsights.org')
     skip_team_memberships = options.fetch(:skip_team_memberships, false)
+    skip_imported_forms = options.fetch(:skip_imported_forms, false)
 
     # Uri works in the central office, and is the admin for the
     # project at the district.
@@ -470,6 +471,7 @@ class TestPals
     )
 
     add_team_memberships unless skip_team_memberships
+    add_student_voice_surveys unless skip_imported_forms
 
     reindex!
     self
@@ -492,6 +494,42 @@ class TestPals
       coach_text: 'Jonathan Fishman',
       season_key: this_season_key,
       school_year_text: school_year_text
+    })
+  end
+
+  # time_now, not wall clock
+  def add_student_voice_surveys
+    ImportedForm.create!({
+      "educator_id"=>shs_jodi.id,
+      "student_id"=>shs_freshman_mari.id,
+      'form_timestamp' => time_now - 2.days,
+      "form_key"=>"shs_what_i_want_my_teacher_to_know_mid_year",
+      'form_url' => 'https://example.com/mid_year_survey_form_url',
+      'form_json' => {
+        "What was the high point for you in school this year so far?"=>"A high point has been my grade in Biology since I had to work a lot for it",
+        "I am proud that I..."=>"Have good grades in my classes",
+        "My best qualities are..."=>"helping others when they don't know how to do homework assignments",
+        "My activities and interests outside of school are..."=>"cheering",
+        "I get nervous or stressed in school when..."=>"I get a low grade on an assignment that I thought I would do well on",
+        "I learn best when my teachers..."=>"show me each step of what I have to do"
+      }
+    })
+    ImportedForm.create!({
+      "educator_id"=>shs_jodi.id,
+      "student_id"=>shs_freshman_mari.id,
+      'form_timestamp' => time_now - 2.days,
+      "form_key"=>"shs_q2_self_reflection",
+      'form_url' => 'https://example.com/q2_self_reflection_form_url',
+      'form_json' => {
+        "What classes are you doing well in?"=>"Computer Science, French",
+        "Why are you doing well in those classes?"=>"I make time in my afternoon each day for doing homework and stick to it",
+        "What courses are you struggling in?"=>"Nothing really",
+        "Why are you struggling in those courses?"=>"I have to work really hard ",
+        "In the classes that you are struggling in, how can your teachers support you so that your grades, experience, work load, etc, improve?"=>"Change the way homework works, it's too much",
+        "When you are struggling, who do you go to for support, encouragement, advice, etc?"=>"Being able to stay after school and work with teachers when I need help",
+        "At the end of the quarter 3, what would make you most proud of your accomplishments in your course?"=>"Keeping grades high in all classes since I'm worried about college",
+        "What other information is important for your teachers to know so that we can support you and your learning? (For example, tutor, mentor, before school HW help, study group, etc)"=>"Help in the morning before school"
+      }
     })
   end
 

--- a/ui/config/.storybook/config.js
+++ b/ui/config/.storybook/config.js
@@ -18,7 +18,10 @@ function loadStories() {
 
   // home
   require('../../../app/assets/javascripts/home/CheckStudentsWithHighAbsences.story');
+
+  // feed
   require('../../../app/assets/javascripts/feed/IncidentCard.story');
+  require('../../../app/assets/javascripts/feed/StudentVoiceCard.story');
 
   // student profile
   require('../../../app/assets/javascripts/student_profile/TakeNotes.story');


### PR DESCRIPTION
# Who is this PR for?
SHS educators, students

# What problem does this PR fix?
When students share their perspectives in mid-year surveys or Q2 self-reflections, these are visible as notes in their profile pages (eg https://github.com/studentinsights/studentinsights/pull/2381 and https://github.com/studentinsights/studentinsights/pull/2379).  But educators can't see that this is happening without going and looking for it.

# What does this PR do?
Adds cards into the home feed about new student voice surveys, with links to profiles.

# Screenshot (if adding a client-side feature)
### example
<img width="517" alt="screen shot 2019-01-29 at 12 06 54 pm" src="https://user-images.githubusercontent.com/1056957/51931551-1b9b3300-23cb-11e9-9441-bbdd862c1ed1.png">

### click to expand when many students
<img width="804" alt="screen shot 2019-01-29 at 1 38 33 pm" src="https://user-images.githubusercontent.com/1056957/51931599-3c638880-23cb-11e9-9d47-6a875f7f275f.png">

### permutations, with sampling different students to highlight on each component mounting
<img width="713" alt="screen shot 2019-01-29 at 1 38 28 pm" src="https://user-images.githubusercontent.com/1056957/51931589-366da780-23cb-11e9-9c99-52a43c1ca8e5.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Home page

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here