### PR TITLE
Student voice: Fix timezone bug on imports; release profile insights with feature switch for Q2 self-reflection

### DIFF
--- a/app/assets/javascripts/student_profile/LightCarousel.js
+++ b/app/assets/javascripts/student_profile/LightCarousel.js
@@ -100,8 +100,7 @@ export default class LightCarousel extends React.Component {
       />
     );
 
-    const areWinterInsightsEnabled = (window.location.search.indexOf('winterinsights') !== -1);
-    if (insightType === IMPORTED_FORM_INSIGHT_TYPE && areWinterInsightsEnabled) return (
+    if (insightType === IMPORTED_FORM_INSIGHT_TYPE) return (
       <LightInsightImportedForm
         student={student}
         insightPayload={insightPayload} 

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -118,6 +118,10 @@ class PerDistrict
     EnvironmentVariable.is_true('FEED_INCLUDE_STUDENT_VOICE_CARDS') || false
   end
 
+  def include_q2_self_reflection_insights?
+    EnvironmentVariable.is_true('PROFILE_INCLUDE_Q2_SELF_REFLECTION_INSIGHTS') || false
+  end
+
   def high_school_enabled?
     @district_key == SOMERVILLE
   end

--- a/app/importers/helpers/import_matcher.rb
+++ b/app/importers/helpers/import_matcher.rb
@@ -1,15 +1,9 @@
 # Helper functions for doing an import, and matching different values in an imported row to
 # the database.
 class ImportMatcher
-  # Timestamps have differnet formats if you download a Google Form as a CSV
-  # versus if you export that same form to Sheets (and then download that).
-  GOOGLE_FORM_CSV_TIMESTAMP_FORMAT = '%Y/%m/%d %l:%M:%S %p %Z'
-  GOOGLE_FORM_EXPORTED_TO_GOOGLE_SHEETS_TIMESTAMP_FORMAT_ASSUMING_UTC = '%m/%d/%Y %k:%M:%S'
-  GOOGLE_FORM_EXPORTED_TO_GOOGLE_SHEETS_TIMESTAMP_FORMAT_WITH_TIMEZONE = '%m/%d/%Y %k:%M:%S %Z'
-
   def initialize(options = {})
-    @strptime_format = options.fetch(:strptime_format, GOOGLE_FORM_CSV_TIMESTAMP_FORMAT)
     @google_email_address_mapping = options.fetch(:google_email_address_mapping, PerDistrict.new.google_email_address_mapping)
+
     reset_counters!
   end
 
@@ -23,6 +17,17 @@ class ImportMatcher
       return nil
     end
     student_id
+  end
+
+  # full_name_text is natural order (eg "Edgar Alan Poe")
+  def find_student_id_with_exact_or_fuzzy_match(local_id_text, full_name_text)
+    student_id = self.find_student_id(local_id_text)
+    return student_id if student_id.present?
+
+    fuzzy_match = FuzzyStudentMatcher.new.match_from_full_name(full_name_text)
+    return fuzzy_match[:student_id] if fuzzy_match.present?
+
+    nil
   end
 
   # educator? also support mapping from Google email to SIS/LDAP/Insights email
@@ -62,9 +67,22 @@ class ImportMatcher
     ed_plan_id
   end
 
-  # parse timestamp into DateTime
-  def parse_timestamp(value)
-    DateTime.strptime(value, @strptime_format)
+  # Parse timestamp into UTC DateTime
+  #
+  # Timestamps have differnet formats if you download a Google Form as a CSV
+  # versus if you export that same form to Sheets (and then download that).
+  # eg, Google Forms downloaded as CSV are'%Y/%m/%d %l:%M:%S %p %Z' instead
+  #
+  # For values in Sheets expressed in EST but without a timezone,
+  # this reads them in and converts them to the same time in a
+  # UTC DateTime
+  def parse_sheets_est_timestamp(string_est_without_timezone, options = {})
+    # Since Rails TZ is America/New_York, and Sheets uses the same, we can 
+    # check the server timezone to infer whether the time in Sheets should be
+    # interpreted as EST or EDT.
+    timezone_code = options.fetch(:timezone_code, Time.now.zone)
+    est_with_timezeone = "#{string_est_without_timezone} #{timezone_code}"
+    DateTime.strptime(est_with_timezeone, '%m/%d/%Y %k:%M:%S %Z').new_offset(0)
   end
 
   def count_valid_row

--- a/app/importers/helpers/import_matcher.rb
+++ b/app/importers/helpers/import_matcher.rb
@@ -4,7 +4,8 @@ class ImportMatcher
   # Timestamps have differnet formats if you download a Google Form as a CSV
   # versus if you export that same form to Sheets (and then download that).
   GOOGLE_FORM_CSV_TIMESTAMP_FORMAT = '%Y/%m/%d %l:%M:%S %p %Z'
-  GOOGLE_FORM_EXPORTED_TO_GOOGLE_SHEETS_TIMESTAMP_FORMAT = '%m/%d/%Y %k:%M:%S'
+  GOOGLE_FORM_EXPORTED_TO_GOOGLE_SHEETS_TIMESTAMP_FORMAT_ASSUMING_UTC = '%m/%d/%Y %k:%M:%S'
+  GOOGLE_FORM_EXPORTED_TO_GOOGLE_SHEETS_TIMESTAMP_FORMAT_WITH_TIMEZONE = '%m/%d/%Y %k:%M:%S %Z'
 
   def initialize(options = {})
     @strptime_format = options.fetch(:strptime_format, GOOGLE_FORM_CSV_TIMESTAMP_FORMAT)

--- a/app/importers/homework_help_importer/homework_help_importer.rb
+++ b/app/importers/homework_help_importer/homework_help_importer.rb
@@ -10,7 +10,7 @@ class HomeworkHelpImporter
   def initialize(educator_id, options = {})
     @educator_id = educator_id
     @log = options.fetch(:log, Rails.env.test? ? LogHelper::Redirect.instance.file : STDOUT)
-    @matcher = options.fetch(:matcher, ::ImportMatcher.new(strptime_format: ImportMatcher::GOOGLE_FORM_EXPORTED_TO_GOOGLE_SHEETS_TIMESTAMP_FORMAT))
+    @matcher = options.fetch(:matcher, ImportMatcher.new)
   end
 
   def import(file_text, options = {})
@@ -41,7 +41,7 @@ class HomeworkHelpImporter
     student_id = @matcher.find_student_id(row['Student Local ID Number'])
     return nil if student_id.nil?
 
-    form_timestamp = @matcher.parse_timestamp(row['Timestamp'])
+    form_timestamp = @matcher.parse_sheets_est_timestamp(row['Timestamp'])
     return nil if form_timestamp.nil?
 
     {

--- a/app/importers/mtss_referral/mtss_referral_importer.rb
+++ b/app/importers/mtss_referral/mtss_referral_importer.rb
@@ -8,7 +8,6 @@
 class MtssReferralImporter
   def initialize(options = {})
     @log = options.fetch(:log, Rails.env.test? ? LogHelper::Redirect.instance.file : STDOUT)
-    @strptime_format = options.fetch(:strptime_format, ImportMatcher::GOOGLE_FORM_EXPORTED_TO_GOOGLE_SHEETS_TIMESTAMP_FORMAT)
 
     @matcher = ImportMatcher.new
     @fuzzy_student_matcher = FuzzyStudentMatcher.new
@@ -53,7 +52,7 @@ class MtssReferralImporter
     educator_id = @matcher.find_educator_id(row['Email Address'])
 
     # timestamp
-    recorded_at = DateTime.strptime(row['Timestamp'], @strptime_format)
+    recorded_at = @matcher.parse_sheets_est_timestamp(row['Timestamp'])
 
     # flatten the rest of the fields
     {

--- a/app/importers/student_voice_surveys/generic_survey_processor.rb
+++ b/app/importers/student_voice_surveys/generic_survey_processor.rb
@@ -3,11 +3,8 @@
 class GenericSurveyProcessor
   def initialize(options, &block)
     @log = options.fetch(:log, Rails.env.test? ? LogHelper::Redirect.instance.file : STDOUT)
-    @strptime_format = options.fetch(:strptime_format, ImportMatcher::GOOGLE_FORM_EXPORTED_TO_GOOGLE_SHEETS_TIMESTAMP_FORMAT)
     @process_row_or_nil_block = block
 
-    @matcher = ImportMatcher.new
-    @fuzzy_student_matcher = FuzzyStudentMatcher.new
     reset_counters!
   end
 
@@ -40,17 +37,6 @@ class GenericSurveyProcessor
     end
 
     row_attrs
-  end
-
-  # for use by block
-  def exact_or_fuzzy_match_for_student(local_id_text, full_name_text)
-    student_id = @matcher.find_student_id(local_id_text)
-    return student_id if student_id.present?
-
-    fuzzy_match = @fuzzy_student_matcher.match_from_full_name(full_name_text)
-    return fuzzy_match[:student_id] if fuzzy_match.present?
-
-    nil
   end
 
   def stats

--- a/app/importers/student_voice_surveys/mid_year_survey_importer.rb
+++ b/app/importers/student_voice_surveys/mid_year_survey_importer.rb
@@ -9,11 +9,11 @@
 class MidYearSurveyImporter
   def initialize(educator_id, form_url, options = {})
     @log = options.fetch(:log, Rails.env.test? ? LogHelper::Redirect.instance.file : STDOUT)
-    @strptime_format = options.fetch(:strptime_format, ImportMatcher::GOOGLE_FORM_EXPORTED_TO_GOOGLE_SHEETS_TIMESTAMP_FORMAT)
 
     @educator_id = educator_id
     @form_url = form_url
     @form_key = ImportedForm::SHS_WHAT_I_WANT_MY_TEACHER_TO_KNOW_MID_YEAR
+    @matcher = ImportMatcher.new
     @processor = GenericSurveyProcessor.new(log: @log) do |row|
       process_row_or_nil(row)
     end
@@ -32,11 +32,11 @@ class MidYearSurveyImporter
   def process_row_or_nil(row)
     # match student by id first, fall back to name
     local_id_text = row['Student ID Number']
-    student_id = @processor.exact_or_fuzzy_match_for_student(local_id_text, row['First and Last Name'])
+    student_id = @matcher.find_student_id_with_exact_or_fuzzy_match(local_id_text, row['First and Last Name'])
     return nil if student_id.nil?
 
     # timestamp
-    form_timestamp = DateTime.strptime(row['Timestamp'], @strptime_format)
+    form_timestamp = @matcher.parse_sheets_est_timestamp(row['Timestamp'])
 
     # whitelist prompts and responses
     form_json = row.to_h.slice(*ImportedForm.prompts(@form_key))

--- a/app/importers/student_voice_surveys/q2_self_reflection_importer.rb
+++ b/app/importers/student_voice_surveys/q2_self_reflection_importer.rb
@@ -9,7 +9,6 @@
 class Q2SelfReflectionImporter
   def initialize(educator_id, form_url, options = {})
     @log = options.fetch(:log, Rails.env.test? ? LogHelper::Redirect.instance.file : STDOUT)
-    @strptime_format = options.fetch(:strptime_format, ImportMatcher::GOOGLE_FORM_EXPORTED_TO_GOOGLE_SHEETS_TIMESTAMP_FORMAT)
 
     @educator_id = educator_id
     @form_url = form_url
@@ -36,7 +35,8 @@ class Q2SelfReflectionImporter
     return nil if student_id.nil?
 
     # timestamp
-    form_timestamp = DateTime.strptime(row['Timestamp'], @strptime_format)
+    timestamp_with_timezone = "#{row['Timestamp']} EST"
+    form_timestamp = DateTime.strptime(timestamp_with_timezone, ImportMatcher::GOOGLE_FORM_EXPORTED_TO_GOOGLE_SHEETS_TIMESTAMP_FORMAT_WITH_TIMEZONE)
 
     # whitelist prompts and responses
     form_json = row.to_h.slice(*ImportedForm.prompts(@form_key))

--- a/app/importers/survey_note_importer/student_meeting_importer.rb
+++ b/app/importers/survey_note_importer/student_meeting_importer.rb
@@ -21,7 +21,6 @@ class StudentMeetingImporter
       student_local_id: 'Student Local ID Number',
       educator_email: 'Email Address',
       timestamp: 'Timestamp',
-      strptime_format: SurveyReader::GOOGLE_FORM_EXPORTED_TO_GOOGLE_SHEETS_TIMESTAMP_FORMAT,
       ignore_keys: [
         'Student Name',
         'Teacher Name'

--- a/app/importers/survey_note_importer/survey_reader.rb
+++ b/app/importers/survey_note_importer/survey_reader.rb
@@ -13,18 +13,14 @@
 #  1) rows aren't guaranteed to be unique in the source data
 #  2) in-place edits are unlikely, but will update records in-place
 class SurveyReader
-  # Timestamps have differnet formats if you download a Google Form as a CSV
-  # versus if you export that same form to Sheets (and then download that).
-  GOOGLE_FORM_CSV_TIMESTAMP_FORMAT = '%Y/%m/%d %l:%M:%S %p %Z'
-  GOOGLE_FORM_EXPORTED_TO_GOOGLE_SHEETS_TIMESTAMP_FORMAT = '%m/%d/%Y %k:%M:%S'
-
   def initialize(file_text, options = {})
     @file_text = file_text
     @source_key = options[:source_key]
     @config = options[:config]
     @log = options.fetch(:log, Rails.env.test? ? LogHelper::Redirect.instance.file : STDOUT)
-    @strptime_format = options.fetch(:strptime_format, GOOGLE_FORM_CSV_TIMESTAMP_FORMAT)
     @google_email_address_mapping = options.fetch(:google_email_address_mapping, PerDistrict.new.google_email_address_mapping)
+    @matcher = ImportMatcher.new
+    
     reset_counters!
   end
 
@@ -71,7 +67,7 @@ class SurveyReader
     end
 
     # parse timestamp into DateTime
-    source_timestamp = DateTime.strptime(row[config[:timestamp]], config[:strptime_format])
+    source_timestamp = @matcher.parse_sheets_est_timestamp(row[config[:timestamp]])
 
     # grab other fields, filtering out special ones and `ignore_keys`
     special_keys = [config[:student_local_id], config[:educator_email], config[:timestamp]]

--- a/app/lib/profile_insights.rb
+++ b/app/lib/profile_insights.rb
@@ -43,9 +43,11 @@ class ProfileInsights
   def student_voice_survey_insights
     insights = []
 
-    # always add any q2 self reflection
-    self_reflection_form = ImportedForm.latest_for_student_id(@student.id, ImportedForm::SHS_Q2_SELF_REFLECTION)
-    insights += imported_form_insights(self_reflection_form) if self_reflection_form.present?
+    # always add any q2 self reflection, if enabled
+    if PerDistrict.new.include_q2_self_reflection_insights?
+      self_reflection_form = ImportedForm.latest_for_student_id(@student.id, ImportedForm::SHS_Q2_SELF_REFLECTION)
+      insights += imported_form_insights(self_reflection_form) if self_reflection_form.present?
+    end
 
     # check for mid-year and take if it it's there
     mid_year_form = ImportedForm.latest_for_student_id(@student.id, ImportedForm::SHS_WHAT_I_WANT_MY_TEACHER_TO_KNOW_MID_YEAR)

--- a/spec/importers/helpers/import_matcher_spec.rb
+++ b/spec/importers/helpers/import_matcher_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ImportMatcher do
+  def make_log
+    LogHelper::FakeLog.new
+  end
+
+  describe '#parse_sheets_est_timestamp' do
+    it 'works when EST (+5)' do
+      Timecop.freeze(Time.parse('2019-01-30 12:22:02 -0400')) do
+        form_timestamp = ImportMatcher.new.parse_sheets_est_timestamp('1/29/2019 9:01:24')
+        expect(form_timestamp).to eq(Time.parse('2019-01-29T14:01:24.000Z'))
+      end
+    end
+
+    it 'works when EDT (+4)' do
+      Timecop.freeze(Time.parse('2018-07-13 12:22:02 -0400')) do
+        form_timestamp = ImportMatcher.new.parse_sheets_est_timestamp('1/29/2019 9:01:24')
+        expect(form_timestamp).to eq(Time.parse('2019-01-29T13:01:24.000Z'))
+      end
+    end
+  end
+end

--- a/spec/importers/homework_help_importer/homework_help_importer_spec.rb
+++ b/spec/importers/homework_help_importer/homework_help_importer_spec.rb
@@ -15,21 +15,27 @@ RSpec.describe HomeworkHelpImporter do
     it 'works for importing notes' do
       log = LogHelper::FakeLog.new
       importer = HomeworkHelpImporter.new(pals.shs_jodi.id, log: log)
-      homework_help_sessions = importer.import(fixture_file_text)
+
+      # freeze test, since importing sheets timestamps depends on EST/EDT
+      test_time = Time.parse('2019-01-30 12:22:02 -0400')
+      homework_help_sessions = Timecop.freeze(test_time) do
+        importer.import(fixture_file_text)
+      end
+
       expect(HomeworkHelpSession.all.size).to eq 3
       expect(homework_help_sessions.as_json(except: [:id, :created_at, :updated_at])).to contain_exactly(*[{
         'student_id' => pals.shs_freshman_mari.id,
-        'form_timestamp' => Time.parse('Tue, 25 Sep 2018 13:41:43.000000000 +0000'),
+        'form_timestamp' => Time.parse('Tue, 25 Sep 2018 18:41:43.000000000 +0000'),
         'course_ids' => [history.id, algebra.id],
         'recorded_by_educator_id' => pals.shs_jodi.id
       }, {
         'student_id' => pals.shs_freshman_amir.id,
-        'form_timestamp' => Time.parse('Mon, 01 Oct 2018 13:25:23.000000000 +0000'),
+        'form_timestamp' => Time.parse('Mon, 01 Oct 2018 18:25:23.000000000 +0000'),
         'course_ids' => [english.id, history.id, algebra.id],
         'recorded_by_educator_id' => pals.shs_jodi.id
       }, {
         'student_id' => pals.shs_senior_kylo.id,
-        'form_timestamp' => Time.parse('Mon, 01 Oct 2018 13:45:12.000000000 +0000'),
+        'form_timestamp' => Time.parse('Mon, 01 Oct 2018 18:45:12.000000000 +0000'),
         'course_ids' => [geometry.id],
         'recorded_by_educator_id' => pals.shs_jodi.id
       }])

--- a/spec/importers/student_voice_surveys/mid_year_survey_importer_spec.rb
+++ b/spec/importers/student_voice_surveys/mid_year_survey_importer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe MidYearSurveyImporter do
         'educator_id' => pals.shs_jodi.id,
         'form_key' => ImportedForm::SHS_WHAT_I_WANT_MY_TEACHER_TO_KNOW_MID_YEAR,
         'form_url' => 'https://example.com/form_url',
-        'form_timestamp' => Time.parse('2019-01-28 09:23:43.000000000 +0000'),
+        'form_timestamp' => Time.parse('2019-01-28 14:23:43.000000000 +0000'),
         'form_json' => {
           "What was the high point for you in school this year so far?"=>"A high point has been my grade in Biology since I had to work a lot for it",
           "I am proud that I..."=>"Have good grades in my classes",

--- a/spec/importers/student_voice_surveys/q2_self_reflection_importer_spec.rb
+++ b/spec/importers/student_voice_surveys/q2_self_reflection_importer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Q2SelfReflectionImporter do
         'educator_id' => pals.shs_jodi.id,
         'form_key' => ImportedForm::SHS_Q2_SELF_REFLECTION,
         'form_url' => 'https://example.com/form_url',
-        'form_timestamp' => Time.parse('2019-01-29T09:01:24.000Z'),
+        'form_timestamp' => Time.parse('2019-01-29T14:01:24.000Z'),
         'form_json' => {
           "What classes are you doing well in?"=>"Computer Science, French",
           "Why are you doing well in those classes?"=>"I make time in my afternoon each day for doing homework and stick to it",

--- a/spec/lib/profile_insights_spec.rb
+++ b/spec/lib/profile_insights_spec.rb
@@ -71,10 +71,10 @@ RSpec.describe ProfileInsights do
         insights_json = ProfileInsights.new(pals.shs_freshman_mari).as_json
         expect(insights_json.size).to eq 14
         expect(insights_json.map {|i| i['type'] }.uniq).to eq ['imported_form_insight']
-        expect(insights_json.map {|i| i['json']['form_key'] }.uniq).to eq [
+        expect(insights_json.map {|i| i['json']['form_key'] }.uniq).to contain_exactly(*[
           'shs_what_i_want_my_teacher_to_know_mid_year',
           'shs_q2_self_reflection'
-        ]
+        ])
         expect(insights_json).to include({
           "type"=>"imported_form_insight",
           "json"=> {


### PR DESCRIPTION
Building on https://github.com/studentinsights/studentinsights/pull/2382, https://github.com/studentinsights/studentinsights/pull/2381, https://github.com/studentinsights/studentinsights/pull/2383, https://github.com/studentinsights/studentinsights/pull/2384 and https://github.com/studentinsights/studentinsights/pull/2379.

# Who is this PR for?
SHS educators, students

# What problem does this PR fix?
There was a bug with importing timestamps from Sheets, so these timestamps were in the wrong timezone and then wouldn't be visible in the feed like they should be.

# What does this PR do?
This reworks timestamp parsing for all survey importers, moving it into `ImportMatcher` and adding a test.

This also removes the `?winterinsights` switch for profile insights, enabling it for all students and educators.  It adds instead a `PROFILE_INCLUDE_Q2_SELF_REFLECTION_INSIGHTS` ENV switch for controlling whether the Q2 self-reflection is included, or whether it is just from "What I want my teachers to know about me."

# Checklists
*Which features or pages does this PR touch?*
+ [x] Home page
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage