### PR TITLE
Sessions: Include querystring when forcibly reloaded

### DIFF
--- a/app/assets/javascripts/components/SessionRenewal.js
+++ b/app/assets/javascripts/components/SessionRenewal.js
@@ -71,7 +71,7 @@ export default class SessionRenewal extends React.Component {
       forciblyClearPage();
     } else {
       this.rollbar('SessionRenewal#forciblyClearPage');
-      window.location = '/';
+      window.location = '/?expired';
     }
   }
 


### PR DESCRIPTION
This is to gather more information to debug issues where educators report they are being signed out and their session is expiring more quickly than they expect.