### PR TITLE
Session renewal: Fix bug from IE11 fetch polyfill

### DIFF
--- a/app/assets/javascripts/components/SessionRenewal-Three.test.js
+++ b/app/assets/javascripts/components/SessionRenewal-Three.test.js
@@ -6,8 +6,7 @@ beforeEach(() => {
   fetchMock.restore();
   fetchMock.get('/educators/reset', {});
   fetchMock.get('/educators/probe', new Response('{}', {
-    status: 302,
-    redirectUrl: '/educators/probe'
+    status: 401
   }));
 });
 
@@ -17,7 +16,7 @@ it('if probe fails, calls forciblyClearPage', done => {
 
   setTimeout(() => {
     expect(props.forciblyClearPage).toHaveBeenCalled();
-    expect(props.warnFn).toHaveBeenCalledWith('SessionRenewal#onProbed-TIMED_OUT');
+    expect(props.warnFn).toHaveBeenCalledWith('SessionRenewal-v3-forciblyClearPage', {});
     expect($(el).text()).toEqual('');
     done();
   }, TEST_DELAY);

--- a/app/assets/javascripts/components/SessionRenewal-Two.test.js
+++ b/app/assets/javascripts/components/SessionRenewal-Two.test.js
@@ -18,7 +18,7 @@ it('when renew is clicked, makes HTTP request to renew', done => {
     expect($(el).text()).toEqual('Please click this link or your session will timeout due to inactivity.');
     ReactTestUtils.Simulate.click($(el).find('a').get(0));
     expect(callUrls(fetchMock)).toContain('/educators/reset');
-    expect(props.warnFn).toHaveBeenCalledWith('SessionRenewal#onRenewClicked');
+    expect(props.warnFn).toHaveBeenCalledWith('SessionRenewal-v3-onRenewClicked', {});
     done();
   }, TEST_DELAY);  
 }); 

--- a/app/assets/javascripts/helpers/apiFetchJson.js
+++ b/app/assets/javascripts/helpers/apiFetchJson.js
@@ -1,24 +1,19 @@
-// Fetch with common headers
-function apiFetch(url, options = {}) {
+// Fetch with common headers, don't parse
+export function apiFetch(url, options = {}) {
   const fetchOptions = {
+    method: 'GET',
     credentials: 'same-origin',
     headers: {
       'Accept': 'application/json'
     },
     ...options
   };
-  return fetch(url, fetchOptions)
-    .then(response => response.json());
+  return fetch(url, fetchOptions);
 }
 
 
 export function apiFetchJson(url) {
-  return apiFetch(url, {
-    method: 'GET',
-    headers: {
-      'Accept': 'application/json'
-    }
-  });
+  return apiFetch(url).then(response => response.json());
 }
 
 // This relies on a Rails CSRF token being rendered on the page
@@ -38,7 +33,7 @@ export function apiPostJson(url, body, options = {}) {
       'X-CSRF-Token': csrfToken
     },
     ...(options.fetchOptions || {})
-  });
+  }).then(response => response.json());
 }
 
 // This relies on a Rails CSRF token being rendered on the page


### PR DESCRIPTION
The `whatwg-fetch` polyfill kicks in in IE11, and it doesn't support non-transparent redirection, or the `redirected` flag, since `XmlHttpRequest` follows redirects without any indication to the caller.  So this changes to request JSON so the server responds with a 401 instead and avoids the issue.

This also updates the instrumentation, and makes a noop refactor to `apiFetchJson` to expose the plain method.