### PR TITLE
Removing educator label feature switch for student voice feed cards

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -10,9 +10,7 @@ class HomeController < ApplicationController
       Feed.students_for_feed(view_as_educator)
     end
     feed = Feed.new(authorized_students)
-    feed_cards = feed.all_cards(time_now, limit, {
-      include_student_voice_cards: current_educator.labels.include?('enable_student_voice_cards_in_feed')
-    })
+    feed_cards = feed.all_cards(time_now, limit)
     render json: {
       feed_cards: feed_cards
     }

--- a/app/lib/feed.rb
+++ b/app/lib/feed.rb
@@ -25,9 +25,7 @@ class Feed
   # we query and combine them. Ideally we'd query in parallel but we'd
   # need to push this out to the client to do that (and still would have to
   # delay rendering until both came back and were merged anyway).
-  def all_cards(time_now, limit, options = {})
-    include_student_voice_cards = options.fetch(:include_student_voice_cards, false)
-
+  def all_cards(time_now, limit)
     event_note_cards = self.event_note_cards(time_now, limit)
     birthday_cards = self.birthday_cards(time_now, limit, {
       limit: 3,
@@ -39,7 +37,7 @@ class Feed
     else
       []
     end
-    student_voice_cards = if PerDistrict.new.include_student_voice_cards? && include_student_voice_cards
+    student_voice_cards = if PerDistrict.new.include_student_voice_cards?
       self.student_voice_cards(time_now)
     else
       []

--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -18,7 +18,6 @@ class EducatorLabel < ApplicationRecord
         'use_section_based_feed',
         'use_ell_based_feed',
         'use_community_school_based_feed',
-        'enable_student_voice_cards_in_feed',
 
         # reading
         'profile_enable_minimal_reading_data',

--- a/spec/lib/feed_spec.rb
+++ b/spec/lib/feed_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Feed do
       })
 
       feed = feed_for(pals.shs_jodi)
-      feed_cards = feed.all_cards(time_now, limit, include_student_voice_cards: true)
+      feed_cards = feed.all_cards(time_now, limit)
       expect(feed_cards.size).to eq 4
       expect(feed_cards.as_json).to eq([{
         "type"=>"birthday_card",


### PR DESCRIPTION
This is fully released now, removes some `EducatorLabel` feature switching code.