### PR TITLE
Student voice: Fix timezone parsing in importing form timestamps

### DIFF
--- a/spec/importers/helpers/import_matcher_spec.rb
+++ b/spec/importers/helpers/import_matcher_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe ImportMatcher do
 
   describe '#parse_sheets_est_timestamp' do
     it 'works when EST (+5)' do
-      Timecop.freeze(Time.parse('2019-01-30 12:22:02 -0400')) do
+      Timecop.freeze(Time.parse('2019-01-30 12:22:02 -0000')) do
         form_timestamp = ImportMatcher.new.parse_sheets_est_timestamp('1/29/2019 9:01:24')
         expect(form_timestamp).to eq(Time.parse('2019-01-29T14:01:24.000Z'))
       end
     end
 
     it 'works when EDT (+4)' do
-      Timecop.freeze(Time.parse('2018-07-13 12:22:02 -0400')) do
-        form_timestamp = ImportMatcher.new.parse_sheets_est_timestamp('1/29/2019 9:01:24')
-        expect(form_timestamp).to eq(Time.parse('2019-01-29T13:01:24.000Z'))
+      Timecop.freeze(Time.parse('2019-01-30 12:22:02 -0000')) do
+        form_timestamp = ImportMatcher.new.parse_sheets_est_timestamp('7/13/2018 9:01:24')
+        expect(form_timestamp).to eq(Time.parse('2018-07-13T13:01:24.000Z'))
       end
     end
   end

--- a/spec/importers/homework_help_importer/homework_help_importer_spec.rb
+++ b/spec/importers/homework_help_importer/homework_help_importer_spec.rb
@@ -15,27 +15,23 @@ RSpec.describe HomeworkHelpImporter do
     it 'works for importing notes' do
       log = LogHelper::FakeLog.new
       importer = HomeworkHelpImporter.new(pals.shs_jodi.id, log: log)
-
-      # freeze test, since importing sheets timestamps depends on EST/EDT
-      test_time = Time.parse('2019-01-30 12:22:02 -0400')
-      homework_help_sessions = Timecop.freeze(test_time) do
-        importer.import(fixture_file_text)
-      end
+      homework_help_sessions = importer.import(fixture_file_text)
 
       expect(HomeworkHelpSession.all.size).to eq 3
+      puts homework_help_sessions.as_json.first['form_timestamp']
       expect(homework_help_sessions.as_json(except: [:id, :created_at, :updated_at])).to contain_exactly(*[{
         'student_id' => pals.shs_freshman_mari.id,
-        'form_timestamp' => Time.parse('Tue, 25 Sep 2018 18:41:43.000000000 +0000'),
+        'form_timestamp' => Time.parse('Tue, 25 Sep 2018 17:41:43 +0000'),
         'course_ids' => [history.id, algebra.id],
         'recorded_by_educator_id' => pals.shs_jodi.id
       }, {
         'student_id' => pals.shs_freshman_amir.id,
-        'form_timestamp' => Time.parse('Mon, 01 Oct 2018 18:25:23.000000000 +0000'),
+        'form_timestamp' => Time.parse('Mon, 01 Oct 2018 17:25:23 +0000'),
         'course_ids' => [english.id, history.id, algebra.id],
         'recorded_by_educator_id' => pals.shs_jodi.id
       }, {
         'student_id' => pals.shs_senior_kylo.id,
-        'form_timestamp' => Time.parse('Mon, 01 Oct 2018 18:45:12.000000000 +0000'),
+        'form_timestamp' => Time.parse('Mon, 01 Oct 2018 17:45:12 +0000'),
         'course_ids' => [geometry.id],
         'recorded_by_educator_id' => pals.shs_jodi.id
       }])

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,6 @@ SimpleCov.start
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
-ENV['TZ'] ||= 'America/New_York'
 
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production


### PR DESCRIPTION
Makes sure Rails is always running in UTC, and fix check for EDT when parsing Sheets timestamps that don't say the timezone explicitly.