### PR TITLE
Profile: Rework state for text while taking notes to remove lag

### DIFF
--- a/app/assets/javascripts/helpers/InsightsPropTypes.js
+++ b/app/assets/javascripts/helpers/InsightsPropTypes.js
@@ -8,8 +8,7 @@ export const actions = PropTypes.shape({
   onClickSaveService: PropTypes.func,
   onClickDiscontinueService: PropTypes.func,
   onChangeNoteInProgressText: PropTypes.func,
-  onClickNoteType: PropTypes.func,
-  onChangeAttachmentUrl: PropTypes.func,
+  onClickNoteType: PropTypes.func
 });
 
 export const requests = PropTypes.shape({

--- a/app/assets/javascripts/student_profile/LightNotesDetails.js
+++ b/app/assets/javascripts/student_profile/LightNotesDetails.js
@@ -17,9 +17,6 @@ export default class LightNotesDetails extends React.Component {
 
   constructor(props){
     super(props);
-    this.state = {
-      isTakingNotes: false
-    };
 
     this.onClickTakeNotes = this.onClickTakeNotes.bind(this);
     this.onClickSaveNotes = this.onClickSaveNotes.bind(this);
@@ -28,22 +25,22 @@ export default class LightNotesDetails extends React.Component {
 
   isTakingNotes() {
     return (
-      this.state.isTakingNotes ||
+      this.props.isTakingNotes ||
       this.props.requests.saveNote !== null
     );
   }
 
   onClickTakeNotes(event) {
-    this.setState({ isTakingNotes: true });
+    this.props.onTakingNotesChanged(true);
   }
 
   onCancelNotes(event) {
-    this.setState({ isTakingNotes: false });
+    this.props.onTakingNotesChanged(false);
   }
 
   onClickSaveNotes(eventNoteParams, event) {
     this.props.actions.onClickSaveNotes(eventNoteParams);
-    this.setState({ isTakingNotes: false });
+    this.props.onTakingNotesChanged(false);
   }
 
   render() {
@@ -121,6 +118,8 @@ LightNotesDetails.propTypes = {
   title: PropTypes.string.isRequired,
   helpContent: PropTypes.node.isRequired,
   helpTitle: PropTypes.string.isRequired,
+  isTakingNotes: PropTypes.bool.isRequired,
+  onTakingNotesChanged: PropTypes.func.isRequired
 };
 
 

--- a/app/assets/javascripts/student_profile/LightNotesDetails.js
+++ b/app/assets/javascripts/student_profile/LightNotesDetails.js
@@ -29,9 +29,7 @@ export default class LightNotesDetails extends React.Component {
   isTakingNotes() {
     return (
       this.state.isTakingNotes ||
-      this.props.requests.saveNote !== null ||
-      this.props.noteInProgressText.length > 0 ||
-      this.props.noteInProgressAttachmentUrls.length > 0
+      this.props.requests.saveNote !== null
     );
   }
 
@@ -79,10 +77,6 @@ export default class LightNotesDetails extends React.Component {
   renderTakeNotesDialog() {
     const {
       currentEducator,
-      noteInProgressText,
-      noteInProgressType,
-      noteInProgressAttachmentUrls,
-      actions,
       requests
     } = this.props;
 
@@ -94,12 +88,6 @@ export default class LightNotesDetails extends React.Component {
         onSave={this.onClickSaveNotes}
         onCancel={this.onCancelNotes}
         requestState={requests.saveNote}
-        noteInProgressText={noteInProgressText}
-        noteInProgressType={noteInProgressType}
-        noteInProgressAttachmentUrls={noteInProgressAttachmentUrls}
-        onClickNoteType={actions.onClickNoteType}
-        onChangeNoteInProgressText={actions.onChangeNoteInProgressText}
-        onChangeAttachmentUrl={actions.onChangeAttachmentUrl}
         showRestrictedCheckbox={currentEducator.can_view_restricted_notes}
       />
     );
@@ -125,20 +113,10 @@ LightNotesDetails.propTypes = {
   }).isRequired,
   actions: PropTypes.shape({
     onClickSaveNotes: PropTypes.func.isRequired,
-    onEventNoteAttachmentDeleted: PropTypes.func,
-    onDeleteEventNoteAttachment: PropTypes.func,
-    onChangeNoteInProgressText: PropTypes.func.isRequired,
-    onClickNoteType: PropTypes.func.isRequired,
-    onChangeAttachmentUrl: PropTypes.func.isRequired,
+    onDeleteEventNoteAttachment: PropTypes.func
   }),
   feed: InsightsPropTypes.feed.isRequired,
   requests: PropTypes.object.isRequired,
-
-  noteInProgressText: PropTypes.string.isRequired,
-  noteInProgressType: PropTypes.number,
-  noteInProgressAttachmentUrls: PropTypes.arrayOf(
-    PropTypes.string
-  ).isRequired,
 
   title: PropTypes.string.isRequired,
   helpContent: PropTypes.node.isRequired,

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -365,7 +365,7 @@ export default class LightProfilePage extends React.Component {
   }
 
   renderNotes() {
-    const {feed, actions, requests, noteInProgressText, noteInProgressType, noteInProgressAttachmentUrls} = this.props;
+    const {feed, actions, requests} = this.props;
     const {student, educatorsIndex, serviceTypesIndex, currentEducator} = this.props.profileJson;
     return (
       <div className="LightProfilePage-notes" style={{display: 'flex', flexDirection: 'row'}}>
@@ -379,9 +379,7 @@ export default class LightProfilePage extends React.Component {
           helpContent={<LightNotesHelpContext />}
           helpTitle="What is a Note?"
           title="Notes"
-          noteInProgressText={noteInProgressText}
-          noteInProgressType={noteInProgressType}
-          noteInProgressAttachmentUrls={noteInProgressAttachmentUrls }/>
+        />
         <LightServiceDetails
           student={student}
           serviceTypesIndex={serviceTypesIndex}
@@ -515,11 +513,6 @@ LightProfilePage.propTypes = {
 
   // mutable data
   feed: PropTypes.object.isRequired,
-  noteInProgressText: PropTypes.string.isRequired,
-  noteInProgressType: PropTypes.number,
-  noteInProgressAttachmentUrls: PropTypes.arrayOf(
-    PropTypes.string
-  ).isRequired,
 
   // static data
   profileJson: PropTypes.shape({

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -27,6 +27,15 @@ import testingColumnTexts, {interpretEla, interpretMath} from './testingColumnTe
 // Prototype of profile v3
 const DAYS_AGO = 45;
 export default class LightProfilePage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isTakingNotes: false
+    };
+
+    this.onTakingNotesChanged = this.onTakingNotesChanged.bind(this);
+  }
+
   componentDidMount() {
     updateGlobalStylesToRemoveHorizontalScrollbars();
     alwaysShowVerticalScrollbars();
@@ -39,7 +48,19 @@ export default class LightProfilePage extends React.Component {
   }
 
   onColumnClicked(columnKey) {
+    const {isTakingNotes} = this.state;
+
+    if (isTakingNotes) {
+      const shouldDiscardNote = confirm("You have a note in progress.\n\nDiscard that note?");
+      if (!shouldDiscardNote) return;
+    }
+    
+    this.setState({isTakingNotes: false});
     this.props.actions.onColumnClicked(columnKey);
+  }
+
+  onTakingNotesChanged(isTakingNotes) {
+    this.setState({isTakingNotes});
   }
 
   render() {
@@ -367,9 +388,13 @@ export default class LightProfilePage extends React.Component {
   renderNotes() {
     const {feed, actions, requests} = this.props;
     const {student, educatorsIndex, serviceTypesIndex, currentEducator} = this.props.profileJson;
+    const {isTakingNotes} = this.state;
+
     return (
       <div className="LightProfilePage-notes" style={{display: 'flex', flexDirection: 'row'}}>
         <LightNotesDetails
+          isTakingNotes={isTakingNotes}
+          onTakingNotesChanged={this.onTakingNotesChanged}
           student={student}
           educatorsIndex={educatorsIndex}
           currentEducator={currentEducator}

--- a/app/assets/javascripts/student_profile/PageContainer.js
+++ b/app/assets/javascripts/student_profile/PageContainer.js
@@ -29,9 +29,6 @@ export default class PageContainer extends React.Component {
     this.onDeleteEventNoteAttachment = this.onDeleteEventNoteAttachment.bind(this);
     this.onClickSaveService = this.onClickSaveService.bind(this);
     this.onClickDiscontinueService = this.onClickDiscontinueService.bind(this);
-    this.onChangeNoteInProgressText = this.onChangeNoteInProgressText.bind(this);
-    this.onClickNoteType = this.onClickNoteType.bind(this);
-    this.onChangeAttachmentUrl = this.onChangeAttachmentUrl.bind(this);
     this.onClickSaveTransitionNote = this.onClickSaveTransitionNote.bind(this);
     this.onSaveTransitionNoteDone = this.onSaveTransitionNoteDone.bind(this);
     this.onSaveTransitionNoteFail = this.onSaveTransitionNoteFail.bind(this);
@@ -72,34 +69,6 @@ export default class PageContainer extends React.Component {
 
   onColumnClicked(columnKey) {
     this.setState({ selectedColumnKey: columnKey });
-  }
-
-  onClickNoteType(event) {
-    const noteInProgressType = parseInt(event.target.name);
-
-    this.setState({ noteInProgressType });
-  }
-
-  onChangeNoteInProgressText(event) {
-    this.setState({ noteInProgressText: event.target.value });
-  }
-
-  onChangeAttachmentUrl(event) {
-    const newValue = event.target.value;
-    const changedIndex = parseInt(event.target.name);
-    const {noteInProgressAttachmentUrls} = this.state;
-
-    const updatedAttachmentUrls = (noteInProgressAttachmentUrls.length === changedIndex)
-      ? noteInProgressAttachmentUrls.concat(newValue)
-      : noteInProgressAttachmentUrls.map((attachmentUrl, index) => {
-        return (changedIndex === index) ? newValue : attachmentUrl;
-      });
-
-    const filteredAttachments = updatedAttachmentUrls.filter((urlString) => {
-      return urlString.length !== 0;
-    });
-
-    this.setState({ noteInProgressAttachmentUrls: filteredAttachments });
   }
 
   onClickSaveNotes(eventNoteParams) {
@@ -160,10 +129,7 @@ export default class PageContainer extends React.Component {
 
     this.setState({
       feed: updatedFeed,
-      requests: merge(this.state.requests, { saveNote: null }),
-      noteInProgressText: '',
-      noteInProgressType: null,
-      noteInProgressAttachmentUrls: []
+      requests: merge(this.state.requests, { saveNote: null })
     });
   }
 
@@ -171,6 +137,7 @@ export default class PageContainer extends React.Component {
     this.setState({ requests: merge(this.state.requests, { saveNote: 'error' }) });
   }
 
+  // TODO(kr) does this work for not-yet-created notes?
   onDeleteEventNoteAttachment(eventNoteAttachmentId) {
     // optimistically update the UI
     // essentially, find the eventNote that has eventNoteAttachmentId in attachments
@@ -255,10 +222,7 @@ export default class PageContainer extends React.Component {
     const {
       feed,
       selectedColumnKey,
-      requests,
-      noteInProgressText,
-      noteInProgressType,
-      noteInProgressAttachmentUrls
+      requests
     } = this.state;
 
     const actions = {
@@ -268,9 +232,6 @@ export default class PageContainer extends React.Component {
       onDeleteEventNoteAttachment: this.onDeleteEventNoteAttachment,
       onClickSaveService: this.onClickSaveService,
       onClickDiscontinueService: this.onClickDiscontinueService,
-      onChangeNoteInProgressText: this.onChangeNoteInProgressText,
-      onClickNoteType: this.onClickNoteType,
-      onChangeAttachmentUrl: this.onChangeAttachmentUrl,
       ...(this.props.actions || {}) // for test
     };
 
@@ -282,9 +243,6 @@ export default class PageContainer extends React.Component {
           actions={actions}
           selectedColumnKey={selectedColumnKey}
           requests={requests}
-          noteInProgressText={noteInProgressText}
-          noteInProgressType={noteInProgressType}
-          noteInProgressAttachmentUrls={noteInProgressAttachmentUrls}
         />
       </div>
     );
@@ -321,9 +279,6 @@ export function initialState(props) {
     feed: defaultFeed,
 
     // ui
-    noteInProgressText: '',
-    noteInProgressType: null,
-    noteInProgressAttachmentUrls: [],
     selectedColumnKey: queryParams.column || defaultColumnKey,
 
     // This map holds the state of network requests for various actions.  This allows UI components to branch on this

--- a/app/assets/javascripts/student_profile/TakeNotes.js
+++ b/app/assets/javascripts/student_profile/TakeNotes.js
@@ -60,11 +60,10 @@ export default class TakeNotes extends React.Component {
     });
   }
 
-  onChangeAttachmentUrl(event) {
+  onChangeAttachmentUrl(changedIndex, event) {
     const {noteInProgressAttachmentUrls} = this.state;
 
     const newValue = event.target.value;
-    const changedIndex = parseInt(event.target.name);
     const updatedAttachmentUrls = (noteInProgressAttachmentUrls.length === changedIndex)
       ? noteInProgressAttachmentUrls.concat(newValue)
       : noteInProgressAttachmentUrls.map((attachmentUrl, index) => {
@@ -256,9 +255,9 @@ export default class TakeNotes extends React.Component {
     return (
       <div key={index}>
         <input
+          className="TakeNotes-attachment-link-input"
           value={value}
-          name={index}
-          onChange={this.onChangeAttachmentUrl}
+          onChange={this.onChangeAttachmentUrl.bind(this, index)}
           placeholder="Please use the format https://www.example.com."
           style={{
             marginBottom: '20px',

--- a/app/assets/javascripts/student_profile/TakeNotes.test.js
+++ b/app/assets/javascripts/student_profile/TakeNotes.test.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import ReactTestUtils from 'react-dom/test-utils';
+import changeTextValue from '../testing/changeTextValue';
 import {
   nowMoment,
   currentEducator
@@ -15,13 +17,7 @@ export function testProps(props = {}) {
     currentEducator: currentEducator,
     onSave: jest.fn(),
     onCancel: jest.fn(),
-    onClickNoteType: jest.fn(),
-    onChangeNoteInProgressText: jest.fn(),
-    onChangeAttachmentUrl: jest.fn(),
     requestState: null,
-    noteInProgressText: '',
-    noteInProgressType: null,
-    noteInProgressAttachmentUrls: [],
     ...props
   };
 }
@@ -54,6 +50,24 @@ it('renders without crashing', () => {
   expect($(el).find('.btn.cancel').length).toEqual(1);
 });
 
+
+it('calls onSave with the correct shape', () => {
+  const props = testProps();
+  const {el} = renderTestEl(props, { districtKey: SOMERVILLE });
+
+  changeTextValue($(el).find('textarea').get(0), 'hello!');
+  ReactTestUtils.Simulate.click($(el).find('.btn.note-type:eq(1)').get(0));
+  ReactTestUtils.Simulate.change($(el).find('.TakeNotes-attachment-link-input').get(0), {target: {value: 'https://example.com/foo'}});
+  ReactTestUtils.Simulate.click($(el).find('.btn.save').get(0));
+  
+  expect(props.onSave).toHaveBeenCalledWith({
+    "text": "hello!",
+    "eventNoteTypeId": 301,
+    "eventNoteAttachments": [{
+      url: 'https://example.com/foo'
+    }]
+  });
+});
 
 describe('buttons for taking notes', () => {
   it('works for Somerville', () => {


### PR DESCRIPTION
# Who is this PR for?
educators on older computers, or on IE11

# What problem does this PR fix?
This resolves a performance issue in taking notes.  This has only been visible in developer recently, but I assumed that on my old laptop it was mostly from battery issues and the OS throttling the CPU.  But this came up for an educator today, so I looked into it more.

With my laptop at full power, there's no lag impacting the UX while typing.  But I can simulate the lag in Chrome by throttling CPU by a factor of 4x or 6x, although never enough to freeze things altogether or crash the tab.  On a battery-impaired laptop where the OS is throttling the CPU severely, I can reliably get up 10 second (!) latency on keystrokes in Chrome, or can crash the tab.  This can lead to crashing Firefox altogether.

So I think the impact of this is limited to folks like me with degraded laptop batteries, and some educators working on older computers with IE11, where there is very little compute available.


### CPU throttled from battery, examples of slow script warnings
<img width="433" alt="screen shot 2019-02-15 at 9 15 38 am" src="https://user-images.githubusercontent.com/1056957/52869282-4d263500-3113-11e9-832a-c5d188ca01ae.png">
<img width="905" alt="screen shot 2019-02-15 at 8 59 10 am" src="https://user-images.githubusercontent.com/1056957/52869285-4f888f00-3113-11e9-9ff7-51c034c2f5dc.png">
<img width="911" alt="screen shot 2019-02-15 at 9 03 25 am" src="https://user-images.githubusercontent.com/1056957/52869286-4f888f00-3113-11e9-952d-7eff928b6c46.png">

It's surprising to me that this is a problem, since this code hasn't changed in a long time.  I suspected it might be related to the React update in https://github.com/studentinsights/studentinsights/pull/2397 but performance is actually worse on commit 6f8d2d80eae4e62c0029d66f1d62d8e804f7cead.   So my understanding is that this is probably only impacting low-end CPUs on IE11.

Using the JS and React profiler, it's clear this is in JS script executing, that most of it is inside React and that it's related to the state tracking text as the user types, and it being lifted up and causing renders of unrelated bits of the page.


# What does this PR do?
Since this is causing an immediate problem, and since we were going to replace this part of the UI altogether in the next week or two, this PR takes a shortcut and removing lifting up the state to avoid the renders, rather than optimizing code we're about to replace.

The state was lifted previously to preserve in-progress notes as the user navigates to other tabs.  This is uncommon, and will be reworked anyway with autosaving notes.  So as a guardrail in the meantime, this only hoists that a new note is in-progress, and then pops a confirm box up to warn the user they'll lose it if they navigate away.

### profiling caveat
Keep in mind these are on a laptop with a busted old battery, so it's usually doing CPU throttling :)  This has a really severe impact on performance.

<img width="282" alt="screen shot 2019-02-15 at 10 54 43 am" src="https://user-images.githubusercontent.com/1056957/52869190-19e3a600-3113-11e9-9c0b-f466f2f4c5bf.png">

### before, profiling with full battery
<img width="733" alt="screen shot 2019-02-15 at 11 44 52 am" src="https://user-images.githubusercontent.com/1056957/52871085-4699bc80-3117-11e9-8433-80f890b90e78.png">
<img width="1013" alt="screen shot 2019-02-15 at 11 45 17 am" src="https://user-images.githubusercontent.com/1056957/52871087-47325300-3117-11e9-80df-5834d88b3964.png">

### before, profiling with impaired battery
<img width="1002" alt="screen shot 2019-02-15 at 10 41 50 am" src="https://user-images.githubusercontent.com/1056957/52869115-f1f44280-3112-11e9-8fd9-2d74f7ab9538.png">
<img width="1019" alt="screen shot 2019-02-15 at 10 42 11 am" src="https://user-images.githubusercontent.com/1056957/52869116-f1f44280-3112-11e9-8a5f-5278faaa662d.png">

### after, profiling with impaired battery
<img width="1015" alt="screen shot 2019-02-15 at 11 01 34 am" src="https://user-images.githubusercontent.com/1056957/52869211-249e3b00-3113-11e9-9393-15a4675da21a.png">
<img width="1017" alt="screen shot 2019-02-15 at 11 05 04 am" src="https://user-images.githubusercontent.com/1056957/52869214-249e3b00-3113-11e9-96c4-985e964bcbe9.png">

# Screenshot (if adding a client-side feature)
### ux warning on clicking another tab while taking notes
<img width="447" alt="screen shot 2019-02-15 at 10 47 43 am" src="https://user-images.githubusercontent.com/1056957/52869108-ec96f800-3112-11e9-8017-5c59026a168d.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Improved automated test coverage
+ [x] Manual testing made more sense here