### PR TITLE
Profile: Remove second 'ago' suffix from testing tab to prevent overflow

### DIFF
--- a/app/assets/javascripts/student_profile/LightProfilePage.test.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.test.js
@@ -82,7 +82,7 @@ describe('HS testing tab', () => {
       'Testing',
       'M',
       'ELA and Math MCAS',
-      '10 months ago / 2 years ago'
+      '10 months / 2 years ago'
     ]);
   });
 

--- a/app/assets/javascripts/student_profile/testingColumnTexts.js
+++ b/app/assets/javascripts/student_profile/testingColumnTexts.js
@@ -34,7 +34,7 @@ export default function testingColumnTexts(nowMoment, chartData) {
     : 'ELA / Math MCAS';
   const dateText = (ela.dateText === math.dateText)
     ? ela.dateText
-    : `${ela.dateText} / ${math.dateText}`;
+    : `${ela.dateText.replace(' ago','')} / ${math.dateText}`; // truncate first ago to preserve width
 
   return {scoreText, testText, dateText};
 }


### PR DESCRIPTION
# Who is this PR for?
HS educators

# What problem does this PR fix?
Overflow when separate test times for MCAS.

# What does this PR do?
Fixes it by removing one of the "ago" suffixes.

# Screenshot (if adding a client-side feature)
### before
<img width="227" alt="screen shot 2019-02-15 at 12 22 51 pm" src="https://user-images.githubusercontent.com/1056957/52873268-94fd8a00-311c-11e9-9c26-20e183d20a29.png">

### after
<img width="214" alt="screen shot 2019-02-15 at 12 23 15 pm" src="https://user-images.githubusercontent.com/1056957/52873276-98911100-311c-11e9-848c-16c039dafe93.png">


# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here