### PR TITLE
Add audits for vulnerabilities in Ruby dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ install:
   - if [[ $TRAVIS_TEST_SUITE == "js" ]]; then yarn install; fi
 
 script:
+  - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle exec ruby-audit check; fi
   - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle audit check --update; fi
   - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle exec rake db:create db:migrate DATABASE_URL=postgres://localhost/student_insights_test; fi
   - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle exec rake immigrant:check_keys; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ install:
   - if [[ $TRAVIS_TEST_SUITE == "js" ]]; then yarn install; fi
 
 script:
+  - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle audit check --update; fi
   - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle exec rake db:create db:migrate DATABASE_URL=postgres://localhost/student_insights_test; fi
   - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle exec rake immigrant:check_keys; fi
   - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then rubocop; fi

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'wicked_pdf'
 gem 'wkhtmltopdf-binary'
 gem 'rubyzip', '~> 1.2.2'
+gem 'bundler-audit'
 
 # used to seed demo data in production
 gem 'factory_bot_rails'

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,10 @@ gem 'uglifier', '>= 1.3.0'
 gem 'wicked_pdf'
 gem 'wkhtmltopdf-binary'
 gem 'rubyzip', '~> 1.2.2'
+
+# security audits
 gem 'bundler-audit'
+gem 'ruby_audit'
 
 # used to seed demo data in production
 gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,8 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-graphviz (1.2.3)
     ruby-progressbar (1.9.0)
+    ruby_audit (1.2.0)
+      bundler-audit (~> 0.6.0)
     rubyzip (1.2.2)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
@@ -383,6 +385,7 @@ DEPENDENCIES
   rqrcode
   rspec-rails
   rubocop
+  ruby_audit
   rubyzip (~> 1.2.2)
   sass-rails (~> 5.0)
   secure_headers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,9 @@ GEM
       thor (~> 0.19)
     brakeman (4.3.0)
     builder (3.2.3)
+    bundler-audit (0.6.1)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 0.18)
     capybara (3.0.1)
       addressable
       mini_mime (>= 0.1.3)
@@ -342,6 +345,7 @@ DEPENDENCIES
   better_errors
   bourbon (~> 4.3.2)
   brakeman
+  bundler-audit
   capybara
   dalli
   database_cleaner


### PR DESCRIPTION
For auditing Ruby dependencies for CVEs, using https://github.com/rubysec/bundler-audit and https://github.com/civisanalytics/ruby_audit