### PR TITLE
Sign in: Feedback while signing in, using rails-ujs

### DIFF
--- a/app/views/educators/sessions/new.html.erb
+++ b/app/views/educators/sessions/new.html.erb
@@ -28,7 +28,8 @@
             autocomplete: 'off',
             required: true,
             autofocus: true,
-            placeholder: 'Login, username only'
+            placeholder: 'Login, username only',
+            'data-disable' => true, # rails-ujs
           }) %>
         </div>
         <div class="SignInPage-item">
@@ -36,11 +37,16 @@
             class: 'SignInPage-input-text SignInPage-input-password',
             autocomplete: 'off',
             required: true,
-            placeholder: 'Password'
+            placeholder: 'Password',
+            'data-disable' => true, # rails-ujs
           }) %>
         </div>
         <div class="SignInPage-login-buttons">
-          <%= submit_tag 'Sign in', class: "btn btn-primary SignInPage-login-button", name: nil %>
+          <%= submit_tag('Sign in', {
+            class: "btn btn-primary SignInPage-login-button",
+              name: nil,
+              'data-disable-with' => 'Signing in...' # rails-ujs
+          }) %>
           <div class="SignInPage-multifactor">
             <%= link_to('Use multifactor login', "#multifactor", class: 'SignInPage-authentication-type-link') %>
             <%= text_field_tag('educator[login_code]', nil, {
@@ -48,7 +54,8 @@
               placeholder: 'Sign in code',
               autocomplete: 'off',
               required: true,
-              value: 'NO_CODE' # Devise requires a value
+              value: 'NO_CODE', # Devise requires a value
+              'data-disable' => true, # rails-ujs
             }) %>
           </div>
         </div>


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
Limited visual feedback while waiting for sign-in to process.

# What does this PR do?
Disables input elements, updates button text to show sign-in is in-progress.  See https://github.com/rails/jquery-ujs/wiki/Unobtrusive-scripting-support-for-jQuery

# Screenshot (if adding a client-side feature)
<img width="427" alt="screen shot 2019-03-05 at 5 40 12 pm" src="https://user-images.githubusercontent.com/1056957/53842847-a218d680-3f6e-11e9-801a-839557ba9098.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Sign in

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here