### PR TITLE
Notes: Remove older props no longer used for restricted note

### DIFF
--- a/app/assets/javascripts/student_profile/NotesList.js
+++ b/app/assets/javascripts/student_profile/NotesList.js
@@ -82,18 +82,15 @@ export default class NotesList extends React.Component {
       educatorsIndex,
       onSaveNote,
       onEventNoteAttachmentDeleted,
-      showRestrictedNoteContent,
-      allowDirectEditingOfRestrictedNoteText,
       canUserAccessRestrictedNotes,
       currentEducatorId
     } = this.props;
-    const isRedacted = eventNote.is_restricted && !showRestrictedNoteContent;
+    const isRedacted = eventNote.is_restricted;
     const isReadonly = (
       !onSaveNote ||
       !onEventNoteAttachmentDeleted ||
       (currentEducatorId !== eventNote.educator_id) ||
-      isRedacted ||
-      (eventNote.is_restricted && !allowDirectEditingOfRestrictedNoteText)
+      isRedacted
     );
     const urlForRestrictedNoteContent = (canUserAccessRestrictedNotes)
       ? urlForRestrictedEventNoteContent(eventNote)
@@ -137,8 +134,8 @@ export default class NotesList extends React.Component {
   }
 
   renderTransitionNote(transitionNote) {
-    const {showRestrictedNoteContent, canUserAccessRestrictedNotes} = this.props;
-    const isRedacted = transitionNote.is_restricted && !showRestrictedNoteContent;
+    const {canUserAccessRestrictedNotes} = this.props;
+    const isRedacted = transitionNote.is_restricted;
     const urlForRestrictedNoteContent = (canUserAccessRestrictedNotes)
       ? urlForRestrictedTransitionNoteContent(transitionNote)
       : null;
@@ -222,9 +219,6 @@ NotesList.propTypes = {
   feed: InsightsPropTypes.feed.isRequired,
   educatorsIndex: PropTypes.object.isRequired,
   includeStudentPanel: PropTypes.bool,
-  showRestrictedNoteContent: PropTypes.bool,
-  allowDirectEditingOfRestrictedNoteText: PropTypes.bool,
-  allowViewingRestrictedNotes: PropTypes.bool,
   canUserAccessRestrictedNotes: PropTypes.bool,
   onSaveNote: PropTypes.func,
   onEventNoteAttachmentDeleted: PropTypes.func,

--- a/app/assets/javascripts/student_profile/NotesList.test.js
+++ b/app/assets/javascripts/student_profile/NotesList.test.js
@@ -189,17 +189,6 @@ describe('props impacting restricted notes', () => {
     expect(el.innerHTML).not.toContain('https://www.example.com/');
     expect(el.innerHTML).toContain('marked this note as restricted');
   });
-
-  it('for restricted notes page', () => {
-    const el = testRender(testPropsForRestrictedNote({
-      showRestrictedNoteContent: true,
-      allowDirectEditingOfRestrictedNoteText: true
-    }));
-    expect(el.innerHTML).toContain('RESTRICTED-this-is-the-note-text');
-    expect(el.innerHTML).toContain('https://www.example.com/');
-    expect(el.innerHTML).not.toContain('marked this note as restricted');
-    expect($(el).find('.EditableNoteText').length).toEqual(1);
-  });
 });
 
 


### PR DESCRIPTION
# Who is this PR for?
developers

# What does this PR do?
These aren't used anymore; in working towards improving some UX improvements to reading and taking notes, this removes this old code to simplify the upcoming work.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile
+ [x] My Notes

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
