### PR TITLE
Layout: Update min-width on body, navbar sizing

### DIFF
--- a/app/assets/javascripts/class_lists/ClassListCreatorPage.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorPage.js
@@ -2,10 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import {sortByGrade} from '../helpers/SortHelpers';
-import {
-  updateGlobalStylesToTakeFullHeight,
-  updateGlobalStylesToRemoveHorizontalScrollbars
-} from '../helpers/globalStylingWorkarounds';
+import {updateGlobalStylesToTakeFullHeight} from '../helpers/globalStylingWorkarounds';
 import {
   fetchGradeLevelsJson,
   fetchStudentsJson,
@@ -194,7 +191,6 @@ export default class ClassListCreatorPage extends React.Component {
     const {disableSizing} = this.props;
     if (disableSizing) return;
     updateGlobalStylesToTakeFullHeight();
-    updateGlobalStylesToRemoveHorizontalScrollbars();
   }
   
   // Trigger fetches and other initialization

--- a/app/assets/javascripts/helpers/globalStylingWorkarounds.js
+++ b/app/assets/javascripts/helpers/globalStylingWorkarounds.js
@@ -16,11 +16,6 @@ export function updateGlobalStylesToTakeFullHeight() {
   window.document.getElementById('main').style['flex-direction'] = 'column';
 }
 
-// Prevent horizontal scrollbar from showing.
-export function updateGlobalStylesToRemoveHorizontalScrollbars() {
-  window.document.body.style['min-width'] = '1000px';
-}
-
 export function alwaysShowVerticalScrollbars() {
   window.document.body.style['overflow-y'] = 'scroll';
 }

--- a/app/assets/javascripts/levels/LevelsPage.js
+++ b/app/assets/javascripts/levels/LevelsPage.js
@@ -3,10 +3,7 @@ import PropTypes from 'prop-types';
 import SectionHeading from '../components/SectionHeading';
 import GenericLoader from '../components/GenericLoader';
 import {apiFetchJson} from '../helpers/apiFetchJson';
-import {
-  updateGlobalStylesToTakeFullHeight,
-  updateGlobalStylesToRemoveHorizontalScrollbars
-} from '../helpers/globalStylingWorkarounds';
+import {updateGlobalStylesToTakeFullHeight} from '../helpers/globalStylingWorkarounds';
 import LevelsView from './LevelsView';
 
 
@@ -21,7 +18,6 @@ export default class LevelsPage extends React.Component {
   }
 
   componentDidMount() {
-    updateGlobalStylesToRemoveHorizontalScrollbars();
     updateGlobalStylesToTakeFullHeight();
   }
 

--- a/app/assets/javascripts/reading/ReadingGroupingPage.js
+++ b/app/assets/javascripts/reading/ReadingGroupingPage.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  updateGlobalStylesToTakeFullHeight,
-  updateGlobalStylesToRemoveHorizontalScrollbars
-} from '../helpers/globalStylingWorkarounds';
+import {updateGlobalStylesToTakeFullHeight} from '../helpers/globalStylingWorkarounds';
 import {apiFetchJson} from '../helpers/apiFetchJson';
 import GenericLoader from '../components/GenericLoader';
 import ReadingGroupingWorkflow from './ReadingGroupingWorkflow';
@@ -19,7 +16,6 @@ export default class ReadingGroupingPage extends React.Component {
 
   componentDidMount() {
     updateGlobalStylesToTakeFullHeight();
-    updateGlobalStylesToRemoveHorizontalScrollbars();
   }
 
   fetchJson() {

--- a/app/assets/javascripts/school_absences/SchoolAbsencesPage.js
+++ b/app/assets/javascripts/school_absences/SchoolAbsencesPage.js
@@ -3,10 +3,7 @@ import PropTypes from 'prop-types';
 import GenericLoader from '../components/GenericLoader';
 import {apiFetchJson} from '../helpers/apiFetchJson';
 import SchoolAbsencesDashboard from './SchoolAbsencesDashboard';
-import {
-  updateGlobalStylesToTakeFullHeight,
-  updateGlobalStylesToRemoveHorizontalScrollbars
-} from '../helpers/globalStylingWorkarounds';
+import {updateGlobalStylesToTakeFullHeight} from '../helpers/globalStylingWorkarounds';
 
 
 // For school or house admin to see students missing school, that the
@@ -25,7 +22,6 @@ export default class SchoolAbsencesPage extends React.Component {
     const {disableStylingForTest} = this.props;
     if (disableStylingForTest) return;
     updateGlobalStylesToTakeFullHeight();
-    updateGlobalStylesToRemoveHorizontalScrollbars();
   }
 
   fetchJson() {

--- a/app/assets/javascripts/school_administrator_dashboard/DashboardLoader.js
+++ b/app/assets/javascripts/school_administrator_dashboard/DashboardLoader.js
@@ -4,10 +4,7 @@ import GenericLoader from '../components/GenericLoader';
 import {apiFetchJson} from '../helpers/apiFetchJson';
 import SchoolwideTardies from './tardies_dashboard/SchoolwideTardies';
 import SchoolDisciplineDashboard from './discipline_dashboard/SchoolDisciplineDashboard';
-import {
-  updateGlobalStylesToTakeFullHeight,
-  updateGlobalStylesToRemoveHorizontalScrollbars
-} from '../helpers/globalStylingWorkarounds';
+import {updateGlobalStylesToTakeFullHeight} from '../helpers/globalStylingWorkarounds';
 
 class DashboardLoader extends React.Component {
   constructor(props) {
@@ -18,7 +15,6 @@ class DashboardLoader extends React.Component {
 
   componentDidMount() {
     updateGlobalStylesToTakeFullHeight();
-    updateGlobalStylesToRemoveHorizontalScrollbars();
   }
 
   fetchDashboardStudents() {

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import _ from 'lodash';
-import {updateGlobalStylesToRemoveHorizontalScrollbars, alwaysShowVerticalScrollbars} from '../helpers/globalStylingWorkarounds';
+import {alwaysShowVerticalScrollbars} from '../helpers/globalStylingWorkarounds';
 import * as InsightsPropTypes from '../helpers/InsightsPropTypes';
 import {toMomentFromTimestamp} from '../helpers/toMoment';
 import * as FeedHelpers from '../helpers/FeedHelpers';
@@ -37,7 +37,6 @@ export default class LightProfilePage extends React.Component {
   }
 
   componentDidMount() {
-    updateGlobalStylesToRemoveHorizontalScrollbars();
     alwaysShowVerticalScrollbars();
   }
 

--- a/app/assets/stylesheets/globals.scss
+++ b/app/assets/stylesheets/globals.scss
@@ -13,7 +13,7 @@ pre, code {
 }
 
 body {
-  min-width: 1024px;
+  min-width: 1000px;
 }
 
 label {

--- a/app/assets/stylesheets/navbar_signed_in.scss
+++ b/app/assets/stylesheets/navbar_signed_in.scss
@@ -48,8 +48,9 @@
     width: 15px;
   }
 
-  .NavbarSignedIn-student-searchbar .student-searchbar {
+  .NavbarSignedIn-student-searchbar.student-searchbar {
     font-size: 14px;
+    width: 160px;
     padding: 3px 5px;
     margin-top: 1px;
     border: 1px solid $light-line;

--- a/app/views/shared/_navbar_signed_in.html.erb
+++ b/app/views/shared/_navbar_signed_in.html.erb
@@ -47,8 +47,7 @@
     <%= link_to "My notes", educators_my_notes_path %>
     <%= link_to 'My students', educators_my_students_path %>
     <span class="NavbarSignedIn-spacer"></span>
-    <p>Search:</p>
-    <input class="NavbarSignedIn-student-searchbar student-searchbar" />
+    <input class="NavbarSignedIn-student-searchbar student-searchbar" placeholder="Search..." />
     <span class="NavbarSignedIn-spacer"></span>
     <div>
       <% if masquerade.authorized? %>

--- a/spec/features/sign_in_feature_spec.rb
+++ b/spec/features/sign_in_feature_spec.rb
@@ -12,7 +12,7 @@ describe 'educator sign in using Mock LDAP', type: :feature do
     context 'teacher signs in' do
       def expect_successful_sign_in_for(educator)
         feature_sign_in(educator)
-        expect(page).to have_content 'Search:'
+        expect(page).to have_content 'Sign Out'
       end
 
       it { expect_successful_sign_in_for(pals.healey_sarah_teacher) }
@@ -33,28 +33,28 @@ describe 'educator sign in using Mock LDAP', type: :feature do
       TestPals.create!(email_domain: 'k12.somerville.ma.us')
       allow(PerDistrict).to receive(:new).and_return(PerDistrict.new(district_key: PerDistrict::SOMERVILLE))
       feature_plain_sign_in('jodi@k12.somerville.ma.us', 'demo-password')
-      expect(page).to have_content 'Search:'
+      expect(page).to have_content 'Sign Out'
     end
 
     it 'works for New Bedford using email' do
       TestPals.create!(email_domain: 'newbedfordschools.org')
       allow(PerDistrict).to receive(:new).and_return(PerDistrict.new(district_key: PerDistrict::NEW_BEDFORD))
       feature_plain_sign_in('jodi@newbedfordschools.org', 'demo-password')
-      expect(page).to have_content 'Search:'
+      expect(page).to have_content 'Sign Out'
     end
 
     it 'works for Bedford using plain login_name, and separate email address for LDAP authentication' do
       TestPals.create!(email_domain: 'bedfordps.org')
       allow(PerDistrict).to receive(:new).and_return(PerDistrict.new(district_key: PerDistrict::BEDFORD))
       feature_plain_sign_in('jodi', 'demo-password')
-      expect(page).to have_content 'Search:'
+      expect(page).to have_content 'Sign Out'
     end
 
     it 'works for demo' do
       TestPals.create!
       allow(PerDistrict).to receive(:new).and_return(PerDistrict.new(district_key: PerDistrict::DEMO))
       feature_plain_sign_in('jodi@demo.studentinsights.org', 'demo-password')
-      expect(page).to have_content 'Search:'
+      expect(page).to have_content 'Sign Out'
     end
   end
 
@@ -63,28 +63,28 @@ describe 'educator sign in using Mock LDAP', type: :feature do
       pals = TestPals.create!(email_domain: 'k12.somerville.ma.us')
       allow(PerDistrict).to receive(:new).and_return(PerDistrict.new(district_key: PerDistrict::SOMERVILLE))
       feature_multifactor_sign_in_by_peeking(pals.uri)
-      expect(page).to have_content 'Search:'
+      expect(page).to have_content 'Sign Out'
     end
 
     it 'works for New Bedford' do
       pals = TestPals.create!(email_domain: 'newbedfordschools.org')
       allow(PerDistrict).to receive(:new).and_return(PerDistrict.new(district_key: PerDistrict::NEW_BEDFORD))
       feature_multifactor_sign_in_by_peeking(pals.uri)
-      expect(page).to have_content 'Search:'
+      expect(page).to have_content 'Sign Out'
     end
 
     it 'works for Bedford using plain login_name' do
       pals = TestPals.create!(email_domain: 'bedfordps.org')
       allow(PerDistrict).to receive(:new).and_return(PerDistrict.new(district_key: PerDistrict::BEDFORD))
       feature_multifactor_sign_in_by_peeking(pals.uri, login_text: 'uri')
-      expect(page).to have_content 'Search:'
+      expect(page).to have_content 'Sign Out'
     end
 
     it 'works for demo' do
       pals = TestPals.create!
       allow(PerDistrict).to receive(:new).and_return(PerDistrict.new(district_key: PerDistrict::DEMO))
       feature_multifactor_sign_in_by_peeking(pals.uri)
-      expect(page).to have_content 'Search:'
+      expect(page).to have_content 'Sign Out'
     end
   end
 
@@ -93,28 +93,28 @@ describe 'educator sign in using Mock LDAP', type: :feature do
       pals = TestPals.create!(email_domain: 'k12.somerville.ma.us')
       allow(PerDistrict).to receive(:new).and_return(PerDistrict.new(district_key: PerDistrict::SOMERVILLE))
       feature_multifactor_sign_in_by_peeking(pals.rich_districtwide)
-      expect(page).to have_content 'Search:'
+      expect(page).to have_content 'Sign Out'
     end
 
     it 'works for New Bedford' do
       pals = TestPals.create!(email_domain: 'newbedfordschools.org')
       allow(PerDistrict).to receive(:new).and_return(PerDistrict.new(district_key: PerDistrict::NEW_BEDFORD))
       feature_multifactor_sign_in_by_peeking(pals.rich_districtwide)
-      expect(page).to have_content 'Search:'
+      expect(page).to have_content 'Sign Out'
     end
 
     it 'works for Bedford using plain login_name' do
       pals = TestPals.create!(email_domain: 'bedfordps.org')
       allow(PerDistrict).to receive(:new).and_return(PerDistrict.new(district_key: PerDistrict::BEDFORD))
       feature_multifactor_sign_in_by_peeking(pals.rich_districtwide, login_text: 'rich')
-      expect(page).to have_content 'Search:'
+      expect(page).to have_content 'Sign Out'
     end
 
     it 'works for demo' do
       pals = TestPals.create!
       allow(PerDistrict).to receive(:new).and_return(PerDistrict.new(district_key: PerDistrict::DEMO))
       feature_multifactor_sign_in_by_peeking(pals.rich_districtwide)
-      expect(page).to have_content 'Search:'
+      expect(page).to have_content 'Sign Out'
     end
   end
 
@@ -133,7 +133,7 @@ describe 'educator sign in using Mock LDAP', type: :feature do
       allow(PerDistrict).to receive(:new).and_return(PerDistrict.new(district_key: PerDistrict::SOMERVILLE))
       peeked_login_code = LoginTests.peek_at_correct_multifactor_code(pals.rich_districtwide)
       feature_multifactor_sign_in_by_peeking(pals.rich_districtwide)
-      expect(page).to have_content 'Search:'
+      expect(page).to have_content 'Sign Out'
 
       expect(log.output).not_to include('rich@')
       expect(log.output).not_to include('k12.somerville.ma.us')

--- a/spec/views/shared/_navbar_signed_in_spec.rb
+++ b/spec/views/shared/_navbar_signed_in_spec.rb
@@ -14,7 +14,7 @@ describe '_navbar_signed_in partial' do
   def expect_common_links(rendered)
     expect(rendered).to include('My notes')
     expect(rendered).to include('My students')
-    expect(rendered).to include('Search:')
+    expect(rendered).to include('Search...')
     expect(rendered).to include('Sign Out')
   end
 


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
Two layout issues: horizontal scrollbars showing unnecessarily on 1024px wide IE11 browsers, and navbar width leading to text wrapping for particular users when many links.

# What does this PR do?
Updates body min-width to match workaround JS function and removes that fn.  Fixes the width of the searchbar to prevent jumping when font is initially loaded (there was a bug in the CSS before), and use placeholder instead of label to reduce its overall width while increasing size that's interactable.

# Screenshot (if adding a client-side feature)
<img width="1020" alt="Screen Shot 2019-03-29 at 12 02 55 PM" src="https://user-images.githubusercontent.com/1056957/55246169-03089700-521b-11e9-89e4-4671cbc59454.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Layout and navbar

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here