### PR TITLE
Class lists: Open for making lists KF-8 and include early childhood schools

### DIFF
--- a/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.test.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorWorkflow.test.js
@@ -68,7 +68,7 @@ export function chooseYourGradeProps(props = {}) {
     schools: available_grade_levels_json.schools,
     schoolId: available_grade_levels_json.schools[2].id,
     gradeLevelsNextYear: available_grade_levels_json.grade_levels_next_year,
-    gradeLevelNextYear: available_grade_levels_json.grade_levels_next_year[0],
+    gradeLevelNextYear: '1',
     ...props
   };
 }
@@ -100,7 +100,7 @@ export function exportProps(props = {}) {
     stepIndex: 5,
     schools: available_grade_levels_json.schools,
     schoolId: available_grade_levels_json.schools[2].id,
-    gradeLevelNextYear: available_grade_levels_json.grade_levels_next_year[0],
+    gradeLevelNextYear: '1',
     students: students_for_grade_level_next_year_json.students,
     studentIdsByRoom: class_list_json.class_list.json.studentIdsByRoom,
     educators: students_for_grade_level_next_year_json.educators,

--- a/app/assets/javascripts/class_lists/fixtures/available_grade_levels_json.js
+++ b/app/assets/javascripts/class_lists/fixtures/available_grade_levels_json.js
@@ -34,11 +34,14 @@ export default {
     }
   ],
   "grade_levels_next_year": [
+    "KF",
     "1",
     "2",
     "3",
     "4",
     "5",
-    "6"
+    "6",
+    "7",
+    "8"
   ]
 };

--- a/app/lib/class_list_queries.rb
+++ b/app/lib/class_list_queries.rb
@@ -63,12 +63,12 @@ class ClassListQueries
 
   # What grade levels do we want to support creating class lists for?
   def supported_grade_levels_next_year
-    ['1','2','3','4','5','6']
+    ['KF', '1','2','3','4','5','6', '7', '8']
   end
 
   # What schools are supported?
   def supported_schools
-    @supported_schools ||= School.where(school_type: ['ESMS', 'ES', 'MS'])
+    @supported_schools ||= School.where(school_type: ['ECS', 'ESMS', 'ES', 'MS'])
   end
 
   # This is authorization-aware, and checks authorization for the grade level

--- a/spec/controllers/class_lists_controller_spec.rb
+++ b/spec/controllers/class_lists_controller_spec.rb
@@ -228,7 +228,7 @@ describe ClassListsController, :type => :controller do
       request_available_grade_levels_json(pals.healey_laura_principal)
       json = JSON.parse(response.body)
       expect(response.status).to eq 200
-      expect(json["grade_levels_next_year"]).to eq(["1", "2", "3", "4", "5", "6"])
+      expect(json["grade_levels_next_year"]).to eq(['KF', '1', '2', '3', '4', '5', '6', '7', '8'])
       expect(json["schools"].length).to eq 1
       expect(json["schools"][0]["id"]).to eq pals.healey.id
     end
@@ -236,8 +236,8 @@ describe ClassListsController, :type => :controller do
     it 'works for Uri' do
       request_available_grade_levels_json(pals.uri)
       json = JSON.parse(response.body)
-      expect(json["grade_levels_next_year"]).to eq(["1", "2", "3", "4", "5", "6"])
-      expect(json["schools"].length).to eq 8
+      expect(json["grade_levels_next_year"]).to eq(['KF', '1', '2', '3', '4', '5', '6', '7', '8'])
+      expect(json["schools"].length).to eq 9
     end
   end
 

--- a/spec/lib/class_list_queries_spec.rb
+++ b/spec/lib/class_list_queries_spec.rb
@@ -153,41 +153,44 @@ RSpec.describe ClassListQueries do
   end
 
   describe 'is_authorized_for_grade_level_now?' do
-    def allowed?(educator, school, grade_level_now)
+    def allowed_now?(educator, school, grade_level_now)
       ClassListQueries.new(educator).is_authorized_for_grade_level_now?(school.id, grade_level_now)
     end
 
     it 'does not let anyone outside expected grade levels' do
-      expect(allowed?(pals.healey_vivian_teacher, pals.healey, 'PK')).to eq false
-      expect(allowed?(pals.uri, pals.healey, '7')).to eq false
-      expect(allowed?(pals.healey_laura_principal, pals.healey, '8')).to eq false
+      expect(allowed_now?(pals.healey_vivian_teacher, pals.healey, 'TK')).to eq false
+      expect(allowed_now?(pals.uri, pals.healey, '8')).to eq false
+      expect(allowed_now?(pals.healey_laura_principal, pals.healey, '8')).to eq false
     end
 
     it 'does not let anyone outside expected schools' do
-      expect(allowed?(pals.uri, pals.shs, '11')).to eq false
+      expect(allowed_now?(pals.uri, pals.shs, '11')).to eq false
     end
 
     it 'works across roles in a school' do
-      expect(allowed?(pals.uri, pals.healey, '3')).to eq true
-      expect(allowed?(pals.uri, pals.healey, '5')).to eq true
-      expect(allowed?(pals.healey_laura_principal, pals.healey, 'KF')).to eq true
-      expect(allowed?(pals.healey_laura_principal, pals.healey, '3')).to eq true
-      expect(allowed?(pals.healey_laura_principal, pals.healey, '5')).to eq true
-      expect(allowed?(pals.healey_vivian_teacher, pals.healey, 'KF')).to eq true
-      expect(allowed?(pals.healey_vivian_teacher, pals.healey, '1')).to eq false
-      expect(allowed?(pals.healey_sarah_teacher, pals.healey, '5')).to eq true
-      expect(allowed?(pals.healey_sarah_teacher, pals.healey, '6')).to eq false
+      expect(allowed_now?(pals.uri, pals.healey, 'PK')).to eq true
+      expect(allowed_now?(pals.uri, pals.healey, 'KF')).to eq true
+      expect(allowed_now?(pals.uri, pals.healey, '3')).to eq true
+      expect(allowed_now?(pals.uri, pals.healey, '5')).to eq true
+      expect(allowed_now?(pals.uri, pals.healey, '7')).to eq true
+      expect(allowed_now?(pals.healey_laura_principal, pals.healey, 'KF')).to eq true
+      expect(allowed_now?(pals.healey_laura_principal, pals.healey, '3')).to eq true
+      expect(allowed_now?(pals.healey_laura_principal, pals.healey, '5')).to eq true
+      expect(allowed_now?(pals.healey_vivian_teacher, pals.healey, 'KF')).to eq true
+      expect(allowed_now?(pals.healey_vivian_teacher, pals.healey, '1')).to eq false
+      expect(allowed_now?(pals.healey_sarah_teacher, pals.healey, '5')).to eq true
+      expect(allowed_now?(pals.healey_sarah_teacher, pals.healey, '6')).to eq false
     end
 
     it 'does not let reaching across grades' do
-      expect(allowed?(pals.healey_sarah_teacher, pals.healey, '3')).to eq false
-      expect(allowed?(pals.healey_sarah_teacher, pals.healey, '6')).to eq false
+      expect(allowed_now?(pals.healey_sarah_teacher, pals.healey, '3')).to eq false
+      expect(allowed_now?(pals.healey_sarah_teacher, pals.healey, '6')).to eq false
     end
 
     it 'does not let reaching across schools' do
-      expect(allowed?(pals.west_marcus_teacher, pals.healey, '5')).to eq false
-      expect(allowed?(pals.shs_jodi, pals.healey, '5')).to eq false
-      expect(allowed?(pals.shs_bill_nye, pals.healey, '5')).to eq false
+      expect(allowed_now?(pals.west_marcus_teacher, pals.healey, '5')).to eq false
+      expect(allowed_now?(pals.shs_jodi, pals.healey, '5')).to eq false
+      expect(allowed_now?(pals.shs_bill_nye, pals.healey, '5')).to eq false
     end
   end
 


### PR DESCRIPTION
# Who is this PR for?
Pre-K teams, middle school teams wanting to make multiple academic class lists

# What problem does this PR fix?
This was limited to 1-6 in the first year, so folks wanting to use the same tool in other ways couldn't

# What does this PR do?
Allows class lists for KF classrooms and middle school classrooms as well (the entire feature is separately disabled still).

# Checklists
*Which features or pages does this PR touch?*
+ [x] Class lists

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
