### PR TITLE
Allow demo to use Somerville school year calculations to demo levels page

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -378,16 +378,18 @@ class PerDistrict
   end
 
   def current_quarter(date_time)
-    raise_not_handled! unless @district_key == SOMERVILLE
-
-    # See https://docs.google.com/document/d/1HCWMlbzw1KzniitW24aeo_IgjzNDSR-U9Rx_md1Qto8/edit
-    year = SchoolYear.to_school_year(date_time)
-    return 'SUMMER' if date_time < DateTime.new(year, 8, 29)
-    return 'Q1' if date_time < DateTime.new(year, 11, 5)
-    return 'Q2' if date_time < DateTime.new(year + 1, 1, 23)
-    return 'Q3' if date_time < DateTime.new(year + 1, 4, 3)
-    return 'Q4' if date_time < DateTime.new(year + 1, 6, 12)
-    'SUMMER'
+    if @district_key == SOMERVILLE || @district_key == DEMO
+      # See https://docs.google.com/document/d/1HCWMlbzw1KzniitW24aeo_IgjzNDSR-U9Rx_md1Qto8/edit
+      year = SchoolYear.to_school_year(date_time)
+      return 'SUMMER' if date_time < DateTime.new(year, 8, 29)
+      return 'Q1' if date_time < DateTime.new(year, 11, 5)
+      return 'Q2' if date_time < DateTime.new(year + 1, 1, 23)
+      return 'Q3' if date_time < DateTime.new(year + 1, 4, 3)
+      return 'Q4' if date_time < DateTime.new(year + 1, 6, 12)
+      'SUMMER'
+    else
+      raise_not_handled!
+    end
   end
 
   # When importing data from Google Forms, educator emails may not be the same

--- a/spec/config_objects/per_district_spec.rb
+++ b/spec/config_objects/per_district_spec.rb
@@ -140,6 +140,12 @@ RSpec.describe PerDistrict do
       expect(PerDistrict.new.current_quarter(DateTime.new(2018, 6, 1))).to eq 'Q4'
       expect(PerDistrict.new.current_quarter(DateTime.new(2018, 6, 24))).to eq 'SUMMER'
     end
+
+    it 'works for demo but raises for Bedford and New Bedford' do
+      expect { for_demo.current_quarter(Time.now) }.not_to raise_error Exceptions::DistrictKeyNotHandledError
+      expect { for_bedford.current_quarter(Time.now) }.to raise_error Exceptions::DistrictKeyNotHandledError
+      expect { for_new_bedford.current_quarter(Time.now) }.to raise_error Exceptions::DistrictKeyNotHandledError
+    end
   end
 
   describe '#parse_counselor_during_import' do


### PR DESCRIPTION
This is for the levels page, which is enabled in demo, but raises because the school year calculations aren't supported in the demo env.  For the demo page to work, it's fine to use the Somerville definitions.  