### PR TITLE
Class lists: Use CleanSlateMessage and apply policy to notes within dialog

### DIFF
--- a/app/assets/javascripts/class_lists/InlineStudentProfile.js
+++ b/app/assets/javascripts/class_lists/InlineStudentProfile.js
@@ -8,10 +8,25 @@ import StudentPhotoCropped from '../components/StudentPhotoCropped';
 import FeedView from '../feed/FeedView';
 import {highlightStyleForKey, userFacingValueForKey} from './highlights';
 import {equityChecks, equityCheckFlags} from './ClassroomStats';
+import CleanSlateMessage, {defaultSchoolYearsBack, filteredFeedCardsForCleanSlate} from '../student_profile/CleanSlateMessage';
 
 
 // Inline student profile for classroom list creator, shown as a modal
 export default class InlineStudentProfile extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isViewingAllNotes: false
+    };
+
+    this.onToggleCaseHistory = this.onToggleCaseHistory.bind(this);
+  }
+
+  onToggleCaseHistory(e) {
+    const {isViewingAllNotes} = this.state;
+    this.setState({isViewingAllNotes: !isViewingAllNotes});
+  }
+
   render() {
     const {student} = this.props;
     return (
@@ -74,9 +89,26 @@ export default class InlineStudentProfile extends React.Component {
   }
 
   renderFeedWithData(json) {
-    return <FeedView feedCards={json.feed_cards} />;
+    const {nowFn} = this.context;
+    const {isViewingAllNotes} = this.state;
+    const schoolYearsBack = defaultSchoolYearsBack;
+    const cleanSlateFeedCards = filteredFeedCardsForCleanSlate(json.feed_cards, schoolYearsBack.number, nowFn);
+    return (
+      <div style={{maxWidth: 500}}>
+        <FeedView feedCards={cleanSlateFeedCards} />
+        <CleanSlateMessage
+          canViewFullHistory={true}
+          isViewingFullHistory={isViewingAllNotes}
+          onToggleVisibility={this.onToggleCaseHistory}
+          xAmountOfDataText={`${schoolYearsBack.textYears} of data`}
+      />
+      </div>
+    );
   }
 }
+InlineStudentProfile.contextTypes = {
+  nowFn: PropTypes.func.isRequired
+};
 InlineStudentProfile.propTypes = {
   fetchProfile: PropTypes.func.isRequired,
   student: PropTypes.object.isRequired
@@ -97,12 +129,12 @@ const styles = {
     flexDirection: 'column'
   },
   equityCheckLabel: {
-    flex: 1,
     padding: 5,
-    paddingBottom: 0
+    paddingBottom: 0,
+    minHeight: '2em'
   },
   equityCheckValue: {
-    minHeight: '4em',
+    minHeight: '5em',
     margin: 5,
     padding: 5,
     display: 'flex',

--- a/app/assets/javascripts/class_lists/__snapshots__/InlineStudentProfile.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/InlineStudentProfile.test.js.snap
@@ -129,7 +129,7 @@ exports[`snapshots 1`] = `
           <div
             style={
               Object {
-                "flex": 1,
+                "minHeight": "2em",
                 "padding": 5,
                 "paddingBottom": 0,
               }
@@ -146,7 +146,7 @@ exports[`snapshots 1`] = `
                 "display": "flex",
                 "justifyContent": "center",
                 "margin": 5,
-                "minHeight": "4em",
+                "minHeight": "5em",
                 "padding": 5,
                 "textAlign": "center",
               }
@@ -165,7 +165,7 @@ exports[`snapshots 1`] = `
           <div
             style={
               Object {
-                "flex": 1,
+                "minHeight": "2em",
                 "padding": 5,
                 "paddingBottom": 0,
               }
@@ -182,7 +182,7 @@ exports[`snapshots 1`] = `
                 "display": "flex",
                 "justifyContent": "center",
                 "margin": 5,
-                "minHeight": "4em",
+                "minHeight": "5em",
                 "padding": 5,
                 "textAlign": "center",
               }
@@ -201,7 +201,7 @@ exports[`snapshots 1`] = `
           <div
             style={
               Object {
-                "flex": 1,
+                "minHeight": "2em",
                 "padding": 5,
                 "paddingBottom": 0,
               }
@@ -218,7 +218,7 @@ exports[`snapshots 1`] = `
                 "display": "flex",
                 "justifyContent": "center",
                 "margin": 5,
-                "minHeight": "4em",
+                "minHeight": "5em",
                 "padding": 5,
                 "textAlign": "center",
               }
@@ -237,7 +237,7 @@ exports[`snapshots 1`] = `
           <div
             style={
               Object {
-                "flex": 1,
+                "minHeight": "2em",
                 "padding": 5,
                 "paddingBottom": 0,
               }
@@ -254,7 +254,7 @@ exports[`snapshots 1`] = `
                 "display": "flex",
                 "justifyContent": "center",
                 "margin": 5,
-                "minHeight": "4em",
+                "minHeight": "5em",
                 "padding": 5,
                 "textAlign": "center",
               }
@@ -273,7 +273,7 @@ exports[`snapshots 1`] = `
           <div
             style={
               Object {
-                "flex": 1,
+                "minHeight": "2em",
                 "padding": 5,
                 "paddingBottom": 0,
               }
@@ -306,7 +306,7 @@ shown as purple"
                 "display": "flex",
                 "justifyContent": "center",
                 "margin": 5,
-                "minHeight": "4em",
+                "minHeight": "5em",
                 "padding": 5,
                 "textAlign": "center",
               }
@@ -337,7 +337,7 @@ shown as purple"
           <div
             style={
               Object {
-                "flex": 1,
+                "minHeight": "2em",
                 "padding": 5,
                 "paddingBottom": 0,
               }
@@ -354,7 +354,7 @@ shown as purple"
                 "display": "flex",
                 "justifyContent": "center",
                 "margin": 5,
-                "minHeight": "4em",
+                "minHeight": "5em",
                 "padding": 5,
                 "textAlign": "center",
               }

--- a/app/assets/javascripts/student_profile/CleanSlateMessage.js
+++ b/app/assets/javascripts/student_profile/CleanSlateMessage.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {toSchoolYear, firstDayOfSchool} from '../helpers/schoolYear';
+import {toMomentFromRailsDate} from '../helpers/toMoment';
 
 
 // UI component, showing a message about "clean slate", and allows folks with
@@ -65,4 +67,30 @@ const styles = {
     cursor: 'pointer',
     color: '#999'
   }
+};
+
+
+// Limit how back notes are shown
+export function filteredNotesForCleanSlate(mergedNotes, nSchoolYearsBack, nowFn) {
+  const nowMoment = nowFn();
+  const oldestSchoolYearToInclude = toSchoolYear(nowMoment) - nSchoolYearsBack;
+  const schoolYearsBackCutoffMoment = firstDayOfSchool(oldestSchoolYearToInclude);
+  return mergedNotes.filter(mergedNote => {
+    return toMomentFromRailsDate(mergedNote.sort_timestamp).isAfter(schoolYearsBackCutoffMoment);
+  });
+}
+
+// Limit how back feed cards are shown
+export function filteredFeedCardsForCleanSlate(feedCards, nSchoolYearsBack, nowFn) {
+  const nowMoment = nowFn();
+  const oldestSchoolYearToInclude = toSchoolYear(nowMoment) - nSchoolYearsBack;
+  const schoolYearsBackCutoffMoment = firstDayOfSchool(oldestSchoolYearToInclude);
+  return feedCards.filter(feedCard => {
+    return toMomentFromRailsDate(feedCard.timestamp).isAfter(schoolYearsBackCutoffMoment);
+  });
+}
+
+export const defaultSchoolYearsBack = {
+  number: 1,
+  textYears: 'one year'
 };

--- a/app/assets/javascripts/student_profile/NotesList.js
+++ b/app/assets/javascripts/student_profile/NotesList.js
@@ -7,11 +7,10 @@ import * as InsightsPropTypes from '../helpers/InsightsPropTypes';
 import * as FeedHelpers from '../helpers/FeedHelpers';
 import {eventNoteTypeText} from '../helpers/eventNoteType';
 import {IDLE} from '../helpers/requestStates';
-import {toSchoolYear, firstDayOfSchool} from '../helpers/schoolYear';
 import NoteCard from './NoteCard';
 import {parseAndReRender} from './transitionNoteParser';
 import {urlForRestrictedEventNoteContent, urlForRestrictedTransitionNoteContent} from './RestrictedNotePresence';
-import CleanSlateMessage from './CleanSlateMessage';
+import CleanSlateMessage, {defaultSchoolYearsBack, filteredNotesForCleanSlate} from './CleanSlateMessage';
 
 
 /*
@@ -31,15 +30,10 @@ export default class NotesList extends React.Component {
   filteredNotes(mergedNotes) {
     const {isViewingAllNotes} = this.state;
     if (isViewingAllNotes) return mergedNotes;
-
+    
     const {nowFn} = this.context;
     const {defaultSchoolYearsBack} = this.props;
-    const nowMoment = nowFn();
-    const oldestSchoolYearToIncluce = toSchoolYear(nowMoment) - defaultSchoolYearsBack.number;
-    const schoolYearsBackCutoffMoment = firstDayOfSchool(oldestSchoolYearToIncluce);
-    return mergedNotes.filter(mergedNote => {
-      return toMomentFromRailsDate(mergedNote.sort_timestamp).isAfter(schoolYearsBackCutoffMoment);
-    });
+    return filteredNotesForCleanSlate(mergedNotes, defaultSchoolYearsBack.number, nowFn);
   }
 
   onToggleCaseHistory() {
@@ -237,10 +231,7 @@ NotesList.propTypes = {
 };
 NotesList.defaultProps = {
   forceShowingAllNotes: false,
-  defaultSchoolYearsBack: {
-    number: 1,
-    textYears: 'one year'
-  }
+  defaultSchoolYearsBack
 };
 NotesList.contextTypes = {
   nowFn: PropTypes.func.isRequired


### PR DESCRIPTION
# Who is this PR for?
K8 teaching teams

# What problem does this PR fix?
The `<InlineStudentProfile />` shown within the class list maker doesn't apply the "clean slate" policy for notes, and shows historical notes further back than it should.

Also makes some UI tweaks for IE.

# What does this PR do?
Refactors the filtering, and applies it to the class list dialog as well.  Adjusts the width of notes column in the dialog, the "equity checks" sizing to work properly on IE11.

# Screenshot (if adding a client-side feature)
<img width="979" alt="Screen Shot 2019-05-07 at 8 55 49 AM" src="https://user-images.githubusercontent.com/1056957/57301358-d14edf80-70a6-11e9-99a0-82917b8e6a92.png">


# Checklists
*Which features or pages does this PR touch?*
+ [x] Class lists
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here