### PR TITLE
Class lists: Remove link to school page on list page

### DIFF
--- a/app/assets/javascripts/class_lists/ClassListsViewPage.js
+++ b/app/assets/javascripts/class_lists/ClassListsViewPage.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import * as Routes from '../helpers/Routes';
 import Button from '../components/Button';
-import School from '../components/School';
 import Educator from '../components/Educator';
 import GenericLoader from '../components/GenericLoader';
 import SectionHeading from '../components/SectionHeading';
@@ -106,7 +105,7 @@ export class ClassListsViewPageView extends React.Component {
               : {};
             return (
               <tr key={workspace.workspace_id}>
-                <td style={cell}><School {...classList.school} /></td>
+                <td style={cell}>{classList.school.name}</td>
                 <td style={cell}>
                   {gradeText(classList.grade_level_next_year)}
                 </td>

--- a/app/assets/javascripts/class_lists/__snapshots__/ClassListsViewPage.test.js.snap
+++ b/app/assets/javascripts/class_lists/__snapshots__/ClassListsViewPage.test.js.snap
@@ -178,13 +178,7 @@ exports[`snapshots view 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -312,13 +306,7 @@ exports[`snapshots view 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -446,13 +434,7 @@ exports[`snapshots view 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -580,13 +562,7 @@ exports[`snapshots view 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -728,13 +704,7 @@ exports[`snapshots view 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -876,13 +846,7 @@ exports[`snapshots view 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -1002,13 +966,7 @@ exports[`snapshots view 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -1132,13 +1090,7 @@ exports[`snapshots view 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -1266,13 +1218,7 @@ exports[`snapshots view 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -1569,13 +1515,7 @@ exports[`snapshots view with text links 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -1703,13 +1643,7 @@ exports[`snapshots view with text links 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -1837,13 +1771,7 @@ exports[`snapshots view with text links 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -1971,13 +1899,7 @@ exports[`snapshots view with text links 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -2119,13 +2041,7 @@ exports[`snapshots view with text links 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -2267,13 +2183,7 @@ exports[`snapshots view with text links 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -2393,13 +2303,7 @@ exports[`snapshots view with text links 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -2523,13 +2427,7 @@ exports[`snapshots view with text links 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={
@@ -2657,13 +2555,7 @@ exports[`snapshots view with text links 1`] = `
               }
             }
           >
-            <a
-              className="School"
-              href="/schools/2"
-              style={Object {}}
-            >
-              Arthur D Healey
-            </a>
+            Arthur D Healey
           </td>
           <td
             style={


### PR DESCRIPTION
This needs to branch on whether the user can access that page, and it doesn't now.  So remove the link, which isn't really useful here other than for exploring context.

<img width="926" alt="Screen Shot 2019-05-08 at 9 43 24 AM" src="https://user-images.githubusercontent.com/1056957/57379902-cfa01d00-7175-11e9-8cbd-37277f72ccd9.png">
