### PR TITLE
Update brakeman, force SSL in two places

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     bourbon (4.3.4)
       sass (~> 3.4)
       thor (~> 0.19)
-    brakeman (4.5.0)
+    brakeman (4.5.1)
     builder (3.2.3)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Using debug leads to database queries being logged, and sensitive information being leaked to 
   # logs.


### PR DESCRIPTION
We already set `force_ssl` in `application_controller` but Brakeman recommends doing it in `production.rb` so saying it twice seems fine :)