### PR TITLE
Reading: Enable exporting reading debug data

### DIFF
--- a/app/assets/javascripts/components/DownloadIcon.js
+++ b/app/assets/javascripts/components/DownloadIcon.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function DownloadIcon() {
+  return <svg style={{fill: "#3177c9", opacity: 0.5, cursor: 'pointer'}} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>;
+}

--- a/app/assets/javascripts/levels/LevelsView.js
+++ b/app/assets/javascripts/levels/LevelsView.js
@@ -6,6 +6,7 @@ import ReactModal from 'react-modal';
 import {toCsvTextFromTable} from '../helpers/toCsvFromTable';
 import DownloadCsvLink from '../components/DownloadCsvLink';
 import EscapeListener from '../components/EscapeListener';
+import DownloadIcon from '../components/DownloadIcon';
 import FilterBar from '../components/FilterBar';
 import SimpleFilterSelect, {ALL} from '../components/SimpleFilterSelect';
 import SelectGrade from '../components/SelectGrade';
@@ -259,7 +260,7 @@ export default class LevelsView extends React.Component {
               style={modalFromRight}>
               {this.renderLinkWithCsvDataInline(columns, students)}
             </ReactModal>
-          : <svg style={{fill: "#3177c9", opacity: 0.5, cursor: 'pointer'}} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
+          : <DownloadIcon />
         }
       </div>
     );

--- a/app/assets/javascripts/reading/LazyExportLink.js
+++ b/app/assets/javascripts/reading/LazyExportLink.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
 import {modalFromRight} from '../components/HelpBubble';
 import DownloadCsvLink from '../components/DownloadCsvLink';
+import DownloadIcon from '../components/DownloadIcon';
 
 
 // This tracks the modal state on its own rather than using <HelpBubble /> so that it
@@ -34,7 +35,7 @@ export default class LazyExportLink extends React.Component {
               style={modalFromRight}>
               {this.renderDialog()}
             </ReactModal>
-          : <svg style={{fill: "#3177c9", opacity: 0.5, cursor: 'pointer'}} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
+          : <DownloadIcon />
         }
       </div>
     );

--- a/app/assets/javascripts/reading_debug/ReadingDebugPage.js
+++ b/app/assets/javascripts/reading_debug/ReadingDebugPage.js
@@ -16,6 +16,7 @@ import GenericLoader from '../components/GenericLoader';
 import SectionHeading from '../components/SectionHeading';
 import {modalFullScreenWithVerticalScroll} from '../components/HelpBubble';
 import SimpleFilterSelect, {ALL} from '../components/SimpleFilterSelect';
+import DownloadIcon from '../components/DownloadIcon';
 import ExperimentalBanner from '../components/ExperimentalBanner';
 import StudentPhotoCropped from '../components/StudentPhotoCropped';
 import DibelsBreakdownBar from '../components/DibelsBreakdownBar';
@@ -61,14 +62,17 @@ export default class ReadingDebugPage extends React.Component {
   }
 
   fetchJson() {
-    return apiFetchJson('/api/reading/reading_debug_json');
+    return apiFetchJson('/api/reading_debug/reading_debug_json');
   }
 
   render() {
     return (
       <div className="ReadingDebugPage" style={styles.flexVertical}>
         <ExperimentalBanner />
-        <SectionHeading>Benchmark Reading Data (DEBUG)</SectionHeading>
+        <SectionHeading titleStyle={styles.title}>
+          <div>Benchmark Reading Data (DEBUG)</div>
+          <a href="/reading/debug_csv"><DownloadIcon /></a>
+        </SectionHeading>
         <GenericLoader
           promiseFn={this.fetchJson}
           style={styles.flexVertical}

--- a/app/assets/javascripts/reading_debug/ReadingDebugPage.test.js
+++ b/app/assets/javascripts/reading_debug/ReadingDebugPage.test.js
@@ -8,7 +8,7 @@ import readingDebugJson from './reading_debug_json.fixture';
 beforeEach(() => {
   fetchMock.reset();
   fetchMock.restore();
-  fetchMock.get('express:/api/reading/reading_debug_json', readingDebugJson);
+  fetchMock.get('express:/api/reading_debug/reading_debug_json', readingDebugJson);
 });
 
 export function testProps(props = {}) {

--- a/app/assets/javascripts/reading_debug/ReadingDebugStarPage.js
+++ b/app/assets/javascripts/reading_debug/ReadingDebugStarPage.js
@@ -42,7 +42,7 @@ export default class ReadingDebugStarPage extends React.Component {
   }
 
   fetchJson() {
-    return apiFetchJson('/api/reading/star_reading_debug_json');
+    return apiFetchJson('/api/reading_debug/star_reading_debug_json');
   }
 
   render() {

--- a/app/assets/javascripts/reading_debug/ReadingDebugStarPage.test.js
+++ b/app/assets/javascripts/reading_debug/ReadingDebugStarPage.test.js
@@ -9,7 +9,7 @@ import starReadingDebugJson from './star_reading_debug_json.fixture.js';
 beforeEach(() => {
   fetchMock.reset();
   fetchMock.restore();
-  fetchMock.get('express:/api/reading/star_reading_debug_json', starReadingDebugJson);
+  fetchMock.get('express:/api/reading_debug/star_reading_debug_json', starReadingDebugJson);
 });
 
 export function testProps(props = {}) {

--- a/app/assets/javascripts/school_absences/DownloadAbsences.js
+++ b/app/assets/javascripts/school_absences/DownloadAbsences.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
 import DownloadCsvLink, {joinCsvRow} from '../components/DownloadCsvLink';
+import DownloadIcon from '../components/DownloadIcon';
 import {modalFromRight} from '../components/HelpBubble';
 
 
@@ -32,7 +33,7 @@ export default class DownloadAbsences extends React.Component {
               style={modalFromRight}>
               {this.renderLinkWithCsvDataInline()}
             </ReactModal>
-          : <svg style={{fill: "#3177c9", opacity: 0.5, cursor: 'pointer'}} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
+          : <DownloadIcon />
         }
       </div>
     );

--- a/app/controllers/reading_controller.rb
+++ b/app/controllers/reading_controller.rb
@@ -109,21 +109,7 @@ class ReadingController < ApplicationController
       :grade,
       :has_photo
     ])
-    reading_benchmark_data_points = ReadingBenchmarkDataPoint.all
-      .where(student_id: students.pluck(:id))
-      .order(updated_at: :asc)
-
-    # as an optimization, group these for the UI grid on server
-    students_by_id = {}
-    students.each {|student| students_by_id[student.id] = student }
-    groups = reading_benchmark_data_points.group_by do |d|
-      student = students_by_id[d.student_id]
-      [
-        d.benchmark_school_year,
-        d.benchmark_period_key,
-        student.grade,
-      ].join('-')
-    end
+    groups = ReadingQueries.new.groups_for_grid(students)
 
     render json: {
       students: students_json,

--- a/app/controllers/reading_debug_controller.rb
+++ b/app/controllers/reading_debug_controller.rb
@@ -1,0 +1,84 @@
+require 'csv'
+
+class ReadingDebugController < ApplicationController
+  before_action :ensure_authorized_for_feature!
+
+  def reading_debug_json
+    students, groups = reading_debug()
+    students_json = students.as_json(only: [
+      :id,
+      :first_name,
+      :last_name,
+      :grade,
+      :has_photo
+    ])
+    render json: {
+      students: students_json,
+      groups: groups
+    }
+  end
+
+  def reading_debug_csv
+    students, groups = reading_debug()
+    students_by_id = students.reduce({}) {|map, s| map.merge(s.id => s)}
+
+    # flatten
+    csv_text = CSV.generate do |csv|
+      csv << [
+        'student.local_id',
+        'student.full_name',
+        'student.grade_now',
+        'student.school_id_now',
+        'data_point.grid_key',
+        'data_point.benchmark_school_year',
+        'data_point.benchmark_period_key',
+        'data_point.json[value]',
+        'data_point.id'
+      ]
+
+      groups.each do |group, data_points|
+        data_points.each do |data_point|
+          student = students_by_id[data_point.student_id]
+          csv << [
+            student.local_id,
+            "#{student.last_name}, #{student.first_name}",
+            student.grade,
+            student.school_id,
+            data_point.grid_key(student),
+            data_point.benchmark_school_year,
+            data_point.benchmark_period_key,
+            data_point.json['value'],
+            data_point.id
+          ]
+        end
+      end
+    end
+
+    # download
+    filename = [
+      'reading_debug',
+      Time.now.strftime("%Y%m%d-%H%M%S"),
+      current_educator.login_name,
+      PerDistrict.new.district_key
+    ].join('_') + '.csv'
+    send_data csv_text, filename: filename, type: 'text/csv', disposition: 'inline'
+  end
+
+  def star_reading_debug_json
+    grades = ['2','3','4','5','6','7','8']
+    students = authorized { Student.active.where(grade: grades).to_a }
+    json = StarDebugQueries.new.fetch_json(students)
+    render json: json.merge(grades: grades)
+  end
+
+  private
+  def ensure_authorized_for_feature!
+    raise Exceptions::EducatorNotAuthorized unless current_educator.labels.include?('enable_reading_debug')
+  end
+
+  def reading_debug
+    students = authorized { Student.active.to_a }
+    groups = ReadingQueries.new.groups_for_grid(students)
+    [students, groups]
+  end
+end

--- a/app/lib/reading_queries.rb
+++ b/app/lib/reading_queries.rb
@@ -1,0 +1,14 @@
+class ReadingQueries
+  def groups_for_grid(students)
+    reading_benchmark_data_points = ReadingBenchmarkDataPoint.all
+      .where(student_id: students.pluck(:id))
+      .order(updated_at: :asc)
+
+    # as an optimization, group these for the UI grid on server
+    students_by_id = students.reduce({}) {|map, s| map.merge(s.id => s)}
+    reading_benchmark_data_points.group_by do |d|
+      student = students_by_id[d.student_id]
+      d.grid_key(student)
+    end
+  end
+end

--- a/app/models/reading_benchmark_data_point.rb
+++ b/app/models/reading_benchmark_data_point.rb
@@ -63,4 +63,13 @@ class ReadingBenchmarkDataPoint < ApplicationRecord
       :summer
     end
   end
+
+  # Relies on `student` for now
+  def grid_key(student)
+    [
+      self.benchmark_school_year,
+      self.benchmark_period_key,
+      student.grade, # migrate this to be on this model instead
+    ].join('-')
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,8 +48,10 @@ Rails.application.routes.draw do
   put '/api/reading/update_data_point_json' => 'reading#update_data_point_json'
   get '/api/reading/teams_json' => 'reading#teams_json'
   post '/api/reading/grouping_snapshot_json/:grouping_workspace_id' => 'reading#grouping_snapshot_json'
-  get '/api/reading/reading_debug_json' => 'reading#reading_debug_json'
-  get '/api/reading/star_reading_debug_json' => 'reading#star_reading_debug_json'
+
+  # reading_debug
+  get '/api/reading_debug/reading_debug_json' => 'reading_debug#reading_debug_json'
+  get '/api/reading_debug/star_reading_debug_json' => 'reading_debug#star_reading_debug_json'
 
   # classroom list creator
   get '/api/class_lists/workspaces_json' => 'class_lists#workspaces_json'
@@ -201,6 +203,7 @@ Rails.application.routes.draw do
     member do
       get '/debug' => 'ui#ui'
       get '/debug_star' => 'ui#ui'
+      get '/debug_csv' => 'reading_debug#reading_debug_csv'
     end
   end
 

--- a/spec/controllers/reading_controller_spec.rb
+++ b/spec/controllers/reading_controller_spec.rb
@@ -252,32 +252,4 @@ describe ReadingController, :type => :controller do
       })
     end
   end
-
-  describe '#reading_debug_json' do
-    it 'guards access' do
-      (Educator.all - [pals.uri]).each do |educator|
-        sign_in(educator)
-        get :reading_debug_json, params: { format: :json }
-        expect(response.status).to eq 403
-      end
-    end
-
-    it 'returns correct shape' do
-      sign_in(pals.uri)
-      get :reading_debug_json, params: { format: :json }
-      expect(response.status).to eq 200
-      json = JSON.parse(response.body)
-      expect(json.keys).to contain_exactly(*[
-        'students',
-        'groups'
-      ])
-      expect(json['students'].size).to eq 5
-      expect(json['students'].first.keys).to contain_exactly(*[
-        'id',
-        'first_name',
-        'last_name',
-        'grade'
-      ])
-    end
-  end
 end

--- a/spec/controllers/reading_debug_controller_spec.rb
+++ b/spec/controllers/reading_debug_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe ReadingDebugController, :type => :controller do
+  before { request.env['HTTPS'] = 'on' }
+  let!(:pals) { TestPals.create! }
+  let!(:time_now) { pals.time_now }
+
+  describe '#reading_debug_json' do
+    it 'guards access' do
+      (Educator.all - [pals.uri]).each do |educator|
+        sign_in(educator)
+        get :reading_debug_json, params: { format: :json }
+        expect(response.status).to eq 403
+      end
+    end
+
+    it 'returns correct shape' do
+      sign_in(pals.uri)
+      get :reading_debug_json, params: { format: :json }
+      expect(response.status).to eq 200
+      json = JSON.parse(response.body)
+      expect(json.keys).to contain_exactly(*[
+        'students',
+        'groups'
+      ])
+      expect(json['students'].size).to eq 5
+      expect(json['students'].first.keys).to contain_exactly(*[
+        'id',
+        'first_name',
+        'last_name',
+        'grade'
+      ])
+    end
+  end
+end


### PR DESCRIPTION
# Who is this PR for?
internal team, reading specialists or literacy coaches

# What problem does this PR fix?
There's no way to get all the reading data out for other analysis.  As we migrate more data in, this keeps other uses open.

Also factors out `<DownloadIcon />` svg.

# Screenshot (if adding a client-side feature)
<img width="1122" alt="Screen Shot 2019-05-17 at 10 26 06 AM" src="https://user-images.githubusercontent.com/1056957/57934699-40d68300-788e-11e9-81b1-c398e7a48bdb.png">


# Checklists
*Which features or pages does this PR touch?*
+ [x] Reading debug

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here