### PR TITLE
Counselor meetings: Limit scope to SHS and 9-12, regardless of authorization

### DIFF
--- a/app/controllers/counselor_meetings_controller.rb
+++ b/app/controllers/counselor_meetings_controller.rb
@@ -22,7 +22,7 @@ class CounselorMeetingsController < ApplicationController
     params.permit(:school_year)
     school_year = params.fetch(:school_year, SchoolYear.to_school_year(Time.now))
 
-    students = authorized do 
+    students = authorized do
       allowed_students.includes(:school, :student_photos).to_a
     end
     first_day_of_school = SchoolYear.first_day_of_school_for_year(school_year)
@@ -79,12 +79,12 @@ class CounselorMeetingsController < ApplicationController
   def allowed_students
     allowed_grades = ['9', '10', '11', '12']
     allowed_school_ids = [School.find_by_local_id('SHS').try(:id)].compact
-    
+
     Student.active
       .where(grade: allowed_grades)
       .where(school_id: allowed_school_ids)
   end
-  
+
   def students_json(students)
     students.as_json({
       only: [

--- a/app/controllers/counselor_meetings_controller.rb
+++ b/app/controllers/counselor_meetings_controller.rb
@@ -6,9 +6,7 @@ class CounselorMeetingsController < ApplicationController
     params.require(:student_id)
     params.require(:meeting_date)
 
-    student = authorized_or_raise! do
-      Student.find(params[:student_id])
-    end
+    student = find_authorized_student_or_raise!(params[:student_id])
     meeting = CounselorMeeting.create!({
       educator_id: current_educator.id,
       student_id: student.id,
@@ -24,7 +22,9 @@ class CounselorMeetingsController < ApplicationController
     params.permit(:school_year)
     school_year = params.fetch(:school_year, SchoolYear.to_school_year(Time.now))
 
-    students = authorized { Student.active.includes(:school, :student_photos).to_a }
+    students = authorized do 
+      allowed_students.includes(:school, :student_photos).to_a
+    end
     first_day_of_school = SchoolYear.first_day_of_school_for_year(school_year)
     meetings = CounselorMeeting.all
       .where(student_id: students.map(&:id))
@@ -40,7 +40,8 @@ class CounselorMeetingsController < ApplicationController
   def student_feed_cards_json
     params.require(:student_id)
     params.permit(:time_now)
-    student = authorized_or_raise! { Student.find(params[:student_id]) }
+    student = find_authorized_student_or_raise!(params[:student_id])
+
     time_now = time_now_or_param(params[:time_now])
     limit = 10
 
@@ -58,6 +59,13 @@ class CounselorMeetingsController < ApplicationController
     raise Exceptions::EducatorNotAuthorized unless current_educator.labels.include?('enable_counselor_meetings_page')
   end
 
+  # Also restrict by grade
+  def find_authorized_student_or_raise!(student_id)
+    authorized_or_raise! do
+      allowed_students.find(student_id)
+    end
+  end
+
   # Use time from value or fall back to Time.now
   def time_now_or_param(params_time_now)
     if params_time_now.present?
@@ -67,6 +75,16 @@ class CounselorMeetingsController < ApplicationController
     end
   end
 
+  # Limit by grade and school
+  def allowed_students
+    allowed_grades = ['9', '10', '11', '12']
+    allowed_school_ids = [School.find_by_local_id('SHS').try(:id)].compact
+    
+    Student.active
+      .where(grade: allowed_grades)
+      .where(school_id: allowed_school_ids)
+  end
+  
   def students_json(students)
     students.as_json({
       only: [

--- a/app/controllers/counselor_meetings_controller.rb
+++ b/app/controllers/counselor_meetings_controller.rb
@@ -62,7 +62,7 @@ class CounselorMeetingsController < ApplicationController
   # Also restrict by grade
   def find_authorized_student_or_raise!(student_id)
     authorized_or_raise! do
-      allowed_students.find(student_id)
+      allowed_students.find(student_id) # can raise a 404
     end
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -447,8 +447,6 @@ ActiveRecord::Schema.define(version: 2019_05_24_190130) do
     t.integer "educator_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "source"
-    t.text "benchmark_assessment_grade_level"
     t.index ["benchmark_assessment_key"], name: "index_reading_benchmark_data_points_on_benchmark_assessment_key"
     t.index ["benchmark_school_year", "benchmark_period_key"], name: "index_reading_benchmark_data_points_on_year_and_period_keys"
     t.index ["student_id"], name: "index_reading_benchmark_data_points_on_student_id"
@@ -475,19 +473,6 @@ ActiveRecord::Schema.define(version: 2019_05_24_190130) do
     t.string "local_id", null: false
     t.string "slug", null: false
     t.index ["local_id"], name: "index_schools_on_local_id"
-  end
-
-  create_table "second_transition_notes", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "educator_id"
-    t.bigint "student_id"
-    t.text "form_key", null: false
-    t.json "form_json", null: false
-    t.text "restricted_text"
-    t.boolean "starred", default: false
-    t.index ["educator_id"], name: "index_second_transition_notes_on_educator_id"
-    t.index ["student_id"], name: "index_second_transition_notes_on_student_id"
   end
 
   create_table "sections", id: :serial, force: :cascade do |t|
@@ -748,8 +733,6 @@ ActiveRecord::Schema.define(version: 2019_05_24_190130) do
   add_foreign_key "reading_benchmark_data_points", "students"
   add_foreign_key "reading_grouping_snapshots", "educators"
   add_foreign_key "reading_grouping_snapshots", "schools"
-  add_foreign_key "second_transition_notes", "educators"
-  add_foreign_key "second_transition_notes", "students"
   add_foreign_key "sections", "courses", name: "sections_course_id_fk"
   add_foreign_key "service_uploads", "educators", column: "uploaded_by_educator_id", name: "service_uploads_uploaded_by_educator_id_fk"
   add_foreign_key "services", "educators", column: "recorded_by_educator_id", name: "services_recorded_by_educator_id_fk"

--- a/spec/controllers/counselor_meetings_controller_spec.rb
+++ b/spec/controllers/counselor_meetings_controller_spec.rb
@@ -38,7 +38,7 @@ describe CounselorMeetingsController, :type => :controller do
           student_id: student.id,
           meeting_date: '2017-03-21'
         })
-        expect(response.status).to eq 403
+        expect(response.status).to eq 404
       end
     end
 
@@ -137,7 +137,7 @@ describe CounselorMeetingsController, :type => :controller do
     it 'guards access by student' do
       [pals.healey_kindergarten_student, pals.west_eighth_ryan].each do |student|
         get_student_feed_cards_json(pals.shs_sofia_counselor, student_id: student.id)
-        expect(response.status).to eq 403
+        expect(response.status).to eq 404
       end
     end
 


### PR DESCRIPTION
Follow on to https://github.com/studentinsights/studentinsights/pull/2477, explicitly limiting to SHS students.