### PR TITLE
Transition notes: Simplified inline read path, refactoring RestrictedNotePresence

### DIFF
--- a/app/assets/javascripts/my_notes/NotesFeed.js
+++ b/app/assets/javascripts/my_notes/NotesFeed.js
@@ -7,7 +7,7 @@ import BoxCard from '../components/BoxCard';
 import SectionHeading from '../components/SectionHeading';
 import WordCloud from '../components/WordCloud';
 import EventNoteCard from '../feed/EventNoteCard';
-import {urlForRestrictedEventNoteContent} from '../student_profile/RestrictedNotePresence';
+import {fetchRestrictedNoteText} from '../student_profile/RestrictedNotePresence';
 import NoteCard from '../student_profile/NoteCard';
 
 // Shows the feed of notes
@@ -56,8 +56,8 @@ export default class NotesFeed extends React.Component {
   renderEventNoteCard(eventNote, student, educator) {
     const {canUserAccessRestrictedNotes} = this.props;
     const isRedacted = eventNote.is_restricted;
-    const urlForRestrictedNoteContent = (canUserAccessRestrictedNotes && isRedacted)
-      ? urlForRestrictedEventNoteContent(eventNote)
+    const fetchRestrictedText = (canUserAccessRestrictedNotes && isRedacted)
+      ? () => fetchRestrictedNoteText(eventNote)
       : null;
     return (
       <NoteCard
@@ -69,7 +69,7 @@ export default class NotesFeed extends React.Component {
         lastRevisedAtMoment={eventNote.latest_revision_at ? toMomentFromRailsDate(eventNote.latest_revision_at) : null}
         attachments={eventNote.attachments}
         showRestrictedNoteRedaction={isRedacted}
-        urlForRestrictedNoteContent={urlForRestrictedNoteContent}
+        fetchRestrictedText={fetchRestrictedText}
         substanceOnly={true} // no shell
       />
     );

--- a/app/assets/javascripts/student_profile/NoteCard.js
+++ b/app/assets/javascripts/student_profile/NoteCard.js
@@ -99,7 +99,7 @@ export default class NoteCard extends React.Component {
   }
 
   renderRestrictedNoteRedaction() {
-    const {educator, urlForRestrictedNoteContent} = this.props;
+    const {educator, fetchRestrictedText} = this.props;
     const educatorName = formatEducatorName(educator);
     const educatorFirstNameOrEmail = educatorName.indexOf(' ') !== -1
       ? educatorName.split(' ')[0]
@@ -109,7 +109,7 @@ export default class NoteCard extends React.Component {
       <RestrictedNotePresence
         studentFirstName={null} // The student name isn't passed
         educatorName={educatorFirstNameOrEmail}
-        urlForRestrictedNoteContent={urlForRestrictedNoteContent}
+        fetchRestrictedText={fetchRestrictedText}
       />
     );
   }
@@ -238,7 +238,7 @@ NoteCard.propTypes = {
 
   // Configuring for different uses
   showRestrictedNoteRedaction: PropTypes.bool,
-  urlForRestrictedNoteContent: PropTypes.string,
+  fetchRestrictedText: PropTypes.func,
   substanceOnly: PropTypes.bool
 };
 

--- a/app/assets/javascripts/student_profile/NoteCard.test.js
+++ b/app/assets/javascripts/student_profile/NoteCard.test.js
@@ -4,6 +4,7 @@ import renderer from 'react-test-renderer';
 import _ from 'lodash';
 import moment from 'moment';
 import {IDLE, PENDING, ERROR} from '../helpers/requestStates';
+import {apiFetchJson} from '../helpers/apiFetchJson';
 import {studentProfile} from './fixtures/fixtures';
 import {withDefaultNowContext} from '../testing/NowContainer';
 import changeTextValue from '../testing/changeTextValue';
@@ -27,7 +28,7 @@ export function testProps(props = {}) {
 // Different scenarios for test/story
 export function testScenarios() {
   const attachments = [{id: 789, url: 'https://example.com/foo-is-a-really-long-fake-url-path-like-a-unique-doc-id-link'}];
-  const urlForRestrictedNoteContent = '/mocked-url-for-restricted-note-content';
+  const fetchRestrictedText = () => apiFetchJson('/mocked-url-for-restricted-note-content');
 
   const readonly = { onSave: null };
   const recentRevision = { lastRevisedAtMoment: moment.utc('2018-03-01T09:00:01.123Z') };
@@ -40,7 +41,7 @@ export function testScenarios() {
   const removableAttachments = { attachments, onEventNoteAttachmentDeleted: _.identity };
 
   const redacted = { showRestrictedNoteRedaction: true };
-  const canShowRedacted = { urlForRestrictedNoteContent };
+  const canShowRedacted = { fetchRestrictedText };
   
 
   return [
@@ -65,7 +66,7 @@ export function testScenarios() {
     { label: 'redacted, oldRevision', propsDiff: {...redacted, ...oldRevision} },
     { label: 'redacted, readonlyAttachments', propsDiff: {...redacted, ...readonlyAttachments} },
     { label: 'redacted, removableAttachments', propsDiff: {...redacted, ...removableAttachments} },
-    { label: 'redacted, canShowRedacted, urlForRestrictedNoteContent', propsDiff: {...redacted, ...canShowRedacted, ...urlForRestrictedNoteContent} },
+    { label: 'redacted, canShowRedacted, fetchRestrictedText', propsDiff: {...redacted, ...canShowRedacted, ...fetchRestrictedText} },
 
     { label: 'buggy call, editable, redacted', propsDiff: {...editable,...redacted} }
   ];

--- a/app/assets/javascripts/student_profile/NotesList.js
+++ b/app/assets/javascripts/student_profile/NotesList.js
@@ -13,7 +13,7 @@ import Educator from '../components/Educator';
 import NoteCard from './NoteCard';
 import SecondTransitionNoteInline from './SecondTransitionNoteInline';
 import {parseAndReRender} from './transitionNoteParser';
-import {urlForRestrictedEventNoteContent, urlForRestrictedTransitionNoteContent} from './RestrictedNotePresence';
+import {fetchRestrictedTransitionNoteText, fetchRestrictedNoteText} from './RestrictedNotePresence';
 import CleanSlateMessage, {defaultSchoolYearsBack, filteredNotesForCleanSlate} from './CleanSlateMessage';
 
 /*
@@ -83,8 +83,8 @@ export default class NotesList extends React.Component {
       (currentEducator.id !== eventNote.educator_id) ||
       isRedacted
     );
-    const urlForRestrictedNoteContent = (canUserAccessRestrictedNotes)
-      ? urlForRestrictedEventNoteContent(eventNote)
+    const fetchRestrictedText = (canUserAccessRestrictedNotes)
+      ? () => fetchRestrictedNoteText(eventNote)
       : null;
     const requestState = (isReadonly || !requests)
       ? IDLE
@@ -103,7 +103,7 @@ export default class NotesList extends React.Component {
         requestState={requestState}
         onSave={isReadonly ? null : onSaveNote}
         showRestrictedNoteRedaction={isRedacted}
-        urlForRestrictedNoteContent={urlForRestrictedNoteContent}
+        fetchRestrictedText={fetchRestrictedText}
         onEventNoteAttachmentDeleted={isReadonly ? null : onEventNoteAttachmentDeleted} />
     );
   }
@@ -112,8 +112,8 @@ export default class NotesList extends React.Component {
   renderTransitionNote(transitionNote) {
     const {canUserAccessRestrictedNotes, educatorsIndex} = this.props;
     const isRedacted = transitionNote.is_restricted;
-    const urlForRestrictedNoteContent = (canUserAccessRestrictedNotes)
-      ? urlForRestrictedTransitionNoteContent(transitionNote)
+    const fetchRestrictedText = (canUserAccessRestrictedNotes)
+      ? () => fetchRestrictedTransitionNoteText(transitionNote)
       : null;
     
     return (
@@ -124,7 +124,7 @@ export default class NotesList extends React.Component {
         educator={educatorsIndex[transitionNote.educator_id]}
         text={parseAndReRender(transitionNote.text)}
         showRestrictedNoteRedaction={isRedacted}
-        urlForRestrictedNoteContent={urlForRestrictedNoteContent}
+        fetchRestrictedText={fetchRestrictedText}
         attachments={[]} />
     );
   }

--- a/app/assets/javascripts/student_profile/RestrictedNotePresence.js
+++ b/app/assets/javascripts/student_profile/RestrictedNotePresence.js
@@ -81,7 +81,7 @@ export default class RestrictedNotePresence extends React.Component {
 RestrictedNotePresence.propTypes = {
   studentFirstName: PropTypes.string,
   educatorName: PropTypes.string,
-  fetchRestrictedText: PropTypes.string
+  fetchRestrictedText: PropTypes.func
 };
 
 const styles = {

--- a/app/assets/javascripts/student_profile/RestrictedNotePresence.js
+++ b/app/assets/javascripts/student_profile/RestrictedNotePresence.js
@@ -14,14 +14,8 @@ export default class RestrictedNotePresence extends React.Component {
       isViewing: false
     };
 
-    this.fetchRestrictedContent = this.fetchRestrictedContent.bind(this);
     this.onViewClicked = this.onViewClicked.bind(this);
-    this.renderRestrictedContent = this.renderRestrictedContent.bind(this);
-  }
-
-  fetchRestrictedContent() {
-    const {urlForRestrictedNoteContent} = this.props;
-    return apiFetchJson(urlForRestrictedNoteContent);
+    this.renderRestrictedText = this.renderRestrictedText.bind(this);
   }
 
   onViewClicked(e) {
@@ -30,10 +24,10 @@ export default class RestrictedNotePresence extends React.Component {
   }
 
   render() {
-    const {isViewing, urlForRestrictedNoteContent} = this.state;
+    const {isViewing, fetchRestrictedText} = this.state;
     return (
       <div className="RestrictedNotePresence">
-        {isViewing && !urlForRestrictedNoteContent
+        {isViewing && !fetchRestrictedText
           ? this.renderViewing()
           : this.renderRedaction()}
       </div>
@@ -41,7 +35,7 @@ export default class RestrictedNotePresence extends React.Component {
   }
 
   renderRedaction() {
-    const {studentFirstName, educatorName, urlForRestrictedNoteContent} = this.props;
+    const {studentFirstName, educatorName, fetchRestrictedText} = this.props;
     const educatorNameOrAdministrator = (educatorName)
       ? `${educatorName} or an administrator`
       : 'an administrator';
@@ -55,7 +49,7 @@ export default class RestrictedNotePresence extends React.Component {
           style={styles.restrictedNoteRedaction}
           text={`To respect ${studentFirstNameOrTheir} privacy, ${educatorNameOrAdministrator} marked this note as restricted.`}
         />
-        {urlForRestrictedNoteContent && 
+        {fetchRestrictedText && 
           <a
             href="#"
             style={styles.showLink}
@@ -66,19 +60,19 @@ export default class RestrictedNotePresence extends React.Component {
   }
 
   renderViewing() {
+    const {fetchRestrictedText} = this.props;
     return (
       <GenericLoader
-        promiseFn={this.fetchRestrictedContent}
-        render={this.renderRestrictedContent}
+        promiseFn={fetchRestrictedText}
+        render={this.renderRestrictedText}
       />
     );
   }
 
-  renderRestrictedContent(json) {
-    const {text} = json;
+  renderRestrictedText(restrictedText) {
     return (
       <div>
-        <NoteText text={text} />
+        <NoteText text={restrictedText} />
         <div style={styles.restrictedNoteLabel}>This is a restricted note.</div>
       </div>
     );
@@ -87,7 +81,7 @@ export default class RestrictedNotePresence extends React.Component {
 RestrictedNotePresence.propTypes = {
   studentFirstName: PropTypes.string,
   educatorName: PropTypes.string,
-  urlForRestrictedNoteContent: PropTypes.string
+  fetchRestrictedText: PropTypes.string
 };
 
 const styles = {
@@ -109,10 +103,12 @@ const styles = {
   }
 };
 
-export function urlForRestrictedTransitionNoteContent(transitionNote) {
-  return `/api/students/${transitionNote.student_id}/restricted_transition_note_json`;
+export function fetchRestrictedTransitionNoteText(transitionNote) {
+  const url = `/api/students/${transitionNote.student_id}/restricted_transition_note_json`;
+  return apiFetchJson(url).then(json => json.text);
 }
 
-export function urlForRestrictedEventNoteContent(eventNote) {
-  return `/api/event_notes/${eventNote.id}/restricted_note_json`;
+export function fetchRestrictedNoteText(eventNote) {
+  const url = `/api/event_notes/${eventNote.id}/restricted_note_json`;
+  return apiFetchJson(url).then(json => json.text);
 }

--- a/app/assets/javascripts/student_profile/RestrictedNotePresence.test.js
+++ b/app/assets/javascripts/student_profile/RestrictedNotePresence.test.js
@@ -3,14 +3,17 @@ import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 import renderer from 'react-test-renderer';
 import fetchMock from 'fetch-mock/es5/client';
-import RestrictedNotePresence from './RestrictedNotePresence';
+import RestrictedNotePresence, {
+  fetchRestrictedTransitionNoteText,
+  fetchRestrictedNoteText
+} from './RestrictedNotePresence';
 
 
 export function testProps(props = {}) {
   return {
     studentFirstName: 'Cassandra',
     educatorName: 'Darnell',
-    urlForRestrictedNoteContent: null,
+    fetchRestrictedText: null,
     ...props
   };
 }
@@ -37,10 +40,10 @@ it('renders without crashing', () => {
   expect(el.innerHTML).not.toContain('RESTRICTED');
 });
 
-it('allows viewing by EventNote URL', done => {
+it('works with fetchRestrictedNoteText', done => {
   mockFetch();
-  const urlForRestrictedNoteContent = '/api/event_notes/42/restricted_note_json';
-  const props = testProps({urlForRestrictedNoteContent});
+  const fetchRestrictedText = () => fetchRestrictedNoteText({id: 42 });
+  const props = testProps({fetchRestrictedText});
   const el = document.createElement('div');
   ReactDOM.render(testEl(props), el);
   expect(el.innerHTML).toContain('show restricted note');
@@ -54,10 +57,10 @@ it('allows viewing by EventNote URL', done => {
   }, 0);
 });
 
-it('allows viewing TransitionNote', done => {
+it('works with fetchRestrictedTransitionNoteText', done => {
   mockFetch();
-  const urlForRestrictedNoteContent = '/api/students/73/restricted_transition_note_json';
-  const props = testProps({urlForRestrictedNoteContent});
+  const fetchRestrictedText = () => fetchRestrictedTransitionNoteText({student_id: 63 });
+  const props = testProps({fetchRestrictedText});
   const el = document.createElement('div');
   ReactDOM.render(testEl(props), el);
   expect(el.innerHTML).toContain('show restricted note');

--- a/app/assets/javascripts/student_profile/SecondTransitionNoteDialog.js
+++ b/app/assets/javascripts/student_profile/SecondTransitionNoteDialog.js
@@ -341,7 +341,7 @@ function promptFor(firstName, key) {
   }[key];
 }
 
-export function renderAsText(studentFirstName, json) {
+export function renderAsTextWithoutRestrictedText(studentFirstName, json) {
   const keys = [STRENGTHS, CONNECTING, COMMUNITY, PEERS, FAMILY, OTHER];
   const pieces = keys.map(key => {
     return [
@@ -349,10 +349,7 @@ export function renderAsText(studentFirstName, json) {
       json.form_json[key]
     ].join("\n");
   });
-  const maybeRestrictedPiece = (json.has_restricted_text)
-    ? 'What other services do they receive?\nReach out to the counselor if you need to more about anything confidential or sensitive.'
-    : '';
-  return pieces.concat(maybeRestrictedPiece).join('\n\n').trim();
+  return pieces.join('\n\n').trim();
 }
 
 // restricted text is not included here

--- a/app/assets/javascripts/student_profile/SecondTransitionNoteInline.js
+++ b/app/assets/javascripts/student_profile/SecondTransitionNoteInline.js
@@ -1,13 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {apiFetchJson} from '../helpers/apiFetchJson';
+import {formatEducatorName} from '../helpers/educatorName';
 import SecondTransitionNoteDialog, {
-  renderAsText,
+  renderAsTextWithoutRestrictedText,
   docFromJson,
   enableTransitionNoteDialog
 } from './SecondTransitionNoteDialog';
 import GenericLoader from '../components/GenericLoader';
 import NoteText from '../components/NoteText';
+import RestrictedNotePresence from '../student_profile/RestrictedNotePresence';
 
 
 export default class SecondTransitionNoteInline extends React.Component {
@@ -19,33 +21,63 @@ export default class SecondTransitionNoteInline extends React.Component {
   }
 
   render() {
-    const {json, student, currentEducator} = this.props;
+    const {json, student} = this.props;
+    const text = renderAsTextWithoutRestrictedText(student.first_name, json);
+
+    return (
+      <div className="SecondTransitionNoteInline">
+        <NoteText text={text} />
+        {this.renderRestrictedInline()}
+        {this.renderEditLink()}
+      </div>
+    );
+  }
+
+  renderRestrictedInline() {
+    const {student, currentEducator, json} = this.props;
+    const educatorName = formatEducatorName(currentEducator);
+    const educatorFirstNameOrEmail = educatorName.indexOf(' ') !== -1
+      ? educatorName.split(' ')[0]
+      : educatorName;
+    const url = `/api/students/${student.id}/second_transition_notes/${json.id}/restricted_text_json`;
+    const fetchRestrictedText = () => apiFetchJson(url).then(json => json.restricted_text);
+    
+    return (
+      <div>
+        <div><br/>What other services does {student.first_name} receive now, and who are the points of contact (eg, social workers, mental health counselors)?</div>
+        <RestrictedNotePresence
+          studentFirstName={student.first_name}
+          educatorName={educatorFirstNameOrEmail}
+          fetchRestrictedText={fetchRestrictedText}
+        />
+      </div>
+    );
+  }
+
+  renderEditLink() {
+    const {student, currentEducator} = this.props;
     const {isOpen} = this.state;
-    const text = renderAsText(student.first_name, json);
     const showEditLink = (
       (window.location.search.indexOf('enable_editing') !== -1) &&
       enableTransitionNoteDialog(currentEducator, student.grade)
     );
 
     return (
-      <div className="SecondTransitionNoteInline">
-        <NoteText text={text} />
-        <div style={{display: 'flex', flexDirection: 'row'}}>
-          {showEditLink && (
-            <a style={styles.link} href="#" onClick={e => {
-              e.preventDefault();
-              this.setState({isOpen: true});
-            }}>Edit transition note</a>
-          )}
-          <div style={{display: 'inline-block'}}>
-            {isOpen && this.renderTransitionNoteDialog()}
-          </div>
+      <div style={{display: 'flex', flexDirection: 'row'}}>
+        {showEditLink && (
+          <a style={styles.link} href="#" onClick={e => {
+            e.preventDefault();
+            this.setState({isOpen: true});
+          }}>Edit transition note</a>
+        )}
+        <div style={{display: 'inline-block'}}>
+          {isOpen && this.renderTransitionNoteDialog()}
         </div>
       </div>
     );
   }
 
-  // Before loading, fetching the actual content of the 
+  // Before loading, fetching the actual content of the restricted note too.
   renderTransitionNoteDialog() {
     const {student, json} = this.props;
     const studentId = json.student_id;

--- a/app/assets/javascripts/student_profile/__snapshots__/NoteCard.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/NoteCard.test.js.snap
@@ -2635,7 +2635,7 @@ Array [
   <div>
     <h3>
       scenario for snapshot: 
-      redacted, canShowRedacted, urlForRestrictedNoteContent
+      redacted, canShowRedacted, fetchRestrictedText
     </h3>
     <div
       className="NoteShell"


### PR DESCRIPTION
# Who is this PR for?
9th grade counselors

# What problem does this PR fix?
The dialog view for editing and viewing transition notes is more complex, and the inline view didn't let them read restricted information.

# What does this PR do?
Refactors `<RestrictedNotePresence />` to use it inline for reading transition notes.

# Screenshot (if adding a client-side feature)
<img width="515" alt="Screen Shot 2019-05-28 at 10 14 26 AM" src="https://user-images.githubusercontent.com/1056957/58485268-b31e5180-8131-11e9-95fd-b160a10c5bd4.png">
<img width="508" alt="Screen Shot 2019-05-28 at 10 14 38 AM" src="https://user-images.githubusercontent.com/1056957/58485269-b31e5180-8131-11e9-8bd3-4334ac82aa56.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile
+ [x] My notes

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here