### PR TITLE
Transition notes: Show new transition inline in profile list after saving

### DIFF
--- a/app/assets/javascripts/helpers/InsightsPropTypes.js
+++ b/app/assets/javascripts/helpers/InsightsPropTypes.js
@@ -8,7 +8,8 @@ export const actions = PropTypes.shape({
   onCreateNewNote: PropTypes.func.isRequired,
   onDeleteEventNoteAttachment: PropTypes.func.isRequired,
   onSaveService: PropTypes.func.isRequired,
-  onDiscontinueService: PropTypes.func.isRequired
+  onDiscontinueService: PropTypes.func.isRequired,
+  onSecondTransitionNoteAdded: PropTypes.func.isRequired
 });
 
 export const requests = PropTypes.shape({

--- a/app/assets/javascripts/home/TransitionNotesBox.js
+++ b/app/assets/javascripts/home/TransitionNotesBox.js
@@ -15,7 +15,7 @@ export default class TransitionNotesBox extends React.Component {
       <div style={style}>
         <div style={titleStyle}>School transitions for {schoolYear+1}</div>
         <Card style={{border: 'none'}}>
-          <div>Add <a style={{fontWeight: 'bold'}} href="/counselors/transitions">transition notes</a> and introduce your students to the educators working with them next year.</div>
+          <div>Add <a style={{fontWeight: 'bold'}} href="/counselors/transitions">transition notes</a> to introduce your colleagues to the students you worked with this year.</div>
         </Card>
       </div>
     );

--- a/app/assets/javascripts/home/__snapshots__/TransitionNotesBox.test.js.snap
+++ b/app/assets/javascripts/home/__snapshots__/TransitionNotesBox.test.js.snap
@@ -40,7 +40,7 @@ exports[`snapshots if label is set 1`] = `
       >
         transition notes
       </a>
-       and introduce your students to the educators working with them next year.
+       to introduce your colleagues to the students you worked with this year.
     </div>
   </div>
 </div>

--- a/app/assets/javascripts/student_profile/LightNotesDetails.js
+++ b/app/assets/javascripts/student_profile/LightNotesDetails.js
@@ -95,12 +95,20 @@ export default class LightNotesDetails extends React.Component {
   }
 
   renderSecondTransitionNoteDialog() {
-    const {student, isWritingTransitionNote, onWritingTransitionNoteChanged} = this.props;
+    const {
+      actions,
+      student,
+      currentEducator,
+      isWritingTransitionNote,
+      onWritingTransitionNoteChanged
+    } = this.props;
 
     if (!isWritingTransitionNote) return null;
     return (
       <SecondTransitionNoteDialog
         student={student}
+        educatorId={currentEducator.id}
+        onSavedJson={json => actions.onSecondTransitionNoteAdded(json)}
         onClose={() => onWritingTransitionNoteChanged(false)}
       />
     );

--- a/app/assets/javascripts/student_profile/NotesList.js
+++ b/app/assets/javascripts/student_profile/NotesList.js
@@ -119,7 +119,7 @@ export default class NotesList extends React.Component {
     return (
       <NoteCard
         key={['transition_note', transitionNote.id].join()}
-        noteMoment={toMomentFromRailsDate(transitionNote.created_at)}
+        noteMoment={toMomentFromRailsDate(transitionNote.recorded_at)}
         badgeEl="Transition note"
         educator={educatorsIndex[transitionNote.educator_id]}
         text={parseAndReRender(transitionNote.text)}
@@ -154,7 +154,7 @@ export default class NotesList extends React.Component {
     return (
       <NoteShell
         key={['second_transition_note', secondTransitionNote.id].join()}
-        whenEl={whenText(secondTransitionNote.created_at)}
+        whenEl={whenText(secondTransitionNote.recorded_at)}
         badgeEl="Transition note"
         educatorEl={<Educator educator={educator} />}
         substanceEl={

--- a/app/assets/javascripts/student_profile/PageContainer.js
+++ b/app/assets/javascripts/student_profile/PageContainer.js
@@ -26,6 +26,7 @@ export default class PageContainer extends React.Component {
     this.onUpdateExistingNoteDone = this.onUpdateExistingNoteDone.bind(this);
     this.onUpdateExistingNoteFail = this.onUpdateExistingNoteFail.bind(this);
     this.onDeleteEventNoteAttachment = this.onDeleteEventNoteAttachment.bind(this);
+    this.onSecondTransitionNoteAdded = this.onSecondTransitionNoteAdded.bind(this);
 
     this.onSaveService = this.onSaveService.bind(this);
     this.onSaveServiceDone = this.onSaveServiceDone.bind(this);
@@ -142,6 +143,19 @@ export default class PageContainer extends React.Component {
     }));
   }
 
+  // The transition note UI handles server communication, state changes, etc.
+  // but notifies back when this is done so the profile notes list can update.
+  onSecondTransitionNoteAdded(secondTransitionNote) {
+    const {feed} = this.state;
+    const secondTransitionNotes = feed.second_transition_notes;
+    this.setState({
+      feed: {
+        ...feed,
+        second_transition_notes: [secondTransitionNote].concat(secondTransitionNotes)
+      }
+    });
+  }
+
   // TODO(kr) does this work for not-yet-created notes?
   onDeleteEventNoteAttachment(eventNoteAttachmentId) {
     // optimistically update the UI
@@ -244,6 +258,7 @@ export default class PageContainer extends React.Component {
       onColumnClicked: this.onColumnClicked,
       onUpdateExistingNote: this.onUpdateExistingNote,
       onCreateNewNote: this.onCreateNewNote,
+      onSecondTransitionNoteAdded: this.onSecondTransitionNoteAdded,
       onDeleteEventNoteAttachment: this.onDeleteEventNoteAttachment,
       onSaveService: this.onSaveService,
       onDiscontinueService: this.onDiscontinueService,

--- a/app/assets/javascripts/student_profile/PageContainer.mocks.js
+++ b/app/assets/javascripts/student_profile/PageContainer.mocks.js
@@ -7,7 +7,8 @@ export function createSpyActions() {
     onCreateNewNote: jest.fn(),
     onDeleteEventNoteAttachment: jest.fn(),
     onSaveService: jest.fn(),
-    onDiscontinueService: jest.fn()
+    onDiscontinueService: jest.fn(),
+    onSecondTransitionNoteAdded: jest.fn()
   };
 }
 

--- a/app/assets/javascripts/student_profile/SecondTransitionNoteDialog.js
+++ b/app/assets/javascripts/student_profile/SecondTransitionNoteDialog.js
@@ -41,7 +41,8 @@ export default class SecondTransitionNoteDialog extends React.Component {
 
   onSaveClick(doSave, e) {
     e.preventDefault();
-    doSave();
+    const {onSavedJson} = this.props;
+    doSave().then(json => onSavedJson && onSavedJson(json));
   }
 
   onNextClick(doSave, e) {
@@ -69,12 +70,13 @@ export default class SecondTransitionNoteDialog extends React.Component {
   }
 
   render() {
-    const {student, initialId, initialDoc} = this.props;
+    const {student, initialId, initialDoc, educatorId} = this.props;
     return (
       <SecondTransitionNoteServerBridge
         initialId={initialId}
         initialDoc={initialDoc}
-        studentId={student.id}>
+        studentId={student.id}
+        educatorId={educatorId}>
         {bridge => (
           <ReactModal
             isOpen={true}
@@ -237,10 +239,12 @@ export default class SecondTransitionNoteDialog extends React.Component {
   }
 }
 SecondTransitionNoteDialog.propTypes = {
+  educatorId: PropTypes.number.isRequired,
   student: PropTypes.shape({
     id: PropTypes.number.isRequired,
     first_name: PropTypes.string.isRequired
   }).isRequired,
+  onSavedJson: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   initialId: PropTypes.number,
   initialDoc: PropTypes.object

--- a/app/assets/javascripts/student_profile/SecondTransitionNoteInline.js
+++ b/app/assets/javascripts/student_profile/SecondTransitionNoteInline.js
@@ -35,13 +35,14 @@ export default class SecondTransitionNoteInline extends React.Component {
 
   renderRestrictedInline() {
     const {student, currentEducator, json} = this.props;
+    if (!json.has_restricted_text) return null;
+    
     const educatorName = formatEducatorName(currentEducator);
     const educatorFirstNameOrEmail = educatorName.indexOf(' ') !== -1
       ? educatorName.split(' ')[0]
       : educatorName;
     const url = `/api/students/${student.id}/second_transition_notes/${json.id}/restricted_text_json`;
     const fetchRestrictedText = () => apiFetchJson(url).then(json => json.restricted_text);
-    
     return (
       <div>
         <div><br/>What other services does {student.first_name} receive now, and who are the points of contact (eg, social workers, mental health counselors)?</div>

--- a/app/assets/javascripts/student_profile/SecondTransitionNoteInline.js
+++ b/app/assets/javascripts/student_profile/SecondTransitionNoteInline.js
@@ -26,9 +26,36 @@ export default class SecondTransitionNoteInline extends React.Component {
 
     return (
       <div className="SecondTransitionNoteInline">
+        {this.renderStarred()}
         <NoteText text={text} />
         {this.renderRestrictedInline()}
         {this.renderEditLink()}
+      </div>
+    );
+  }
+
+  renderStarred() {
+    const {json} = this.props;
+
+    if (!json.starred) return null;
+    return (
+      <div style={{
+        display: 'inline-block',
+        marginTop: 5,
+        marginBottom: 10
+      }}>
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          border: '1px solid #ffe10080',
+          borderRadius: 3,
+          padding: 5,
+          paddingRight: 15,
+          background: '#ffe1001a'
+        }}>
+          <span style={{fontSize: 20, marginRight: 5}}>⭐</span>
+          <span>Starred for transition discussion</span>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
# Who is this PR for?
8th grade counselors

# What problem does this PR fix?
New transition notes don't appear inline, so it's not clear that they are saved.

# What does this PR do?
Fixes that, updating the UI on confirmed save.  This punts on editing inline still.


# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here