### PR TITLE
Transition notes: Support limited transition from 5th > 6th in Somerville

### DIFF
--- a/app/assets/javascripts/student_profile/LightNotesDetails.js
+++ b/app/assets/javascripts/student_profile/LightNotesDetails.js
@@ -117,9 +117,7 @@ export default class LightNotesDetails extends React.Component {
   renderTakeNotesButton() {
     const {currentEducator, student} = this.props;
 
-    // Only K8 counselors with access can write transition notes,
-    // and only for 8th graders.
-    const showSecondTransitionNoteLink = enableTransitionNoteDialog(currentEducator, student.grade);
+    const showSecondTransitionNoteLink = enableTransitionNoteDialog(currentEducator, student);
     return (
       <div>
         {showSecondTransitionNoteLink && (

--- a/app/assets/javascripts/student_profile/SecondTransitionNoteDialog.js
+++ b/app/assets/javascripts/student_profile/SecondTransitionNoteDialog.js
@@ -373,13 +373,27 @@ export function docFromJson(json) {
 }
 
 
-// Only K8 counselors with access can write or edit transition notes,
-// and only for 8th graders.
-export function enableTransitionNoteDialog(currentEducator, studentGrade) {
-  return (
+/*
+Two buckets of transition notes:
+  1) K8 counselors with access can write transition notes for 8th > 9th graders.
+  2) Anyone with restricted acccess at a particular school, for 5th > 6th graders.
+*/
+export function enableTransitionNoteDialog(currentEducator, studentFromProfile) {
+  // 8th > 9th
+  if (
     (currentEducator.labels.indexOf('k8_counselor') !== -1) &&
     (currentEducator.labels.indexOf('enable_transition_note_features') !== -1) &&
     (currentEducator.can_view_restricted_notes) &&
-    (studentGrade === '8')
-  );
+    (studentFromProfile.grade === '8')
+  ) return true;
+
+  // 5th > 6th
+  if (
+    (currentEducator.labels.indexOf('enable_transition_note_features') !== -1) &&
+    (currentEducator.can_view_restricted_notes) &&
+    (studentFromProfile.school.local_id.toUpperCase() === 'BRN') &&
+    (studentFromProfile.grade === '5')
+  ) return true;
+
+  return false;
 }

--- a/app/assets/javascripts/student_profile/SecondTransitionNoteInline.js
+++ b/app/assets/javascripts/student_profile/SecondTransitionNoteInline.js
@@ -87,7 +87,7 @@ export default class SecondTransitionNoteInline extends React.Component {
     const {isOpen} = this.state;
     const showEditLink = (
       (window.location.search.indexOf('enable_editing') !== -1) &&
-      enableTransitionNoteDialog(currentEducator, student.grade)
+      enableTransitionNoteDialog(currentEducator, student)
     );
 
     return (

--- a/app/models/second_transition_note.rb
+++ b/app/models/second_transition_note.rb
@@ -1,6 +1,6 @@
 class SecondTransitionNote < ApplicationRecord
-  SOMERVILLE_8TH_TO_9TH_GRADE = 'somerville_8th_to_9th_grade'
-  SOMERVILLE_8TH_TO_9TH_GRADE_KEYS = [
+  SOMERVILLE_TRANSITION_2019 = 'somerville_8th_to_9th_grade' # also used for 5th > 6th
+  SOMERVILLE_TRANSITION_2019_KEYS = [
     'strengths',
     'connecting',
     'community',
@@ -18,7 +18,7 @@ class SecondTransitionNote < ApplicationRecord
   validates :form_json, presence: true
   validates :form_key, inclusion: {
     in: [
-      SOMERVILLE_8TH_TO_9TH_GRADE
+      SOMERVILLE_TRANSITION_2019
     ]
   }
   validate :validate_form_json_keys
@@ -48,11 +48,11 @@ class SecondTransitionNote < ApplicationRecord
 
   private
   def validate_form_json_keys
-    if self.form_key == SOMERVILLE_8TH_TO_9TH_GRADE
-      missing_keys = (SOMERVILLE_8TH_TO_9TH_GRADE_KEYS - self.form_json.keys).sort
+    if self.form_key == SOMERVILLE_TRANSITION_2019
+      missing_keys = (SOMERVILLE_TRANSITION_2019_KEYS - self.form_json.keys).sort
       errors.add(:form_json, "missing expected keys: #{missing_keys.join(',')}") if missing_keys.size > 0
 
-      extra_keys = (self.form_json.keys - SOMERVILLE_8TH_TO_9TH_GRADE_KEYS).sort
+      extra_keys = (self.form_json.keys - SOMERVILLE_TRANSITION_2019_KEYS).sort
       errors.add(:form_json, "extra keys: #{extra_keys.join(',')}") if extra_keys.size > 0
     end
   end

--- a/spec/controllers/second_transition_notes_controller_spec.rb
+++ b/spec/controllers/second_transition_notes_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SecondTransitionNotesController, type: :controller do
   def create_note_attrs(attrs = {})
     {
       recorded_at: pals.time_now - 4.days,
-      form_key: SecondTransitionNote::SOMERVILLE_8TH_TO_9TH_GRADE,
+      form_key: SecondTransitionNote::SOMERVILLE_TRANSITION_2019,
       starred: false,
       form_json: {
         'strengths' => 'foo strengths',

--- a/spec/models/second_transition_note_spec.rb
+++ b/spec/models/second_transition_note_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe SecondTransitionNote, type: :model do
   end
 
   describe 'validations' do
-    it 'enforces form_json keys for SOMERVILLE_8TH_TO_9TH_GRADE' do
+    it 'enforces form_json keys for SOMERVILLE_TRANSITION_2019' do
       note = SecondTransitionNote.create({
         recorded_at: pals.time_now - 5.days,
         educator: pals.west_counselor,
         student: pals.west_eighth_ryan,
-        form_key: SecondTransitionNote::SOMERVILLE_8TH_TO_9TH_GRADE,
+        form_key: SecondTransitionNote::SOMERVILLE_TRANSITION_2019,
         form_json: {
           strengths: '',
           connecting: '',

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -263,7 +263,7 @@ class TestPals
       recorded_at: time_now - 4.days,
       educator: @west_counselor,
       student: @west_eighth_ryan,
-      form_key: SecondTransitionNote::SOMERVILLE_8TH_TO_9TH_GRADE,
+      form_key: SecondTransitionNote::SOMERVILLE_TRANSITION_2019,
       form_json: {
         strengths: 'Ryan is polite and able to diffuse difficult social situations or potential conflicts.  He enjoys playing with technology and swimming.',
         connecting: 'Asking him about scouting can work well talking 1:1, or in the classroom he sometimes like being seen as a leader with setting up the computer or projector system.',


### PR DESCRIPTION
# Who is this PR for?
Students and families in 5th grade at once school, transitioning schools

# What problem does this PR fix?
Help support counselors and admin in transitions across years and buildings.

# What does this PR do?
Extends the 8th > 9th grade transition to be used in a similar way for counselors and admin in one school for students transitioning schools at 6th grade.  This maps mostly directly to the 8th > 9th grade transition, in particular with how restricted information is handled.

Separately, other schools with program shifts where students switch buildings will do this also, but in different ways (eg, Somerville Argenziano program, Bedford elementary schools), and those import processes can be tackled separately in the summer so they're all ready for the fall.  They may re-use parts of the model or UI here but for now this PR punts on that to the minimal change needed during the time before the end of the school year.

As a caveat, for folks working K5 with districtwide access, the "Jump to next student" isn't smart enough to know they are only doing this for a smaller subset of students, but they can workaround using the "School transitions page."

# Checklists
*Which features or pages does this PR touch?*
+ [x] School transitions
+ [x] Student profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here