### PR TITLE
Reader profile: Update date info to be months, not days

### DIFF
--- a/app/assets/javascripts/reader_profile/ChipForDibels.js
+++ b/app/assets/javascripts/reader_profile/ChipForDibels.js
@@ -13,7 +13,7 @@ import {
   DIBELS_UNKNOWN
 } from '../reading/readingData';
 import {somervilleReadingThresholdsFor} from '../reading/thresholds';
-import HoverSummary, {thresholdsExplanation, secondLineDaysAgo} from './HoverSummary';
+import HoverSummary, {thresholdsExplanation, secondLineMonthsAgo} from './HoverSummary';
 import Tooltip from './Tooltip';
 import Freshness from './Freshness';
 import {TwoLineChip} from './layout';
@@ -56,7 +56,7 @@ export default class ChipForDibels extends React.Component {
           <Tooltip tooltipStyle={{minWidth: 400}} title={
             <HoverSummary
               name={prettyAssessmentText}
-              atMoment={dataPointMoment(mostRecentDataPoint)}
+              atMoment={atMoment}
               period={`${mostRecentDataPoint.benchmark_period_key} ${mostRecentDataPoint.benchmark_school_year} in ${gradeText(gradeThen)}`}
               score={score}
               thresholds={thresholdsExplanation(thresholds)}
@@ -69,7 +69,7 @@ export default class ChipForDibels extends React.Component {
                   ? prettyAssessmentText
                   : shortDibelsText(mostRecentDataPoint.benchmark_assessment_key);
               }}
-              secondLine={({width}) => secondLineDaysAgo(daysAgo, width)}
+              secondLine={({width}) => secondLineMonthsAgo(daysAgo, width)}
             />
           </Tooltip>
         </Concern>

--- a/app/assets/javascripts/reader_profile/ChipForFAndPEnglish.js
+++ b/app/assets/javascripts/reader_profile/ChipForFAndPEnglish.js
@@ -7,7 +7,7 @@ import {
   benchmarkPeriodToMoment
 } from '../reading/readingData';
 import {somervilleReadingThresholdsFor} from '../reading/thresholds';
-import HoverSummary, {thresholdsExplanation, secondLineDaysAgo} from './HoverSummary';
+import HoverSummary, {thresholdsExplanation, secondLineMonthsAgo} from './HoverSummary';
 import Tooltip from './Tooltip';
 import Freshness from './Freshness';
 import {TwoLineChip} from './layout';
@@ -63,7 +63,7 @@ export default class ChipForFAndPEnglish extends React.Component {
                   ? prettyAssessmentText
                   : 'F&P';
               }}
-              secondLine={({width}) => secondLineDaysAgo(daysAgo, width)}
+              secondLine={({width}) => secondLineMonthsAgo(daysAgo, width)}
             />
           </Tooltip>
         </Concern>

--- a/app/assets/javascripts/reader_profile/ChipForLanguage.js
+++ b/app/assets/javascripts/reader_profile/ChipForLanguage.js
@@ -5,7 +5,7 @@ import {toMomentFromTimestamp} from '../helpers/toMoment';
 import LanguageStatusLink from '../student_profile/LanguageStatusLink';
 import {TwoLineChip} from './layout';
 import {Concern} from './containers';
-import HoverSummary, {secondLineDaysAgo} from './HoverSummary';
+import HoverSummary, {secondLineMonthsAgo} from './HoverSummary';
 import Tooltip from './Tooltip';
 import Freshness from './Freshness';
 
@@ -55,7 +55,7 @@ export default class ChipForLanguage extends React.Component {
           }>
             <TwoLineChip
               firstLine={languageStatusEl}
-              secondLine={({width}) => secondLineDaysAgo(daysAgo, width)}
+              secondLine={({width}) => secondLineMonthsAgo(daysAgo, width)}
             />
           </Tooltip>
         </Concern>

--- a/app/assets/javascripts/reader_profile/HoverSummary.js
+++ b/app/assets/javascripts/reader_profile/HoverSummary.js
@@ -12,11 +12,11 @@ export default class HoverSummary extends React.Component {
     const {nowFn} = this.context;
     const {name, atMoment, period, score, thresholds, concernKey} = this.props;
 
-    const daysAgoText = atMoment
-      ? `${nowFn().clone().diff(atMoment, 'days')} days ago`
+    const monthsAgoText = atMoment
+      ? `${nowFn().clone().diff(atMoment, 'months')} months ago`
       : `unknown`;
     const title = _.compact([
-      `Freshness: ${daysAgoText}`,
+      `Freshness: ${monthsAgoText}`,
       (period ? `Period: ${period}` : null),
       ((score || thresholds) ? '' : null),
       (score ? `Score: ${score}` : null),
@@ -44,6 +44,10 @@ HoverSummary.propTypes = {
   concernKey: PropTypes.string
 };
 
+
+export function secondLineMonthsAgo(daysAgo, width) {
+  return `${Math.round(daysAgo / 30)} mos`;
+}
 
 export function secondLineDaysAgo(daysAgo, width) {
   if (daysAgo === null || daysAgo === undefined) return null;

--- a/app/assets/javascripts/reader_profile/__snapshots__/ReaderProfileJune.test.js.snap
+++ b/app/assets/javascripts/reader_profile/__snapshots__/ReaderProfileJune.test.js.snap
@@ -705,6 +705,16 @@ exports[`snapshots view 1`] = `
                               No English Learner data
                             </div>
                           </div>
+                          <div
+                            style={
+                              Object {
+                                "height": 19,
+                                "overflow": "hidden",
+                              }
+                            }
+                          >
+                            0 mos
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -884,6 +894,16 @@ exports[`snapshots view 1`] = `
                             >
                               No English Learner data
                             </div>
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "height": 19,
+                                "overflow": "hidden",
+                              }
+                            }
+                          >
+                            0 mos
                           </div>
                         </div>
                       </div>
@@ -2087,7 +2107,7 @@ exports[`snapshots view 1`] = `
                                   }
                                 }
                               >
-                                -413d
+                                -14 mos
                               </div>
                             </div>
                           </div>


### PR DESCRIPTION
# Who is this PR for?
K3 educators

# What problem does this PR fix?
Days are not simple enough, and months better indicates the "freshness" opacity gradient

# What does this PR do?
Adjusts times to be reference in terms of "months ago" instead of days.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
