### PR TITLE
Transitions: Fix bug in which students are in scope for elementary transitions

### DIFF
--- a/app/controllers/second_transition_notes_controller.rb
+++ b/app/controllers/second_transition_notes_controller.rb
@@ -138,6 +138,7 @@ class SecondTransitionNotesController < ApplicationController
 
     # 5th > 6th graders at one particular school.
     to_middle_school = Student.active.where({
+      grade: '5',
       school_id: School.find_by_local_id('BRN').try(:id)
     })
 


### PR DESCRIPTION
Fixes a bug in https://github.com/studentinsights/studentinsights/pull/2495 with the scoping for 5th > 6th grade students changing schools.