### PR TITLE
Reader profile: months ago, multiple chips for services

### DIFF
--- a/app/assets/javascripts/reader_profile/ChipForService.js
+++ b/app/assets/javascripts/reader_profile/ChipForService.js
@@ -1,30 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
 import {toMomentFromTimestamp} from '../helpers/toMoment';
 import Freshness from './Freshness';
+import Tooltip from './Tooltip';
 import {Support, noteChipStyle} from './containers';
 import {TwoLineChip} from './layout';
-
+import HoverSummary, {secondLineMonthsAgo} from './HoverSummary';
 
 export default class ChipForService extends React.Component {
   render() {
     const {nowFn} = this.context;
-    const {serviceTypeId, matchingServices} = this.props;
-    const daysAgos = _.compact(matchingServices.map(service => {
-      const momentStarted = toMomentFromTimestamp(service.date_started);
-      return momentStarted ? nowFn().clone().diff(momentStarted, 'days') : null;
-    }));
-    const secondLine = daysAgos.map(daysAgo => `${daysAgo} days ago`).join(' and ');
-    
+    const {service} = this.props;
+    const momentStarted = toMomentFromTimestamp(service.date_started);
+    const daysAgo = momentStarted ? nowFn().clone().diff(momentStarted, 'days') : null;
+    const serviceName = service.service_type.name;
+
     return (
-      <Freshness daysAgo={Math.max(...daysAgos)}>
+      <Freshness daysAgo={daysAgo}>
         <Support style={noteChipStyle}>
-          <TwoLineChip
-            key={serviceTypeId}
-            firstLine={matchingServices[0].service_type.name}
-            secondLine={secondLine}
-          />
+          <Tooltip tooltipStyle={{minWidth: 400}} title={
+            <HoverSummary name={serviceName} atMoment={momentStarted} />
+          }>
+            <TwoLineChip
+              firstLine={serviceName}
+              secondLine={secondLineMonthsAgo(daysAgo)}
+            />
+          </Tooltip>
         </Support>
       </Freshness>
     );
@@ -34,13 +35,12 @@ ChipForService.contextTypes = {
   nowFn: PropTypes.func.isRequired
 };
 ChipForService.propTypes = {
-  serviceTypeId: PropTypes.number.isRequired,
-  matchingServices: PropTypes.arrayOf(PropTypes.shape({
+  service: PropTypes.shape({
     id: PropTypes.number.isRequired,
     date_started: PropTypes.string.isRequired,
     service_type_id: PropTypes.number.isRequired,
     service_type: PropTypes.shape({
       name: PropTypes.string.isRequired
     }).isRequired
-  })).isRequired
+  }).isRequired
 };

--- a/app/assets/javascripts/reader_profile/HoverSummary.js
+++ b/app/assets/javascripts/reader_profile/HoverSummary.js
@@ -45,8 +45,10 @@ HoverSummary.propTypes = {
 };
 
 
-export function secondLineMonthsAgo(daysAgo, width) {
-  return `${Math.round(daysAgo / 30)} mos`;
+export function secondLineMonthsAgo(daysAgo, width = null) {
+  return (daysAgo < 30)
+    ? `${daysAgo} days`
+    : `${Math.round(daysAgo / 30)} mos`;
 }
 
 export function secondLineDaysAgo(daysAgo, width) {

--- a/app/assets/javascripts/reader_profile/ReaderProfileJune.js
+++ b/app/assets/javascripts/reader_profile/ReaderProfileJune.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from 'lodash';
+import {toMomentFromTimestamp} from '../helpers/toMoment';
 import External from '../components/External';
 import NoteText from '../components/NoteText';
 import CleanSlateFeedView from '../feed/CleanSlateFeedView';
@@ -99,11 +101,11 @@ export default class ReaderProfileJune extends React.Component {
           subs={[
             <Sub name="spoken"
               screener={this.renderChipForLanguage('oral')}
-              intervention={this.renderChipForService(510)}
+              intervention={<MultipleChips chips={this.renderChipsForServices([510])} />}
             />,
             <Sub name="written"
               screener={this.renderChipForLanguage('literacy')}
-              intervention={this.renderChipForService(510)}
+              intervention={<MultipleChips chips={this.renderChipsForServices([510])} />}
             />
           ]}
         />
@@ -196,11 +198,9 @@ export default class ReaderProfileJune extends React.Component {
                 ]} />
               }
               intervention={
-                <MultipleChips chips={[
-                  this.renderChipForService(507),
-                  this.renderChipForService(514),
-                  this.renderChipForService(511)
-                ]} />
+                <MultipleChips
+                  chips={this.renderChipsForServices([507, 514, 511])}
+                />
               }
             />,
             <Sub name="comprehension"
@@ -321,17 +321,16 @@ export default class ReaderProfileJune extends React.Component {
     );
   }
 
-  renderChipForService(serviceTypeId) {
+  renderChipsForServices(serviceTypeIds) {
     const {services} = this.props;
-    const matchingServices = services.filter(service => service.service_type_id === serviceTypeId);
-    if (matchingServices.length === 0) return null;
 
-    return (
-      <ChipForService
-        serviceTypeId={serviceTypeId}
-        matchingServices={matchingServices}
-      />
-    );
+    const matchingServices = services.filter(service => serviceTypeIds.indexOf(service.service_type_id) !== -1);
+    if (matchingServices.length === 0) return [];
+
+    const sortedServices = _.sortBy(matchingServices, service => -1 * toMomentFromTimestamp(service.date_started).unix());
+    return sortedServices.map(service => (
+      <ChipForService key={service.id} service={service} />
+    ));
   }
 }
 ReaderProfileJune.contextTypes = {

--- a/app/assets/javascripts/reader_profile/__snapshots__/ReaderProfileJune.test.js.snap
+++ b/app/assets/javascripts/reader_profile/__snapshots__/ReaderProfileJune.test.js.snap
@@ -713,7 +713,7 @@ exports[`snapshots view 1`] = `
                               }
                             }
                           >
-                            0 mos
+                            null days
                           </div>
                         </div>
                       </div>
@@ -757,16 +757,17 @@ exports[`snapshots view 1`] = `
               }
             >
               <div
+                className="MultipleChips"
                 style={
                   Object {
-                    "color": "#eee",
-                    "fontSize": 12,
-                    "padding": 5,
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                    "height": "100%",
+                    "width": "100%",
                   }
                 }
-              >
-                intervention
-              </div>
+              />
             </div>
           </div>
         </div>
@@ -903,7 +904,7 @@ exports[`snapshots view 1`] = `
                               }
                             }
                           >
-                            0 mos
+                            null days
                           </div>
                         </div>
                       </div>
@@ -947,16 +948,17 @@ exports[`snapshots view 1`] = `
               }
             >
               <div
+                className="MultipleChips"
                 style={
                   Object {
-                    "color": "#eee",
-                    "fontSize": 12,
-                    "padding": 5,
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                    "height": "100%",
+                    "width": "100%",
                   }
                 }
-              >
-                intervention
-              </div>
+              />
             </div>
           </div>
         </div>
@@ -2107,7 +2109,7 @@ exports[`snapshots view 1`] = `
                                   }
                                 }
                               >
-                                -14 mos
+                                -413 days
                               </div>
                             </div>
                           </div>

--- a/app/assets/javascripts/reading/thresholds.js
+++ b/app/assets/javascripts/reading/thresholds.js
@@ -27,9 +27,15 @@ const somervilleThresholds = {
       benchmark: 'G',
       risk: 'D'
     },
+    '2:spring': { // check these
+      benchmark: 'J'
+    },
     '3:winter': { // check these
       benchmark: 'O',
       risk: 'M'
+    },
+    '3:spring': { // check these
+      benchmark: 'P'
     }
   },
   [DIBELS_FSF]: {
@@ -75,6 +81,10 @@ const somervilleThresholds = {
     }
   },
   [DIBELS_NWF_CLS]: {
+    'KF:winter': {
+      benchmark: 27,
+      risk: 12
+    },
     'KF:spring': {
       benchmark: 37,
       risk: 27
@@ -123,6 +133,18 @@ const somervilleThresholds = {
       benchmark: 63,
       risk: 36
     },
+    '2:fall': {
+      benchmark: 68,
+      risk: 46
+    },
+    '2:winter': {
+      benchmark: 84,
+      risk: 67
+    },
+    '2:spring': {
+      benchmark: 100,
+      risk: 82
+    },
     '3:fall': {
       benchmark: 93,
       risk: 72
@@ -144,6 +166,18 @@ const somervilleThresholds = {
     '1:spring': {
       benchmark: 92,
       risk: 84
+    },
+    '2:fall': {
+      benchmark: 93,
+      risk: 84
+    },
+    '2:winter': {
+      benchmark: 95,
+      risk: 91
+    },
+    '2:spring': {
+      benchmark: 97,
+      risk: 93
     },
     '3:fall': {
       benchmark: 96,


### PR DESCRIPTION
# Who is this PR for?
K3 educators

# What problem does this PR fix?

# What does this PR do?
Split out multiple iterations of the same kind of service (eg, reading intervention group), show them as multiple chips.

Update the time context in services to be months ago, or days if recent.  Add tooltip.

This needs another pass to consolidate the "time ago" math; this is just making it more usable for critique sessions today.

# Screenshot (if adding a client-side feature)
<img width="1125" alt="Screen Shot 2019-06-07 at 11 32 21 AM" src="https://user-images.githubusercontent.com/1056957/59115825-1a00ef00-8918-11e9-9803-ccf118d04a6b.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Reader profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here