### PR TITLE
Import: Add DataFlow descriptions to importer classes, with tests, for making visible in UI

### DIFF
--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -2,6 +2,24 @@
 # tables.
 # See http://aspenhelp.follettlearning.com/570/SI/guides/Attendance.pdf
 class AttendanceImporter
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_SIS_SFTP_CSV,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      options: [
+        DataFlow::OPTION_SCHOOL_SCOPE,
+        DataFlow::OPTION_IDIOSYNCRATIC
+      ],
+      merge: DataFlow::MERGE_UPDATE_IGNORE_UNMARKED,
+      touches: [
+        Absence.name,
+        Tardy.name
+      ],
+      description: 'SIS attendance data, processed into absences and tardies.'
+    })
+  end
+
   def initialize(options:)
     @log = options.fetch(:log)
 

--- a/app/importers/file_importers/behavior_importer.rb
+++ b/app/importers/file_importers/behavior_importer.rb
@@ -1,4 +1,21 @@
 class BehaviorImporter
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_SIS_SFTP_CSV,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      merge: DataFlow::MERGE_UPDATE_DELETE_UNMARKED,
+      options: [
+        DataFlow::OPTION_SCHOOL_SCOPE,
+        DataFlow::OPTION_SKIP_OLD_RECORDS,
+        DataFlow::OPTION_IDIOSYNCRATIC
+      ],
+      touches: [
+        DisciplineIncident.name
+      ],
+      description: 'SIS discipline incidents'
+    })
+  end
 
   def initialize(options:)
     @school_scope = options.fetch(:school_scope)

--- a/app/importers/file_importers/courses_sections_importer.rb
+++ b/app/importers/file_importers/courses_sections_importer.rb
@@ -1,4 +1,20 @@
 class CoursesSectionsImporter
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_SIS_SFTP_CSV,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      options: [
+        DataFlow::OPTION_SCHOOL_SCOPE
+      ],
+      merge: DataFlow::MERGE_UPDATE_DELETE_UNMARKED,
+      touches: [
+        Section.name,
+        Course.name
+      ],
+      description: 'SIS course and section descriptions.  These may change over time, and primary keys may be recycled in some circumstances.'
+    })
+  end
 
   def initialize(options:)
     @school_scope = options.fetch(:school_scope)

--- a/app/importers/file_importers/ed_plan_accommodations_importer.rb
+++ b/app/importers/file_importers/ed_plan_accommodations_importer.rb
@@ -1,4 +1,20 @@
 class EdPlanAccommodationsImporter
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_SIS_SFTP_CSV,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      merge: DataFlow::MERGE_UPDATE_DELETE_UNMARKED,
+      options: [
+        DataFlow::OPTION_SCHOOL_SCOPE,
+        DataFlow::OPTION_IDIOSYNCRATIC
+      ],
+      touches: [
+        EdPlanAccommodation.name
+      ],
+      description: 'Specific accommodation information about 504 plans'
+    })
+  end
 
   def initialize(options:)
     @log = options.fetch(:log)

--- a/app/importers/file_importers/ed_plans_importer.rb
+++ b/app/importers/file_importers/ed_plans_importer.rb
@@ -1,4 +1,20 @@
 class EdPlansImporter
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_SIS_SFTP_CSV,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      merge: DataFlow::MERGE_UPDATE_DELETE_UNMARKED,
+      options: [
+        DataFlow::OPTION_SCHOOL_SCOPE,
+        DataFlow::OPTION_IDIOSYNCRATIC
+      ],
+      touches: [
+        EdPlan.name
+      ],
+      description: '504 plan records, without specific accommodation information'
+    })
+  end
 
   def initialize(options:)
     @log = options.fetch(:log)

--- a/app/importers/file_importers/educator_section_assignments_importer.rb
+++ b/app/importers/file_importers/educator_section_assignments_importer.rb
@@ -1,4 +1,19 @@
 class EducatorSectionAssignmentsImporter
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_SIS_SFTP_CSV,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      options: [
+        DataFlow::OPTION_SCHOOL_SCOPE
+      ],
+      merge: DataFlow::MERGE_UPDATE_DELETE_UNMARKED,
+      touches: [
+        StudentSectionAssignment.name
+      ],
+      description: 'SIS rosters for educator section assignments.'
+    })
+  end
 
   def initialize(options:)
     @school_local_ids = options.fetch(:school_scope, [])

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -1,5 +1,22 @@
 # This importer also creates Homeroom records.
 class EducatorsImporter
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_SIS_SFTP_CSV,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      merge: DataFlow::MERGE_UPDATE_IGNORE_UNMARKED,
+      options: [
+        DataFlow::OPTION_SCHOOL_SCOPE
+      ],
+      touches: [
+        Educator.name,
+        Homeroom.name
+      ],
+      description: 'SIS educator rosters, which also includes homeroom assignments and impacts permissions.'
+    })
+  end
+
   def initialize(options:)
     @school_scope = options.fetch(:school_scope)
     @log = options.fetch(:log)

--- a/app/importers/file_importers/file_importer_options.rb
+++ b/app/importers/file_importers/file_importer_options.rb
@@ -4,6 +4,17 @@ class FileImporterOptions
     key_to_importers.keys.sort
   end
 
+  # For describing all data flows and showing to users
+  def all_data_flows
+    data_flows = []
+    key_to_importers().each do |key, maybe_importer_class|
+      next if maybe_importer_class.respond_to?(:size)
+      raise "missing #{maybe_importer_class.name}.data_flow method" unless maybe_importer_class.respond_to?(:data_flow)
+      data_flows << maybe_importer_class.data_flow
+    end
+    data_flows
+  end
+
   # Given a set of importer_keys to run, map them to classes
   # then order them by priority
   def prioritized_file_importer_classes(importer_keys)

--- a/app/importers/file_importers/star_math_importer.rb
+++ b/app/importers/file_importers/star_math_importer.rb
@@ -1,4 +1,17 @@
 class StarMathImporter
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_STAR_VENDOR_SFTP_CSV,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      merge: DataFlow::MERGE_UPDATE_IGNORE_UNMARKED,
+      options: [DataFlow::OPTION_SCHOOL_SCOPE],
+      touches: [
+        StarMathResult.name
+      ],
+      description: 'STAR Math scores, imported from vendor'
+    })
+  end
 
   def initialize(options:)
     @school_scope = options.fetch(:school_scope)

--- a/app/importers/file_importers/star_reading_importer.rb
+++ b/app/importers/file_importers/star_reading_importer.rb
@@ -1,4 +1,17 @@
 class StarReadingImporter
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_STAR_VENDOR_SFTP_CSV,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      merge: DataFlow::MERGE_UPDATE_IGNORE_UNMARKED,
+      options: [DataFlow::OPTION_SCHOOL_SCOPE],
+      touches: [
+        StarMathResult.name
+      ],
+      description: 'STAR Reading scores, imported from vendor'
+    })
+  end
 
   def initialize(options:)
     @school_scope = options.fetch(:school_scope)

--- a/app/importers/file_importers/student_section_assignments_importer.rb
+++ b/app/importers/file_importers/student_section_assignments_importer.rb
@@ -1,4 +1,19 @@
 class StudentSectionAssignmentsImporter
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_SIS_SFTP_CSV,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      options: [
+        DataFlow::OPTION_SCHOOL_SCOPE
+      ],
+      merge: DataFlow::MERGE_UPDATE_DELETE_UNMARKED,
+      touches: [
+        StudentSectionAssignment.name
+      ],
+      description: 'SIS rosters for student enrollment in sections.'
+    })
+  end
 
   def initialize(options:)
     @school_local_ids = options.fetch(:school_scope, [])

--- a/app/importers/file_importers/student_section_grades_importer.rb
+++ b/app/importers/file_importers/student_section_grades_importer.rb
@@ -1,4 +1,20 @@
 class StudentSectionGradesImporter
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_SIS_SFTP_CSV,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      options: [
+        DataFlow::OPTION_SCHOOL_SCOPE
+      ],
+      merge: DataFlow::MERGE_UPDATE_IGNORE_UNMARKED,
+      touches: [
+        StudentSectionAssignment.name,
+        HistoricalGrade.name
+      ],
+      description: 'SIS current computer grades for courses.  These may change over time, and primary keys may be recycled in some circumstances.'
+    })
+  end
 
   # Most of our file importer classes match to a SQL file in the /x2_export folder.
   # Somerville IT uses the SQL to export data  nightly, and Rails imports nightly.

--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -1,5 +1,19 @@
 class StudentsImporter
 
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_SIS_SFTP_CSV,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      merge: DataFlow::MERGE_UPDATE_FLAG_UNMARKED,
+      options: [DataFlow::OPTION_SCHOOL_SCOPE],
+      touches: [
+        Student.name
+      ],
+      description: 'Student rosters'
+    })
+  end
+
   def initialize(options:)
     @school_scope = options.fetch(:school_scope)
     @log = options.fetch(:log)

--- a/app/importers/file_importers/x2_assessment_importer.rb
+++ b/app/importers/file_importers/x2_assessment_importer.rb
@@ -1,4 +1,21 @@
 class X2AssessmentImporter
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_SIS_SFTP_CSV,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      options: [
+        DataFlow::OPTION_SCHOOL_SCOPE,
+        DataFlow::OPTION_SKIP_OLD_RECORDS
+      ],
+      merge: DataFlow::MERGE_UPDATE_IGNORE_UNMARKED,
+      touches: [
+        StudentAssessment.name,
+        DibelsResult.name
+      ],
+      description: 'SIS assessments.  These are often complex and contain different data points from different sources in different formats.  This only imports MCAS and ACCESS data, and contains a deprecated variant of DIBELS imports.  For more recent reading data, see ReadingBenchmarkData'
+    })
+  end
 
   def initialize(options:)
     @school_scope = options.fetch(:school_scope)
@@ -114,8 +131,8 @@ class X2AssessmentImporter
       McasRow.new(row, student_id, assessments_array).build
     elsif row_class == AccessRow
       AccessRow.new(row, student_id, assessments_array).build
-    elsif row_class == DibelsRow
-      DibelsRow.new(row, student_id, @log).build
+    elsif row_class == DibelsRow # deprecated
+      DibelsRow.new(row, student_id, @log).build # deprecated
     else
       nil
     end

--- a/app/importers/helpers/data_flow.rb
+++ b/app/importers/helpers/data_flow.rb
@@ -1,0 +1,53 @@
+class DataFlow
+  FREQUENCY_DAILY = 'frequency_daily'
+
+  SOURCE_SIS_SFTP_CSV = 'source_sis_sftp_csv'
+  SOURCE_STAR_VENDOR_SFTP_CSV = 'source_star_vendor_sftp_csv'
+
+  MERGE_UPDATE_DELETE_UNMARKED = 'merge_update_delete_unmarked'
+  MERGE_UPDATE_FLAG_UNMARKED = 'merge_update_flag_unmarked'
+  MERGE_UPDATE_IGNORE_UNMARKED = 'merge_update_ignore_unmarked'
+
+  OPTION_SCHOOL_SCOPE = 'option_school_scope'
+  OPTION_SKIP_OLD_RECORDS = 'option_skip_old_records'
+  OPTION_IDIOSYNCRATIC = 'option_idiosyncratic'
+
+  def initialize(options = {})
+    keys = [:importer, :source, :frequency, :merge, :touches, :options, :description]
+    keys.each {|key| raise "missing option: #{key}" unless options.has_key?(key) }
+    @options = options.slice(*keys)
+  end
+
+  # override
+  def as_json
+    @options.as_json
+  end
+
+  def importer
+    @options[:importer]
+  end
+
+  def source
+    @options[:source]
+  end
+
+  def frequency
+    @options[:frequency]
+  end
+
+  def merge
+    @options[:merge]
+  end
+
+  def touches
+    @options[:touches]
+  end
+
+  def options
+    @options[:options]
+  end
+
+  def description
+    @options[:description]
+  end
+end

--- a/spec/importers/helpers/data_flows_fixture.json
+++ b/spec/importers/helpers/data_flows_fixture.json
@@ -1,0 +1,182 @@
+[
+  {
+    "importer": "AttendanceImporter",
+    "source": "source_sis_sftp_csv",
+    "frequency": "frequency_daily",
+    "merge": "merge_update_ignore_unmarked",
+    "touches": [
+      "Absence",
+      "Tardy"
+    ],
+    "options": [
+      "option_school_scope",
+      "option_idiosyncratic"
+    ],
+    "description": "SIS attendance data, processed into absences and tardies."
+  },
+  {
+    "importer": "BehaviorImporter",
+    "source": "source_sis_sftp_csv",
+    "frequency": "frequency_daily",
+    "merge": "merge_update_delete_unmarked",
+    "touches": [
+      "DisciplineIncident"
+    ],
+    "options": [
+      "option_school_scope",
+      "option_skip_old_records",
+      "option_idiosyncratic"
+    ],
+    "description": "SIS discipline incidents"
+  },
+  {
+    "importer": "CoursesSectionsImporter",
+    "source": "source_sis_sftp_csv",
+    "frequency": "frequency_daily",
+    "merge": "merge_update_delete_unmarked",
+    "touches": [
+      "Section",
+      "Course"
+    ],
+    "options": [
+      "option_school_scope"
+    ],
+    "description": "SIS course and section descriptions.  These may change over time, and primary keys may be recycled in some circumstances."
+  },
+  {
+    "importer": "EdPlanAccommodationsImporter",
+    "source": "source_sis_sftp_csv",
+    "frequency": "frequency_daily",
+    "merge": "merge_update_delete_unmarked",
+    "touches": [
+      "EdPlanAccommodation"
+    ],
+    "options": [
+      "option_school_scope",
+      "option_idiosyncratic"
+    ],
+    "description": "Specific accommodation information about 504 plans"
+  },
+  {
+    "importer": "EdPlansImporter",
+    "source": "source_sis_sftp_csv",
+    "frequency": "frequency_daily",
+    "merge": "merge_update_delete_unmarked",
+    "touches": [
+      "EdPlan"
+    ],
+    "options": [
+      "option_school_scope",
+      "option_idiosyncratic"
+    ],
+    "description": "504 plan records, without specific accommodation information"
+  },
+  {
+    "importer": "EducatorSectionAssignmentsImporter",
+    "source": "source_sis_sftp_csv",
+    "frequency": "frequency_daily",
+    "merge": "merge_update_delete_unmarked",
+    "touches": [
+      "StudentSectionAssignment"
+    ],
+    "options": [
+      "option_school_scope"
+    ],
+    "description": "SIS rosters for educator section assignments."
+  },
+  {
+    "importer": "EducatorsImporter",
+    "source": "source_sis_sftp_csv",
+    "frequency": "frequency_daily",
+    "merge": "merge_update_ignore_unmarked",
+    "touches": [
+      "Educator",
+      "Homeroom"
+    ],
+    "options": [
+      "option_school_scope"
+    ],
+    "description": "SIS educator rosters, which also includes homeroom assignments and impacts permissions."
+  },
+  {
+    "importer": "StarMathImporter",
+    "source": "source_star_vendor_sftp_csv",
+    "frequency": "frequency_daily",
+    "merge": "merge_update_ignore_unmarked",
+    "touches": [
+      "StarMathResult"
+    ],
+    "options": [
+      "option_school_scope"
+    ],
+    "description": "STAR Math scores, imported from vendor"
+  },
+  {
+    "importer": "StarReadingImporter",
+    "source": "source_star_vendor_sftp_csv",
+    "frequency": "frequency_daily",
+    "merge": "merge_update_ignore_unmarked",
+    "touches": [
+      "StarMathResult"
+    ],
+    "options": [
+      "option_school_scope"
+    ],
+    "description": "STAR Reading scores, imported from vendor"
+  },
+  {
+    "importer": "StudentSectionAssignmentsImporter",
+    "source": "source_sis_sftp_csv",
+    "frequency": "frequency_daily",
+    "merge": "merge_update_delete_unmarked",
+    "touches": [
+      "StudentSectionAssignment"
+    ],
+    "options": [
+      "option_school_scope"
+    ],
+    "description": "SIS rosters for student enrollment in sections."
+  },
+  {
+    "importer": "StudentSectionGradesImporter",
+    "source": "source_sis_sftp_csv",
+    "frequency": "frequency_daily",
+    "merge": "merge_update_ignore_unmarked",
+    "touches": [
+      "StudentSectionAssignment",
+      "HistoricalGrade"
+    ],
+    "options": [
+      "option_school_scope"
+    ],
+    "description": "SIS current computer grades for courses.  These may change over time, and primary keys may be recycled in some circumstances."
+  },
+  {
+    "importer": "StudentsImporter",
+    "source": "source_sis_sftp_csv",
+    "frequency": "frequency_daily",
+    "merge": "merge_update_flag_unmarked",
+    "touches": [
+      "Student"
+    ],
+    "options": [
+      "option_school_scope"
+    ],
+    "description": "Student rosters"
+  },
+  {
+    "importer": "X2AssessmentImporter",
+    "source": "source_sis_sftp_csv",
+    "frequency": "frequency_daily",
+    "merge": "merge_update_ignore_unmarked",
+    "touches": [
+      "StudentAssessment",
+      "DibelsResult"
+    ],
+    "options": [
+      "option_school_scope",
+      "option_skip_old_records"
+    ],
+    "description": "SIS assessments.  These are often complex and contain different data points from different sources in different formats.  This only imports MCAS and ACCESS data, and contains a deprecated variant of DIBELS imports.  For more recent reading data, see ReadingBenchmarkData"
+  }
+]


### PR DESCRIPTION
# Who is this PR for?
project leads

# What problem does this PR fix?
The log of import tasks is somewhat visible, but it's more intended for developers.  There's no way for district project leads to see importers directly, particularly for other kinds of imports that are semi-automated, or from different sources other than regular SIS syncs.

# What does this PR do?
Adds some minimal description in code of what these are, intended to be put in a UI for users, alongside other kinds of data flows not yet visible (eg, student voice, reading data, transitions).

I'm mot sure doing this in code over docs adds real value, but trying it out for now.

# Checklists
*Which features or pages does this PR touch?*
+ [ ] Imports

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
