### PR TITLE
District: Add discipline exporter for further analysis

### DIFF
--- a/app/assets/javascripts/district_overview/DistrictOverviewPage.js
+++ b/app/assets/javascripts/district_overview/DistrictOverviewPage.js
@@ -162,18 +162,31 @@ export class DistrictOverviewPageView extends React.Component {
           <ul style={styles.plainList}>
             <li>
               <a href="/district/wide_students_csv" style={styles.link}>
-               Export ’wide’ CSV for all students
+               Export CSV with all students
               </a>
             </li>
             <li>
               <a href="/district/discipline_csv" style={styles.link}>
-               Export discipline incidents
+               Export discipline incidents CSV
               </a>
             </li>
             <li>
               Contact <HelpEmail /> for other exports
             </li>
           </ul>
+          <div style={{
+            marginTop: 5,
+            fontSize: 12,
+            backgroundColor: '#f8f8f8',
+            padding: 10,
+            border: '1px solid #ccc'
+          }}>
+            <div style={{marginBottom: 5}}>When exporting data for further analysis, some helpful guidelines are:</div>
+            <div>- investigate how accurate the data collection process actually is in practice</div>
+            <div>- be careful not to mistake statistical noise for meaningful patterns</div>
+            <div>- check assumptions about stable cohort membership over time</div>
+            <div>- be aware that metrics-based approaches focusing on negative behaviors may unintentionally institutionalize deficit mindsets towards students</div>
+          </div>
         </div>
       </div>
     );

--- a/app/assets/javascripts/district_overview/DistrictOverviewPage.js
+++ b/app/assets/javascripts/district_overview/DistrictOverviewPage.js
@@ -162,7 +162,12 @@ export class DistrictOverviewPageView extends React.Component {
           <ul style={styles.plainList}>
             <li>
               <a href="/district/wide_students_csv" style={styles.link}>
-               Download ’wide’ CSV for all students
+               Export ’wide’ CSV for all students
+              </a>
+            </li>
+            <li>
+              <a href="/district/discipline_csv" style={styles.link}>
+               Export discipline incidents
               </a>
             </li>
             <li>

--- a/app/assets/javascripts/district_overview/__snapshots__/DistrictOverviewPage.test.js.snap
+++ b/app/assets/javascripts/district_overview/__snapshots__/DistrictOverviewPage.test.js.snap
@@ -650,7 +650,19 @@ exports[`DistrictOverviewPageView pure snapshot when \`enable_equity_experiments
                   }
                 }
               >
-                Download ’wide’ CSV for all students
+                Export CSV with all students
+              </a>
+            </li>
+            <li>
+              <a
+                href="/district/discipline_csv"
+                style={
+                  Object {
+                    "fontSize": 14,
+                  }
+                }
+              >
+                Export discipline incidents CSV
               </a>
             </li>
             <li>
@@ -663,6 +675,39 @@ exports[`DistrictOverviewPageView pure snapshot when \`enable_equity_experiments
                for other exports
             </li>
           </ul>
+          <div
+            style={
+              Object {
+                "backgroundColor": "#f8f8f8",
+                "border": "1px solid #ccc",
+                "fontSize": 12,
+                "marginTop": 5,
+                "padding": 10,
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "marginBottom": 5,
+                }
+              }
+            >
+              When exporting data for further analysis, some helpful guidelines are:
+            </div>
+            <div>
+              - investigate how accurate the data collection process actually is in practice
+            </div>
+            <div>
+              - be careful not to mistake statistical noise for meaningful patterns
+            </div>
+            <div>
+              - check assumptions about stable cohort membership over time
+            </div>
+            <div>
+              - be aware that metrics-based approaches focusing on negative behaviors may unintentionally institutionalize deficit mindsets towards students
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -1519,7 +1564,19 @@ exports[`DistrictOverviewPageView pure snapshot, without work board 1`] = `
                   }
                 }
               >
-                Download ’wide’ CSV for all students
+                Export CSV with all students
+              </a>
+            </li>
+            <li>
+              <a
+                href="/district/discipline_csv"
+                style={
+                  Object {
+                    "fontSize": 14,
+                  }
+                }
+              >
+                Export discipline incidents CSV
               </a>
             </li>
             <li>
@@ -1532,6 +1589,39 @@ exports[`DistrictOverviewPageView pure snapshot, without work board 1`] = `
                for other exports
             </li>
           </ul>
+          <div
+            style={
+              Object {
+                "backgroundColor": "#f8f8f8",
+                "border": "1px solid #ccc",
+                "fontSize": 12,
+                "marginTop": 5,
+                "padding": 10,
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "marginBottom": 5,
+                }
+              }
+            >
+              When exporting data for further analysis, some helpful guidelines are:
+            </div>
+            <div>
+              - investigate how accurate the data collection process actually is in practice
+            </div>
+            <div>
+              - be careful not to mistake statistical noise for meaningful patterns
+            </div>
+            <div>
+              - check assumptions about stable cohort membership over time
+            </div>
+            <div>
+              - be aware that metrics-based approaches focusing on negative behaviors may unintentionally institutionalize deficit mindsets towards students
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/app/controllers/district_controller.rb
+++ b/app/controllers/district_controller.rb
@@ -85,10 +85,20 @@ class DistrictController < ApplicationController
 
   # GET download
   def wide_students_csv
-    students = authorized { Student.active.to_a }
+    students = authorized { Student.active.includes(:ed_plans).to_a }
     exporter = WideStudentsExporter.new(current_educator)
     csv_string = exporter.csv_string(students)
     filename = "StudentInsights-WideStudentsExport-all-#{Time.now.strftime("%Y-%m-%d")}.csv"
+    send_data csv_string, filename: filename, type: 'text/csv', disposition: 'inline'
+  end
+
+  # GET download
+  def discipline_csv
+    students = authorized { Student.active.includes(:ed_plans).to_a }
+    records = DisciplineIncident.includes(:student).where(student_id: students.map(&:id))
+    json = records.as_json(include: [:student])
+    csv_string = FlatExporter.new.csv_string(json)
+    filename = "StudentInsights-DisciplineExport-all-#{Time.now.strftime("%Y-%m-%d")}.csv"
     send_data csv_string, filename: filename, type: 'text/csv', disposition: 'inline'
   end
 

--- a/app/lib/flat_exporter.rb
+++ b/app/lib/flat_exporter.rb
@@ -1,0 +1,28 @@
+require 'csv'
+
+# For exporting nested json as a flat CSV
+class FlatExporter
+  def csv_string(json_rows)
+    return '' if json_rows.size == 0
+    row_hashes = json_rows.map {|row| flatten(row) }
+
+    header_row = row_hashes.first.keys # all rows should have the same shape
+    body_rows = row_hashes.map {|row_hash| row_hash.values }
+    ([header_row] + body_rows).map {|row| row.to_csv }.join('')
+  end
+
+  def flatten(row, options = {})
+    flat = {}
+    prefix = options.fetch(:prefix, nil)
+    row.keys.each do |key|
+      flat_key = [prefix, key].compact.join('.')
+      value = row[key]
+      if value.is_a?(Hash)
+        flat.merge!(flatten(row[key], prefix: flat_key))
+      else
+        flat[flat_key] = value
+      end
+    end
+    flat
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,6 +149,7 @@ Rails.application.routes.draw do
     get 'enrollment' => 'ui#ui'
     get 'homerooms' => 'ui#ui'
     get 'wide_students_csv' => 'district#wide_students_csv'
+    get 'discipline_csv' => 'district#discipline_csv'
   end
 
   # search notes

--- a/spec/controllers/district_controller_spec.rb
+++ b/spec/controllers/district_controller_spec.rb
@@ -141,4 +141,23 @@ describe DistrictController, :type => :controller do
       expect(json.keys).to eq ['error']
     end
   end
+
+  describe '#discipline_csv' do
+    it 'guards authorization' do
+      sign_in(pals.shs_jodi)
+      get :discipline_csv
+      expect(response.status).to eq 302
+    end
+
+    it 'returns CSV with correct shape' do
+      3.times do
+        FactoryBot.create(:discipline_incident, student: pals.shs_senior_kylo)
+      end
+      sign_in(pals.uri)
+      get :discipline_csv
+      expect(response.status).to eq 200
+      expect(response.body.split("\n").size).to eq 4
+      expect(response.body.split("\n").first).to eq 'id,incident_code,created_at,updated_at,incident_location,incident_description,occurred_at,has_exact_time,student_id,student.id,student.grade,student.hispanic_latino,student.race,student.free_reduced_lunch,student.created_at,student.updated_at,student.homeroom_id,student.first_name,student.last_name,student.state_id,student.home_language,student.school_id,student.student_address,student.registration_date,student.local_id,student.program_assigned,student.sped_placement,student.disability,student.sped_level_of_need,student.plan_504,student.limited_english_proficiency,student.most_recent_mcas_math_growth,student.most_recent_mcas_ela_growth,student.most_recent_mcas_math_performance,student.most_recent_mcas_ela_performance,student.most_recent_mcas_math_scaled,student.most_recent_mcas_ela_scaled,student.most_recent_star_reading_percentile,student.most_recent_star_math_percentile,student.enrollment_status,student.date_of_birth,student.gender,student.primary_phone,student.primary_email,student.house,student.counselor,student.sped_liaison,student.missing_from_last_export,student.ell_entry_date,student.ell_transition_date'
+    end
+  end
 end

--- a/spec/lib/flat_exporter_spec.rb
+++ b/spec/lib/flat_exporter_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe FlatExporter do
+  let!(:pals) { TestPals.create! }
+
+  describe '#csv_string' do
+    it 'generates a CSV with flattened field names' do
+      json = [
+        { id: '42', name: { first: 'kevin', last: 'youkilis'} }
+      ]
+      csv_string = FlatExporter.new.csv_string(json)
+      expect(csv_string).to eq([
+        'id,name.first,name.last',
+        '42,kevin,youkilis',
+        ''
+      ].join("\n"))
+    end
+  end
+end


### PR DESCRIPTION
# Who is this PR for?
district admin or project leads

# What problem does this PR fix?
There may be some analysis features of discipline data that aren't aligned to our core work, but we still want to help district folks with doing other analysis they are trying to do (eg, research studies).

# What does this PR do?
Allows project leads to download a flat CSV of all discipline data, joined with current student fields.

Adds small guidelines about using this kind of data for other analyses.

# Screenshot (if adding a client-side feature)
<img width="517" alt="Screen Shot 2019-07-01 at 10 00 30 AM" src="https://user-images.githubusercontent.com/1056957/60442558-48a47980-9be7-11e9-82ed-ec835ec46796.png">


# Checklists
*Which features or pages does this PR touch?*
+ [x] District overview page

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here