### PR TITLE
District: Add links to debug reading pages

### DIFF
--- a/app/assets/javascripts/district_overview/DistrictOverviewPage.js
+++ b/app/assets/javascripts/district_overview/DistrictOverviewPage.js
@@ -155,6 +155,16 @@ export class DistrictOverviewPageView extends React.Component {
               </a>
             </li>
             <li>
+              <a href="/reading/debug" style={styles.link}>
+               Benchmark reading data (eg, F&P)
+              </a>
+            </li>
+            <li>
+              <a href="/reading/debug_star" style={styles.link}>
+               STAR reading data
+              </a>
+            </li>
+            <li>
               <a href="/admin/sample_students" style={styles.link}>
                 Student sample for data quality checks
               </a>
@@ -173,6 +183,11 @@ export class DistrictOverviewPageView extends React.Component {
             <li>
               <a href="/district/discipline_csv" style={styles.link}>
                Export discipline incidents CSV
+              </a>
+            </li>
+            <li>
+              <a href="/reading/debug_csv" style={styles.link}>
+               Export reading benchmark data CSV
               </a>
             </li>
             <li>

--- a/app/assets/javascripts/district_overview/__snapshots__/DistrictOverviewPage.test.js.snap
+++ b/app/assets/javascripts/district_overview/__snapshots__/DistrictOverviewPage.test.js.snap
@@ -622,6 +622,30 @@ exports[`DistrictOverviewPageView pure snapshot when \`enable_equity_experiments
             </li>
             <li>
               <a
+                href="/reading/debug"
+                style={
+                  Object {
+                    "fontSize": 14,
+                  }
+                }
+              >
+                Benchmark reading data (eg, F&P)
+              </a>
+            </li>
+            <li>
+              <a
+                href="/reading/debug_star"
+                style={
+                  Object {
+                    "fontSize": 14,
+                  }
+                }
+              >
+                STAR reading data
+              </a>
+            </li>
+            <li>
+              <a
                 href="/admin/sample_students"
                 style={
                   Object {
@@ -675,6 +699,18 @@ exports[`DistrictOverviewPageView pure snapshot when \`enable_equity_experiments
                 }
               >
                 Export discipline incidents CSV
+              </a>
+            </li>
+            <li>
+              <a
+                href="/reading/debug_csv"
+                style={
+                  Object {
+                    "fontSize": 14,
+                  }
+                }
+              >
+                Export reading benchmark data CSV
               </a>
             </li>
             <li>
@@ -1548,6 +1584,30 @@ exports[`DistrictOverviewPageView pure snapshot, without work board 1`] = `
             </li>
             <li>
               <a
+                href="/reading/debug"
+                style={
+                  Object {
+                    "fontSize": 14,
+                  }
+                }
+              >
+                Benchmark reading data (eg, F&P)
+              </a>
+            </li>
+            <li>
+              <a
+                href="/reading/debug_star"
+                style={
+                  Object {
+                    "fontSize": 14,
+                  }
+                }
+              >
+                STAR reading data
+              </a>
+            </li>
+            <li>
+              <a
                 href="/admin/sample_students"
                 style={
                   Object {
@@ -1601,6 +1661,18 @@ exports[`DistrictOverviewPageView pure snapshot, without work board 1`] = `
                 }
               >
                 Export discipline incidents CSV
+              </a>
+            </li>
+            <li>
+              <a
+                href="/reading/debug_csv"
+                style={
+                  Object {
+                    "fontSize": 14,
+                  }
+                }
+              >
+                Export reading benchmark data CSV
               </a>
             </li>
             <li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,6 @@ Rails.application.routes.draw do
     get '/api/student_voice_survey_uploads' => 'student_voice_survey_uploads#index'
   end
 
-
   get '/api/educators/view/:id' => 'educators#show'
   get '/api/educators/my_students_json' => 'educators#my_students_json'
   get '/api/educators/services_json' => 'educators#services_json'
@@ -119,14 +118,14 @@ Rails.application.routes.draw do
   post '/api/counselor_meetings' => 'counselor_meetings#create'
   get '/api/counselor_meetings/student_feed_cards_json' => 'counselor_meetings#student_feed_cards_json'
 
-  # is service working?
+  # internal: is service working?
   get '/api/is_service_working_json/:service_type_id/' => 'is_service_working#is_service_working_json'
 
-
-  ### internal
-  # login activity security monitoring
+  # internal: login activity security monitoring
   get '/api/login_activity' => 'login_activities#index_json'
 
+
+  # --- product URLs --- 
   # home pages
   get '/educators/view/:id' => 'ui#ui'
   get '/educators/my_students'=> 'ui#ui'
@@ -159,12 +158,6 @@ Rails.application.routes.draw do
 
   # SHS levels
   get '/levels/:school_id' => 'ui#ui'
-
-  # login activity security monitoring
-  get '/login_activity' => 'ui#ui'
-
-  # experimental "is service working?"
-  get '/is_service_working' => 'ui#ui'
 
   # K8 homeroom page
   get '/homerooms/:id' => 'ui#ui', as: :homeroom
@@ -235,5 +228,15 @@ Rails.application.routes.draw do
   resource :counselors, only: [] do
     get '/meetings' => 'ui#ui'
     get '/transitions' => 'ui#ui'
+  end
+
+  # internal tools, either early product prototypes or
+  # for product team tools
+  resource :internal, only: [] do
+    # login activity security monitoring
+    get '/login_activity' => 'ui#ui'
+
+    # experimental "is service working?"
+    get '/is_service_working' => 'ui#ui'
   end
 end


### PR DESCRIPTION
# Who is this PR for?
project team, district project leads

# What does this PR do?
Add in links to pages about reading data.

# Screenshot (if adding a client-side feature)
<img width="505" alt="Screen Shot 2019-07-08 at 11 42 37 AM" src="https://user-images.githubusercontent.com/1056957/60823509-abf95300-a175-11e9-923d-03fcd84dfbd3.png">


# Checklists
*Which features or pages does this PR touch?*
+ [x] Districtwide

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes