### PR TITLE
Monitoring: Rollbar functions can't be called without explicitly setting 'this'

### DIFF
--- a/app/assets/javascripts/components/NotifyAboutError.js
+++ b/app/assets/javascripts/components/NotifyAboutError.js
@@ -12,10 +12,9 @@ export default class NotifyAboutError extends React.Component {
   }
 
   rollbarErrorFn(msg, obj = {}) {
-    const rollbarErrorFn = (this.props.rollbarErrorFn)
-      ? this.props.rollbarErrorFn
-      : window.Rollbar && window.Rollbar.error;
-    if (rollbarErrorFn) rollbarErrorFn(msg, obj);
+    if (this.props.rollbarErrorFn) return this.props.rollbarErrorFn(msg, obj);
+    if (window.Rollbar.error) return window.Rollbar.error(msg, obj);
+    console.error('NotifyAboutError#rollbarErrorFn could not find function for reporting error:', msg, obj);
   }
 
   render() {

--- a/app/assets/javascripts/components/RollbarErrorBoundary.js
+++ b/app/assets/javascripts/components/RollbarErrorBoundary.js
@@ -25,10 +25,9 @@ export default class RollbarErrorBoundary extends React.Component {
   }
 
   rollbarErrorFn(msg, obj = {}) {
-    const rollbarErrorFn = (window.Rollbar && window.Rollbar.error)
-      ? window.Rollbar.error
-      : this.props.rollbarErrorFn;
-    if (rollbarErrorFn) rollbarErrorFn(msg, obj);
+    if (this.props.rollbarErrorFn) return this.props.rollbarErrorFn(msg, obj);
+    if (window.Rollbar.error) return window.Rollbar.error(msg, obj);
+    console.error('RollbarErrorBoundary#rollbarErrorFn could not find function for reporting error:', msg, obj);
   }
 
   render() {


### PR DESCRIPTION
# What problem does this PR fix?
Rollbar reporting in `RollbarErrorBoundary` wasn't working because our code assigned the reporting function to a variable without binding 'this'.  This led to the Rollbar library code throwing and dropping the errors. 👣 🔫 

# What does this PR do?
Removes use of variable.


*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here