### PR TITLE
Defer freezing Object.prototype until after vendor code

### DIFF
--- a/ui/freeze.js
+++ b/ui/freeze.js
@@ -1,13 +1,16 @@
-// Prevent further Object.prototype pollution from happening
+// Prevent further Object.prototype pollution from happening after
+// our code initially loads.
 // (example: https://snyk.io/vuln/SNYK-JS-SETVALUE-450213)
-
+//
 // This is split out as a separate file, since unfortunately
-// Moment.js modifies `Object.prototype` unnecessarily.
-// So this works around by importing it before freezing Object.prototype.
-import 'moment';
-
-// Prevent further Object.prototype pollution from happening
-// (example: https://snyk.io/vuln/SNYK-JS-SETVALUE-450213)
+// some vendor code (eg, Moment.js) modifies `Object.prototype` unnecessarily,
+// so we want that to be able to load and do its thing first.
+//
+// Other vendor code (eg, Lunr.js) does the "override mistake" which means
+// its overrides to things like `toString` no longer work.
+// see http://web.archive.org/web/20141230041441/http://wiki.ecmascript.org/doku.php?id=strawman:fixing_override_mistake
+// or https://github.com/tc39/ecma262/pull/1307#issuecomment-421606419
+// or https://esdiscuss.org/topic/object-freeze-object-prototype-vs-reality
 try {
   Object.freeze(Object.prototype);
 } catch (err) {

--- a/ui/freeze.test.js
+++ b/ui/freeze.test.js
@@ -1,0 +1,8 @@
+import './freeze';
+
+it('prevents changing Object.prototype', () => {
+  expect(() => {
+    "use strict";
+    Object.prototype.toString = function() { return "ok"; };
+  }).toThrow();
+});

--- a/ui/index.js
+++ b/ui/index.js
@@ -1,10 +1,10 @@
-import './freeze.js';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {BrowserRouter} from 'react-router-dom';
 import {readEnv} from '../app/assets/javascripts/envForJs';
 import StudentSearchbar, {clearStorage} from '../app/assets/javascripts/components/StudentSearchbar';
 import App from './App';
+import './freeze.js';
 
 
 // Clear browser cache on sign out, and add extra guard that


### PR DESCRIPTION
Fixing "malformed field ref string" in https://rollbar.com/somerville-teacher-tool/studentinsights/items/408 coming from lunr.

This was introduced inhttps://github.com/studentinsights/studentinsights/pull/2521/files#diff-9fcaa1e447bc24f5885b46562d22090dR1, trying to add another layer of defense for JS.  While that work surfaced the Object.prototype pollution from moment.js, this bug came from a related issue, in that the common pattern `Foo.prototype.toString = function() { ...}` no longer works if `Object.prototype` is frozen.  This led to errors in lunr at read time, because building the index didn't work as expected because `toString` methods couldn't be defined using the pattern above.

There's probably not a lot of value here, so just moving this freeze until after our code loads.  If there are more problems, not sure it's worth keeping at all.