### PR TITLE
Somerville: Disable STAR importer

### DIFF
--- a/config/district_somerville.yml
+++ b/config/district_somerville.yml
@@ -23,12 +23,6 @@ sftp_filenames:
     - /home/jbreslin/data/student-documents-2.zip
     - /home/jbreslin/data/student-documents-1.zip
 
-star_filenames:
-  FILENAME_FOR_STAR_READING_IMPORT:                 SR.csv
-  FILENAME_FOR_STAR_MATH_IMPORT:                    SM.csv
-  FILENAME_FOR_STAR_ZIP_FILE:                       Somerville Public Schools.zip
-
-
 # See FeedFilter::CommunitySchoolFilter
 # Manual through console
 community_schools_educators_sheet:


### PR DESCRIPTION
The vendor is doing some kind of migration, and started this for Somerville in June 2019.  This changed the format of the export, and there are other aspects to this that are moving slowly.  This PR turns off importing from the vendor altogether in Somerville, and district folks have the ball for collaborating with the vendor on these changes and then moving forward again in the fall.
