### PR TITLE
Educators import: Mark `missing_from_last_export` and show project leads in permissions tools

### DIFF
--- a/app/dashboards/educator_dashboard.rb
+++ b/app/dashboards/educator_dashboard.rb
@@ -1,5 +1,6 @@
 require "administrate/base_dashboard"
 
+# See https://administrate-prototype.herokuapp.com/getting_started
 class EducatorDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
@@ -8,35 +9,26 @@ class EducatorDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    school_id: SchoolNameField.with_options(searchable: false),
-    homeroom: HomeroomNameField.with_options(searchable: false),
-    students: Field::HasMany.with_options(searchable: false),
-    interventions: Field::HasMany.with_options(searchable: false),
-    id: Field::Number.with_options(searchable: false),
-    email: Field::String.with_options(searchable: false),
-    encrypted_password: Field::String.with_options(searchable: false),
-    reset_password_token: Field::String.with_options(searchable: false),
-    reset_password_sent_at: Field::DateTime.with_options(searchable: false),
-    remember_created_at: Field::DateTime.with_options(searchable: false),
-    sign_in_count: Field::Number.with_options(searchable: false),
-    current_sign_in_at: Field::DateTime.with_options(searchable: false),
-    last_sign_in_at: Field::DateTime.with_options(searchable: false),
-    current_sign_in_ip: Field::String.with_options(searchable: false),
-    last_sign_in_ip: Field::String.with_options(searchable: false),
-    created_at: Field::DateTime.with_options(searchable: false),
-    updated_at: Field::DateTime.with_options(searchable: false),
-    admin: YesNoBooleanField.with_options(searchable: false),
-    phone: Field::String.with_options(searchable: false),
-    full_name: Field::String,
-    state_id: Field::String.with_options(searchable: false),
-    local_id: Field::String.with_options(searchable: false),
-    staff_type: Field::String.with_options(searchable: false),
-    schoolwide_access: YesNoBooleanField.with_options(searchable: false),
-    grade_level_access: PostgresArrayField.with_options(searchable: false),
-    restricted_to_sped_students: YesNoBooleanField.with_options(searchable: false),
-    restricted_to_english_language_learners: YesNoBooleanField.with_options(searchable: false),
-    can_view_restricted_notes: YesNoBooleanField.with_options(searchable: false),
-    districtwide_access: YesNoBooleanField.with_options(searchable: false),
+    email: Field::String.with_options(searchable: true),
+    full_name: Field::String.with_options(searchable: true),
+    local_id: Field::String.with_options(searchable: true),
+
+    school_id: SchoolNameField.with_options(),
+    homeroom: HomeroomNameField.with_options(),
+
+    created_at: Field::DateTime.with_options(),
+    updated_at: Field::DateTime.with_options(),
+    admin: YesNoBooleanField.with_options(),
+    staff_type: Field::String.with_options(),
+    schoolwide_access: YesNoBooleanField.with_options(),
+    grade_level_access: PostgresArrayField.with_options(),
+    restricted_to_sped_students: YesNoBooleanField.with_options(),
+    restricted_to_english_language_learners: YesNoBooleanField.with_options(),
+    can_view_restricted_notes: YesNoBooleanField.with_options(),
+    districtwide_access: YesNoBooleanField.with_options(),
+    can_set_districtwide_access: YesNoBooleanField.with_options(),
+    active: YesNoBooleanField.with_options(),
+    missing_from_last_export: YesNoBooleanField.with_options()
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -47,26 +39,32 @@ class EducatorDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = [
     :full_name,
     :school_id,
-    :homeroom,
+    :active,
     :schoolwide_access,
+    :districtwide_access,
     :can_view_restricted_notes,
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = [
+    :email,
+    :full_name,
+    :local_id,
+    :active,
+    :missing_from_last_export,
+
     :school_id,
     :homeroom,
-    :email,
-    :sign_in_count,
+
     :admin,
-    :full_name,
-    :schoolwide_access,
     :grade_level_access,
     :restricted_to_sped_students,
     :restricted_to_english_language_learners,
+    :schoolwide_access,
+    :districtwide_access,
     :can_view_restricted_notes,
-    :districtwide_access
+    :can_set_districtwide_access
   ].freeze
 
   # FORM_ATTRIBUTES

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -63,9 +63,8 @@ class EducatorsImporter
     log("Educator RecordSyncer#stats: #{@educator_syncer.stats}")
     log("@missing_from_last_export_count: #{@missing_from_last_export_count}")
 
-    # Similar for Homeroom, for now.  We can tighten this but would need to do a pass
-    # on making sure there are key constraints before deleting these (or other changes if
-    # we just mark them).
+    # Preserve Homeroom records that aren't exported any more as well.
+    # This doesn't mark them though and leaves them untouched.
     log('For Homeroom, skipping the call to  RecordSyncer#delete_unmarked_records, to preserve references to older Homeroom records.')
     log("Homeroom RecordSyncer#stats: #{@homeroom_syncer.stats}")
   end

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -54,7 +54,7 @@ class EducatorsImporter
     # these two separate systems independently in ways we do not control.  But an additional
     # sanity check on our end is to disallow access if the educator wasn't in the latest
     # export (and alert).
-    # 
+    #
     log('For Educator, RecordSyncer#process_unmarked_records! to set missing_from_last_export...')
     @educator_syncer.process_unmarked_records!(educator_records_within_scope) do |educator, index|
       educator.update!(missing_from_last_export: true)
@@ -83,7 +83,7 @@ class EducatorsImporter
   def educator_records_within_scope
     # match semantics of SchoolFilter, which treats `nil` as "process everything."
     return Educator.all if @school_scope.nil?
-    
+
     Educator.joins(:school).where(schools: {local_id: @school_scope})
   end
 

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -47,12 +47,25 @@ class EducatorsImporter
 
     # We don't want to remove old Educator records, since notes and other records
     # refence them, and this is important information we want to preserve even if
-    # an Educator is no longer an active employee.
-    log('For Educator, skipping the call to  RecordSyncer#delete_unmarked_records, to preserve references to older Educator records.')
+    # an Educator is no longer an active employee.  We'll remove those records in
+    # a separate retention policy sweep.
+    #
+    # District authentication systems ultimately control access, and districts managed
+    # these two separate systems independently in ways we do not control.  But an additional
+    # sanity check on our end is to disallow access if the educator wasn't in the latest
+    # export (and alert).
+    # 
+    log('For Educator, RecordSyncer#process_unmarked_records! to set missing_from_last_export...')
+    @educator_syncer.process_unmarked_records!(educator_records_within_scope) do |educator, index|
+      educator.update!(missing_from_last_export: true)
+      @missing_from_last_export_count += 1
+    end
     log("Educator RecordSyncer#stats: #{@educator_syncer.stats}")
+    log("@missing_from_last_export_count: #{@missing_from_last_export_count}")
 
     # Similar for Homeroom, for now.  We can tighten this but would need to do a pass
-    # on making sure there are key constraints before deleting these.
+    # on making sure there are key constraints before deleting these (or other changes if
+    # we just mark them).
     log('For Homeroom, skipping the call to  RecordSyncer#delete_unmarked_records, to preserve references to older Homeroom records.')
     log("Homeroom RecordSyncer#stats: #{@homeroom_syncer.stats}")
   end
@@ -64,6 +77,14 @@ class EducatorsImporter
     @ignored_special_nil_homeroom_count = 0
     @ignored_no_homeroom_count = 0
     @ignored_homeroom_because_no_school_count = 0
+    @missing_from_last_export_count = 0
+  end
+
+  def educator_records_within_scope
+    # match semantics of SchoolFilter, which treats `nil` as "process everything."
+    return Educator.all if @school_scope.nil?
+    
+    Educator.joins(:school).where(schools: {local_id: @school_scope})
   end
 
   def download_csv

--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -74,7 +74,11 @@ class StudentsImporter
     @missing_from_last_export_count = 0
   end
 
+  
   def records_within_scope
+    # match semantics of SchoolFilter, which treats `nil` as "process everything."
+    return Student.all if @school_scope.nil?
+    
     Student.joins(:school).where(schools: {local_id: @school_scope})
   end
 

--- a/app/importers/file_importers/students_importer.rb
+++ b/app/importers/file_importers/students_importer.rb
@@ -74,11 +74,10 @@ class StudentsImporter
     @missing_from_last_export_count = 0
   end
 
-  
   def records_within_scope
     # match semantics of SchoolFilter, which treats `nil` as "process everything."
     return Student.all if @school_scope.nil?
-    
+
     Student.joins(:school).where(schools: {local_id: @school_scope})
   end
 

--- a/app/importers/rows/educator_row.rb
+++ b/app/importers/rows/educator_row.rb
@@ -11,6 +11,7 @@ class EducatorRow < Struct.new(:row, :school_ids_dictionary)
     # login_name is the primary key, and email is always secondary
     educator = Educator.find_or_initialize_by(login_name: login_name)
     educator.assign_attributes({
+      missing_from_last_export: false,
       email: email,
       state_id: row[:state_id],
       full_name: row[:full_name],

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -24,6 +24,16 @@ class Educator < ApplicationRecord
 
   VALID_GRADES = [ 'PK', 'KF', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12' ].freeze
 
+  # Indicates the educator was missing from the last export where we expected to
+  # find them, so we treat them as no longer active.
+  def self.active
+    where(missing_from_last_export: false)
+  end
+
+  def active?
+    missing_from_last_export == false
+  end
+
   def is_principal?
     staff_type.try(:downcase) == 'principal'
   end

--- a/app/reports/weekly_report.rb
+++ b/app/reports/weekly_report.rb
@@ -35,7 +35,7 @@ class WeeklyReport
     output
     output
     output
-    output "#{PerDistrict.new.district_name}: Student Insights usage (n=#{Educator.all.size})"
+    output "#{PerDistrict.new.district_name}: Student Insights usage (n=#{Educator.active.size})"
     output usage_table(include_project_leads: true)
     output
     output

--- a/app/views/admin/educators/authorization.html.erb
+++ b/app/views/admin/educators/authorization.html.erb
@@ -1,4 +1,13 @@
 <%= render 'navbar_for_admin_educator_permissions' %>
+<%
+  def row_style_string(educator)
+    if educator.missing_from_last_export
+      'background-color: #f8f8f8; opacity: 0.5; text-decoration: line-through;'
+    else
+      ''
+    end
+  end
+%>
 
 <div style="margin: 20px;">
   <h4 style="color: black; font-size: 24px; border-bottom: 1px solid #333; margin-bottom: 20px; padding-bottom: 10px;">
@@ -20,9 +29,12 @@
           </tr>
         </thead>
         <tbody>
-          <% educators = (@can_set_educators + @admin_educators + @districtwide_educators).uniq %>
+          <% educators = (@can_set_educators + @admin_educators + @districtwide_educators).uniq.sort_by do |educator|
+              [educator.missing_from_last_export ? 1 : 0]
+            end
+          %>
           <% educators.map do |educator| %>
-            <tr>
+            <tr style="<%= row_style_string(educator) %>">
               <td style="padding: 10px; padding-left: 5px;"><%= educator.email %></td>
               <td style="padding: 10px; padding-left: 5px;"><%= link_to educator.full_name, "/educators/view/#{educator.id}" %></td>
               <td style="padding: 10px; padding-left: 5px;">
@@ -78,11 +90,11 @@
               sorted_educators = @all_educators.sort_by do |educator|
                 navbar_links = PathsForEducator.new(educator).navbar_links
                 @navbar_links_map[educator.id] = navbar_links
-                navbar_links.keys
+                [educator.missing_from_last_export ? 1 : 0, navbar_links.keys]
               end
             %>
             <% sorted_educators.map do |educator| %>
-              <tr style="vertical-align: top;">
+              <tr style="vertical-align: top; <%= row_style_string(educator) %>">
                 <td style="padding: 10px; padding-left: 5px;"><%= educator.email %></td>
                 <td style="padding: 10px; padding-left: 5px;"><%= link_to educator.full_name, "/educators/view/#{educator.id}" %></td>
                 <td style="padding: 10px; padding-left: 5px;"><%= educator.school.try(:name) %></td>

--- a/db/migrate/20190823145929_educators_missing_from_last_export.rb
+++ b/db/migrate/20190823145929_educators_missing_from_last_export.rb
@@ -1,0 +1,5 @@
+class EducatorsMissingFromLastExport < ActiveRecord::Migration[5.2]
+  def change
+    add_column :educators, :missing_from_last_export, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_30_151440) do
+ActiveRecord::Schema.define(version: 2019_08_23_145929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -224,6 +224,7 @@ ActiveRecord::Schema.define(version: 2019_07_30_151440) do
     t.boolean "districtwide_access", default: false, null: false
     t.boolean "can_set_districtwide_access", default: false, null: false
     t.text "login_name", null: false
+    t.boolean "missing_from_last_export", default: false, null: false
     t.index ["email"], name: "index_educators_on_email", unique: true
     t.index ["grade_level_access"], name: "index_educators_on_grade_level_access", using: :gin
     t.index ["login_name"], name: "index_educators_on_login_name", unique: true

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "lodash.mergewith": "^4.6.2",
     "lodash-es": "^4.17.14",
     "mixin-deep":"^1.3.2",
-    "set-value":"^3.0.1"
+    "set-value":"^3.0.1",
+    "eslint-utils":"^1.4.1"
   }
 }

--- a/spec/importers/file_importers/educators_importer_spec.rb
+++ b/spec/importers/file_importers/educators_importer_spec.rb
@@ -423,7 +423,7 @@ RSpec.describe EducatorsImporter do
       expect(Educator.all.size).to eq 1
       expect(Educator.find_by_login_name('ntufts').missing_from_last_export).to eq true
     end
-    
+
     it 'does not set missing_from_last_export for existing students when only importing SHS' do
       pals = TestPals.create!
 

--- a/spec/importers/file_importers/students_importer_spec.rb
+++ b/spec/importers/file_importers/students_importer_spec.rb
@@ -172,6 +172,23 @@ RSpec.describe StudentsImporter do
         expect(pals.healey.students.active.size).to eq 1
         expect(pals.west.students.active.size).to eq 1
       end
+
+      it 'processes and marks all records when explicitly called with `school_scope: nil`, matching SchoolFilter behavior' do
+        TestPals.create!
+
+        log = LogHelper::FakeLog.new
+        importer = make_students_importer(log: log, school_scope: nil)
+        mock_importer_with_csv(importer, fixture_filename)
+        importer.import
+
+        # turns whole db over from TestPals to fixture
+        expect(log.output).to include('records_within_import_scope.size: 9 in Insights')
+        expect(log.output).to include(':created_rows_count=>4')
+        expect(log.output).to include('@missing_from_last_export_count: 5')
+        expect(Student.active.size).to eq 4
+        expect(Student.where(missing_from_last_export: true).size).to eq 5
+        expect(Student.all.size).to eq 9
+      end
     end
   end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4837,10 +4837,12 @@ eslint-scope@^4.0.0, eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
-  integrity sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==
+eslint-utils@^1.3.1, eslint-utils@^1.4.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
+  integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
+  dependencies:
+    eslint-visitor-keys "^1.0.0"
 
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
# Who is this PR for?
Project leads across districts

# What problem does this PR fix?
Typically project leads or district IT staff remove educators from the authentication system (eg, LDAP), which means they are not allowed to use Student Insights at all, regardless of past permissions.

By design, the district LDAP system controls who has access regardless of any data within Student Insights.  But Student Insights stores records for staff and students after they have been removed from the daily export, so that it can maintain past information (eg, who wrote a note about a student).  This distinction isn't tracked or shown.

# What does this PR do?
Updates the importer and educator model to track this with `missing_from_last_export`, similar to the `StudentsImporter`.   It also backports a fix for an edge case that hasn't come up to the `StudentsImporter`.

Uses this info in permissions tools for project leads so this process is visible for them.  Removes some old cruft from the administrate config.

This PR doesn't update the authentication process, but a separate one will add a defensive layer beyond the district's own authentication check that ensures the educator record was still present in the latest SIS export.

# Screenshot (if adding a client-side feature)
### adjust permissions list
<img width="1050" alt="Screen Shot 2019-08-23 at 12 04 17 PM" src="https://user-images.githubusercontent.com/1056957/63606755-c741e580-c59e-11e9-83f5-793e9408ae8b.png">

### view
<img width="383" alt="Screen Shot 2019-08-23 at 12 09 18 PM" src="https://user-images.githubusercontent.com/1056957/63606786-da54b580-c59e-11e9-9b86-e640bdda6ca5.png">

### edit
<img width="849" alt="Screen Shot 2019-08-23 at 12 04 30 PM" src="https://user-images.githubusercontent.com/1056957/63606769-d032b700-c59e-11e9-959b-4c0c9c529001.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Educators import
+ [x] Project lead permissions tools

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here