### PR TITLE
Fix administrate use of active instead of active?

### DIFF
--- a/app/dashboards/educator_dashboard.rb
+++ b/app/dashboards/educator_dashboard.rb
@@ -27,7 +27,7 @@ class EducatorDashboard < Administrate::BaseDashboard
     can_view_restricted_notes: YesNoBooleanField.with_options(),
     districtwide_access: YesNoBooleanField.with_options(),
     can_set_districtwide_access: YesNoBooleanField.with_options(),
-    active: YesNoBooleanField.with_options(),
+    active?: YesNoBooleanField.with_options(),
     missing_from_last_export: YesNoBooleanField.with_options()
   }.freeze
 
@@ -39,7 +39,7 @@ class EducatorDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = [
     :full_name,
     :school_id,
-    :active,
+    :active?,
     :schoolwide_access,
     :districtwide_access,
     :can_view_restricted_notes,
@@ -51,7 +51,7 @@ class EducatorDashboard < Administrate::BaseDashboard
     :email,
     :full_name,
     :local_id,
-    :active,
+    :active?,
     :missing_from_last_export,
 
     :school_id,

--- a/app/views/admin/educators/_collection.html.erb
+++ b/app/views/admin/educators/_collection.html.erb
@@ -18,6 +18,7 @@ to display a collection of resources in an HTML table.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
 %>
 
+<% # see educator_dashboard.rb file %>
 <table aria-labelledby="<%= table_title %>">
   <thead>
     <tr>

--- a/app/views/admin/educators/index.html.erb
+++ b/app/views/admin/educators/index.html.erb
@@ -23,6 +23,7 @@ It renders the `_table` partial to display details about the resources.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
 %>
 
+<% # see educator_dashboard.rb file %>
 <%= render 'navbar_for_admin_educator_permissions' %>
 
 <div style="margin: 10px;">

--- a/app/views/fields/yes_no_boolean_field/_form.html.erb
+++ b/app/views/fields/yes_no_boolean_field/_form.html.erb
@@ -5,14 +5,10 @@ This partial renders an input element for a YesNoBoolean attribute.
 By default, the input is a checkbox.
 %>
 
-<% unless field.name == 'districtwide_access' &&
-          !current_educator.can_set_districtwide_access
-          # Don't show the districtwide access field if user doesn't have access
-  %>
-  <div class="field-unit__label">
-    <%= f.label field.attribute %>
-  </div>
-  <div class="field-unit__field">
-    <%= f.check_box field.attribute %>
-  </div>
-<% end %>
+
+<div class="field-unit__label">
+  <%= f.label field.attribute %>
+</div>
+<div class="field-unit__field">
+  <%= f.check_box field.attribute %>
+</div>


### PR DESCRIPTION
Follow-on to https://github.com/studentinsights/studentinsights/pull/2546; the administrate setup is apparently is cool with you describing fields that don't exist on the model and doing its best to try to display them anyway.

Also remove a line that looks like it used to be a permissions guard, but doesn't make sense anymore given there are more restrictive guards elsewhere and the check is in a place unrelated to what the boolean class is about.