### PR TITLE
Educator home page view: Show missing_from_last_export

### DIFF
--- a/app/controllers/educators_controller.rb
+++ b/app/controllers/educators_controller.rb
@@ -28,6 +28,7 @@ class EducatorsController < ApplicationController
         :schoolwide_access,
         :districtwide_access,
         :grade_level_access,
+        :missing_from_last_export,
         :admin
       ],
       :methods => [:labels],


### PR DESCRIPTION
Follows from https://github.com/studentinsights/studentinsights/pull/2546, this feature works the same, but this field is now important context.