### PR TITLE
Patch/allow whitelisting educators as active when missing

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -207,6 +207,14 @@ class PerDistrict
     ENV.fetch('EDUCATORS_IMPORTER_LOGIN_NAME_WHITELIST', '').split(',')
   end
 
+  # Allow specific educator records to always be considered
+  # 'active' regardless of whether they were in the latest SIS
+  # export.  This should only apply to developer accounts, which
+  # districts sometimes handle differently.
+  def educator_login_names_whitelisted_as_active
+    ENV.fetch('EDUCATOR_LOGIN_NAMES_WHITELISTED_AS_ACTIVE', '').split(',')
+  end
+
   # Allows username or full email address, depending on district.
   # Transitioning to username only.
   def find_educator_by_login_text(login_text)

--- a/app/controllers/educators_controller.rb
+++ b/app/controllers/educators_controller.rb
@@ -28,6 +28,7 @@ class EducatorsController < ApplicationController
         :schoolwide_access,
         :districtwide_access,
         :grade_level_access,
+        :missing_from_last_export,
         :admin
       ],
       :methods => [:labels],

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -26,12 +26,24 @@ class Educator < ApplicationRecord
 
   # Indicates the educator was missing from the last export where we expected to
   # find them, so we treat them as no longer active.
+  # 
+  # Student Insights admin accounts are sometimes handled differently by districts,
+  # so this enables those whitelisted accounts to be "active" regardless.
+  #
+  # `missing_from_last_export` will always reflect the SIS, while `active` is an
+  # Insights concept.
   def self.active
-    where(missing_from_last_export: false)
+    (
+      where(missing_from_last_export: false) +
+      where(login_name: PerDistrict.new.educator_login_names_whitelisted_as_active())
+    )
   end
 
   def active?
-    missing_from_last_export == false
+    (
+      missing_from_last_export == false || 
+      PerDistrict.new.educator_login_names_whitelisted_as_active().include?(login_name)
+    )
   end
 
   def is_principal?


### PR DESCRIPTION
https://github.com/studentinsights/studentinsights/pull/2546 Revealed that in some districts, Student Insights admin or developer users are set up for authentication but not in the SIS export.

Rather than trying to standardize this with districts (which might have other complex interactions on their size), this PR adds a whitelist so that the concepts of `missing_since_last_export` are always descriptive of the SIS data, while `active` within Student Insights can be whitelisted for these few cases.
