### PR TITLE
Section exports: Update Somerville section exports to query for school year

### DIFF
--- a/x2_export/sql/courses_sections_export.sql
+++ b/x2_export/sql/courses_sections_export.sql
@@ -27,8 +27,10 @@ LEFT JOIN course_school
   ON schedule_master.MST_CSK_OID = course_school.CSK_OID
 INNER JOIN school
   ON course_school.CSK_SKL_OID = school.SKL_OID
-AND CTX_SCHOOL_YEAR=2019 -- when does the school year end?
-  INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/courses_sections_export.txt"
+INNER JOIN school_schedule_context
+  ON school_schedule_context.SKX_OID = school.SKL_SKX_OID_ACTIV # no "E" at the end of active
+ AND school_schedule_context.SKX_SCH_OID_ACTIVE = schedule.SCH_OID
+INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/courses_sections_export.txt"
   FIELDS TERMINATED BY ','
   ENCLOSED BY '"'
   LINES TERMINATED BY '\r\n'

--- a/x2_export/sql/educator_section_assignment_export.sql
+++ b/x2_export/sql/educator_section_assignment_export.sql
@@ -33,8 +33,10 @@ INNER JOIN person
   ON staff.STF_PSN_OID=person.PSN_OID
 INNER JOIN user_info
   ON person.PSN_OID=user_info.USR_PSN_OID
-AND CTX_SCHOOL_YEAR=2019 -- when does the school year end?
-  INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/educator_section_assignment_export.txt"
+INNER JOIN school_schedule_context
+  ON school_schedule_context.SKX_OID = school.SKL_SKX_OID_ACTIV # no "E" at the end of active
+ AND school_schedule_context.SKX_SCH_OID_ACTIVE = schedule.SCH_OID
+INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/educator_section_assignment_export.txt"
   FIELDS TERMINATED BY ','
   ENCLOSED BY '"'
   LINES TERMINATED BY '\r\n'

--- a/x2_export/sql/student_section_assignment_export.sql
+++ b/x2_export/sql/student_section_assignment_export.sql
@@ -27,7 +27,9 @@ INNER JOIN student_schedule
   ON schedule_master.MST_OID = student_schedule.SSC_MST_OID
 INNER JOIN student
   ON student_schedule.SSC_STD_OID = student.STD_OID
-AND CTX_SCHOOL_YEAR=2019 -- when does the school year end?
+INNER JOIN school_schedule_context
+  ON school_schedule_context.SKX_OID = school.SKL_SKX_OID_ACTIV # no "E" at the end of active
+ AND school_schedule_context.SKX_SCH_OID_ACTIVE = schedule.SCH_OID
   INTO OUTFILE "E:/_BACKUP_MYSQL/CodeForAmerica/student_section_assignment_export.txt"
   FIELDS TERMINATED BY ','
   ENCLOSED BY '"'


### PR DESCRIPTION
# Who is this PR for?
Somerville IT pals

# What problem does this PR fix?
These scripts required IT folks to update the school year in each one, and if one is missed then the import processes can't process the incomplete data.

# What does this PR do?
With help from JB, these are now updated to query the master schedule for the current school year.  (note the the "district_school_year" convention here is unchanged, and remains different from the Student Insights numbering in `school_year.rb`).

# Checklists
*Which features or pages does this PR touch?*
+ [X] SHS section importers

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here