### PR TITLE
Counselor meetings: Update inline profile to have clearer links to full profile

### DIFF
--- a/app/assets/javascripts/counselor_meetings/CounselorMeetingsView.js
+++ b/app/assets/javascripts/counselor_meetings/CounselorMeetingsView.js
@@ -286,11 +286,17 @@ export default class CounselorMeetingsView extends React.Component {
     const feedCards = json.feed_cards;
     return (
       <div style={{background: 'white', fontSize: 14}}>
-        <StudentPhoto
-          style={{height: 200, border: '2px solid #1b82ea'}}
-          student={student}
-          fallbackEl={<span>😃</span>}
-        />
+        <a
+          href={`/students/${student.id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <StudentPhoto
+            style={{height: 200, border: '2px solid #1b82ea'}}
+            student={student}
+            fallbackEl={<span>😃</span>}
+          />
+        </a>
         <div style={{
           display: 'flex',
           flexDirection: 'row'
@@ -302,15 +308,30 @@ export default class CounselorMeetingsView extends React.Component {
           }}>
             {this.renderBubble(student.meetingMoment)}
           </div>
-          <div style={{
-            marginLeft: 10,
-            fontSize: 24,
-            marginTop: 5
-          }}> {student.first_name} {student.last_name}</div>
+          <a
+            href={`/students/${student.id}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              marginLeft: 10,
+              fontSize: 24,
+              marginTop: 5
+            }}> {student.first_name} {student.last_name}</a>
         </div>
 
-        <SectionHeading style={{marginTop: 15}}>
-          Notes for {student.first_name}
+        <SectionHeading
+          style={{marginTop: 15}}
+          titleStyle={{
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center'
+          }}
+        >
+          <div>Notes for {student.first_name}</div>
+          <a style={{fontSize: 14}} href={`/students/${student.id}`} target="_blank" rel="noopener noreferrer">
+            Open profile
+          </a>
         </SectionHeading>
         <CleanSlateFeedView feedCards={feedCards} />
       </div>


### PR DESCRIPTION
# Who is this PR for?
SHS counselors

# What does this PR do?
Make more ways to get to the full profile, including an explicit link.

# Screenshot (if adding a client-side feature)
<img width="1033" alt="Screen Shot 2019-08-27 at 3 11 00 PM" src="https://user-images.githubusercontent.com/1056957/63801024-60ddff80-c8dd-11e9-9da8-92285a0cbed0.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Counselor meetings

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here