### PR TITLE
Counselor meeting: Remove link on row

### DIFF
--- a/app/assets/javascripts/counselor_meetings/CounselorMeetingsView.js
+++ b/app/assets/javascripts/counselor_meetings/CounselorMeetingsView.js
@@ -398,11 +398,12 @@ export default class CounselorMeetingsView extends React.Component {
     );
   }
 
+  // No link, since row is clickable; folks can navigate to profile after viewing inline
   renderName(cellProps) {
     const student = cellProps.rowData;
     return (
       <div style={styles.nameBlock}>
-        <a style={{fontSize: 14}} href={`/students/${student.id}`} target="_blank" rel="noopener noreferrer">{student.first_name} {student.last_name}</a>
+        <span style={{fontSize: 14}}>{student.first_name} {student.last_name}</span>
         {student.has_photo && (
           <StudentPhotoCropped
             studentId={student.id}


### PR DESCRIPTION
With https://github.com/studentinsights/studentinsights/pull/2552, this link is a bit redundant and can be confusing if folks try to click on the row (although it is like that in other pages).