### PR TITLE
Permissions tools: Add all educators with restricted notes access to sensitive users

### DIFF
--- a/app/views/admin/educators/authorization.html.erb
+++ b/app/views/admin/educators/authorization.html.erb
@@ -29,7 +29,7 @@
           </tr>
         </thead>
         <tbody>
-          <% educators = (@can_set_educators + @admin_educators + @districtwide_educators).uniq.sort_by do |educator|
+          <% educators = (@can_set_educators + @restricted_notes_educators + @districtwide_educators + @admin_educators).uniq.sort_by do |educator|
               [educator.active? ? 0 : 1]
             end
           %>


### PR DESCRIPTION
This is discoverable in a few different ways, but make this more explicit.