### PR TITLE
Monitoring: Add debugKey to RollbarErrorBoundary

### DIFF
--- a/app/assets/javascripts/components/RollbarErrorBoundary.js
+++ b/app/assets/javascripts/components/RollbarErrorBoundary.js
@@ -21,7 +21,11 @@ export default class RollbarErrorBoundary extends React.Component {
   }
 
   componentDidCatch(error, info) {
-    this.rollbarErrorFn('RollbarErrorBoundary#componentDidCatch', {error, info});
+    const {debugKey} = this.props;
+    const msg = (debugKey)
+      ? 'RollbarErrorBoundary#componentDidCatch'
+      : `RollbarErrorBoundary#componentDidCatch for debugKey=${debugKey}`;
+    this.rollbarErrorFn(msg, {error, info, debugKey});
   }
 
   rollbarErrorFn(msg, obj = {}) {
@@ -46,5 +50,6 @@ export default class RollbarErrorBoundary extends React.Component {
 }
 RollbarErrorBoundary.propTypes = {
   children: PropTypes.node.isRequired,
-  rollbarErrorFn: PropTypes.func
+  rollbarErrorFn: PropTypes.func,
+  debugKey: PropTypes.string
 };

--- a/app/assets/javascripts/reader_profile/ReaderProfileJunePage.js
+++ b/app/assets/javascripts/reader_profile/ReaderProfileJunePage.js
@@ -14,7 +14,7 @@ export default class ReaderProfileJunePage extends React.Component {
     const url = `/api/students/${student.id}/reader_profile_json`;
 
     return (
-      <RollbarErrorBoundary>
+      <RollbarErrorBoundary debugKey="ReaderProfileJunePage">
         <div className="ReaderProfileJunePage">
           <SectionHeading>Reader Profile (June v2)</SectionHeading>
           <GenericLoader

--- a/ui/App.js
+++ b/ui/App.js
@@ -62,7 +62,7 @@ export default class App extends React.Component {
   render() {
     const {districtKey, rollbarErrorFn, sessionTimeoutInSeconds} = this.props;
     return (
-      <RollbarErrorBoundary rollbarErrorFn={rollbarErrorFn}>
+      <RollbarErrorBoundary debugKey="App" rollbarErrorFn={rollbarErrorFn}>
         <NowContainer nowFn={() => moment.utc()}>
           <PerDistrictContainer districtKey={districtKey}>
             <div className="App-content" style={styles.flexVertical}>


### PR DESCRIPTION
`componentStack` in production is not super useful :\ so this at least lets us tell where the boundary component itself is being rendered.