### PR TITLE
Monitoring: Include displayName in production build

### DIFF
--- a/ui/config/webpack.prod.js
+++ b/ui/config/webpack.prod.js
@@ -20,7 +20,15 @@ module.exports = merge(common, {
 
   plugins: [
     new CleanWebpackPlugin(['../../public/build'], { allowExternal: true }),
-    new UglifyJSPlugin({sourceMap: true}),
+    new UglifyJSPlugin({
+      sourceMap: true,
+
+      // so that Function.name works for React inferring `displayName`
+      // see plugin docs here https://github.com/mishoo/UglifyJS2#mangle-options
+      mangle: {
+        keep_fnames: true
+      }
+    }),
     new webpack.DefinePlugin({
       'process.env': {
         'NODE_ENV': JSON.stringify('production')


### PR DESCRIPTION
This is for developers and understanding what's in `componenStack` and related monitoring information coming from Rollbar.  This does add to the build size, but going to see what this does first.  Definitely better to optimize for visibility into errors and faster response time over first-time load.