### PR TITLE
Searchbar: Update job to run based on active educators, not sign in

### DIFF
--- a/lib/tasks/searchbar.rake
+++ b/lib/tasks/searchbar.rake
@@ -1,15 +1,23 @@
 namespace :searchbar do
   desc 'Update educator student searchbar cached data'
   task update_for_all_educators: :environment do
-    Educator.all.each do |educator|
-      EducatorSearchbar.update_student_searchbar_json!(educator)
-    end
-  end
+    # This is a long-running task, and can take an hour or two to run slowly as an
+    # overnight task.
 
-  desc 'Update educator student searchbar data for those who have logged in'
-  task update_for_educators_who_log_in: :environment do
-    Educator.where("sign_in_count > ?", 0).each do |educator|
+    # First, update this for all active educators.
+    puts 'Starting update for active educators...'
+    active_educators = Educator.active
+    active_educators.each do |educator|
+      puts "  updating searchbar for educator.id: #{educator.id}..."
       EducatorSearchbar.update_student_searchbar_json!(educator)
     end
+    puts 'Done update.'
+
+    # Then prune any old records, for educators who are no longer active.
+    puts 'Pruning old records...'
+    records_to_prune = EducatorSearchbar.where.not(educator_id: active_educators.map(&:id))
+    puts "  found #{records_to_prune.size} records_to_prune, destroying them..."
+    records_to_prune.destroy!
+    puts 'Done prune.'
   end
 end


### PR DESCRIPTION
# Who is this PR for?
new educators

# What problem does this PR fix?
The previous strategy looked at login, which meant that first-time users wouldn't have a great experience here.  We've seen this happen for folks this week in monitoring.

Related:
- https://rollbar.com/somerville-teacher-tool/studentinsights/items/418/
- https://rollbar.com/somerville-teacher-tool/studentinsights/items/383/

# What does this PR do?
We can use the work in https://github.com/studentinsights/studentinsights/pull/2546 to based this off of the latest export instead, and spend more offline computation time to cache these ahead of time so the first-time UX is better, especially at the start of the year.

Also update the job to prune stale values from this cache (note that this is just a cache for the UI, and doesn't influence authorization to records at all).

After shipping this, I'll run this manually and then update the jobs to use this instead of the task that this PR removes.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Core navigation UX - searchbar

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here