### PR TITLE
Fix list of educators in permissions tool to not repeat

### DIFF
--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -42,8 +42,7 @@ module Admin
 
     def sorted_sensitive_educators(educators)
       filtered = educators.select do |educator|
-        (
-          educator.active? ||
+        educator.active? && (
           educator.can_set_districtwide_access ||
           educator.can_view_restricted_notes ||
           educator.districtwide_access ||


### PR DESCRIPTION
Don't always include all active educators in sensitive area, only those with elevated permissions.