### PR TITLE
Transition notes: Add more specs for reading restricted notes, update…

### DIFF
--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -27,7 +27,7 @@ class EducatorLabel < ApplicationRecord
         # transition notes
         'k8_counselor',
         'high_school_house_master',
-        'enable_transition_note_features',
+        'enable_transition_note_features', # Controls whether user can create new transition notes, not whether they are viewable.
         'enable_transition_note_editing',
 
         # class lists


### PR DESCRIPTION
… to allow all with restricted access to read

# Who is this PR for?
SHS counselors, APs

# What problem does this PR fix?
Transition notes were controlled by a feature switch previously, which mostly controlled access to writing.  It also incorrectly controlled access to read the restricted section, which should instead just be controlled by `can_view_restricted_notes`.  Some test setup for this specific endpoint were present, but test cases weren't added.

Related to https://rollbar.com/somerville-teacher-tool/studentinsights/items/246/occurrences/93530182055/

# What does this PR do?
Changes authorization for accessing the restricted transition note text.  This doesn't require access to any labels, but is available for all educators with `can_view_restricted_notes:true`.

Adds more test cases.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage