### PR TITLE
Transition notes: Update branching in UI for show restricted note

### DIFF
--- a/app/assets/javascripts/student_profile/NotesList.js
+++ b/app/assets/javascripts/student_profile/NotesList.js
@@ -152,7 +152,7 @@ export default class NotesList extends React.Component {
   }
 
   renderSecondTransitionNote(secondTransitionNote) {
-    const {educatorsIndex, currentEducator, student} = this.props;
+    const {canUserAccessRestrictedNotes, educatorsIndex, currentEducator, student} = this.props;
     const educator = educatorsIndex[secondTransitionNote.educator_id];
     const allowEditing = enableTransitionNoteDialog(currentEducator, student) && (
       (currentEducator.labels.indexOf('enable_transition_note_editing') !== -1) ||
@@ -167,6 +167,7 @@ export default class NotesList extends React.Component {
         educatorEl={<Educator educator={educator} />}
         substanceEl={
           <SecondTransitionNoteInline
+            canUserAccessRestrictedNotes={canUserAccessRestrictedNotes}
             allowEditing={allowEditing}
             currentEducator={currentEducator}
             student={student}

--- a/app/assets/javascripts/student_profile/NotesList.test.js
+++ b/app/assets/javascripts/student_profile/NotesList.test.js
@@ -88,6 +88,34 @@ function testPropsForHomeworkHelp(props = {}) {
   });
 }
 
+function testPropsForSecondTransitionNotes(props = {}) {
+  return testProps({
+    feed: {
+      ...feedWithEventNotesJson([]),
+      second_transition_notes: [{
+        id: 42,
+        created_at: '2017-05-18T14:31:29.113Z',
+        updated_at: '2017-05-18T14:31:29.113Z',
+        educator_id: 1,
+        student_id: 1,
+        form_key: 'somerville_8th_to_9th_grade',
+        form_json: {
+          strengths: '...strengths...',
+          connecting: '...connecting...',
+          community: '...community...',
+          peers: '...peers...',
+          family: '...family...',
+          other: '...other...',
+        },
+        starred: true,
+        recorded_at: '2019-05-18T14:31:29.102Z',
+        has_restricted_text: true
+      }]
+    },
+    ...props
+  });
+}
+
 function testRender(props) {
   const el = document.createElement('div');
   ReactDOM.render(withDefaultNowContext(<NotesList {...props} />), el);
@@ -266,4 +294,41 @@ it('works for Bedford transition notes', () => {
   expect($(el).find('.BedfordTransitionSubstanceForProfile').length).toEqual(1);
   expect($(el).find('.EditableNoteText').length).toEqual(0);
   expect($(el).text()).toContain('Transition information');
+});
+
+describe('second transition notes, inline', () => {
+  it('works on happy path', () => {
+    const props = testPropsForSecondTransitionNotes();
+    const el = testRender(props);
+    expect($(el).find('.SecondTransitionNoteInline').length).toEqual(1);
+    expect($(el).find('.NoteText:eq(0)').text()).toEqual([
+      "What are Daisy's strengths?",
+      "...strengths...",
+      '',
+      "What works well for connecting with Daisy?",
+      "...connecting...",
+      '',
+      "How does Daisy relate to their peers?",
+      "...community...",
+      '',
+      "How has Daisy become involved with the school community?",
+      "...peers...",
+      '',
+      "What works well for communicating with Daisy’s family?",
+      "...family...",
+      '',
+      "Any additional comments or good things to know?",
+      "...other..."
+    ].join("\n"));
+    expect($(el).text()).toContain('What other services does Daisy receive now, and who are the points of contact (eg, social workers, mental health counselors)?');
+    expect($(el).find('.RestrictedNotePresence').length).toEqual(1);
+  });
+
+  it('includes link for restricted note when canUserAccessRestrictedNotes', () => {
+    const props = testPropsForSecondTransitionNotes({
+      canUserAccessRestrictedNotes: true
+    });
+    const el = testRender(props);
+    expect($(el).find('.RestrictedNotePresence a').text()).toEqual('show restricted note');
+  });
 });

--- a/app/assets/javascripts/student_profile/SecondTransitionNoteInline.js
+++ b/app/assets/javascripts/student_profile/SecondTransitionNoteInline.js
@@ -60,7 +60,7 @@ export default class SecondTransitionNoteInline extends React.Component {
   }
 
   renderRestrictedInline() {
-    const {student, currentEducator, json} = this.props;
+    const {canUserAccessRestrictedNotes, student, currentEducator, json} = this.props;
     if (!json.has_restricted_text) return null;
     
     const educatorName = formatEducatorName(currentEducator);
@@ -75,7 +75,7 @@ export default class SecondTransitionNoteInline extends React.Component {
         <RestrictedNotePresence
           studentFirstName={student.first_name}
           educatorName={educatorFirstNameOrEmail}
-          fetchRestrictedText={fetchRestrictedText}
+          fetchRestrictedText={canUserAccessRestrictedNotes && fetchRestrictedText}
         />
       </div>
     );
@@ -132,6 +132,7 @@ SecondTransitionNoteInline.propTypes = {
     first_name: PropTypes.string.isRequired,
     grade: PropTypes.string.isRequired
   }).isRequired,
+  canUserAccessRestrictedNotes: PropTypes.bool,
   allowEditing: PropTypes.bool
 };
 

--- a/app/assets/javascripts/student_profile/fixtures/fixtures.js
+++ b/app/assets/javascripts/student_profile/fixtures/fixtures.js
@@ -824,7 +824,8 @@ export const studentProfile = {
       "schoolwide_access": true,
       "grade_level_access": [],
       "restricted_to_sped_students": false,
-      "restricted_to_english_language_learners": false
+      "restricted_to_english_language_learners": false,
+      "labels": []
     },
     "2": {
       "id": 2,
@@ -841,7 +842,8 @@ export const studentProfile = {
       "schoolwide_access": false,
       "grade_level_access": [],
       "restricted_to_sped_students": false,
-      "restricted_to_english_language_learners": false
+      "restricted_to_english_language_learners": false,
+      "labels": []
     }
   },
   "currentEducator": currentEducator,


### PR DESCRIPTION
Related to https://github.com/studentinsights/studentinsights/pull/2565.

# Who is this PR for?
SHS counselors and APs

# What problem does this PR fix?
https://github.com/studentinsights/studentinsights/pull/2565 made the authorization more permissive to allow folks with access to view restricted text in transition notes.  But the UI code would show the link for folks who didn't have permission, which came up verifying https://github.com/studentinsights/studentinsights/pull/2565.  None of these granted access where it should not have been granted.

# What does this PR do?
Updates the UI code to branch, and adds tests for this.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile, inline transition notes

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
