### PR TITLE
Update static error pages, email links

### DIFF
--- a/app/assets/javascripts/components/PublicLinks.js
+++ b/app/assets/javascripts/components/PublicLinks.js
@@ -8,7 +8,7 @@ export function Website(props) {
 
 
 export function HelpEmail(props) {
-  return <a {...props} href="mailto://help@studentinsights.org">{props.children || 'help@studentinsights.org'}</a>;
+  return <a {...props} href="mailto:help@studentinsights.org">{props.children || 'help@studentinsights.org'}</a>;
 }
 HelpEmail.propTypes = {
   children: PropTypes.node
@@ -16,7 +16,7 @@ HelpEmail.propTypes = {
 
 
 export function Email(props) {
-  return <a {...props} href="mailto://ideas@studentinsights.org">{props.children || 'ideas@studentinsights.org'}</a>;
+  return <a {...props} href="mailto:ideas@studentinsights.org">{props.children || 'ideas@studentinsights.org'}</a>;
 }
 Email.propTypes = {
   children: PropTypes.node

--- a/app/assets/javascripts/district_overview/__snapshots__/DistrictOverviewPage.test.js.snap
+++ b/app/assets/javascripts/district_overview/__snapshots__/DistrictOverviewPage.test.js.snap
@@ -716,7 +716,7 @@ exports[`DistrictOverviewPageView pure snapshot when \`enable_equity_experiments
             <li>
               Contact 
               <a
-                href="mailto://help@studentinsights.org"
+                href="mailto:help@studentinsights.org"
               >
                 help@studentinsights.org
               </a>
@@ -809,7 +809,7 @@ exports[`DistrictOverviewPageView pure snapshot when \`enable_equity_experiments
       >
         Please share your feedback with 
         <a
-          href="mailto://ideas@studentinsights.org"
+          href="mailto:ideas@studentinsights.org"
           style={
             Object {
               "fontWeight": "bold",
@@ -1678,7 +1678,7 @@ exports[`DistrictOverviewPageView pure snapshot, without work board 1`] = `
             <li>
               Contact 
               <a
-                href="mailto://help@studentinsights.org"
+                href="mailto:help@studentinsights.org"
               >
                 help@studentinsights.org
               </a>

--- a/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
@@ -472,7 +472,7 @@ exports[`snapshots works for aladdin grades 1`] = `
                   </a>
                    and email 
                   <a
-                    href="mailto://ideas@studentinsights.org"
+                    href="mailto:ideas@studentinsights.org"
                     style={
                       Object {
                         "fontSize": 12,
@@ -1698,7 +1698,7 @@ exports[`snapshots works for aladdin notes 1`] = `
                   </a>
                    and email 
                   <a
-                    href="mailto://ideas@studentinsights.org"
+                    href="mailto:ideas@studentinsights.org"
                     style={
                       Object {
                         "fontSize": 12,
@@ -3073,7 +3073,7 @@ exports[`snapshots works for aladdin testing 1`] = `
                   </a>
                    and email 
                   <a
-                    href="mailto://ideas@studentinsights.org"
+                    href="mailto:ideas@studentinsights.org"
                     style={
                       Object {
                         "fontSize": 12,
@@ -3727,7 +3727,7 @@ exports[`snapshots works for aladdin testing 1`] = `
           <div>
             Please reach out to your district lead or 
             <a
-              href="mailto://ideas@studentinsights.org"
+              href="mailto:ideas@studentinsights.org"
             >
               ideas@studentinsights.org
             </a>
@@ -3794,7 +3794,7 @@ exports[`snapshots works for aladdin testing 1`] = `
           <div>
             Please reach out to your district lead or 
             <a
-              href="mailto://ideas@studentinsights.org"
+              href="mailto:ideas@studentinsights.org"
             >
               ideas@studentinsights.org
             </a>
@@ -4231,7 +4231,7 @@ exports[`snapshots works for olaf math 1`] = `
                   </a>
                    and email 
                   <a
-                    href="mailto://ideas@studentinsights.org"
+                    href="mailto:ideas@studentinsights.org"
                     style={
                       Object {
                         "fontSize": 12,
@@ -5487,7 +5487,7 @@ exports[`snapshots works for olaf notes 1`] = `
                   </a>
                    and email 
                   <a
-                    href="mailto://ideas@studentinsights.org"
+                    href="mailto:ideas@studentinsights.org"
                     style={
                       Object {
                         "fontSize": 12,
@@ -6814,7 +6814,7 @@ exports[`snapshots works for olaf reading 1`] = `
                   </a>
                    and email 
                   <a
-                    href="mailto://ideas@studentinsights.org"
+                    href="mailto:ideas@studentinsights.org"
                     style={
                       Object {
                         "fontSize": 12,
@@ -8063,7 +8063,7 @@ exports[`snapshots works for pluto attendance 1`] = `
                   </a>
                    and email 
                   <a
-                    href="mailto://ideas@studentinsights.org"
+                    href="mailto:ideas@studentinsights.org"
                     style={
                       Object {
                         "fontSize": 12,
@@ -9190,7 +9190,7 @@ exports[`snapshots works for pluto behavior 1`] = `
                   </a>
                    and email 
                   <a
-                    href="mailto://ideas@studentinsights.org"
+                    href="mailto:ideas@studentinsights.org"
                     style={
                       Object {
                         "fontSize": 12,
@@ -10417,7 +10417,7 @@ exports[`snapshots works for pluto notes 1`] = `
                   </a>
                    and email 
                   <a
-                    href="mailto://ideas@studentinsights.org"
+                    href="mailto:ideas@studentinsights.org"
                     style={
                       Object {
                         "fontSize": 12,

--- a/public/404.html
+++ b/public/404.html
@@ -41,6 +41,7 @@
       <div>
         <div>We can't find the page you're looking for.
         <div>Please head back to <a href="/">Student Insights Home</a>.
+        <div>If you need help immediately, email <a href="mailto:help@studentinsights.org">help@studentinsights.org</a> directly.</div>
       </div>
     </div>
   </div>

--- a/public/422.html
+++ b/public/422.html
@@ -42,7 +42,7 @@
         <div>We're sorry, something went wrong with processing that action.  :(</div>
         <br />
         <div>The developers have been alerted automatically.</div>
-        <div>If you need help immediately, <a href="https://github.com/studentinsights/studentinsights/issues/new">open a GitHub issue</a> or email them directly.</div>
+        <div>If you need help immediately, email <a href="mailto:help@studentinsights.org">help@studentinsights.org</a> directly.</div>
         <div>Back to <a href="/">Student Insights Home</a>.
       </div>
     </div>

--- a/public/500.html
+++ b/public/500.html
@@ -42,7 +42,7 @@
         <div>We're sorry, something went wrong.  :(</div>
         <br />
         <div>The developers have been alerted automatically.</div>
-        <div>If you need help immediately, <a href="https://github.com/studentinsights/studentinsights/issues/new">open a GitHub issue</a> or email them directly.</div>
+        <div>If you need help immediately, email <a href="mailto:help@studentinsights.org">help@studentinsights.org</a> directly.</div>
         <div>Back to <a href="/">Student Insights Home</a>.
       </div>
     </div>


### PR DESCRIPTION
Use email instead of asking folks to open GitHub issues, and update to proper `mailto:` hrefs.