### PR TITLE
Home page feed: Show homerooms for all schools but SHS

### DIFF
--- a/app/assets/javascripts/feed/FeedCardFrame.js
+++ b/app/assets/javascripts/feed/FeedCardFrame.js
@@ -99,36 +99,42 @@ const styles = {
 };
 
 
-function FrameHeader(props) {
-  const {student, byEl, whereEl, whenEl, hidePhoto} = props;
-  const {homeroom, school} = student;
-  const shouldShowHomeroom = homeroom && school && isHomeroomMeaningful(school.school_type);
-  const shouldShowPhoto = (student.has_photo && !hidePhoto);
-  return (
-    <div style={styles.header} className="FeedCardFrame-FrameHeader">
-      <div style={{display: 'flex'}}>
-        {shouldShowPhoto && <StudentPhotoCropped studentId={student.id} />}
-        <div style={styles.studentHeader}>
-          <div>
-            <a style={styles.person} href={`/students/${student.id}`}>{student.first_name} {student.last_name}</a>
-          </div>
-          <div>{gradeText(student.grade)}</div>
-          <div>
-            {shouldShowHomeroom && <Homeroom
-              id={homeroom.id}
-              name={homeroom.name}
-              educator={homeroom.educator} />}
+class FrameHeader extends React.Component {
+  render() {
+    const {districtKey} = this.context;
+    const {student, byEl, whereEl, whenEl, hidePhoto} = this.props;
+    const {homeroom, school} = student;
+    const shouldShowHomeroom = homeroom && school && isHomeroomMeaningful(districtKey, school.local_id);
+    const shouldShowPhoto = (student.has_photo && !hidePhoto);
+    return (
+      <div style={styles.header} className="FeedCardFrame-FrameHeader">
+        <div style={{display: 'flex'}}>
+          {shouldShowPhoto && <StudentPhotoCropped studentId={student.id} />}
+          <div style={styles.studentHeader}>
+            <div>
+              <a style={styles.person} href={`/students/${student.id}`}>{student.first_name} {student.last_name}</a>
+            </div>
+            <div>{gradeText(student.grade)}</div>
+            <div>
+              {shouldShowHomeroom && <Homeroom
+                id={homeroom.id}
+                name={homeroom.name}
+                educator={homeroom.educator} />}
+            </div>
           </div>
         </div>
+        <div style={styles.by}>
+          <div>{byEl}</div>
+          <div>{whereEl}</div>
+          <div>{whenEl}</div>
+        </div>
       </div>
-      <div style={styles.by}>
-        <div>{byEl}</div>
-        <div>{whereEl}</div>
-        <div>{whenEl}</div>
-      </div>
-    </div>
-  );
+    );
+  }
 }
+FrameHeader.contextTypes = {
+  districtKey: PropTypes.string.isRequired
+};
 FrameHeader.propTypes = {
   student: PropTypes.shape({
     id: PropTypes.number.isRequired,

--- a/app/assets/javascripts/feed/FeedCardFrame.test.js
+++ b/app/assets/javascripts/feed/FeedCardFrame.test.js
@@ -29,6 +29,29 @@ function testStudent() {
   };
 }
 
+function testStudentFullCircle() {
+  return {
+    id: 66,
+    first_name: 'Obi',
+    last_name: 'Ren',
+    grade: '9',
+    house: null,
+    school: {
+      local_id: 'FC',
+      school_type: 'HS'
+    },
+    homeroom: {
+      id: 15,
+      name: 'FC-004',
+      educator: {
+        id: 5,
+        email: 'dt@demo.studentinsights.org',
+        full_name: 'Teacher, Darth',
+      }
+    }
+  };
+}
+
 function testStudentElementary() {
   return {
     id: 32,
@@ -78,7 +101,7 @@ function testRender(props = {}, context = {}) {
   return el;
 }
 
-it('renders for HS without crashing', () => {
+it('renders for SHS without homeroom info', () => {
   const el = testRender(testProps(testStudent()));
   expect($(el).text()).toContain('Mari Skywalker');
   expect($(el).text()).toContain('9th grade');
@@ -89,6 +112,13 @@ it('renders for HS without crashing', () => {
   expect($(el).text()).toContain('when');
   expect($(el).text()).toContain('badges');
   expect($(el).text()).toContain('kids');
+});
+
+it('renders homeroom info for FC', () => {
+  const el = testRender(testProps(testStudentFullCircle()));
+  expect($(el).text()).toContain('Obi Ren');
+  expect($(el).text()).toContain('FC-004');
+  expect($(el).text()).toContain('with Darth Teacher');
 });
 
 it('renders homeroom for ESMS', () => {
@@ -104,6 +134,7 @@ it('matches all snapshots', () => {
       <div>
         {testEl(testProps(testStudent()))}
         {testEl(testProps(testStudentElementary()))}
+        {testEl(testProps(testStudentFullCircle()))}
       </div>
     )
     .toJSON();

--- a/app/assets/javascripts/feed/__snapshots__/FeedCardFrame.test.js.snap
+++ b/app/assets/javascripts/feed/__snapshots__/FeedCardFrame.test.js.snap
@@ -248,5 +248,140 @@ exports[`matches all snapshots 1`] = `
       </div>
     </div>
   </div>
+  <div
+    className="Card FeedCardFrame"
+    style={
+      Object {
+        "border": "1px solid #ccc",
+        "borderRadius": 3,
+        "padding": 10,
+      }
+    }
+  >
+    <div
+      className="FeedCardFrame-FrameHeader"
+      style={
+        Object {
+          "alignItems": "flex-start",
+          "display": "flex",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "display": "flex",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "flex-start",
+              "display": "flex",
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
+            }
+          }
+        >
+          <div>
+            <a
+              href="/students/66"
+              style={
+                Object {
+                  "fontWeight": "bold",
+                }
+              }
+            >
+              Obi
+               
+              Ren
+            </a>
+          </div>
+          <div>
+            9th grade
+          </div>
+          <div>
+            <span
+              className="Homeroom"
+              style={Object {}}
+            >
+              <a
+                href="/homerooms/15"
+              >
+                FC-004
+              </a>
+              <span>
+                <span>
+                   
+                </span>
+                 with 
+                <a
+                  className="Educator"
+                  href="mailto:dt@demo.studentinsights.org"
+                  style={Object {}}
+                >
+                  Darth Teacher
+                </a>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "display": "flex",
+            "flexDirection": "column",
+            "textAlign": "right",
+          }
+        }
+      >
+        <div>
+          <div>
+            by
+          </div>
+        </div>
+        <div>
+          <div>
+            where
+          </div>
+        </div>
+        <div>
+          <div>
+            when
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      style={
+        Object {
+          "marginBottom": 20,
+          "marginTop": 20,
+        }
+      }
+    >
+      kids
+    </div>
+    <div
+      className="FeedCardFrame-footer"
+      style={
+        Object {
+          "display": "flex",
+          "justifyContent": "space-between",
+          "marginBottom": 5,
+        }
+      }
+    >
+      <div />
+      <div>
+        badges
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -166,11 +166,12 @@ export function supportsExcusedAbsences(districtKey) {
   return false;
 }
 
-// In high school, homeroom is a logical administrative assignment,
+// In SHS high school, homeroom is a logical administrative assignment,
 // but isn't meaningful to teachers or educators.  If there is
 // a homeroom, it might not necessarily be worth showing.
-export function isHomeroomMeaningful(schoolType) {
-  return (schoolType !== 'HS');
+export function isHomeroomMeaningful(districtKey, schoolLocalId) {
+  if (districtKey === SOMERVILLE && schoolLocalId === 'SHS') return false;
+  return true;
 }
 
 // What is the eventNoteTypeId to use in user-facing text about how to support

--- a/app/assets/javascripts/student_profile/LightProfileHeader.js
+++ b/app/assets/javascripts/student_profile/LightProfileHeader.js
@@ -129,6 +129,7 @@ export default class LightProfileHeader extends React.Component {
   }
 
   renderHomeroomOrEnrollmentStatus() {
+    const {districtKey} = this.context;
     const {student} =  this.props;
 
     // Not enrolled
@@ -146,14 +147,14 @@ export default class LightProfileHeader extends React.Component {
     }
 
     // Render as link or plain text
-    // (HS homeroom doesn't mean anything, and authorization
+    // (SHS homeroom doesn't mean anything, and authorization
     // rules around whether they can link to the homeroom page
     // are more complex).
     const {id, name, educator} = student.homeroom;
     return (
       <Homeroom
         style={styles.subtitleItem}
-        disableLink={!isHomeroomMeaningful(student.school_type)}
+        disableLink={!isHomeroomMeaningful(districtKey, student.school_local_id)}
         id={id}
         name={name}
         educator={educator}


### PR DESCRIPTION
# Who is this PR for?
FC students, educators

# What problem does this PR fix?
For SHS, homerooms are administrative and not super meaningful, and this previously was removed from the home page feed.  But it was done by checking for high schools, when it should have been more tightly scoped.  This led to homeroom and teacher info not being shown in the feed for FC students.

# What does this PR do?
Updates the check to only hide for SHS in Somerville in particular.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Home page
+ [x] Student Profile
+ [x] My Notes

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage