### PR TITLE
Monitoring: Send error objects to Rollbar separately so it can serialize

### DIFF
--- a/app/assets/javascripts/class_lists/ClassListCreatorPage.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorPage.js
@@ -127,8 +127,8 @@ export default class ClassListCreatorPage extends React.Component {
     if (this.doAutoSaveChanges.flush) this.doAutoSaveChanges.flush(); // flush any queued changes
   }
 
-  rollbarError(message, params) {
-    window.Rollbar.error(message, params);
+  rollbarError(message, error) {
+    window.Rollbar.error(message, error);
   }
 
   beforeUnloadMessage() {

--- a/app/assets/javascripts/components/NotifyAboutError.js
+++ b/app/assets/javascripts/components/NotifyAboutError.js
@@ -11,10 +11,10 @@ export default class NotifyAboutError extends React.Component {
     this.rollbarErrorFn('NotifyAboutError', {src});
   }
 
-  rollbarErrorFn(msg, obj = {}) {
-    if (this.props.rollbarErrorFn) return this.props.rollbarErrorFn(msg, obj);
-    if (window.Rollbar.error) return window.Rollbar.error(msg, obj);
-    console.error('NotifyAboutError#rollbarErrorFn could not find function for reporting error:', msg, obj);
+  rollbarErrorFn(msg, ...params) {
+    if (this.props.rollbarErrorFn) return this.props.rollbarErrorFn(msg, ...params);
+    if (window.Rollbar.error) return window.Rollbar.error(msg, ...params);
+    console.error('NotifyAboutError#rollbarErrorFn could not find function for reporting error:', msg, ...params);
   }
 
   render() {

--- a/ui/App.js
+++ b/ui/App.js
@@ -52,8 +52,8 @@ import ClassListsEquityIndexPage from '../app/assets/javascripts/equity/ClassLis
 // The core model is still "new page, new load," this just
 // handles routing on initial page load for JS code.
 export default class App extends React.Component {
-  rollbarErrorFn(msg, obj = {}) {
-    this.props.rollbarErrorFn(msg, obj);
+  rollbarErrorFn(msg, ...params) {
+    this.props.rollbarErrorFn(msg, ...params);
   }
 
   // `NowContainer` provides a fn to read the time


### PR DESCRIPTION
JS properties in `Error` objects are non-enumerable by default, so `{error, moreInfo}` means Rollbar serializes the error as `{}`.  Update the way we call to keep these separate params.