### PR TITLE
Monitoring: Adjust how RecordSyncer reports alerts

### DIFF
--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -20,8 +20,8 @@ class EducatorsImporter
   def initialize(options:)
     @school_scope = options.fetch(:school_scope)
     @log = options.fetch(:log)
-    @educator_syncer = ::RecordSyncer.new(log: @log)
-    @homeroom_syncer = ::RecordSyncer.new(log: @log)
+    @educator_syncer = ::RecordSyncer.new(log: @log, notification_tag: 'EducatorsImporter.educator')
+    @homeroom_syncer = ::RecordSyncer.new(log: @log, notification_tag: 'EducatorsImporter.homeroom')
     reset_counters!
   end
 


### PR DESCRIPTION
# Who is this PR for?
internal team

# What problem does this PR fix?
These notifications are helpful, but Rollbar groups them in ways we don't want, that make it harder to keep track of.

# What does this PR do?
Add more context to message, first just for EducatorsImporter.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Monitoring

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
