### PR TITLE
Sign in: Add another layer of defense on our side, whether educator is active

### DIFF
--- a/app/controllers/multifactor_controller.rb
+++ b/app/controllers/multifactor_controller.rb
@@ -32,6 +32,7 @@ class MultifactorController < ApplicationController
 
     educator = PerDistrict.new.find_educator_by_login_text(login_text.downcase.strip)
     return nil if educator.nil?
+    return nil if !educator.active?
 
     authenticator = MultifactorAuthenticator.new(educator)
     return nil unless authenticator.is_multifactor_enabled?

--- a/app/lib/ldap_authenticatable_tiny/strategy.rb
+++ b/app/lib/ldap_authenticatable_tiny/strategy.rb
@@ -43,9 +43,11 @@ module Devise
             return fail!(:invalid)
           end
 
-          # First, see if we can find an Educator record
+          # First, see if we can find an Educator record, and verify
+          # that it is active.
           educator = PerDistrict.new.find_educator_by_login_text(login_text)
           return fail!(:not_found_in_database) unless educator.present?
+          return fail!(:not_active) unless educator.active?
 
           # Next, check if login code if multifactor is enabled for their account.
           # Also fail if they passed something unexpected for login code when it isn't enabled

--- a/spec/controllers/multifactor_controller_spec.rb
+++ b/spec/controllers/multifactor_controller_spec.rb
@@ -78,6 +78,16 @@ describe MultifactorController, :type => :controller do
       expect(response.status).to eq 204
     end
 
+    it 'does not call send_login_code_if_necessary! for Uri, when active? false' do
+      pals.uri.update!(missing_from_last_export: true)
+      fake_authenticator = MultifactorAuthenticator.new(pals.uri)
+      allow(MultifactorAuthenticator).to receive(:new).and_return(fake_authenticator)
+      expect(fake_authenticator).not_to receive(:send_login_code_if_necessary!)
+
+      post_multifactor(multifactor: { login_text: 'uri@demo.studentinsights.org' })
+      expect(response.status).to eq 204
+    end
+
     it 'fails when already signed in' do
       request.env['HTTPS'] = 'on'
       sign_in(pals.uri)

--- a/spec/lib/ldap_authenticatable_tiny_spec.rb
+++ b/spec/lib/ldap_authenticatable_tiny_spec.rb
@@ -183,6 +183,22 @@ RSpec.describe 'LdapAuthenticatableTiny' do
       expect_failure(strategy, :not_found_in_database)
     end
 
+    it 'calls fail when email found but not active?, without querying LDAP' do
+      pals.shs_jodi.update!(missing_from_last_export: true)
+      strategy = test_strategy
+      allow(strategy).to receive_messages({
+        authentication_hash: {
+          login_text: 'jodi',
+          login_code: 'NO_CODE'
+        },
+        password: 'correct-password'
+      })
+      expect(strategy).not_to receive(:is_authorized_by_ldap?)
+
+      strategy.authenticate!
+      expect_failure(strategy, :not_active)
+    end
+
     it 'calls fail when email found but not is_authorized_by_ldap?' do
       strategy = test_strategy
       allow(strategy).to receive_messages({


### PR DESCRIPTION
District IT systems are responsible for authenticating users, but Student Insights has an additional layer of defense that checked the user matches a known user from the SIS export.  Building on https://github.com/studentinsights/studentinsights/pull/2546, this adds another layer of defense to the sign in process on our side, before communicating with districts, and essentially checks that the user was also included in the most recent export.  This further protects district authentication systems.