### PR TITLE
Authorized students: Optimize query for lower-access users

### DIFF
--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -67,8 +67,7 @@ class EducatorLabel < ApplicationRecord
     end
 
     # Levels link: Anyone at SHS (can also be added manually)
-    shs_school_id = School.find_by_local_id('SHS').try(:id)
-    if shs_school_id.present? && educator.school_id == shs_school_id
+    if educator.school.present? && educator.school.local_id == 'SHS'
       dynamic_labels << 'should_show_levels_shs_link'
     end
 


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
Optimizes `authorized { Student.all }` style queries.  These are used in the home page feed and my students pages, among other places.  It came up working on some unrelated features that performance regressed here for folks who fall through to the later lines in `why_authorized_for_student?`

# What does this PR do?
Essentially removes `n+1` across students, and moves the query in this method into something that can be eagerly included or cached on the `Educator` model or collection, and adds a short-circuit case too.

Numbers on `PerfTest.authorized` are pretty clear:
```
somerville
  before median: 7627ms    p95: 14195ms   (1% sample)
  after  median:  540ms    p95:  1197ms   (1% sample)
  revert median: 7294ms    p95:  8967ms   (1% sample)
  after  median:  720ms    p95:  6625ms  (10% sample)

new_bedford
  before median: 30805ms   p95: 43297ms   (1% sample)
  after  median:  1125ms   p95:  1762ms   (1% sample)
  after  median:  1527ms    p95: 2693ms  (10% sample)

bedford
  before median: 1719ms    p95: 2143ms   (1% sample)
  after  median:   99ms    p95:  172ms   (1% sample)
  after  median:  101ms     p95: 163ms  (50% sample)
```

# Checklists
*Which features or pages does this PR touch?*
+ [x] Home page
+ [x] My Students
+ [x] Core 

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here