### PR TITLE
Profile insights: Update SHS prioritization

### DIFF
--- a/app/lib/profile_insights.rb
+++ b/app/lib/profile_insights.rb
@@ -4,10 +4,11 @@ class ProfileInsights
     @time_now = options.fetch(:time_now, Time.now)
   end
 
+  # order matters; students > transitions > adult perspectives > other
   def as_json(options = {})
     all_insights = (
+      from_somerville_high_student_voice_surveys +
       from_first_transition_note_strength +
-      from_first_student_voice_survey +
       about_team_membership +
       from_bedford_elementary_transition +
       from_bedford_sixth_grade_student_voice_transition_form
@@ -23,6 +24,34 @@ class ProfileInsights
   end
 
   private
+  # This doesn't pick differently based on the time of year (yet!)
+  # Includes:
+  # 1. what i want my teachers to know (start of year)
+  # 2. Q2 self-reflection
+  # 3. what i want my teachers to know (mid-year)
+  def from_somerville_high_student_voice_surveys
+    insights = []
+
+    # include fall survey insights if there are any
+    most_recent_fall_survey = StudentVoiceCompletedSurvey.most_recent_fall_student_voice_survey(@student.id)
+    if most_recent_fall_survey.present?
+      insights += profile_insights_from_survey(most_recent_fall_survey)
+    end
+
+    # add any q2 self reflection, if enabled
+    if PerDistrict.new.include_q2_self_reflection_insights?
+      insights += from_q2_self_reflection()
+    end
+
+    # check for latest mid-year and take if it it's there
+    mid_year_form = ImportedForm.latest_for_student_id(@student.id, ImportedForm::SHS_WHAT_I_WANT_MY_TEACHER_TO_KNOW_MID_YEAR)
+    if mid_year_form.present?
+      insights += insights_from_generic_imported_form(mid_year_form)
+    end
+
+    insights
+  end
+
   def from_first_transition_note_strength
     transition_note = @student.transition_notes.find_by(is_restricted: false)
     return [] if transition_note.nil?
@@ -44,74 +73,6 @@ class ProfileInsights
       transition_note: transition_note_json
     })
     [profile_insight]
-  end
-
-  # Include:
-  # 1. Q2 self-reflection and
-  # 2. the more recent of (What I want my teachers to know, fall student voice survey)
-  def from_first_student_voice_survey
-    insights = []
-
-    # always add any q2 self reflection, if enabled
-    if PerDistrict.new.include_q2_self_reflection_insights?
-      insights += from_q2_self_reflection()
-    end
-
-    # check for mid-year and take if it it's there
-    mid_year_form = ImportedForm.latest_for_student_id(@student.id, ImportedForm::SHS_WHAT_I_WANT_MY_TEACHER_TO_KNOW_MID_YEAR)
-    return insights + insights_from_generic_imported_form(mid_year_form) if mid_year_form.present?
-
-    # if not, include fall survey insights if there are any
-    most_recent_fall_survey = StudentVoiceCompletedSurvey.most_recent_fall_student_voice_survey(@student.id)
-    if most_recent_fall_survey.present?
-      insights += profile_insights_from_survey(most_recent_fall_survey)
-    end
-
-    insights
-  end
-
-  def insights_from_generic_imported_form(imported_form)
-    ImportedForm.prompts(imported_form.form_key).map do |prompt_key|
-      if imported_form.form_json[prompt_key].nil?
-        nil
-      else
-        ProfileInsight.new(FROM_GENERIC_IMPORTED_FORM, {
-          form_key: imported_form.form_key,
-          prompt_text: prompt_key,
-          response_text: imported_form.form_json[prompt_key],
-          flattened_form_json: imported_form.as_flattened_form
-        })
-      end
-    end.compact
-  end
-
-  # Unroll each question from the survey into a separate insight
-  def profile_insights_from_survey(most_recent_survey)
-    survey_insights = []
-
-    prompt_keys_to_include = [
-      :proud,
-      :best_qualities,
-      :activities_and_interests,
-      :nervous_or_stressed,
-      :learn_best
-    ]
-    prompt_keys_to_include.each do |prompt_key|
-      survey_response_text = most_recent_survey[prompt_key].strip
-      next if survey_response_text.nil? || survey_response_text == ''
-
-      survey_text = most_recent_survey.flat_text(prompt_keys_to_include: prompt_keys_to_include)
-      student_voice_completed_survey_json = most_recent_survey.as_json({
-        only: [:id, :form_timestamp, :created_at]
-      }).merge(survey_text: survey_text)
-      survey_insights << ProfileInsight.new(FROM_FIRST_STUDENT_VOICE_SURVEY, {
-        prompt_key: prompt_key,
-        prompt_text: StudentVoiceCompletedSurvey.columns_for_form_v2[prompt_key],
-        survey_response_text: survey_response_text,
-        student_voice_completed_survey: student_voice_completed_survey_json
-      })
-    end
-    survey_insights
   end
 
   def about_team_membership
@@ -159,6 +120,50 @@ class ProfileInsights
   end
 
   private
+  def insights_from_generic_imported_form(imported_form)
+    ImportedForm.prompts(imported_form.form_key).map do |prompt_key|
+      if imported_form.form_json[prompt_key].nil?
+        nil
+      else
+        ProfileInsight.new(FROM_GENERIC_IMPORTED_FORM, {
+          form_key: imported_form.form_key,
+          prompt_text: prompt_key,
+          response_text: imported_form.form_json[prompt_key],
+          flattened_form_json: imported_form.as_flattened_form
+        })
+      end
+    end.compact
+  end
+
+  # Unroll each question from the survey into a separate insight
+  def profile_insights_from_survey(most_recent_survey)
+    survey_insights = []
+
+    prompt_keys_to_include = [
+      :proud,
+      :best_qualities,
+      :activities_and_interests,
+      :nervous_or_stressed,
+      :learn_best
+    ]
+    prompt_keys_to_include.each do |prompt_key|
+      survey_response_text = most_recent_survey[prompt_key].strip
+      next if survey_response_text.nil? || survey_response_text == ''
+
+      survey_text = most_recent_survey.flat_text(prompt_keys_to_include: prompt_keys_to_include)
+      student_voice_completed_survey_json = most_recent_survey.as_json({
+        only: [:id, :form_timestamp, :created_at]
+      }).merge(survey_text: survey_text)
+      survey_insights << ProfileInsight.new(FROM_FIRST_STUDENT_VOICE_SURVEY, {
+        prompt_key: prompt_key,
+        prompt_text: StudentVoiceCompletedSurvey.columns_for_form_v2[prompt_key],
+        survey_response_text: survey_response_text,
+        student_voice_completed_survey: student_voice_completed_survey_json
+      })
+    end
+    survey_insights
+  end
+
   # See InsightsCarousel.js
   ABOUT_TEAM_MEMBERSHIP = 'about_team_membership'
   FROM_BEDFORD_TRANSITION = 'from_bedford_transition'


### PR DESCRIPTION
# Who is this PR for?
SHS students, families, educators

# What problem does this PR fix?
The fall student voice surveys at SHS aren't showing in the insights box, since previously we favored mid-year reflections if they were present (eg, in the middle of the year).  This doesn't make sense at the start of the year, but hadn't been updated yet.

# What does this PR do?
Update profile insights box to include fall surveys, and previous year surveys as well.  We can make this smarter later, probably should ask for all insights (with timestamps) then sort, or have them express some prioritization.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here