### PR TITLE
My students: Remove school link for all

### DIFF
--- a/app/assets/javascripts/my_students/MyStudentsPage.js
+++ b/app/assets/javascripts/my_students/MyStudentsPage.js
@@ -209,7 +209,12 @@ export class MyStudentsPageView extends React.Component {
 
   renderSchool(cellProps) {
     const student = cellProps.rowData;
-    return <School {...student.school} style={{marginRight: 10}} />;
+    const {id, name} = student.school;
+
+    const shouldShowSchoolLink = false; // should check this
+    return (shouldShowSchoolLink)
+      ? <a style={{marginRight: 10}} href={`/schools/${id}`}>{name}</a>
+      : <School {...student.school}  />;
   }
 
   renderHouse(cellProps) {


### PR DESCRIPTION
This link is misleading; not all folks have access so they click in and get denied.  A few teachers have run into this in the last few days, so removing the link for now and can add a check back later.  Folks with districtwide access don't lose anything other than convenience clicking in.