### PR TITLE
Import: Update to run all tasks by default

### DIFF
--- a/app/importers/file_importers/file_importer_options.rb
+++ b/app/importers/file_importers/file_importer_options.rb
@@ -49,9 +49,16 @@ class FileImporterOptions
         EdPlansImporter,
         EdPlanAccommodationsImporter
       ],
+      '504' => [
+        EdPlansImporter,
+        EdPlanAccommodationsImporter
+      ],
       'star' => [
         StarReadingImporter,
         StarMathImporter
+      ],
+      'google' => [
+        StudentVoiceSurveyImporter
       ],
       'students' => StudentsImporter,
       'assessments' => X2AssessmentImporter,
@@ -62,14 +69,10 @@ class FileImporterOptions
       'student_section_assignments' => StudentSectionAssignmentsImporter,
       'student_section_grades' => StudentSectionGradesImporter,
       'educator_section_assignments' => EducatorSectionAssignmentsImporter,
-      'star_math' => StarMathImporter,
-      'star_reading' => StarReadingImporter,
       'ed_plans' => EdPlansImporter,
       'ed_plan_accommodations' => EdPlanAccommodationsImporter,
-      '504' => [
-        EdPlansImporter,
-        EdPlanAccommodationsImporter
-      ],
+      'star_math' => StarMathImporter,
+      'star_reading' => StarReadingImporter,
       'student_voice_surveys' => StudentVoiceSurveyImporter
     }
   end

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -11,7 +11,7 @@ class Import
     class_option :source,
       type: :array,
       default: FileImporterOptions.new.all_importer_keys,
-      desc: "Import data from one of #{FileImporterOptions.new.all_importer_keys}"
+      desc: "Import data from one of the keys in 'FileImporterOptions'"
     class_option :only_recent_attendance,
       type: :boolean,
       default: false,

--- a/lib/tasks/import.thor
+++ b/lib/tasks/import.thor
@@ -10,7 +10,7 @@ class Import
       desc: "Scope by school"
     class_option :source,
       type: :array,
-      default: ['x2', 'star'],  # This runs all X2 and STAR importers
+      default: FileImporterOptions.new.all_importer_keys,
       desc: "Import data from one of #{FileImporterOptions.new.all_importer_keys}"
     class_option :only_recent_attendance,
       type: :boolean,

--- a/spec/importers/file_importers/file_importer_options_spec.rb
+++ b/spec/importers/file_importers/file_importer_options_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe FileImporterOptions do
     it 'requires writing the keys written out again test to verify they are correct' do
       expect(FileImporterOptions.new.all_importer_keys).to contain_exactly(*[
         'x2',
+        '504',
         'star',
+        'google',
         'students',
         'assessments',
         'behavior',
@@ -45,7 +47,6 @@ RSpec.describe FileImporterOptions do
         'star_reading',
         'ed_plans',
         'ed_plan_accommodations',
-        '504',
         'student_voice_surveys'
       ])
     end


### PR DESCRIPTION
Update to https://github.com/studentinsights/studentinsights/pull/2579, the defaults in `import.thor` only included `x2` and `star` importers, and I assumed it was all.  This updates it to be all, and also adds the `google` group to the list of importer keys.

```
$ thor import:start --help

Usage:
  thor import:start

Options:
  [--school=one two three]                                   # Scope by school
  [--source=one two three]                                   # Import data from one of the keys in 'FileImporterOptions'
                                                             # Default: ["504", "assessments", "attendance", "behavior", "courses_sections", "ed_plan_accommodations", "ed_plans", "educator_section_assignments", "educators", "google", "star", "star_math", "star_reading", "student_section_assignments", "student_section_grades", "student_voice_surveys", "students", "x2"]
  [--only-recent-attendance], [--no-only-recent-attendance]  # Only import attendance rows from the past 90 days for faster attendance import
  [--skip-old-records], [--no-skip-old-records]              # Skip old data (eg, more than a calendar year old)
  [--skip-index-updates], [--no-skip-index-updates]          # Skip updating indexes after the import task is completed (not recommended except for when profiling)

Import data into your Student Insights instance
```