### PR TITLE
Maintenance: Remove older homeroom and student factories

### DIFF
--- a/app/models/homeroom.rb
+++ b/app/models/homeroom.rb
@@ -14,6 +14,9 @@ class Homeroom < ApplicationRecord
   validate :validate_school_matches_educator_school
 
   private
+  # This doesn't work for mixed-grade homerooms (eg, special education).
+  # We should migrate to `Homeroom#grades` or querying students on-demand
+  # instead.
   def update_grade(student)
     # Set homeroom grade level to be first student's grade level, since
     # we don't have any crosswalk between homerooms and grades in
@@ -21,6 +24,7 @@ class Homeroom < ApplicationRecord
 
     return if self.grade.present?
     return if student.grade.blank?
+
     update_attribute(:grade, student.grade)
   end
 

--- a/spec/factories/homerooms.rb
+++ b/spec/factories/homerooms.rb
@@ -4,24 +4,5 @@ FactoryBot.define do
   factory :homeroom do
     name { FactoryBot.generate(:name) }
     association :school
-
-    factory :homeroom_with_student do
-      after(:create) do |homeroom|
-        homeroom.students << FactoryBot.create(:student, :registered_last_year, homeroom: homeroom)
-      end
-    end
-
-    factory :homeroom_with_second_grader do
-      after(:create) do |homeroom|
-        homeroom.students << FactoryBot.create(:second_grade_student, :registered_last_year, homeroom: homeroom)
-      end
-    end
-
-    factory :homeroom_with_pre_k_student do
-      after(:create) do |homeroom|
-        homeroom.students << FactoryBot.create(:pre_k_student, :registered_last_year, homeroom: homeroom)
-      end
-    end
-
   end
 end

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -85,14 +85,8 @@ FactoryBot.define do
     factory :student_who_registered_in_2013_2014 do
       registration_date Date.new(2013, 8, 1)
     end
-    factory :second_grade_student do
-      grade "2"
-    end
     factory :high_school_student do
       grade "11"
-    end
-    factory :pre_k_student do
-      grade "PK"
     end
     factory :student_we_want_to_update do       # Test importing data
       local_id "10"                             # State ID matches fixture


### PR DESCRIPTION
Maintenance that came up working on homeroom authorization.

This also documents in specs some unexpected behavior related to `Homeroom#grade`, which we should migrate away from separately (towards querying students on-demand)