### PR TITLE
Maintenance: Remove authorizer instance variable on ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -109,6 +109,6 @@ class ApplicationController < ActionController::Base
 
   private
   def authorizer
-    @authorizer ||= Authorizer.new(current_educator)
+    Authorizer.new(current_educator)
   end
 end

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -254,7 +254,7 @@ describe HomeroomsController, :type => :controller do
 
       it 'works as expected, when unit testing #authorized_homerooms method' do
         allowed_access_map = Educator.all.reduce({}) do |map, educator|
-          controller.instance_variable_set(:@authorizer, Authorizer.new(educator))
+          allow(controller).to receive(:current_educator).and_return(educator)
           homeroom_slugs = controller.send(:authorized_homerooms).map(&:slug).sort
           map.merge(educator.login_name.to_sym => homeroom_slugs)
         end
@@ -282,18 +282,6 @@ describe HomeroomsController, :type => :controller do
       let!(:pals) { TestPals.create! }
 
       def get_homeroom(educator, homeroom)
-        # Avoid test pollution; instance variables on the controller
-        # itself are fine, but experimenting with this shows that
-        # ApplicationController instance variable are NOT cleared
-        # by a call into a controller action by rspec.  This violates
-        # how I would expect this to work, but makes sense if you want
-        # to enforce one example to test one action.
-        #
-        # For our case here, it's helpful to loop through fixture
-        # data and make assertions across all cases at once,
-        # so this explicitly clears authorizations.
-        controller.instance_variable_set(:@authorizer, nil)
-
         request.env['HTTPS'] = 'on'
         sign_in(educator)
         request.env['HTTP_ACCEPT'] = 'application/json'


### PR DESCRIPTION
This is for after https://github.com/studentinsights/studentinsights/pull/2584 lands.

In https://github.com/studentinsights/studentinsights/pull/2584, it came up that instance variables on `ApplicationController` leak across calls to controller actions in rspec tests.  This is not how I thought it worked, but turns out all the other uses of tests like this never came across this particular combo.  Those kinds of tests are useful for exhaustively testing authorization rules for a given setup (eg across combinations of things like `[educator, student]`).

This removes the instance variable in `ApplicationController` related to authorization; it's not doing much there.  This has no impact on authorization rules.