### PR TITLE
Homeroom paths: Match by id only, not slug

### DIFF
--- a/app/assets/javascripts/homeroom/HomeroomPage.js
+++ b/app/assets/javascripts/homeroom/HomeroomPage.js
@@ -21,8 +21,8 @@ export default class HomeroomPage extends React.Component {
   }
 
   fetchJson() {
-    const {homeroomIdOrSlug} = this.props;
-    const url = `/api/homerooms/${homeroomIdOrSlug}/homeroom_json`;
+    const {homeroomId} = this.props;
+    const url = `/api/homerooms/${homeroomId}/homeroom_json`;
     return apiFetchJson(url);
   }
 
@@ -49,7 +49,7 @@ export default class HomeroomPage extends React.Component {
   }
 }
 HomeroomPage.propTypes = {
-  homeroomIdOrSlug: PropTypes.string.isRequired
+  homeroomId: PropTypes.number.isRequired
 };
 
 class HomeroomPageView extends React.Component {

--- a/app/assets/javascripts/homeroom/HomeroomPage.test.js
+++ b/app/assets/javascripts/homeroom/HomeroomPage.test.js
@@ -9,7 +9,7 @@ import homeroomJson from './homeroomJson.fixture';
 
 function testProps(props = {}) {
   return {
-    homeroomIdOrSlug: 'hea-500',
+    homeroomId: 2,
     ...props
   };
 }
@@ -27,7 +27,7 @@ function testRender(props = {}, context = {}) {
 
 beforeEach(() => {
   fetchMock.restore();
-  fetchMock.get('/api/homerooms/hea-500/homeroom_json', homeroomJson);
+  fetchMock.get('/api/homerooms/2/homeroom_json', homeroomJson);
 });
 
 it('renders without crashing', () => {

--- a/app/controllers/homerooms_controller.rb
+++ b/app/controllers/homerooms_controller.rb
@@ -79,6 +79,8 @@ class HomeroomsController < ApplicationController
   # > Homeroom.find_by_id('7-263') => #<Homeroom id: 7, name: "H-001", ... >
   # So ensure that this any id lookup is really an integer and manually convert these
   # types.
+  #
+  # See https://github.com/studentinsights/studentinsights/pull/2588 for more.
   def find_homeroom_by_id(homeroom_id)
     strict_homeroom_id = homeroom_id.to_i.to_s.to_i
     if homeroom_id.to_s == strict_homeroom_id.to_s

--- a/app/controllers/homerooms_controller.rb
+++ b/app/controllers/homerooms_controller.rb
@@ -1,7 +1,7 @@
 class HomeroomsController < ApplicationController
   def homeroom_json
-    homeroom_id_or_slug = params.permit(:id)[:id]
-    homeroom = authorize_and_assign_homeroom!(homeroom_id_or_slug)
+    homeroom_id = params.permit(:id)[:id]
+    homeroom = authorize_and_assign_homeroom!(homeroom_id)
 
     rows = eager_students(homeroom).map {|student| fat_student_hash(student) }
 
@@ -26,8 +26,8 @@ class HomeroomsController < ApplicationController
   end
 
   private
-  def authorize_and_assign_homeroom!(homeroom_id_or_slug)
-    homeroom = find_homeroom_by_id_or_slug(homeroom_id_or_slug)
+  def authorize_and_assign_homeroom!(homeroom_id)
+    homeroom = find_homeroom_by_id(homeroom_id)
     raise Exceptions::EducatorNotAuthorized unless authorized_homerooms().include? homeroom
     homeroom
   end
@@ -71,26 +71,20 @@ class HomeroomsController < ApplicationController
     }))
   end
 
-  # Calling `Homeroom.friendly.find` with a string version of an id will first
-  # not match on id, and will match on the name for another homeroom with that
-  # same value.  Be explicit here that we match first on id and
-  # then if not we look to match on the slug.
+  # This only matches on homeroom_id, not `slug`, since this has led to bugs from
+  # type coercion and from collisions on ids and slugs.  Works around FriendlyId,
+  # which we should move away from.
   #
-  # But type coercion can lead to bugs here too, like:
+  # Type coercion can lead to bugs like:
   # > Homeroom.find_by_id('7-263') => #<Homeroom id: 7, name: "H-001", ... >
   # So ensure that this any id lookup is really an integer and manually convert these
   # types.
-  def find_homeroom_by_id_or_slug(homeroom_id_or_slug)
-    if homeroom_id_or_slug.to_i.to_s == homeroom_id_or_slug.to_s
-      homeroom_id = homeroom_id_or_slug.to_i
-      homeroom_by_id = Homeroom.find_by_id(homeroom_id)
-      return homeroom_by_id unless homeroom_by_id.nil?
+  def find_homeroom_by_id(homeroom_id)
+    strict_homeroom_id = homeroom_id.to_i.to_s.to_i
+    if homeroom_id.to_s == strict_homeroom_id.to_s
+      homeroom = Homeroom.find_by_id(strict_homeroom_id) # FriendlyId patches #find, so this is more explicit
+      return homeroom if homeroom.present? && homeroom.id == strict_homeroom_id
     end
-
-    homeroom_slug = homeroom_id_or_slug.to_s
-    homeroom_by_slug = Homeroom.find_by_slug(homeroom_slug)
-    return homeroom_by_slug unless homeroom_by_slug.nil?
-
     raise ActiveRecord::RecordNotFound
   end
 

--- a/app/lib/paths_for_educator.rb
+++ b/app/lib/paths_for_educator.rb
@@ -39,7 +39,7 @@ class PathsForEducator
     end
 
     if @educator.homeroom.present? && !@educator.homeroom.school.is_high_school?
-      links[:homeroom] = url_helpers.homeroom_path(@educator.homeroom)
+      links[:homeroom] = url_helpers.homeroom_path(@educator.homeroom.id) # explicitly, not slug
     end
 
     links

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -317,7 +317,7 @@ describe HomeroomsController, :type => :controller do
         request.env['HTTPS'] = 'on'
         sign_in(educator)
         request.env['HTTP_ACCEPT'] = 'application/json'
-        get :homeroom_json, params: { id: homeroom.slug }
+        get :homeroom_json, params: { id: homeroom.id }
         r = response
         sign_out(educator)
         r

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -4,10 +4,10 @@ describe HomeroomsController, :type => :controller do
   let!(:school) { FactoryBot.create(:school) }
 
   describe '#homeroom_json' do
-    def make_request(slug = nil)
+    def make_request(id = nil)
       request.env['HTTPS'] = 'on'
       request.env['HTTP_ACCEPT'] = 'application/json'
-      get :homeroom_json, params: { id: slug }
+      get :homeroom_json, params: { id: id }
     end
 
     context 'happy path' do
@@ -17,7 +17,7 @@ describe HomeroomsController, :type => :controller do
       before { sign_in(educator) }
 
       it 'returns the right shape of data' do
-        make_request(educator.homeroom.slug)
+        make_request(educator.homeroom.id)
         expect(response.status).to eq 200
         json = JSON.parse(response.body)
         expect(json['rows'].length).to eq 1
@@ -71,11 +71,16 @@ describe HomeroomsController, :type => :controller do
         ])
       end
 
-      it 'works with an id instead of slug' do
+      it 'works with an id' do
         make_request(educator.homeroom.id)
         expect(response.status).to eq 200
         json = JSON.parse(response.body)
         expect(json['rows'].length).to eq 1
+      end
+
+      it 'does not work with a slug' do
+        make_request(educator.homeroom.slug)
+        expect(response.status).to eq 404
       end
     end
 
@@ -95,18 +100,18 @@ describe HomeroomsController, :type => :controller do
 
         context 'params for homeroom belonging to educator' do
           it 'is successful' do
-            make_request(educator.homeroom.slug)
+            make_request(educator.homeroom.id)
             expect(response.status).to eq 200
           end
           it 'assigns correct homerooms to drop-down' do
-            make_request(educator.homeroom.slug)
+            make_request(educator.homeroom.id)
             json = JSON.parse(response.body)
             expect(json['homerooms']).to eq([educator.homeroom].as_json(only: [:slug, :name]))
           end
 
           context 'when there are no students' do
             it 'assigns rows to empty' do
-              make_request(educator.homeroom.slug)
+              make_request(educator.homeroom.id)
               json = JSON.parse(response.body)
               expect(json['rows']).to be_empty
             end
@@ -118,7 +123,7 @@ describe HomeroomsController, :type => :controller do
             let!(:third_student) { FactoryBot.create(:student, :registered_last_year) }
 
             it 'assigns rows to a non-empty array' do
-              make_request(educator.homeroom.slug)
+              make_request(educator.homeroom.id)
               expected_student_ids = [first_student, second_student].map(&:id)
               json = JSON.parse(response.body)
               expect(json['rows'].map {|row| row['id'] }).to match_array(expected_student_ids)
@@ -131,7 +136,7 @@ describe HomeroomsController, :type => :controller do
           context 'homeroom is grade level as educator\'s and same school' do
             let(:another_homeroom) { FactoryBot.create(:homeroom, grade: '5', school: school) }
             it 'is successful' do
-              make_request(another_homeroom.slug)
+              make_request(another_homeroom.id)
               expect(response.status).to eq 200
             end
           end
@@ -139,7 +144,7 @@ describe HomeroomsController, :type => :controller do
           context 'homeroom is grade level as educator\'s -- but different school!' do
             let(:another_homeroom) { FactoryBot.create(:homeroom, grade: '5', school: FactoryBot.create(:school)) }
             it 'guards access' do
-              make_request(another_homeroom.slug)
+              make_request(another_homeroom.id)
               expect(response.status).to eq 403
             end
           end
@@ -147,7 +152,7 @@ describe HomeroomsController, :type => :controller do
           context 'homeroom is different grade level from educator\'s' do
             let(:yet_another_homeroom) { FactoryBot.create(:homeroom, school: school) }
             it 'guards access' do
-              make_request(yet_another_homeroom.slug)
+              make_request(yet_another_homeroom.id)
               expect(response.status).to eq 403
             end
           end
@@ -157,7 +162,7 @@ describe HomeroomsController, :type => :controller do
             let(:homeroom) { FactoryBot.create(:homeroom, grade: '5', school: school) }
 
             it 'is successful' do
-              make_request(homeroom.slug)
+              make_request(homeroom.id)
               expect(response.status).to eq 200
             end
           end
@@ -169,7 +174,7 @@ describe HomeroomsController, :type => :controller do
             let(:homeroom) { FactoryBot.create(:homeroom, grade: '5', school: school) }
 
             it 'redirects' do
-              make_request(homeroom.slug)
+              make_request(homeroom.id)
               expect(response.status).to eq(403)
             end
           end
@@ -200,11 +205,11 @@ describe HomeroomsController, :type => :controller do
         context 'good homeroom params' do
           let(:homeroom) { FactoryBot.create(:homeroom, grade: '5', school: school) }
           it 'is successful' do
-            make_request(homeroom.slug)
+            make_request(homeroom.id)
             expect(response.status).to eq 200
           end
           it 'assigns correct homerooms to drop-down' do
-            make_request(homeroom.slug)
+            make_request(homeroom.id)
             json = JSON.parse(response.body)
             expect(json['homerooms']).to contain_exactly(*Homeroom.all.as_json(only: [:name, :slug]))
           end
@@ -233,7 +238,7 @@ describe HomeroomsController, :type => :controller do
       context 'homeroom params' do
         let!(:homeroom) { FactoryBot.create(:homeroom) }
         it 'guards access' do
-          make_request(homeroom.slug)
+          make_request(homeroom.id)
           expect(response.status).to eq(403)
         end
       end
@@ -244,7 +249,7 @@ describe HomeroomsController, :type => :controller do
       let!(:homeroom) { FactoryBot.create(:homeroom, educator: educator, grade: "5", school: school) }
 
       it 'redirects to sign in page' do
-        make_request(educator.homeroom.slug)
+        make_request(educator.homeroom.id)
         expect(response.status).to eq(401)
       end
     end
@@ -377,17 +382,28 @@ describe HomeroomsController, :type => :controller do
     end
   end
 
-  describe '#find_homeroom_by_id_or_slug' do
-    it 'works with different input types' do
+  describe '#find_homeroom_by_id' do
+    it 'only works with explicit id' do
       homeroom_one = FactoryBot.create(:homeroom, id: 1, name: '7-263')
       homeroom_two = FactoryBot.create(:homeroom, id: 7, name: '1')
+      homeroom_three = FactoryBot.create(:homeroom, id: 14, name: '7')
+      homeroom_four = FactoryBot.create(:homeroom, id: 77, name: '99')
 
-      expect(controller.send(:find_homeroom_by_id_or_slug, '7-263')).to eq homeroom_one
-      expect(controller.send(:find_homeroom_by_id_or_slug, '1')).to eq homeroom_one
-      expect(controller.send(:find_homeroom_by_id_or_slug, 1)).to eq homeroom_one
-      expect(controller.send(:find_homeroom_by_id_or_slug, '7')).to eq homeroom_two
-      expect(controller.send(:find_homeroom_by_id_or_slug, 7)).to eq homeroom_two
-      expect { controller.send(:find_homeroom_by_id_or_slug, 'xyz') }.to raise_error(ActiveRecord::RecordNotFound)
+      # matching
+      expect(controller.send(:find_homeroom_by_id, '1')).to eq homeroom_one
+      expect(controller.send(:find_homeroom_by_id, 1)).to eq homeroom_one
+      expect(controller.send(:find_homeroom_by_id, '7')).to eq homeroom_two
+      expect(controller.send(:find_homeroom_by_id, 7)).to eq homeroom_two
+      expect(controller.send(:find_homeroom_by_id, '14')).to eq homeroom_three
+      expect(controller.send(:find_homeroom_by_id, 14)).to eq homeroom_three
+      expect(controller.send(:find_homeroom_by_id, '77')).to eq homeroom_four
+      expect(controller.send(:find_homeroom_by_id, 77)).to eq homeroom_four
+
+      # no overmatching
+      expect { controller.send(:find_homeroom_by_id, '99') }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { controller.send(:find_homeroom_by_id, 99) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { controller.send(:find_homeroom_by_id, '7-263') }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { controller.send(:find_homeroom_by_id, 'xyz') }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/spec/lib/paths_for_educator_spec.rb
+++ b/spec/lib/paths_for_educator_spec.rb
@@ -41,17 +41,17 @@ RSpec.describe PathsForEducator do
         expect(navbar_links(pals.healey_sped_teacher)).to eq({})
         expect(navbar_links(pals.healey_vivian_teacher)).to eq({
           classlists: '/classlists',
-          homeroom: '/homerooms/hea-003'
+          homeroom: "/homerooms/#{pals.healey_kindergarten_homeroom.id}"
         })
         expect(navbar_links(pals.healey_sarah_teacher)).to eq({
           classlists: '/classlists',
-          homeroom: '/homerooms/hea-500'
+          homeroom: "/homerooms/#{pals.healey_fifth_homeroom.id}"
         })
 
         # west
         expect(navbar_links(pals.west_marcus_teacher)).to eq({
           classlists: '/classlists',
-          homeroom: '/homerooms/wsns-501'
+          homeroom: "/homerooms/#{pals.west_fifth_homeroom.id}"
         })
 
         # high school (TestPals doesn't match actual production HS roles and permisssions)

--- a/ui/App.js
+++ b/ui/App.js
@@ -110,7 +110,7 @@ export default class App extends React.Component {
         <Route exact path="/schools/:slug/reading/:grade/groups" render={this.renderReadingGroupingPage.bind(this)}/>
         <Route exact path="/reading/debug" render={this.renderReadingDebugPage.bind(this)}/>
         <Route exact path="/reading/debug_star" render={this.renderReadingDebugStarPage.bind(this)}/>
-        <Route exact path="/homerooms/:id_or_slug" render={this.renderHomeroomPage.bind(this)}/>
+        <Route exact path="/homerooms/:id" render={this.renderHomeroomPage.bind(this)}/>
         <Route exact path="/sections/:id" render={this.renderSectionPage.bind(this)}/>
         <Route exact path="/students/:id" render={this.renderStudentProfilePage.bind(this)}/>
         <Route exact path="/students/:id/v3" render={this.renderStudentProfilePage.bind(this)}/>
@@ -257,8 +257,8 @@ export default class App extends React.Component {
   }
 
   renderHomeroomPage(routeProps) {
-    const homeroomIdOrSlug = routeProps.match.params.id_or_slug;
-    return <HomeroomPage homeroomIdOrSlug={homeroomIdOrSlug} />;
+    const homeroomId = parseInt(routeProps.match.params.id, 10);
+    return <HomeroomPage homeroomId={homeroomId} />;
   }
 
   renderSectionPage(routeProps) {

--- a/ui/App.test.js
+++ b/ui/App.test.js
@@ -5,6 +5,7 @@ import App from './App';
 import HomePage from '../app/assets/javascripts/home/HomePage';
 import SearchNotesPage from '../app/assets/javascripts/search_notes/SearchNotesPage';
 import EducatorPage from '../app/assets/javascripts/educator/EducatorPage';
+import HomeroomPage from '../app/assets/javascripts/homeroom/HomeroomPage';
 import MyStudentsPage from '../app/assets/javascripts/my_students/MyStudentsPage';
 import ServicesPage from '../app/assets/javascripts/services/ServicesPage';
 import MyNotesPage from '../app/assets/javascripts/my_notes/MyNotesPage';
@@ -27,6 +28,7 @@ import {MemoryRouter} from 'react-router-dom';
 jest.mock('../app/assets/javascripts/home/HomePage');
 jest.mock('../app/assets/javascripts/search_notes/SearchNotesPage');
 jest.mock('../app/assets/javascripts/educator/EducatorPage');
+jest.mock('../app/assets/javascripts/homeroom/HomeroomPage');
 jest.mock('../app/assets/javascripts/my_students/MyStudentsPage');
 jest.mock('../app/assets/javascripts/services/ServicesPage');
 jest.mock('../app/assets/javascripts/my_notes/MyNotesPage');
@@ -108,6 +110,11 @@ it('renders EducatorPage without crashing', () => {
   expect(wrapper.contains(
     <EducatorPage educatorId={12} />
   )).toEqual(true);
+});
+
+it('renders HomeroomPage without crashing', () => {
+  const wrapper = mount(renderPath('/homerooms/12'));
+  expect(wrapper.contains(<HomeroomPage homeroomId={12} />)).toEqual(true);
 });
 
 it('render SchoolCoursesPage without crashing', () => {


### PR DESCRIPTION
# Who is this PR for?
K8 educators with homeroom access

# What problem does this PR fix?
This has bitten us twice before: https://github.com/studentinsights/studentinsights/pull/2022 and https://github.com/studentinsights/studentinsights/pull/2155.  Another case came up again verifying https://github.com/studentinsights/studentinsights/pull/2584.

In this case, there was a collision between `id` and `slug` spaces for homerooms, which caused the navbar link to be generated with a slug, but be interpreted as if it were an id in the controller lookup code.

# What does this PR do?
Removes `/homerooms/:slug` and only generates and supports `/homerooms/:id`.  There's still a footgun here because the `url_helpers.homeroom_path(homeroom)` will use slug, but that's for another day.  Verifying https://github.com/studentinsights/studentinsights/pull/2584 is more important, and this bug makes that more complicated. 

# Checklists
*Which features or pages does this PR touch?*
+ [x] Navbar links
+ [x] Homeroom

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here