### PR TITLE
Homerooms: Default grades list to active students only

### DIFF
--- a/app/models/homeroom.rb
+++ b/app/models/homeroom.rb
@@ -14,10 +14,14 @@ class Homeroom < ApplicationRecord
 
   validate :validate_school_matches_educator_school
 
-  # Query students on-demand rather than using deprecated `grade`.
+  # Query students on-demand rather than using deprecated `grade`,
+  # and filters by `active` unless told not to.
+  #
   # Returns sorted and compacted list.
-  def grades
-    GradeLevels.sort students.flat_map(&:grade).compact.uniq
+  def grades(options = {})
+    should_include_inactive = options.fetch(:include_inactive_students, false)
+    relevant_students = should_include_inactive ? self.students : self.students.active
+    GradeLevels.sort relevant_students.flat_map(&:grade).compact.uniq
   end
 
   private

--- a/spec/models/homeroom_spec.rb
+++ b/spec/models/homeroom_spec.rb
@@ -38,6 +38,22 @@ RSpec.describe Homeroom do
         expect(homeroom.grades).to eq ['TK', 'PK', '1', '9', '11']
       end
     end
+
+    it 'includes only active students' do
+      homeroom = FactoryBot.create(:homeroom).tap do |h|
+        h.students << FactoryBot.create(:student, missing_from_last_export: true, grade: 'PK')
+        h.students << FactoryBot.create(:student, grade: '1')
+      end
+      expect(homeroom.grades).to eq ['1']
+    end
+
+    it 'includes all students when include_inactive_students:true' do
+      homeroom = FactoryBot.create(:homeroom).tap do |h|
+        h.students << FactoryBot.create(:student, missing_from_last_export: true, grade: 'PK')
+        h.students << FactoryBot.create(:student, grade: '1')
+      end
+      expect(homeroom.grades(include_inactive_students: true)).to eq ['PK', '1']
+    end
   end
 
   describe '#grade' do


### PR DESCRIPTION
Follow-on to https://github.com/studentinsights/studentinsights/pull/2589.  This came up since the homeroom page shows conflicting info in the dropdown (computed from `Homeroom#grades`) and the description of the homeroom the user is viewing (computed from the list of students, which the server limits to only active students).