### PR TITLE
Homerooms: Remove link if no active students

### DIFF
--- a/app/lib/paths_for_educator.rb
+++ b/app/lib/paths_for_educator.rb
@@ -38,8 +38,8 @@ class PathsForEducator
       links[:section] = url_helpers.educators_my_sections_path
     end
 
-    if @educator.homeroom.present? && !@educator.homeroom.school.is_high_school?
-      links[:homeroom] = url_helpers.homeroom_path(@educator.homeroom.id) # explicitly, not slug
+    if @educator.homeroom.present? && !@educator.homeroom.school.is_high_school? && @educator.homeroom.students_count > 0
+      links[:homeroom] = url_helpers.homeroom_path(@educator.homeroom.id) # explicitly use id, not slug.  see Homeroom.rb for more
     end
 
     links

--- a/spec/lib/paths_for_educator_spec.rb
+++ b/spec/lib/paths_for_educator_spec.rb
@@ -44,14 +44,14 @@ RSpec.describe PathsForEducator do
           homeroom: "/homerooms/#{pals.healey_kindergarten_homeroom.id}"
         })
         expect(navbar_links(pals.healey_sarah_teacher)).to eq({
-          classlists: '/classlists',
-          homeroom: "/homerooms/#{pals.healey_fifth_homeroom.id}"
+          classlists: '/classlists'
+          # no homeroom, because no active students
         })
 
         # west
         expect(navbar_links(pals.west_marcus_teacher)).to eq({
           classlists: '/classlists',
-          homeroom: "/homerooms/#{pals.west_fifth_homeroom.id}"
+          # no homeroom, because no active students
         })
 
         # high school (TestPals doesn't match actual production HS roles and permisssions)


### PR DESCRIPTION
Follow-on to https://github.com/studentinsights/studentinsights/pull/2589, which used `Authorizer#homerooms` and filtered out homerooms with no active students.  This leads to an edge case where an educator is assigned a homeroom with no active students having a link that doesn't work for them in the navbar.  This removes the link in that case - it wouldn't have done anything anyway so this essentially hides stale data coming from the SIS.