### PR TITLE
Homeroom: Remove students_count, update link to require active students

### DIFF
--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -20,7 +20,7 @@ module Admin
     end
 
     def authorization
-      educators_with_includes = Educator.all.includes(:educator_labels, :school, :sections, {homeroom: :school})
+      educators_with_includes = Educator.all.includes(:educator_labels, :school, :sections, {homeroom: [:school, :students]})
       @sensitive_educators = sorted_sensitive_educators(educators_with_includes)
       @sorted_educators, @navbar_links_map = sort_list_with_navbar_links(educators_with_includes)
       nil

--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -154,7 +154,7 @@ class EducatorsImporter
       return nil
     end
 
-    # Match Homeroom (guaranteed to be uniqe on {name, school} by database index)
+    # Match Homeroom (guaranteed to be unique on {name, school} by database index)
     homeroom = Homeroom.find_or_initialize_by({
       name: row[:homeroom],
       school_id: school_id

--- a/app/lib/paths_for_educator.rb
+++ b/app/lib/paths_for_educator.rb
@@ -38,7 +38,7 @@ class PathsForEducator
       links[:section] = url_helpers.educators_my_sections_path
     end
 
-    if @educator.homeroom.present? && !@educator.homeroom.school.is_high_school? && @educator.homeroom.students_count > 0
+    if @educator.homeroom.present? && !@educator.homeroom.school.is_high_school? && @educator.homeroom.students.active.size > 0
       links[:homeroom] = url_helpers.homeroom_path(@educator.homeroom.id) # explicitly use id, not slug.  see Homeroom.rb for more
     end
 

--- a/app/lib/perf_test.rb
+++ b/app/lib/perf_test.rb
@@ -26,6 +26,12 @@ class PerfTest
     end
   end
 
+  def self.navbar_links(percentage, options = {})
+    PerfTest.new.simple(percentage, options) do |educator|
+      PathsForEducator.new(educator).navbar_links
+    end
+  end
+
   def self.authorized_homerooms(percentage, options = {})
     PerfTest.new.simple(percentage, options) do |educator|
       Authorizer.new(educator).homerooms

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -33,10 +33,9 @@ class Educator < ApplicationRecord
   # `missing_from_last_export` will always reflect the SIS, while `active` is an
   # Insights concept.
   def self.active
-    (
-      where(missing_from_last_export: false) +
-      where(login_name: PerDistrict.new.educator_login_names_whitelisted_as_active())
-    )
+    missing_arel = Educator.where(missing_from_last_export: false)
+    login_name_arel = Educator.where(login_name: PerDistrict.new.educator_login_names_whitelisted_as_active())
+    missing_arel.or(login_name_arel)
   end
 
   def active?

--- a/app/models/homeroom.rb
+++ b/app/models/homeroom.rb
@@ -10,7 +10,7 @@ class Homeroom < ApplicationRecord
   validates :slug, presence: true, uniqueness: true
   validates :school, presence: true
 
-  has_many :students, after_add: :update_grade
+  has_many :students, after_add: :update_grade # deprecated
 
   validate :validate_school_matches_educator_school
 
@@ -25,6 +25,8 @@ class Homeroom < ApplicationRecord
   end
 
   private
+  # deprecated, use `#grades` instead.
+  #
   # This doesn't work for mixed-grade homerooms (eg, special education).
   # We should migrate to `Homeroom#grades` or querying students on-demand
   # instead.

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -13,7 +13,7 @@ class Student < ApplicationRecord
   # Contrast with student_row.rb, which represents a row imported from X2,
   # (not necessarily in the database yet).
 
-  belongs_to :homeroom, optional: true, counter_cache: true
+  belongs_to :homeroom, optional: true
   belongs_to :school
 
   has_many :student_assessments, dependent: :destroy

--- a/db/migrate/20190905165958_remove_students_count_from_homeroom.rb
+++ b/db/migrate/20190905165958_remove_students_count_from_homeroom.rb
@@ -1,5 +1,5 @@
 class RemoveStudentsCountFromHomeroom < ActiveRecord::Migration[5.2]
   def change
-    remove_column :homerooms, :students_count
+    remove_column :homerooms, :students_count, :integer, default: 0, null: false
   end
 end

--- a/db/migrate/20190905165958_remove_students_count_from_homeroom.rb
+++ b/db/migrate/20190905165958_remove_students_count_from_homeroom.rb
@@ -1,0 +1,5 @@
+class RemoveStudentsCountFromHomeroom < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :homerooms, :students_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_29_165000) do
+ActiveRecord::Schema.define(version: 2019_09_05_165958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -187,8 +187,6 @@ ActiveRecord::Schema.define(version: 2019_08_29_165000) do
   create_table "educator_searchbars", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "educator_id", null: false
     t.json "student_searchbar_json", default: "[]", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["educator_id"], name: "index_educator_searchbars_on_educator_id", unique: true
   end
 
@@ -319,7 +317,6 @@ ActiveRecord::Schema.define(version: 2019_08_29_165000) do
     t.string "slug", null: false
     t.string "grade"
     t.integer "school_id", null: false
-    t.integer "students_count", default: 0, null: false
     t.index ["educator_id"], name: "index_homerooms_on_educator_id"
     t.index ["school_id", "name"], name: "index_homerooms_on_school_id_and_name", unique: true
     t.index ["slug"], name: "index_homerooms_on_slug", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_05_165958) do
+ActiveRecord::Schema.define(version: 2019_08_29_165000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -319,6 +319,7 @@ ActiveRecord::Schema.define(version: 2019_09_05_165958) do
     t.string "slug", null: false
     t.string "grade"
     t.integer "school_id", null: false
+    t.integer "students_count", default: 0, null: false
     t.index ["educator_id"], name: "index_homerooms_on_educator_id"
     t.index ["school_id", "name"], name: "index_homerooms_on_school_id_and_name", unique: true
     t.index ["slug"], name: "index_homerooms_on_slug", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_27_214324) do
+ActiveRecord::Schema.define(version: 2019_09_05_165958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -187,6 +187,8 @@ ActiveRecord::Schema.define(version: 2019_08_27_214324) do
   create_table "educator_searchbars", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "educator_id", null: false
     t.json "student_searchbar_json", default: "[]", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["educator_id"], name: "index_educator_searchbars_on_educator_id", unique: true
   end
 
@@ -313,7 +315,6 @@ ActiveRecord::Schema.define(version: 2019_08_27_214324) do
     t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer "students_count", default: 0, null: false
     t.integer "educator_id"
     t.string "slug", null: false
     t.string "grade"

--- a/spec/importers/student_voice_surveys/student_voice_survey_importer_spec.rb
+++ b/spec/importers/student_voice_surveys/student_voice_survey_importer_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe StudentVoiceSurveyImporter do
 
   it 'raises on call to dry_run' do
     importer, _ = create_importer_with_fetcher_mocked(sheet_id: 'mock_sheet_id_A')
-    expect { importer.import }.to raise_error RuntimeError
+    expect { importer.dry_run }.to raise_error(RuntimeError, 'Not implemented; refactor StudentVoiceSurveyUploader to enable this.')
   end
 
   it 'aborts if env not setup' do
@@ -53,7 +53,6 @@ RSpec.describe StudentVoiceSurveyImporter do
     allow(PerDistrict).to receive(:new).and_return(PerDistrict.new(district_key: PerDistrict::BEDFORD))
     importer, log = create_importer_with_fetcher_mocked(sheet_id: 'mock_sheet_id_A')
     importer.import
-    puts log.output
 
     expect(log.output).to include('Aborting')
     expect(StudentVoiceSurveyUpload.all.size).to eq 0


### PR DESCRIPTION
Following-on from https://github.com/studentinsights/studentinsights/pull/2584.

The semantics of `students_count` are unlikely to be what a developer wants; usually these should be active students, so let's remove this.  Separately fixes a bug in an edge case in production data.

Also optimizes `Educator.active` to one SQL query rather than two joined in memory.