### PR TITLE
Maintenance: Add indexes for Student.active and student voice feed query

### DIFF
--- a/db/migrate/20190905201456_indexes_for_student_voice_surveys.rb
+++ b/db/migrate/20190905201456_indexes_for_student_voice_surveys.rb
@@ -1,0 +1,6 @@
+class IndexesForStudentVoiceSurveys < ActiveRecord::Migration[5.2]
+  def change
+    add_index :student_voice_completed_surveys, :student_id
+    add_index :student_voice_completed_surveys, :form_timestamp
+  end
+end

--- a/db/migrate/20190905201813_index_for_active_students.rb
+++ b/db/migrate/20190905201813_index_for_active_students.rb
@@ -1,0 +1,6 @@
+class IndexForActiveStudents < ActiveRecord::Migration[5.2]
+  def change
+    add_index :students, :missing_from_last_export
+    add_index :students, :enrollment_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_05_165958) do
+ActiveRecord::Schema.define(version: 2019_09_05_201813) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -605,6 +605,8 @@ ActiveRecord::Schema.define(version: 2019_09_05_165958) do
     t.text "learn_best", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["form_timestamp"], name: "index_student_voice_completed_surveys_on_form_timestamp"
+    t.index ["student_id"], name: "index_student_voice_completed_surveys_on_student_id"
   end
 
   create_table "student_voice_survey_uploads", force: :cascade do |t|
@@ -659,8 +661,10 @@ ActiveRecord::Schema.define(version: 2019_09_05_165958) do
     t.boolean "missing_from_last_export", default: false, null: false
     t.date "ell_entry_date"
     t.date "ell_transition_date"
+    t.index ["enrollment_status"], name: "index_students_on_enrollment_status"
     t.index ["homeroom_id"], name: "index_students_on_homeroom_id"
     t.index ["local_id"], name: "index_students_on_local_id", unique: true
+    t.index ["missing_from_last_export"], name: "index_students_on_missing_from_last_export"
     t.index ["school_id"], name: "index_students_on_school_id"
     t.index ["state_id"], name: "index_students_on_state_id"
   end


### PR DESCRIPTION
Looking at `Student.active.explain` and the query in `FeedForStudentVoice.student_voice_surveys_for_cards`.