### PR TITLE
Reading: Add thresholds page, update some thresholds

### DIFF
--- a/app/assets/javascripts/district_overview/DistrictOverviewPage.js
+++ b/app/assets/javascripts/district_overview/DistrictOverviewPage.js
@@ -147,6 +147,11 @@ export class DistrictOverviewPageView extends React.Component {
                Benchmark reading data (eg, F&P)
               </a>
             </li>}
+            {showReadingDebugLinks && <li>
+              <a href="/reading/thresholds" style={styles.link}>
+               Thresholds for reading benchmarks
+              </a>
+            </li>}
           </ul>
         </div>
 

--- a/app/assets/javascripts/district_overview/__snapshots__/DistrictOverviewPage.test.js.snap
+++ b/app/assets/javascripts/district_overview/__snapshots__/DistrictOverviewPage.test.js.snap
@@ -1537,6 +1537,18 @@ exports[`DistrictOverviewPageView pure snapshot when \`enable_reading_debug\` la
                 Benchmark reading data (eg, F&P)
               </a>
             </li>
+            <li>
+              <a
+                href="/reading/thresholds"
+                style={
+                  Object {
+                    "fontSize": 14,
+                  }
+                }
+              >
+                Thresholds for reading benchmarks
+              </a>
+            </li>
           </ul>
         </div>
         <div>

--- a/app/assets/javascripts/reading/thresholds.js
+++ b/app/assets/javascripts/reading/thresholds.js
@@ -12,55 +12,41 @@ export const F_AND_P_SPANISH = 'f_and_p_spanish';
 export const INSTRUCTIONAL_NEEDS = 'instructional_needs';
 
 
+// shared across english and spanish
+const F_AND_P_THRESHOLDS_SHARED = {
+  'KF:fall': {
+    benchmark: 'A'
+  },
+  'KF:winter': {
+    benchmark: 'C',
+    risk: 'A'
+  },
+  'KF:spring': {
+    benchmark: 'C'
+  },
+  '1:winter': {
+    benchmark: 'G',
+    risk: 'D'
+  },
+  '1:spring': {
+    benchmark: 'J'
+  },
+  '2:spring': {
+    benchmark: 'M'
+  },
+  '3:winter': {
+    benchmark: 'O',
+    risk: 'M'
+  },
+  '3:spring': {
+    benchmark: 'P'
+  }
+};
+
+
 // all thresholds are "greater than or equal to" / "less than or equal to"
 // see also "DIBELS cut points" sheet at https://docs.google.com/spreadsheets/d/1Z8t1wmaE2mX6kkNGw_ZtPr2ZDVfXkEaTmRbVUofEo08
 const somervilleThresholds = {
-  [F_AND_P_ENGLISH]: { // based on colors from mega sheet
-    'KF:fall': {
-      benchmark: 'A'
-    },
-    'KF:winter': {
-      benchmark: 'C',
-      risk: 'A'
-    },
-    '1:winter': {
-      benchmark: 'G',
-      risk: 'D'
-    },
-    '2:spring': { // check these
-      benchmark: 'J'
-    },
-    '3:winter': { // check these
-      benchmark: 'O',
-      risk: 'M'
-    },
-    '3:spring': { // check these
-      benchmark: 'P'
-    }
-  },
-  [F_AND_P_SPANISH]: { // should be same as english
-    'KF:fall': {
-      benchmark: 'A'
-    },
-    'KF:winter': {
-      benchmark: 'C',
-      risk: 'A'
-    },
-    '1:winter': {
-      benchmark: 'G',
-      risk: 'D'
-    },
-    '2:spring': { // check these
-      benchmark: 'J'
-    },
-    '3:winter': { // check these
-      benchmark: 'O',
-      risk: 'M'
-    },
-    '3:spring': { // check these
-      benchmark: 'P'
-    }
-  },
   [DIBELS_FSF]: {
     'KF:fall': {
       benchmark: 18,
@@ -218,9 +204,10 @@ const somervilleThresholds = {
       benchmark: 98,
       risk: 95
     }
-  }
+  },
+  [F_AND_P_ENGLISH]: F_AND_P_THRESHOLDS_SHARED,
+  [F_AND_P_SPANISH]: F_AND_P_THRESHOLDS_SHARED
 };
-
 
 export function somervilleReadingThresholdsFor(benchmarkAssessmentKey, grade, benchmarkPeriodKey) {
   const thresholds = somervilleThresholds[benchmarkAssessmentKey];

--- a/app/assets/javascripts/reading_debug/ReadingThresholdsPage.js
+++ b/app/assets/javascripts/reading_debug/ReadingThresholdsPage.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import _ from 'lodash';
+import Nbsp from '../components/Nbsp';
+import SectionHeading from '../components/SectionHeading';
+import {high, medium, low} from '../helpers/colors';
+import {orderedFAndPLevels} from '../reading/readingData';
+import {
+  DIBELS_DORF_WPM,
+  DIBELS_DORF_ACC,
+  DIBELS_FSF,
+  DIBELS_LNF,
+  DIBELS_PSF,
+  DIBELS_NWF_CLS,
+  DIBELS_NWF_WWR,
+  F_AND_P_ENGLISH,
+  F_AND_P_SPANISH,
+  somervilleReadingThresholdsFor
+} from '../reading/thresholds';
+
+
+// For reviewing, debugging and developing new ways to make use of
+// or revise reading data.
+export default class ReadingThresholdsPage extends React.Component {
+  render() {
+    const SOURCE_CODE_URL = 'https://github.com/studentinsights/studentinsights/blob/master/app/assets/javascripts/reading/thresholds.js';
+    const benchmarkAssessmentKeys = [
+      DIBELS_FSF,
+      DIBELS_LNF,
+      DIBELS_PSF,
+      DIBELS_NWF_CLS,
+      DIBELS_NWF_WWR,
+      DIBELS_DORF_WPM,
+      DIBELS_DORF_ACC,
+      F_AND_P_ENGLISH,
+      F_AND_P_SPANISH
+    ];
+    const periodKeys = [
+      ['fall'],
+      ['winter'],
+      ['spring']
+    ];
+    const grades = ['KF', '1', '2', '3', '4', '5'];
+    const cells = _.flatMap(grades, grade => periodKeys.map(periodKey => [grade, periodKey]));
+    return (
+      <div className="ReadingThresholdsPage">
+        <SectionHeading titleStyle={styles.title}>
+          <div>Reading thresholds</div>
+          <div style={styles.headerLinkContainer}>
+            <a style={styles.headerLink} href={SOURCE_CODE_URL} target="_blank" rel="noopener noreferrer">Source code</a>
+          </div>
+        </SectionHeading>          
+        <table style={{margin: 10, fontSize: 12}}>
+          <thead>
+            <tr>
+              <th><Nbsp /></th>
+              {cells.map(cell => (
+                <th style={{textAlign: 'center', width: 40}} key={cell.join('-')}>
+                  <div>{cell[0]}</div>
+                  <div>{cell[1]}</div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {benchmarkAssessmentKeys.map(benchmarkAssessmentKey => {          
+              return (
+                <tr key={benchmarkAssessmentKey}>
+                  <td style={{width: 80, paddingRight: 10, paddingBottom: 20, verticalAlign: 'top', marginwhiteSpace: 'normal'}}>{prettyText(benchmarkAssessmentKey)}</td>
+                  {cells.map(cell => (
+                    <td key={cell.join('-')}>
+                      {this.renderCell(cell, benchmarkAssessmentKey)}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  renderCell(cell, benchmarkAssessmentKey) {
+    const [grade, benchmarkPeriodKey] = cell;
+    const thresholds = somervilleReadingThresholdsFor(benchmarkAssessmentKey, grade, benchmarkPeriodKey);
+    const mids = computeMids(thresholds, benchmarkAssessmentKey, grade, benchmarkPeriodKey);
+
+    const missingEl = <div><Nbsp /></div>;
+    return (
+      <div key={cell.join('-')} style={{color: 'white', textAlign: 'center', height: 80}}>
+        {thresholds && thresholds.benchmark !== undefined ? <div style={{backgroundColor: high}}>{thresholds.benchmark}</div> : missingEl}
+        {thresholds && thresholds.benchmark !== undefined && thresholds.risk !== undefined ? <div style={{backgroundColor: medium}}>{thresholds.benchmark - 1}</div> : missingEl}
+        {thresholds && thresholds.benchmark !== undefined && thresholds.risk !== undefined ? <div style={{backgroundColor: medium}}>{thresholds.risk + 1}</div> : missingEl}
+        {thresholds && thresholds.risk !== undefined ? <div style={{backgroundColor: low}}>{thresholds.risk}</div> : missingEl}
+      </div>
+    );
+  }
+}
+
+function computeMids(thresholds, benchmarkAssessmentKey, grade, benchmarkPeriodKey) {
+  if (!thresholds) return [null, null];
+  if (thresholds.risk === undefined || thresholds.benchmark === undefined) return [null, null];  
+
+  if ([F_AND_P_ENGLISH, F_AND_P_SPANISH].indexOf(benchmarkAssessmentKey) !== -1) {
+    const levels = orderedFAndPLevels();
+    return [
+      levels[levels.indexOf(thresholds.risk) + 1],
+      levels[levels.indexOf(thresholds.benchmark) - 1]
+    ];
+  }
+
+  return [
+    thresholds.benchmark - 1,
+    thresholds.risk + 1
+  ];
+}
+
+
+const styles = {
+  title: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  headerLinkContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-end'
+  },
+  headerLink: {
+    fontSize: 12
+  }
+};
+
+function prettyText(benchmarkAssessmentKey) {
+  return {
+    [F_AND_P_ENGLISH]: 'F&P English',
+    [F_AND_P_SPANISH]: 'F&P Spanish',
+    [DIBELS_FSF]: 'FSF, First sound fluency',
+    [DIBELS_LNF]: 'LNF, Letter naming fluency',
+    [DIBELS_PSF]: 'PSF, Phonemic segmentation fluency',
+    [DIBELS_NWF_CLS]: 'NWF-CLS, Nonsense word fluency',
+    [DIBELS_NWF_WWR]: 'NWF-WWR, Nonsense word fluency',
+    [DIBELS_DORF_WPM]: 'ORF words/minute',
+    [DIBELS_DORF_ACC]: 'ORF accuracy',
+  }[benchmarkAssessmentKey] || 'Unknown';
+}

--- a/app/assets/javascripts/reading_debug/ReadingThresholdsPage.js
+++ b/app/assets/javascripts/reading_debug/ReadingThresholdsPage.js
@@ -2,7 +2,6 @@ import React from 'react';
 import _ from 'lodash';
 import Nbsp from '../components/Nbsp';
 import SectionHeading from '../components/SectionHeading';
-import {high, medium, low} from '../helpers/colors';
 import {orderedFAndPLevels} from '../reading/readingData';
 import {
   DIBELS_DORF_WPM,
@@ -55,8 +54,8 @@ export default class ReadingThresholdsPage extends React.Component {
               <th><Nbsp /></th>
               {cells.map(cell => (
                 <th style={{textAlign: 'center', width: 40}} key={cell.join('-')}>
-                  <div>{cell[0]}</div>
-                  <div>{cell[1]}</div>
+                  <div style={{width: 40}}>{cell[0]}</div>
+                  <div style={{width: 40}}>{cell[1]}</div>
                 </th>
               ))}
             </tr>
@@ -65,7 +64,9 @@ export default class ReadingThresholdsPage extends React.Component {
             {benchmarkAssessmentKeys.map(benchmarkAssessmentKey => {          
               return (
                 <tr key={benchmarkAssessmentKey}>
-                  <td style={{width: 80, paddingRight: 10, paddingBottom: 20, verticalAlign: 'top', marginwhiteSpace: 'normal'}}>{prettyText(benchmarkAssessmentKey)}</td>
+                  <td style={{width: 80, paddingRight: 10, paddingBottom: 20, verticalAlign: 'top', marginwhiteSpace: 'normal'}}>
+                    {prettyText(benchmarkAssessmentKey)}
+                  </td>
                   {cells.map(cell => (
                     <td key={cell.join('-')}>
                       {this.renderCell(cell, benchmarkAssessmentKey)}
@@ -83,14 +84,14 @@ export default class ReadingThresholdsPage extends React.Component {
   renderCell(cell, benchmarkAssessmentKey) {
     const [grade, benchmarkPeriodKey] = cell;
     const thresholds = somervilleReadingThresholdsFor(benchmarkAssessmentKey, grade, benchmarkPeriodKey);
-    const mids = computeMids(thresholds, benchmarkAssessmentKey, grade, benchmarkPeriodKey);
-
+    const [midLow, midHigh] = computeMids(thresholds, benchmarkAssessmentKey, grade, benchmarkPeriodKey);
+    const [high, medium, low] = ['#F4C7C3','#FCE8B2','#B7E1CD']; // google sheets
     const missingEl = <div><Nbsp /></div>;
     return (
-      <div key={cell.join('-')} style={{color: 'white', textAlign: 'center', height: 80}}>
+      <div key={cell.join('-')} style={{color: '#666', textAlign: 'center', height: 80}}>
         {thresholds && thresholds.benchmark !== undefined ? <div style={{backgroundColor: high}}>{thresholds.benchmark}</div> : missingEl}
-        {thresholds && thresholds.benchmark !== undefined && thresholds.risk !== undefined ? <div style={{backgroundColor: medium}}>{thresholds.benchmark - 1}</div> : missingEl}
-        {thresholds && thresholds.benchmark !== undefined && thresholds.risk !== undefined ? <div style={{backgroundColor: medium}}>{thresholds.risk + 1}</div> : missingEl}
+        {midHigh ? <div style={{backgroundColor: medium}}>{midHigh}</div> : missingEl}
+        {midLow ? <div style={{backgroundColor: medium}}>{midLow}</div> : missingEl}
         {thresholds && thresholds.risk !== undefined ? <div style={{backgroundColor: low}}>{thresholds.risk}</div> : missingEl}
       </div>
     );
@@ -110,8 +111,8 @@ function computeMids(thresholds, benchmarkAssessmentKey, grade, benchmarkPeriodK
   }
 
   return [
-    thresholds.benchmark - 1,
-    thresholds.risk + 1
+    thresholds.risk + 1,
+    thresholds.benchmark - 1
   ];
 }
 

--- a/app/assets/javascripts/reading_debug/ReadingThresholdsPage.test.js
+++ b/app/assets/javascripts/reading_debug/ReadingThresholdsPage.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import renderer from 'react-test-renderer';
+import ReadingThresholdsPage from './ReadingThresholdsPage';
+
+
+it('renders without crashing', () => {
+  const el = document.createElement('div');
+  ReactDOM.render(<ReadingThresholdsPage />, el);
+});
+
+it('snapshots', () => {
+  const tree = renderer
+    .create(<ReadingThresholdsPage />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/assets/javascripts/reading_debug/__snapshots__/ReadingDebugPage.test.js.snap
+++ b/app/assets/javascripts/reading_debug/__snapshots__/ReadingDebugPage.test.js.snap
@@ -700,7 +700,7 @@ exports[`snapshots view 1`] = `
                       <div
                         style={
                           Object {
-                            "background": "#ccc",
+                            "background": "rgba(0,128,0,0.5)",
                             "height": 5,
                             "left": "0%",
                             "position": "absolute",
@@ -713,7 +713,7 @@ exports[`snapshots view 1`] = `
                       <div
                         style={
                           Object {
-                            "color": "#ccc",
+                            "color": "rgba(0,128,0,0.5)",
                             "left": "0%",
                             "paddingRight": 1,
                             "position": "absolute",
@@ -1789,11 +1789,11 @@ exports[`snapshots view 1`] = `
                       <div
                         style={
                           Object {
-                            "background": "#ccc",
+                            "background": "rgba(0,128,0,0.5)",
                             "height": 5,
                             "left": "0%",
                             "position": "absolute",
-                            "width": "100%",
+                            "width": "67%",
                           }
                         }
                       >
@@ -1802,17 +1802,47 @@ exports[`snapshots view 1`] = `
                       <div
                         style={
                           Object {
-                            "color": "#ccc",
+                            "color": "rgba(0,128,0,0.5)",
                             "left": "0%",
                             "paddingRight": 1,
                             "position": "absolute",
                             "textAlign": "right",
                             "top": 5,
-                            "width": "100%",
+                            "width": "67%",
                           }
                         }
                       >
-                        6
+                        4
+                      </div>
+                    </div>
+                    <div>
+                      <div
+                        style={
+                          Object {
+                            "background": "rgba(255,140,0,0.6)",
+                            "height": 5,
+                            "left": "67%",
+                            "position": "absolute",
+                            "width": "34%",
+                          }
+                        }
+                      >
+                         
+                      </div>
+                      <div
+                        style={
+                          Object {
+                            "color": "rgba(255,140,0,0.6)",
+                            "left": "67%",
+                            "paddingRight": 1,
+                            "position": "absolute",
+                            "textAlign": "right",
+                            "top": 5,
+                            "width": "34%",
+                          }
+                        }
+                      >
+                        2
                       </div>
                     </div>
                   </div>

--- a/app/assets/javascripts/reading_debug/__snapshots__/ReadingThresholdsPage.test.js.snap
+++ b/app/assets/javascripts/reading_debug/__snapshots__/ReadingThresholdsPage.test.js.snap
@@ -1,0 +1,7526 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshots 1`] = `
+<div
+  className="ReadingThresholdsPage"
+>
+  <div
+    className="SectionHeading"
+    style={
+      Object {
+        "borderBottom": "1px solid #333",
+        "padding": 10,
+      }
+    }
+  >
+    <h4
+      style={
+        Object {
+          "alignItems": "center",
+          "color": "black",
+          "display": "flex",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+        }
+      }
+    >
+      <div>
+        Reading thresholds
+      </div>
+      <div
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "display": "flex",
+            "flexDirection": "column",
+          }
+        }
+      >
+        <a
+          href="https://github.com/studentinsights/studentinsights/blob/master/app/assets/javascripts/reading/thresholds.js"
+          rel="noopener noreferrer"
+          style={
+            Object {
+              "fontSize": 12,
+            }
+          }
+          target="_blank"
+        >
+          Source code
+        </a>
+      </div>
+    </h4>
+  </div>
+  <table
+    style={
+      Object {
+        "fontSize": 12,
+        "margin": 10,
+      }
+    }
+  >
+    <thead>
+      <tr>
+        <th>
+          <span
+            style={Object {}}
+          >
+             
+          </span>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            KF
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            fall
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            KF
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            winter
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            KF
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            spring
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            1
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            fall
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            1
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            winter
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            1
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            spring
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            2
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            fall
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            2
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            winter
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            2
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            spring
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            3
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            fall
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            3
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            winter
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            3
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            spring
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            4
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            fall
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            4
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            winter
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            4
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            spring
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            5
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            fall
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            5
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            winter
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            5
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            spring
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          FSF, First sound fluency
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              18
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              17
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              8
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              7
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              44
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              43
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              32
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              31
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          LNF, Letter naming fluency
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              22
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              21
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              11
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              10
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              42
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              41
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              20
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              19
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              52
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              51
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              39
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              38
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              50
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              49
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              37
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              36
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          PSF, Phonemic segmentation fluency
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              27
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              26
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              12
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              11
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              45
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              44
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              31
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              30
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              45
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              44
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              31
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              30
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          NWF-CLS, Nonsense word fluency
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              27
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              26
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              13
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              12
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              37
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              36
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              28
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              27
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              33
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              32
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              20
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              19
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              50
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              49
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              31
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              30
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              78
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              77
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              43
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              42
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              62
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              61
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              46
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              45
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          NWF-WWR, Nonsense word fluency
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              4
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              3
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              2
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              1
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              12
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              11
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              6
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              5
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              18
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              17
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              10
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              9
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              18
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              17
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              10
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              9
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          ORF words/minute
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              30
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              29
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              19
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              63
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              62
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              37
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              36
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              68
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              67
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              47
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              46
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              84
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              83
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              68
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              67
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              100
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              99
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              83
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              82
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              93
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              92
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              73
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              72
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              108
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              107
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              89
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              88
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              123
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              122
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              101
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              100
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          ORF accuracy
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              85
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              84
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              74
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              73
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              92
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              91
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              85
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              84
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              93
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              92
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              85
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              84
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              95
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              94
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              92
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              91
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              97
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              96
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              94
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              93
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              96
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              95
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              92
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              91
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              97
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              96
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              94
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              93
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              98
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              97
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              96
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              95
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          F&P English
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              A
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              C
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              B
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              B
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              A
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              C
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              G
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              F
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              E
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              D
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              J
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              M
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              O
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              N
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              N
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              M
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              P
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          F&P Spanish
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              A
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              C
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              B
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              B
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              A
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              C
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              G
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              F
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              E
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              D
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              J
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              M
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              O
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              N
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#FCE8B2",
+                }
+              }
+            >
+              N
+            </div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#B7E1CD",
+                }
+              }
+            >
+              M
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#F4C7C3",
+                }
+              }
+            >
+              P
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+            <div>
+              <span
+                style={Object {}}
+              >
+                 
+              </span>
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,6 +212,7 @@ Rails.application.routes.draw do
 
   resource :reading, only: [] do
     member do
+      get '/thresholds' => 'ui#ui'
       get '/debug' => 'ui#ui'
       get '/debug_star' => 'ui#ui'
       get '/debug_csv' => 'reading_debug#reading_debug_csv'

--- a/ui/App.js
+++ b/ui/App.js
@@ -32,6 +32,7 @@ import SampleStudentsPage from '../app/assets/javascripts/sample_students/Sample
 import MyNotesPage from '../app/assets/javascripts/my_notes/MyNotesPage';
 import ReadingEntryPage from '../app/assets/javascripts/reading/ReadingEntryPage';
 import ReadingGroupingPage from '../app/assets/javascripts/reading/ReadingGroupingPage';
+import ReadingThresholdsPage from '../app/assets/javascripts/reading_debug/ReadingThresholdsPage';
 import ReadingDebugPage from '../app/assets/javascripts/reading_debug/ReadingDebugPage';
 import ReadingDebugStarPage from '../app/assets/javascripts/reading_debug/ReadingDebugStarPage';
 import MyStudentsPage from '../app/assets/javascripts/my_students/MyStudentsPage';
@@ -108,6 +109,7 @@ export default class App extends React.Component {
         <Route exact path="/schools/:id/discipline" render={this.renderDisciplineDashboard.bind(this)}/>
         <Route exact path="/schools/:slug/reading/:grade/entry" render={this.renderReadingEntryPage.bind(this)}/>
         <Route exact path="/schools/:slug/reading/:grade/groups" render={this.renderReadingGroupingPage.bind(this)}/>
+        <Route exact path="/reading/thresholds" render={this.renderReadingThresholdsPage.bind(this)}/>
         <Route exact path="/reading/debug" render={this.renderReadingDebugPage.bind(this)}/>
         <Route exact path="/reading/debug_star" render={this.renderReadingDebugStarPage.bind(this)}/>
         <Route exact path="/homerooms/:id" render={this.renderHomeroomPage.bind(this)}/>
@@ -187,6 +189,10 @@ export default class App extends React.Component {
         queryParams={queryParams}
         history={window.history} />
     );
+  }
+
+  renderReadingThresholdsPage(routeProps) {
+    return <ReadingThresholdsPage />;
   }
 
   renderReadingDebugPage(routeProps) {

--- a/ui/App.test.js
+++ b/ui/App.test.js
@@ -13,6 +13,7 @@ import SchoolCoursesPage from '../app/assets/javascripts/school_courses/SchoolCo
 import SchoolAbsencesPage from '../app/assets/javascripts/school_absences/SchoolAbsencesPage';
 import ReadingEntryPage from '../app/assets/javascripts/reading/ReadingEntryPage';
 import ReadingGroupingPage from '../app/assets/javascripts/reading/ReadingGroupingPage';
+import ReadingThresholdsPage from '../app/assets/javascripts/reading_debug/ReadingThresholdsPage';
 import DashboardLoader from '../app/assets/javascripts/school_administrator_dashboard/DashboardLoader';
 import DistrictEnrollmentPage from '../app/assets/javascripts/district_enrollment/DistrictEnrollmentPage';
 import ClassListCreatorPage from '../app/assets/javascripts/class_lists/ClassListCreatorPage';
@@ -36,6 +37,7 @@ jest.mock('../app/assets/javascripts/school_courses/SchoolCoursesPage');
 jest.mock('../app/assets/javascripts/school_absences/SchoolAbsencesPage');
 jest.mock('../app/assets/javascripts/reading/ReadingEntryPage');
 jest.mock('../app/assets/javascripts/reading/ReadingGroupingPage');
+jest.mock('../app/assets/javascripts/reading_debug/ReadingThresholdsPage');
 jest.mock('../app/assets/javascripts/school_administrator_dashboard/DashboardLoader');
 jest.mock('../app/assets/javascripts/district_enrollment/DistrictEnrollmentPage');
 jest.mock('../app/assets/javascripts/class_lists/ClassListCreatorPage');
@@ -162,6 +164,11 @@ it('render ReadingGroupingPage without crashing', () => {
       schoolSlug="hea"
       grade="3" />
   )).toEqual(true);
+});
+
+it('renders ReadingThresholdsPage without crashing', () => {
+  const wrapper = mount(renderPath('/reading/thresholds'));
+  expect(wrapper.contains(<ReadingThresholdsPage />)).toEqual(true);
 });
 
 it('renders district enrollment', () => {


### PR DESCRIPTION
# Who is this PR for?
project leads, reading educators

# What problem does this PR fix?
Make visible reading thresholds in more visual way.

# What does this PR do?
Adds `/reading/thresholds` with links for project leads with label only.

Also makes some updates to thresholds, which I think were just bugs or inconsistencies.  Separately getting more input on that.

# Screenshot (if adding a client-side feature)
<img width="1059" alt="Screen Shot 2019-09-10 at 5 26 52 PM" src="https://user-images.githubusercontent.com/1056957/64652028-e212b780-d3f0-11e9-947b-df6d370c2b5d.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Reading
+ [x] Student profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here