### PR TITLE
Reading: Fix grade comparison to thresholds in debug view

### DIFF
--- a/app/assets/javascripts/reading_debug/__snapshots__/ReadingDebugPage.test.js.snap
+++ b/app/assets/javascripts/reading_debug/__snapshots__/ReadingDebugPage.test.js.snap
@@ -212,7 +212,7 @@ exports[`snapshots view 1`] = `
     </div>
     <div>
       <a
-        href="https://github.com/studentinsights/studentinsights/blob/master/app/assets/javascripts/reading/thresholds.js"
+        href="/reading/thresholds"
         rel="noopener noreferrer"
         target="_blank"
       >


### PR DESCRIPTION
# Who is this PR for?
internal team for now

# What problem does this PR fix?
On debug page, thresholds are using student's grade now, rather than at the time of the benchmark assessment.  This is a wider issue, and separate work will push this upstream to be explicit during import.

# What does this PR do?
Updates this for F&P and DIBELs.  Also update link to thresholds to point to visual instead of code.

# Screenshot (if adding a client-side feature)
![image](https://user-images.githubusercontent.com/1056957/64782370-0080cc00-d533-11e9-8e50-5b87e22bfa4e.png)

# Checklists
*Which features or pages does this PR touch?*
+ [x] Reading debug

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here