### PR TITLE
New Bedford: Add migration tools for changing school scope

### DIFF
--- a/app/lib/school_scope_migrator.rb
+++ b/app/lib/school_scope_migrator.rb
@@ -1,6 +1,6 @@
-# For manual or semi-automated migrations related to changing school scope 
+# For manual or semi-automated migrations related to changing school scope
 # in definition files or in import jobs.
-# 
+#
 # For example, if removing a school, you might update the definition file,
 # then use this class to run a migration that marks all Student and Educator
 # records that used to be in scope as inactive.

--- a/app/lib/school_scope_migrator.rb
+++ b/app/lib/school_scope_migrator.rb
@@ -1,0 +1,98 @@
+# For manual or semi-automated migrations related to changing school scope 
+# in definition files or in import jobs.
+# 
+# For example, if removing a school, you might update the definition file,
+# then use this class to run a migration that marks all Student and Educator
+# records that used to be in scope as inactive.
+#
+# While school scope in the importers allow them to do "partial imports" for
+# migrations, incremental deploys, or debugging, this class allows us to
+# ask questions and migrate data that is outside that scope when the scope
+# changes.
+class SchoolScopeMigrator
+  def initialize(options = {})
+    @explicit_school_scope = options.fetch(:schools, nil)
+  end
+
+  # As defined in definition file, or passed explicitly.
+  def schools_within_scope
+    return @explicit_school_scope if @explicit_school_scope.present?
+    school_local_ids = PerDistrict.new.school_definitions_for_import.map {|j| j['local_id'] }
+    School.where(local_id: school_local_ids)
+  end
+
+  def migrate_all!
+    puts "Finding schools..."
+    schools = self.schools_within_scope()
+    puts "There are #{schools.size} School records within scope."
+    puts
+    puts
+    migrate_educators!
+    puts
+    puts
+    migrate_students!
+    puts
+    puts
+    puts "All done."
+  end
+
+  def migrate_educators!
+    puts "Starting Educators..."
+    Educator.transaction do
+      puts "  Found #{Educator.active.size} active and #{Educator.all.size} total Educator records."
+      educator_ids_within_scope = self.educators_within_scope().map(&:id)
+      puts "  Found #{educator_ids_within_scope.size} Educator records within scope..."
+      stale_educators = self.stale_educators()
+      puts "  Ensuring missing_from_last_export:true for #{stale_educators.size} stale Educator records..."
+      puts "  Actually setting missing_from_last_export:true for #{stale_educators.active.size} currently active stale Educator records..."
+      stale_educators.active.each do |educator|
+        educator.update!(missing_from_last_export: true)
+      end
+      puts "  Done updating Educators."
+    end
+  end
+
+  def migrate_students!
+    puts "Starting Students..."
+    Student.transaction do
+      puts "  Found #{Student.active.size} active and #{Student.all.size} total Student records."
+      student_ids_within_scope = self.students_within_scope().map(&:id)
+      puts "  Found #{student_ids_within_scope.size} Student records within scope..."
+      stale_students = self.stale_students()
+      puts "  Ensuring missing_from_last_export:true for #{stale_students.size} stale Student records..."
+      puts "  Actually setting missing_from_last_export:true for #{stale_students.active.size} currently active stale Student records..."
+      stale_students.active.each do |student|
+        student.update!(missing_from_last_export: true)
+      end
+      puts "  Done updating Students."
+    end
+  end
+
+  def educators_within_scope
+    schools = schools_within_scope()
+    active_educators = Educator.active
+
+    (
+      active_educators.where(school_id: nil) +
+      active_educators.where(school_id: schools.map(&:id)) +
+      active_educators.where(login_name: PerDistrict.new.educator_login_names_whitelisted_as_active())
+    ).uniq
+  end
+
+  def stale_educators
+    Educator.all.where.not(id: educators_within_scope().map(&:id))
+  end
+
+  def students_within_scope
+    schools = schools_within_scope()
+    active_students = Student.active
+    (
+      active_students.where(school_id: nil) +
+      active_students.where(school_id: schools.map(&:id))
+    ).uniq
+  end
+
+  def stale_students
+    Student.all.where.not(id: students_within_scope().map(&:id))
+  end
+end

--- a/lib/tasks/data_migrations/school_scope_migrator.rake
+++ b/lib/tasks/data_migrations/school_scope_migrator.rake
@@ -1,0 +1,6 @@
+namespace :data_migration do
+  desc "For migrating records when school scope is reduced"
+  task school_scope_migrator_migrate_all: :environment do
+    SchoolScopeMigrator.new.migrate_all!
+  end
+end


### PR DESCRIPTION
# Who is this PR for?
internal team, helping with limiting scope for work related to permissions in New Bedford

# What problem does this PR fix?
Folks in New Bedford are focusing training and workshop efforts in particular schools, differently than the previous scope.  https://github.com/studentinsights/studentinsights/pull/2608 updated to match that scope, but this leaves some drift.

We haven't reduced scope like this before, and the `school_scope` concept in the importers is for supporting incremental deployments, debugging import jobs, or other kinds of partial imports where we only want to update a slice of the db state.  So there aren't tools now for migrating previously imported data.

# What does this PR do?
Adds `SchoolScopeMigrator` class, which has methods for understanding the `Student` and `Educator` records, and which would currently be in scope and which would currently not be, based on the school definition files.  This info can be useful for understanding what's happening, and there are specific methods here for migrating `Student` and `Educator` records in response to reducing the scope of the imports.  It uses the `missing_from_last_export` and `#active` interface on those models.

Separately, these could be purged as part of a more rigorous enforcement of retention policies, but that isn't done here.  This is the 'mark' but there is no 'sweeping' here.

Example output:
```
Finding schools...
There are <N> School records within scope.


Starting Educators...
  Found <N> active and <N> total Educator records.
  Found <N> Educator records within scope...
  Ensuring missing_from_last_export:true for <N> stale Educator records...
  Actually setting missing_from_last_export:true for <N> currently active stale Educator records...
  Done updating Educators.


Starting Students...
  Found <N> active and <N> total Student records.
  Found <N> Student records within scope...
  Ensuring missing_from_last_export:true for <N> stale Student records...
  Actually setting missing_from_last_export:true for <N> currently active stale Student records...
  Done updating Students.


All done.
```
# Checklists
*Which features or pages does this PR touch?*
+ [x] Core 

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here