### PR TITLE
New Bedford: Temporary sections importer

### DIFF
--- a/app/importers/file_importers/temporary_new_bedford_sections_importer.rb
+++ b/app/importers/file_importers/temporary_new_bedford_sections_importer.rb
@@ -1,0 +1,131 @@
+# Patched to work for New Bedford transition file format; temporary class that
+# subclasses private methods in other importers, so the approach is brittle but
+# makes sense for a week or two transition period, when we can remove this after
+# district folks update their formats upstream.
+class TemporaryNewBedfordSectionsImporter
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_SIS_SFTP_CSV,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      options: [
+        DataFlow::OPTION_SCHOOL_SCOPE
+      ],
+      merge: DataFlow::MERGE_UPDATE_IGNORE_UNMARKED, # more complicated, as this wraps multiple importers
+      touches: [
+        Section.name,
+        Course.name,
+        StudentSectionAssignment.name,
+        EducatorSectionAssignment.name,
+      ],
+      description: 'Manual importer for transitioning to different section format in New Bedford.  Wraps other importers.'
+    })
+  end
+
+  # This subclasses private methods, and is generally not a stable solution; this is a transition
+  # approach for the next week or two while district folks update export formats.
+  def import
+    file_text = download_file_text()
+
+    courses_and_sections_importer(file_text).import
+    student_section_assignments_importer(file_text).import
+    educator_section_assignments_importer(file_text).import
+    nil
+  end
+
+  private
+  def download_file_text
+    remote_file_name = PerDistrict.new.try_sftp_filename('FILENAME_FOR_WIDE_SECTIONS_IMPORT')
+    file = SftpClient.for_x2.download_file(remote_file_name)
+    File.read(file)
+  end
+
+  def courses_and_sections_importer(file_text)
+    PatchedCoursesSectionsImporter.new(options: options.merge(file_text: file_text))
+  end
+
+  def student_section_assignments_importer(file_text)
+    PatchedStudentSectionAssignmentsImporter.new(options: options.merge(file_text: file_text))
+  end
+
+  def educator_section_assignments_importer(file_text)
+    PatchedEducatorSectionAssignmentsImporter.new(options: options.merge(file_text: file_text))
+  end
+
+  class PatchedCoursesSectionsImporter < CoursesSectionsImporter
+    def initialize(options:)
+      @file_text = options.fetch(:file_text, '')
+      super(options: options)
+    end
+
+    def remote_file_name
+      'patched'
+    end
+
+    def download_csv
+      rows = []
+      StreamingCsvTransformer.from_text(@log, @file_text, csv_options: {}).each_with_index do |row, index|
+        rows << row.to_h.merge({
+          section_number: row[:course_view],
+          term_local_id: row[:term_view],
+          district_school_year: 2020,
+          section_schedule: row[:schedule_display],
+          section_room_number: row[:room_view]
+        })
+      end
+      rows
+    end
+  end
+
+  class PatchedEducatorSectionAssignmentsImporter < EducatorSectionAssignmentsImporter
+    def initialize(options:)
+      @file_text = options.fetch(:file_text, '')
+      super(options: options)
+    end
+
+    def remote_file_name
+      'patched'
+    end
+
+    def download_csv
+      rows = []
+      StreamingCsvTransformer.from_text(@log, @file_text, csv_options: {}).each_with_index do |row, index|
+        educator_login_name = Educator.find_by_local_id(row[:staff_local_id]).try(:login_name)
+        if educator_login_name.nil?
+          @log.puts(' educator_login_name.nil? ')
+          next
+        end
+        rows << row.to_h.merge({
+          login_name: educator_login_name,
+          section_number: row[:course_view],
+          term_local_id: row[:term_view],
+          district_school_year: 2020
+        })
+      end
+      rows
+    end
+  end
+
+  class PatchedStudentSectionAssignmentsImporter < StudentSectionAssignmentsImporter
+    def initialize(options:)
+      @file_text = options.fetch(:file_text, '')
+      super(options: options)
+    end
+
+    def remote_file_name
+      'patched'
+    end
+
+    def download_csv
+      rows = []
+      StreamingCsvTransformer.from_text(@log, @file_text, csv_options: {}).each_with_index do |row, index|
+        rows << row.to_h.merge({
+          section_number: row[:course_view],
+          term_local_id: row[:term_view],
+          district_school_year: 2020
+        })
+      end
+      rows
+    end
+  end
+end

--- a/app/importers/file_importers/temporary_new_bedford_sections_importer.rb
+++ b/app/importers/file_importers/temporary_new_bedford_sections_importer.rb
@@ -22,6 +22,12 @@ class TemporaryNewBedfordSectionsImporter
     })
   end
 
+  def initialize(options:)
+    @options = options
+    @merged_remote_file_name = @options.fetch(:merged_remote_file_name, nil)
+    raise 'missing merged_remote_file_name' if @merged_remote_file_name.nil?
+  end
+
   # This subclasses private methods, and is generally not a stable solution; this is a transition
   # approach for the next week or two while district folks update export formats.
   def import
@@ -35,21 +41,19 @@ class TemporaryNewBedfordSectionsImporter
 
   private
   def download_file_text
-    remote_file_name = PerDistrict.new.try_sftp_filename('FILENAME_FOR_WIDE_SECTIONS_IMPORT')
-    file = SftpClient.for_x2.download_file(remote_file_name)
-    File.read(file)
+    File.read(SftpClient.for_x2.download_file(@merged_remote_file_name))
   end
 
   def courses_and_sections_importer(file_text)
-    PatchedCoursesSectionsImporter.new(options: options.merge(file_text: file_text))
+    PatchedCoursesSectionsImporter.new(options: @options.merge(file_text: file_text))
   end
 
   def student_section_assignments_importer(file_text)
-    PatchedStudentSectionAssignmentsImporter.new(options: options.merge(file_text: file_text))
+    PatchedStudentSectionAssignmentsImporter.new(options: @options.merge(file_text: file_text))
   end
 
   def educator_section_assignments_importer(file_text)
-    PatchedEducatorSectionAssignmentsImporter.new(options: options.merge(file_text: file_text))
+    PatchedEducatorSectionAssignmentsImporter.new(options: @options.merge(file_text: file_text))
   end
 
   class PatchedCoursesSectionsImporter < CoursesSectionsImporter

--- a/config/district_new_bedford.yml
+++ b/config/district_new_bedford.yml
@@ -4,7 +4,6 @@ sftp_filenames:
   FILENAME_FOR_BEHAVIOR_IMPORT:       ../newbedford/iconduct.csv
   FILENAME_FOR_ATTENDANCE_IMPORT:     ../newbedford/iattendance.csv
   FILENAME_FOR_ASSESSMENT_IMPORT:     ../newbedford/iassessments.csv
-  FILENAME_FOR_WIDE_SECTIONS_IMPORT:     ../newbedford/istudentschedule.csv
 
   # student photos, one-time batch
   FILENAME_FOR_PHOTOS_ZIP:            /home/newbedford/photos.zip

--- a/config/district_new_bedford.yml
+++ b/config/district_new_bedford.yml
@@ -4,6 +4,7 @@ sftp_filenames:
   FILENAME_FOR_BEHAVIOR_IMPORT:       ../newbedford/iconduct.csv
   FILENAME_FOR_ATTENDANCE_IMPORT:     ../newbedford/iattendance.csv
   FILENAME_FOR_ASSESSMENT_IMPORT:     ../newbedford/iassessments.csv
+  FILENAME_FOR_WIDE_SECTIONS_IMPORT:     ../newbedford/istudentschedule.csv
 
   # student photos, one-time batch
   FILENAME_FOR_PHOTOS_ZIP:            /home/newbedford/photos.zip


### PR DESCRIPTION
Building on https://github.com/studentinsights/studentinsights/pull/2612.

# Who is this PR for?
New Bedford students, families and educators

# What problem does this PR fix?
In coordinating with district IT folks, we're waiting a bit for some upstream work.  This is trying to advance work like https://github.com/studentinsights/studentinsights/pull/2612 and enable doing some data quality checks on our end, and enable related product changes before the upstream work is done.  This PR is mostly risk mitigation against timing on the upstream work.

# What does this PR do?
Adds a temporary importer class, using an interim export file format from the district that they'll migrate over to the existing spec formats in the next week or two.  So this composes and patches existing importers.  If for some reason we need to go forward with the mitigation plan in the next few weeks, we'll need to refactor these to remove things like overriding private methods, but there's no forcing function on that yet.

The work here has been manually verified in different ways, and there's no intention for this to be automated.

# Checklists
*Which features or pages does this PR touch?*
+ [x]  Section
+ [x] My Sections
+ [x] My Students
+ [x] Core 

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here