### PR TITLE
WIP: Working towards determnistic dev setup

### DIFF
--- a/app/demo_data/fake_student.rb
+++ b/app/demo_data/fake_student.rb
@@ -369,16 +369,20 @@ class FakeStudent
   def add_ieps
     15.in(100) do
       file_name = "#{@student.local_id}_IEPAtAGlance_#{@student.first_name}_#{@student.last_name}.pdf"
-      file_digest = SecureRandom.hex
+      file_digest = random_hex()
       IepDocument.create!(
         student: @student,
         file_name: file_name,
         file_digest: file_digest,
-        file_size: 1000 + SecureRandom.random_number(100000),
-        s3_filename: "#{SecureRandom.hex}/#{Time.now.strftime('%Y-%m-%d')}/#{file_digest}"
+        file_size: 1000 + rand(100000),
+        s3_filename: "#{random_hex()}/#{Time.now.strftime('%Y-%m-%d')}/#{file_digest}"
       )
     end
     nil
+  end
+
+  def random_hex()
+    32.times.map { rand(16).to_s(16) }.join()
   end
 
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,6 +5,7 @@ Rails.application.configure do
     ENV[key.to_s] = value
   end if File.exists?(env_file)
   Env.set_for_development_and_test!
+  ENV['DETERMINISTIC_SEED_FOR_SEED_TASK'] = '42' # for deterministic dev setup
   ENV['ENABLE_CLASS_LISTS'] = 'true'
   ENV['USE_PLACEHOLDER_STUDENT_PHOTO'] = 'true'
   ENV['USE_PLACEHOLDER_IEP_DOCUMENT'] = 'true'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,8 +2,6 @@ require "#{Rails.root}/db/seeds/database_constants"
 require "#{Rails.root}/spec/support/test_pals"
 require "#{Rails.root}/app/lib/environment_variable"
 
-start_time = Time.now
-
 def sample_numeric_grade_from_letter(grade_letter)
   case grade_letter
     when "A" then rand(90..100)
@@ -15,6 +13,21 @@ def sample_numeric_grade_from_letter(grade_letter)
 end
 
 puts 'Starting seeds.rb...'
+start_time = Time.now
+
+# Allow deterministic dev setup, which is also useful for regenerating fixture
+# values for tests after migrations or other changes.
+# 
+# We don't want this in test though; there we want to keep this random to
+# flush out any coupling (seeds can be fixed for specific test runs separately in
+# rspec as needed).
+if Rails.env.development? && ENV.has_key?('DETERMINISTIC_SEED_FOR_SEED_TASK')
+  srand_seed = ENV['DETERMINISTIC_SEED_FOR_SEED_TASK'].to_i
+  puts "Using DETERMINISTIC_SEED_FOR_SEED_TASK=#{srand_seed} for srand."
+  srand srand_seed
+else
+  puts "Allowing default seed for srand."
+end
 
 more_demo_students = EnvironmentVariable.is_true('MORE_DEMO_STUDENTS')
 

--- a/spec/controllers/class_lists_controller_spec.rb
+++ b/spec/controllers/class_lists_controller_spec.rb
@@ -667,12 +667,16 @@ describe ClassListsController, :type => :controller do
       }.merge(params))
     end
 
+    def random_hex
+      32.times.map { rand(16).to_s(16) }.join()
+    end
+    
     def create_student_photo(student_id, params = {})
       StudentPhoto.create({
         student_id: student_id,
-        file_digest: SecureRandom.hex,
-        file_size: 1000 + SecureRandom.random_number(100000),
-        s3_filename: SecureRandom.hex
+        file_digest: random_hex(),
+        file_size: 1000 + rand(100000),
+        s3_filename: random_hex()
       }.merge(params))
     end
 

--- a/spec/controllers/filter_parameter_logging_spec.rb
+++ b/spec/controllers/filter_parameter_logging_spec.rb
@@ -13,9 +13,13 @@ RSpec.describe 'filter_parameter_loggin', :type => :controller do
     log
   end
 
+  def random_hex
+    32.times.map { rand(16).to_s(16) }.join()
+  end
+
   def generated_params(n)
     params = {}
-    n.times { params[SecureRandom.hex] = "SENSITIVE-#{SecureRandom.hex}" }
+    n.times { params[random_hex()] = "SENSITIVE-#{random_hex()}" }
     params
   end
 

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -108,13 +108,17 @@ describe StudentsController, :type => :controller do
       })
     end
 
+    def random_hex
+      32.times.map { rand(16).to_s(16) }.join()
+    end
+
     def create_iep_document(params = {})
       IepDocument.create!({
         student_id: nil,
         file_name: nil,
-        file_digest: SecureRandom.hex,
-        file_size: 1000 + SecureRandom.random_number(100000),
-        s3_filename: SecureRandom.hex
+        file_digest: random_hex(),
+        file_size: 1000 + rand(100000),
+        s3_filename: random_hex()
       }.merge(params))
     end
 

--- a/spec/factories/iep_document.rb
+++ b/spec/factories/iep_document.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
 
     created_at { Time.now }
     file_name { "#{student.local_id}_IEPAtAGlance_#{student.first_name}_#{student.last_name}.pdf" }
-    file_digest { SecureRandom.hex }
-    file_size { 1000 + SecureRandom.random_number(100000) }
+    file_digest { 32.times.map { rand(16).to_s(16) }.join() }
+    file_size { 1000 + rand(100000) }
     s3_filename { "iep_pdfs/#{Digest::SHA256.hexdigest(student.local_id)}/#{created_at.strftime('%Y-%m-%d')}/#{file_digest}" }
   end
 end

--- a/spec/importers/iep_import/iep_storer_spec.rb
+++ b/spec/importers/iep_import/iep_storer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe IepStorer, type: :model do
   end
 
   def create_mocked_iep_storer(attrs = {})
+    random_hex = 32.times.map { rand(16).to_s(16) }.join()
     path_to_file = '/tmp/path/124046632_IEPAtAGlance_Alexander_Hamilton.pdf'
     storer = IepStorer.new({
       path_to_file: path_to_file,
@@ -18,8 +19,8 @@ RSpec.describe IepStorer, type: :model do
     }.merge(attrs))
     allow(File).to receive(:open).and_call_original # ActiveSupport calls this for i8n translations
     allow(File).to receive(:open).with(path_to_file).and_return '<pdfbytes>'
-    allow(File).to receive(:size).with(path_to_file).and_return 1000 + SecureRandom.random_number(100000)
-    allow(storer).to receive(:file_digest).and_return SecureRandom.hex
+    allow(File).to receive(:size).with(path_to_file).and_return 1000 + rand(100000)
+    allow(storer).to receive(:file_digest).and_return random_hex
     storer
   end
 

--- a/spec/lib/reader_profile_spec.rb
+++ b/spec/lib/reader_profile_spec.rb
@@ -20,17 +20,21 @@ RSpec.describe ReaderProfile do
     allow(PDF::Reader).to receive(:new).and_return mock_pdf_reader
   end
 
+  def random_hex
+    32.times.map { rand(16).to_s(16) }.join()
+  end
+
   def create_iep_for!(student, time_now)
     file_name = "#{student.local_id}_IEPAtAGlance_#{student.first_name}_#{student.last_name}.pdf"
-    file_digest = SecureRandom.hex
+    file_digest = random_hex()
     IepDocument.create!(
       student: student,
       file_name: file_name,
       file_digest: file_digest,
-      file_size: 1000 + SecureRandom.random_number(100000),
+      file_size: 1000 + rand(100000),
       created_at: time_now,
       updated_at: time_now,
-      s3_filename: "#{SecureRandom.hex}/#{time_now.strftime('%Y-%m-%d')}/#{file_digest}"
+      s3_filename: "#{random_hex()}/#{time_now.strftime('%Y-%m-%d')}/#{file_digest}"
     )
   end
 

--- a/spec/models/student_photo_spec.rb
+++ b/spec/models/student_photo_spec.rb
@@ -3,12 +3,16 @@ require 'spec_helper'
 RSpec.describe StudentPhoto do
   let!(:pals) { TestPals.create! }
 
+  def random_hex
+    32.times.map { rand(16).to_s(16) }.join()
+  end
+
   def create_student_photo(params = {})
     StudentPhoto.create({
       student_id: pals.healey_kindergarten_student.id,
-      file_digest: SecureRandom.hex,
-      file_size: 1000 + SecureRandom.random_number(100000),
-      s3_filename: SecureRandom.hex
+      file_digest: random_hex(),
+      file_size: 1000 + rand(100000),
+      s3_filename: random_hex()
     }.merge(params))
   end
 


### PR DESCRIPTION
So that seeding the db for dev is determinstic, enabling rebuilding JS fixtures after migrations.

eg, this would be deterministic across `rake db:drop db:create db:migrate db:seed` in dev only:
```
json = Student.all.as_json(except: [:updated_at, :created_at]).to_json;nil
puts json;nil
puts Digest::SHA256.hexdigest(json);nil
> 06d545145f2edc2867777bb29889aaa555bee340c3f3283a2100422aceb35a47
```

This branch is progress, but not there yet.