### PR TITLE
Sections: Limit to sections in district_school_year

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -25,7 +25,12 @@ class SectionsController < ApplicationController
 
     students_json = serialize_students(students.map(&:id), current_section)
     section = serialize_section(current_section)
-    sections_json = current_educator.allowed_sections.includes(:course).as_json({
+
+    # limit navigator to current school year
+    district_school_year = Section.to_district_school_year(SchoolYear.to_school_year(Time.now))
+
+    sections_for_navigator = current_educator.allowed_sections.includes(:course).where(district_school_year: district_school_year)
+    sections_json = sections_for_navigator.as_json({
       only: [:id, :section_number, :term_local_id],
       methods: [:course_description]
     })

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -39,4 +39,8 @@ class Section < ApplicationRecord
     return nil if district_school_year.nil?
     district_school_year - 1
   end
+
+  def self.to_district_school_year(insights_school_year)
+    insights_school_year + 1
+  end
 end

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -77,6 +77,7 @@ class TestPals
     email_domain = options.fetch(:email_domain, 'demo.studentinsights.org')
     skip_team_memberships = options.fetch(:skip_team_memberships, false)
     skip_imported_forms = options.fetch(:skip_imported_forms, false)
+    district_school_year = options.fetch(:district_school_year, Section.to_district_school_year(SchoolYear.to_school_year(time_now)))
 
     # Uri works in the central office, and is the admin for the
     # project at the district.
@@ -374,11 +375,13 @@ class TestPals
         course: @shs_biology_course,
         section_number: 'SHS-BIO-TUES',
         term_local_id: 'Q3',
+        district_school_year: district_school_year,
       ),
       @shs_thursday_biology_section = Section.create!(
         course: @shs_biology_course,
         section_number: 'SHS-BIO-THUR',
         term_local_id: 'Q4',
+        district_school_year: district_school_year,
       )
     ])
     EducatorLabel.create!({
@@ -403,6 +406,7 @@ class TestPals
       @shs_second_period_ceramics = Section.create!(
         section_number: "ART-302A",
         term_local_id: "FY",
+        district_school_year: district_school_year,
         schedule: "2(M,R)",
         room_number: "201",
         course: @shs_ceramics_course
@@ -410,6 +414,7 @@ class TestPals
       @shs_fourth_period_ceramics = Section.create!(
         section_number: "ART-302B",
         term_local_id: "FY",
+        district_school_year: district_school_year,
         schedule: "4(M,R)",
         room_number: "234",
         course: @shs_ceramics_course
@@ -441,6 +446,7 @@ class TestPals
       @shs_third_period_physics = Section.create!(
         section_number: "SCI-201A",
         term_local_id: "S1",
+        district_school_year: district_school_year,
         schedule: "3(M,W,F)",
         room_number: "306W",
         course: @shs_physics_course
@@ -448,6 +454,7 @@ class TestPals
       @shs_fifth_period_physics = Section.create!(
         section_number: "SCI-201B",
         term_local_id: "S1",
+        district_school_year: district_school_year,
         schedule: "5(M,W,F)",
         room_number: "306W",
         course: @shs_physics_course


### PR DESCRIPTION
More visible since https://github.com/studentinsights/studentinsights/pull/2615, this list should really only be for the current year (older ones have no enrolled active students anyway, so are just noise here).