### PR TITLE
Reading: Minimal page for debugging import process by homeroom

### DIFF
--- a/app/assets/javascripts/components/Bar.js
+++ b/app/assets/javascripts/components/Bar.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 // Render a horizontal Bar that is filled with `color` and is a
-// `percentage` of the width of the container.
+// `percent` of the width of the container.
 export default class Bar extends React.Component {
 
   render() {

--- a/app/assets/javascripts/district_overview/DistrictOverviewPage.js
+++ b/app/assets/javascripts/district_overview/DistrictOverviewPage.js
@@ -148,6 +148,11 @@ export class DistrictOverviewPageView extends React.Component {
               </a>
             </li>}
             {showReadingDebugLinks && <li>
+              <a href="/reading/debug" style={styles.link}>
+               Reading benchmark counts by homeroom
+              </a>
+            </li>}
+            {showReadingDebugLinks && <li>
               <a href="/reading/thresholds" style={styles.link}>
                Thresholds for reading benchmarks
               </a>

--- a/app/assets/javascripts/district_overview/__snapshots__/DistrictOverviewPage.test.js.snap
+++ b/app/assets/javascripts/district_overview/__snapshots__/DistrictOverviewPage.test.js.snap
@@ -1539,6 +1539,18 @@ exports[`DistrictOverviewPageView pure snapshot when \`enable_reading_debug\` la
             </li>
             <li>
               <a
+                href="/reading/debug"
+                style={
+                  Object {
+                    "fontSize": 14,
+                  }
+                }
+              >
+                Reading benchmark counts by homeroom
+              </a>
+            </li>
+            <li>
+              <a
                 href="/reading/thresholds"
                 style={
                   Object {

--- a/app/assets/javascripts/reading/readingData.js
+++ b/app/assets/javascripts/reading/readingData.js
@@ -12,9 +12,12 @@ import {
   lastDayOfSchool
 } from '../helpers/schoolYear';
 import {
+  INSTRUCTIONAL_NEEDS,
   F_AND_P_ENGLISH,
+  F_AND_P_SPANISH,
   DIBELS_DORF_WPM,
   DIBELS_DORF_ACC,
+  DIBELS_DORF_ERRORS,
   DIBELS_FSF,
   DIBELS_LNF,
   DIBELS_PSF,
@@ -80,7 +83,11 @@ export function shortDibelsText(benchmarkAssessmentKey) {
     [DIBELS_NWF_CLS]: 'NWF cls',
     [DIBELS_NWF_WWR]: 'NWF wwr',
     [DIBELS_DORF_WPM]: 'ORF wpm',
-    [DIBELS_DORF_ACC]: 'ORF acc'
+    [DIBELS_DORF_ACC]: 'ORF acc',
+    [DIBELS_DORF_ERRORS]: 'ORF errors',
+    [F_AND_P_ENGLISH]: 'F&P English',
+    [F_AND_P_SPANISH]: 'F&P Spanish',
+    [INSTRUCTIONAL_NEEDS]: 'Instructional needs',
   }[benchmarkAssessmentKey];
 }
 

--- a/app/assets/javascripts/reading_debug/ReadingDebugPage.js
+++ b/app/assets/javascripts/reading_debug/ReadingDebugPage.js
@@ -164,6 +164,7 @@ export class ReadingDebugView extends React.Component {
               onClick={this.onFlippedClicked}>Flip table</div>
           </div>
           <div>
+            <a target="_blank" rel="noopener noreferrer" href="/reading/homerooms">homerooms</a>
             <a target="_blank" rel="noopener noreferrer" href="/reading/thresholds">thresholds</a>
           </div>
         </div>

--- a/app/assets/javascripts/reading_debug/ReadingHomeroomsPage.js
+++ b/app/assets/javascripts/reading_debug/ReadingHomeroomsPage.js
@@ -1,0 +1,123 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import {apiFetchJson} from '../helpers/apiFetchJson';
+import GenericLoader from '../components/GenericLoader';
+import SectionHeading from '../components/SectionHeading';
+import ExperimentalBanner from '../components/ExperimentalBanner';
+import Educator from '../components/Educator';
+import {shortDibelsText} from '../reading/readingData';
+import tableStyles from '../components/tableStyles';
+
+
+// For reviewing, debugging and developing new ways to make use of
+// or revise reading data.
+export default class ReadingHomeroomsPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.fetchJson = this.fetchJson.bind(this);
+    this.renderJson = this.renderJson.bind(this);
+  }
+
+
+  fetchJson() {
+    return apiFetchJson('/api/reading_debug/reading_by_homerooms_json');
+  }
+
+  render() {
+    return (
+      <div className="ReadingHomeroomsPage" style={styles.flexVertical}>
+        <ExperimentalBanner />
+        <SectionHeading titleStyle={styles.title}>
+          Benchmark Reading Data by Homeroom (DEBUG)
+        </SectionHeading>
+        <GenericLoader
+          promiseFn={this.fetchJson}
+          style={styles.flexVertical}
+          render={this.renderJson} />
+      </div>
+    );
+  }
+
+  renderJson(json) {
+    return <ReadingHomeroomsView homerooms={json.homerooms_json} />;
+  }
+}
+
+
+export class ReadingHomeroomsView extends React.Component {
+  render() {
+    const {homerooms} = this.props;
+    const benchmarkAssessmentKeys = _.uniq(_.flatMap(homerooms, homeroom => Object.keys(homeroom.counts)));
+
+    return (
+      <div className="ReadingHomeroomsView">
+        <table style={tableStyles.table}>
+          <thead>
+            <tr>
+              <th style={tableStyles.headerCell}>School</th>
+              <th style={tableStyles.headerCell}>Grades</th>
+              <th style={tableStyles.headerCell}>Educator</th>
+              <th style={tableStyles.headerCell}>Students</th>
+              {benchmarkAssessmentKeys.map(benchmarkAssessmentKey => (
+                <th key={benchmarkAssessmentKey} style={tableStyles.headerCell}>
+                  {shortDibelsText(benchmarkAssessmentKey)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {homerooms.map(homeroom => {
+              return (
+                <tr key={homeroom.id}>
+                  <td style={tableStyles.cell}>{homeroom.school.local_id}</td>
+                  <td style={tableStyles.cell}>{homeroom.grades.join(' ')}</td>
+                  <td style={tableStyles.cell}>{homeroom.educator ? <Educator educator={homeroom.educator} /> : 'unknown'}</td>
+                  <td style={tableStyles.cell}>{homeroom.total}</td>
+                  {benchmarkAssessmentKeys.map(benchmarkAssessmentKey => (
+                    <td style={tableStyles.cell} key={benchmarkAssessmentKey}>
+                      {homeroom.counts[benchmarkAssessmentKey] > 0 && (
+                        `${Math.round(homeroom.counts[benchmarkAssessmentKey] / homeroom.total * 100)}%`
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+}
+ReadingHomeroomsView.contextTypes = {
+  nowFn: PropTypes.func.isRequired
+};
+ReadingHomeroomsView.propTypes = {
+  homerooms: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    grades: PropTypes.array.isRequired,
+    educator: PropTypes.object.isRequired,
+    school: PropTypes.object.isRequired,
+    total: PropTypes.number.isRequired,
+    counts: PropTypes.object.isRequired
+  })).isRequired,
+};
+
+
+const styles = {
+  flexVertical: {
+    display: 'flex',
+    flex: 1,
+    flexDirection: 'column'
+  },
+  title: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  cell: {
+    fontWeight: 'bold'
+  }
+};

--- a/app/assets/javascripts/reading_debug/__snapshots__/ReadingDebugPage.test.js.snap
+++ b/app/assets/javascripts/reading_debug/__snapshots__/ReadingDebugPage.test.js.snap
@@ -212,6 +212,13 @@ exports[`snapshots view 1`] = `
     </div>
     <div>
       <a
+        href="/reading/homerooms"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        homerooms
+      </a>
+      <a
         href="/reading/thresholds"
         rel="noopener noreferrer"
         target="_blank"

--- a/app/controllers/reading_debug_controller.rb
+++ b/app/controllers/reading_debug_controller.rb
@@ -19,6 +19,19 @@ class ReadingDebugController < ApplicationController
     }
   end
 
+  def reading_by_homerooms_json
+    safe_params = params.permit(:time_now, :benchmark_period_key, :benchmark_school_year)
+    time_now = time_now_or_param(safe_params[:time_now])
+    benchmark_period_key = safe_params.fetch(:benchmark_period_key, ReadingBenchmarkDataPoint.benchmark_period_key_at(time_now))
+    benchmark_school_year = safe_params.fetch(:benchmark_school_year, SchoolYear.to_school_year(time_now))
+
+    students = authorized { Student.active.includes(:homeroom).to_a }
+    homerooms_json = ReadingQueries.new.by_homerooms_for_period(students, benchmark_period_key, benchmark_school_year)
+    render json: {
+      homerooms_json: homerooms_json
+    }
+  end
+
   def reading_debug_csv
     students, groups = reading_debug()
     students_by_id = students.reduce({}) {|map, s| map.merge(s.id => s)}
@@ -92,5 +105,14 @@ class ReadingDebugController < ApplicationController
       counts_by_grade[student.grade] = counts_by_grade.fetch(student.grade, 0) + 1
     end
     counts_by_grade
+  end
+
+  # Use time from value or fall back to Time.now
+  def time_now_or_param(params_time_now)
+    if params_time_now.present?
+      Time.at(params_time_now.to_i)
+    else
+      Time.now
+    end
   end
 end

--- a/app/lib/reading_queries.rb
+++ b/app/lib/reading_queries.rb
@@ -11,4 +11,70 @@ class ReadingQueries
       d.grid_key(student)
     end
   end
+
+  def by_homerooms_for_period(students, benchmark_period_key, benchmark_school_year)
+    reading_benchmark_data_points = ReadingBenchmarkDataPoint.all
+      .where(student_id: students.pluck(:id))
+      .where(benchmark_period_key: benchmark_period_key)
+      .where(benchmark_school_year: benchmark_school_year)
+      .includes(student: {homeroom: :educator})
+
+    eager_students = reading_benchmark_data_points.map(&:student)
+    homerooms = eager_students.map {|s| s.try(:homeroom) }.compact.uniq
+    
+    # with data
+    counts_by_homeroom_id = {}
+    reading_benchmark_data_points.each do |d|
+      homeroom_id = d.student.homeroom.try(:id)
+      if !counts_by_homeroom_id.has_key?(homeroom_id)
+        counts_by_homeroom_id[homeroom_id] = {}
+      end  
+      counts_by_homeroom_id[homeroom_id][d.benchmark_assessment_key] = (counts_by_homeroom_id[homeroom_id].fetch(d.benchmark_assessment_key, []) + [d.student.id]).uniq
+    end
+    counts = {}
+    counts_by_homeroom_id.keys.each do |homeroom_id|
+      if !counts.has_key?(homeroom_id)
+        counts[homeroom_id] = {}
+      end
+      counts_by_homeroom_id[homeroom_id].keys.each do |benchmark_assessment_key|
+        counts[homeroom_id][benchmark_assessment_key] = counts_by_homeroom_id[homeroom_id][benchmark_assessment_key].size
+      end
+    end
+
+    # total
+    total_by_homeroom_id = {}
+    students.each do |s|
+      homeroom_id = s.homeroom.try(:id)
+      total_by_homeroom_id[homeroom_id] = (total_by_homeroom_id.fetch(homeroom_id, []) + [s.id]).uniq
+    end
+
+    # output format
+    outs = homerooms.map do |homeroom|
+      {
+        id: homeroom.id,
+        grades: homeroom.grades,
+        educator: homeroom.try(:educator).as_json(only: [
+          :id,
+          :email,
+          :full_name
+        ]),
+        school: homeroom.school.as_json(only: [
+          :id,
+          :slug,
+          :local_id,
+          :name,
+          :school_type
+        ]),
+        total: total_by_homeroom_id[homeroom.id].size,
+        counts: counts[homeroom.id]
+      }
+    end
+
+    outs.sort_by do |o|
+      [
+        o[:school][:name],
+        o[:grades].map {|grade| GradeLevels::ORDERED_GRADE_LEVELS.index(grade) }.sort
+      ]
+    end
+  end
 end

--- a/app/lib/reading_queries.rb
+++ b/app/lib/reading_queries.rb
@@ -21,14 +21,14 @@ class ReadingQueries
 
     eager_students = reading_benchmark_data_points.map(&:student)
     homerooms = eager_students.map {|s| s.try(:homeroom) }.compact.uniq
-    
+
     # with data
     counts_by_homeroom_id = {}
     reading_benchmark_data_points.each do |d|
       homeroom_id = d.student.homeroom.try(:id)
       if !counts_by_homeroom_id.has_key?(homeroom_id)
         counts_by_homeroom_id[homeroom_id] = {}
-      end  
+      end
       counts_by_homeroom_id[homeroom_id][d.benchmark_assessment_key] = (counts_by_homeroom_id[homeroom_id].fetch(d.benchmark_assessment_key, []) + [d.student.id]).uniq
     end
     counts = {}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
 
   # reading_debug
   get '/api/reading_debug/reading_debug_json' => 'reading_debug#reading_debug_json'
+  get '/api/reading_debug/reading_by_homerooms_json' => 'reading_debug#reading_by_homerooms_json'
   get '/api/reading_debug/star_reading_debug_json' => 'reading_debug#star_reading_debug_json'
 
   # classroom list creator
@@ -213,6 +214,7 @@ Rails.application.routes.draw do
   resource :reading, only: [] do
     member do
       get '/thresholds' => 'ui#ui'
+      get '/homerooms' => 'ui#ui'
       get '/debug' => 'ui#ui'
       get '/debug_star' => 'ui#ui'
       get '/debug_csv' => 'reading_debug#reading_debug_csv'

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "webpack-merge": "^4.1.0"
   },
   "resolutions": {
+    "handlebars":"^4.3.0",
     "rollbar-browser/extend": "^3.0.2",
     "lodash": "^4.17.14",
     "lodash.mergewith": "^4.6.2",

--- a/ui/App.js
+++ b/ui/App.js
@@ -33,6 +33,7 @@ import MyNotesPage from '../app/assets/javascripts/my_notes/MyNotesPage';
 import ReadingEntryPage from '../app/assets/javascripts/reading/ReadingEntryPage';
 import ReadingGroupingPage from '../app/assets/javascripts/reading/ReadingGroupingPage';
 import ReadingThresholdsPage from '../app/assets/javascripts/reading_debug/ReadingThresholdsPage';
+import ReadingHomeroomsPage from '../app/assets/javascripts/reading_debug/ReadingHomeroomsPage';
 import ReadingDebugPage from '../app/assets/javascripts/reading_debug/ReadingDebugPage';
 import ReadingDebugStarPage from '../app/assets/javascripts/reading_debug/ReadingDebugStarPage';
 import MyStudentsPage from '../app/assets/javascripts/my_students/MyStudentsPage';
@@ -110,6 +111,7 @@ export default class App extends React.Component {
         <Route exact path="/schools/:slug/reading/:grade/entry" render={this.renderReadingEntryPage.bind(this)}/>
         <Route exact path="/schools/:slug/reading/:grade/groups" render={this.renderReadingGroupingPage.bind(this)}/>
         <Route exact path="/reading/thresholds" render={this.renderReadingThresholdsPage.bind(this)}/>
+        <Route exact path="/reading/homerooms" render={this.renderReadingHomeroomsPage.bind(this)}/>
         <Route exact path="/reading/debug" render={this.renderReadingDebugPage.bind(this)}/>
         <Route exact path="/reading/debug_star" render={this.renderReadingDebugStarPage.bind(this)}/>
         <Route exact path="/homerooms/:id" render={this.renderHomeroomPage.bind(this)}/>
@@ -197,6 +199,10 @@ export default class App extends React.Component {
 
   renderReadingDebugPage(routeProps) {
     return <ReadingDebugPage />;
+  }
+
+  renderReadingHomeroomsPage(routeProps) {
+    return <ReadingHomeroomsPage />;
   }
 
   renderReadingDebugStarPage(routeProps) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5631,10 +5631,10 @@ gzip-size@5.0.0:
     duplexer "^0.1.1"
     pify "^3.0.0"
 
-handlebars@^4.1.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
-  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+handlebars@^4.1.0, handlebars@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.3.0.tgz#427391b584626c9c9c6ffb7d1fb90aa9789221cc"
+  integrity sha512-7XlnO8yBXOdi7AzowjZssQr47Ctidqm7GbgARapOaqSN9HQhlClnOkR9HieGauIT3A8MBC6u9wPCXs97PCYpWg==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
# Who is this PR for?
internal team

# What problem does this PR fix?
Stats for auditing import process by homeroom.

# What does this PR do?
Adds a new internal page for reviewing imported reading data, grouped by homeroom for a particular assessment period.  This is for internal debugging, not for district admin to use or accountability.

# Screenshot (if adding a client-side feature)
<img width="559" alt="Screen Shot 2019-09-24 at 4 11 59 PM" src="https://user-images.githubusercontent.com/1056957/65546790-308e7e80-dee6-11e9-9018-a3ca20b8e813.png">


# Checklists
*Which features or pages does this PR touch?*
+ [x] Reading by Homeroom page

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here