### PR TITLE
Reading: Update GoogleSheetsFetcher to recur into folders and batch calls

### DIFF
--- a/app/importers/reading/google_sheets_fetcher.rb
+++ b/app/importers/reading/google_sheets_fetcher.rb
@@ -28,17 +28,36 @@ require 'csv'
 
 class GoogleSheetsFetcher
   # returns [Tab]
-  def get_tabs_from_folder(folder_id)
-    sheet_ids = get_sheet_ids(folder_id)
+  # optionally recur into folders with recursive: true
+  # Note that this may hit API quotas, and this class
+  # doesn't batch http requests.
+  def get_tabs_from_folder(folder_id, options = {})
+    puts "get_tabs_from_folder(#{folder_id})"
+    sheets = list_sheets(folder_id)
 
-    sheet_ids.files.flat_map do |file|
-      get_tabs_from_sheet(file.id)
+    tabs = []
+    sheets.files.each do |file|
+      tabs += get_tabs_from_sheet(file.id)
     end
+
+    # Google Drive isn't actually a folder system,
+    # so this recurs manually since the number of files is small.
+    # See https://stackoverflow.com/questions/41741520/how-do-i-search-sub-folders-and-sub-sub-folders-in-google-drive
+    # for more on how Drive works, or the `batch` method in 
+    # the Ruby API for alternatives.
+    if options.fetch(:recursive, false)
+      sub_folders = list_folders(folder_id)
+      sub_folders.files.each do |sub_folder|
+        tabs += get_tabs_from_folder(sub_folder.id, options)
+      end
+    end
+
+    tabs
   end
 
   # returns [Tab]
   def get_tabs_from_sheet(sheet_id)
-    download_tab_csvs(sheet_id)
+    download_tab_csvs_batched(sheet_id)
   end
 
   private
@@ -67,35 +86,43 @@ class GoogleSheetsFetcher
     'Student Insights, GoogleSheetsFetcher'
   end
 
-  # No real escaping for building this query
-  def get_sheet_ids(unsafe_folder_id)
-    # initialize drive API
-    drive_service = Google::Apis::DriveV3::DriveService.new
-    drive_service.client_options.application_name = @application_name
-    drive_service.authorization = check_authorization()
-
-    # minimal check for query injection
-    raise "invalid unsafe_folder_id: #{unsafe_folder_id}" if /[^a-zA-Z0-9\-_]/.match(unsafe_folder_id).present?
-    q = "'#{unsafe_folder_id}' in parents"
-    drive_service.list_files(q: q, fields: 'files(id, name)')
+  # See https://developers.google.com/drive/api/v3/search-files
+  # for info on how queries work.
+  def list_sheets(unsafe_folder_id)
+    puts "  list_sheets(#{unsafe_folder_id})"
+    folder_id = verify_safe_folder_id!(unsafe_folder_id)
+    q = "'#{folder_id}' in parents and mimeType = 'application/vnd.google-apps.spreadsheet'"
+    drive_service.list_files(q: q, fields: 'files(id, name, mimeType)')
   end
 
-  def download_tab_csvs(sheet_id)
-    #Initialize sheets API
-    sheet_service = Google::Apis::SheetsV4::SheetsService.new
-    sheet_service.client_options.application_name = @application_name
-    sheet_service.authorization = check_authorization()
+  def list_folders(unsafe_folder_id)
+    puts "  list_folders(#{unsafe_folder_id})"
+    folder_id = verify_safe_folder_id!(unsafe_folder_id)
+    q = "'#{folder_id}' in parents and mimeType = 'application/vnd.google-apps.folder'"
+    drive_service.list_files(q: q, fields: 'files(id, name, mimeType)')
+  end
 
-    # Get values from sheets indexed by sheet name
+  # minimal check for query injection
+  def verify_safe_folder_id!(unsafe_folder_id)
+    raise "invalid unsafe_folder_id: #{unsafe_folder_id}" if /[^a-zA-Z0-9\-_]/.match(unsafe_folder_id).present?
+    unsafe_folder_id
+  end
+
+  # Returns [Tab] with CSV data for all sheets
+  def download_tab_csvs_batched(sheet_id)
+    # Batch this into two API calls, one for the Spreadsheet to get all metadata,
+    # then a second batch request to get the contents of each tab.
+    spreadsheet = sheets_service.get_spreadsheet(sheet_id)
+    sheet_titles = spreadsheet.sheets.map(&:properties).map(&:title)
+    batch_responses = sheets_service.batch_get_spreadsheet_values(sheet_id, ranges: sheet_titles)
+
+    # iterate through to zip them together
     tabs = []
-    spreadsheet = sheet_service.get_spreadsheet(sheet_id)
-    spreadsheet.sheets.each_with_object({}) do |sheet, hash| # each tab in the spreadsheet
+    spreadsheet.sheets.each_with_index do |sheet, sheet_index|
       tab_csv = CSV.generate do |csv|
-        sheet_values = sheet_service.get_spreadsheet_values(sheet_id, sheet.properties.title).values
-        sheet_values.each do |row|
-          csv << row
-        end
-      end
+        sheet_values = batch_responses.value_ranges[sheet_index].values
+        sheet_values.each {|row| csv << row }
+      end 
       tabs << Tab.new({
         spreadsheet_id: spreadsheet.spreadsheet_id,
         spreadsheet_name: spreadsheet.properties.title,
@@ -106,6 +133,28 @@ class GoogleSheetsFetcher
       })
     end
     tabs
+  end
+
+  def drive_service
+    if @drive_service.nil?
+      drive_service = Google::Apis::DriveV3::DriveService.new
+      drive_service.client_options.application_name = @application_name
+      drive_service.authorization = check_authorization()
+      @drive_service = drive_service
+    end
+    @drive_service
+  end
+
+  # See https://github.com/googleapis/google-api-ruby-client/blob/cb0b81f79451b8dee9df07eb248110b3e6045916/generated/google/apis/sheets_v4/service.rb
+  # and https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/batchGet
+  def sheets_service
+    if @sheets_service.nil?
+      sheets_service = Google::Apis::SheetsV4::SheetsService.new
+      sheets_service.client_options.application_name = @application_name
+      sheets_service.authorization = check_authorization()
+      @sheets_service = sheets_service
+    end
+    @sheets_service
   end
 
   # A tab of a spreadsheet

--- a/app/importers/reading/google_sheets_fetcher.rb
+++ b/app/importers/reading/google_sheets_fetcher.rb
@@ -44,10 +44,10 @@ class GoogleSheetsFetcher
       tabs += get_tabs_from_sheet(file.id)
     end
 
-    # Google Drive isn't actually a folder system, so this 
+    # Google Drive isn't actually a folder system, so this
     # recurs manually since the number of files is small.
     # See https://stackoverflow.com/questions/41741520/how-do-i-search-sub-folders-and-sub-sub-folders-in-google-drive
-    # for more on how Drive works, or the `batch` method in 
+    # for more on how Drive works, or the `batch` method in
     # the Ruby API for alternatives.
     if options.fetch(:recursive, false)
       sub_folders = list_folders(folder_id)
@@ -132,7 +132,7 @@ class GoogleSheetsFetcher
       sheet_values = batch_responses.value_ranges[sheet_index].values || [[]]
       tab_csv = CSV.generate do |csv|
         sheet_values.each {|row| csv << row }
-      end 
+      end
       tabs << Tab.new({
         spreadsheet_id: spreadsheet.spreadsheet_id,
         spreadsheet_name: spreadsheet.properties.title,

--- a/app/importers/reading/google_sheets_fetcher.rb
+++ b/app/importers/reading/google_sheets_fetcher.rb
@@ -97,14 +97,14 @@ class GoogleSheetsFetcher
     log "  list_sheets(#{unsafe_folder_id})"
     folder_id = verify_safe_folder_id!(unsafe_folder_id)
     q = "'#{folder_id}' in parents and mimeType = 'application/vnd.google-apps.spreadsheet'"
-    drive_service.list_files(q: q, fields: 'files(id, name, mimeType)')
+    drive_service.list_files(q: q, fields: 'files(id, name)')
   end
 
   def list_folders(unsafe_folder_id)
     log "  list_folders(#{unsafe_folder_id})"
     folder_id = verify_safe_folder_id!(unsafe_folder_id)
     q = "'#{folder_id}' in parents and mimeType = 'application/vnd.google-apps.folder'"
-    drive_service.list_files(q: q, fields: 'files(id, name, mimeType)')
+    drive_service.list_files(q: q, fields: 'files(id, name)')
   end
 
   # minimal check for query injection

--- a/app/lib/reading_validator.rb
+++ b/app/lib/reading_validator.rb
@@ -2,7 +2,7 @@ class ReadingValidator
   def self.debug_error_messages
     checks = {}
     validator = ReadingValidator.new
-    keys.each do |key|
+    ReadingBenchmarkDataPoint::VALID_BENCHMARK_ASSESSMENT_KEYS.each do |key|
       ds = ReadingBenchmarkDataPoint.where(benchmark_assessment_key: key)
       ds.each do |d|
         msg = validator.validate_json_meaning(key, d.json['value'])
@@ -16,7 +16,7 @@ class ReadingValidator
 
   def self.debug_float_range
     ranges = {}
-    keys.map do |key|
+    ReadingBenchmarkDataPoint::VALID_BENCHMARK_ASSESSMENT_KEYS.map do |key|
       ds = ReadingBenchmarkDataPoint.where(benchmark_assessment_key: key)
       values = ds.map {|d| d.json['value'].try(:to_f) || nil }.compact
       ranges[key] = { min: values.min, max: values.max }


### PR DESCRIPTION
# Who is this PR for?
Somerville K5 students, reading specialists, literacy coaches

# What problem does this PR fix?
Previous PRs like #2619 #2620 #2621 worked out the kinks running the importer task over individual schools, but running it over the whole district ran into a few issues related to fetching data.  First, `#get_tabs_from_folder` assumed that all files within a folder were sheets, but turns out this isn't always the case.  Second, it seems that the `in parent` query in Google Drive searches only within the immediate "children" of a folder and not recursively which I think I was assuming.  Third, when updating to search recursively, we hit API request quotas.

# What does this PR do?
1. Updates the methods making API calls to explicitly limit results to files that are sheets or folders.
2. Adds a `recursive: true` option to `#get_tabs_from_folder`.  
3. Uses a batch method to get values from all sheets in a spreadsheet in one request.
4. Handle the special case of the API returning `nil` when calling `#values` on a newly added sheet.
5. Add optional logging that was useful in debugging.

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here