### PR TITLE
Sections: Rename to Sections from My sections

### DIFF
--- a/app/assets/javascripts/my_sections/MySectionsPage.js
+++ b/app/assets/javascripts/my_sections/MySectionsPage.js
@@ -101,7 +101,7 @@ export class MySectionsPageView extends React.Component {
     const {sections} = this.props;
     return (
       <div style={{...styles.flexVertical, margin: 10}}>
-        <SectionHeading>My sections</SectionHeading>
+        <SectionHeading>Sections</SectionHeading>
         {this.renderTable(sections)}
       </div>
     );

--- a/app/assets/javascripts/my_sections/MySectionsPage.test.js
+++ b/app/assets/javascripts/my_sections/MySectionsPage.test.js
@@ -34,7 +34,7 @@ describe('integration tests', () => {
     expect(wrapper.text()).toContain('Loading...');
 
     setTimeout(() => {
-      expect(wrapper.html()).toContain('My sections');
+      expect(wrapper.html()).toContain('Sections');
       done();
     }, 0);
   });

--- a/app/views/shared/_navbar_signed_in.html.erb
+++ b/app/views/shared/_navbar_signed_in.html.erb
@@ -38,12 +38,11 @@
       <span class="NavbarSignedIn-spacer"></span>
     <% end %>
 
-    <% if links.has_key?(:section) %>
-      <%= link_to 'My sections', links[:section] %>
-    <% end %>
-
     <% if links.has_key?(:homeroom) %>
     <%= link_to 'Homeroom', links[:homeroom] %>
+    <% end %>
+    <% if links.has_key?(:section) %>
+      <%= link_to 'Sections', links[:section] %>
     <% end %>
 
     <% # Everyone has these %>

--- a/spec/views/shared/_navbar_signed_in_spec.rb
+++ b/spec/views/shared/_navbar_signed_in_spec.rb
@@ -26,7 +26,7 @@ describe '_navbar_signed_in partial' do
     expect(rendered).not_to include('Tardies')
     expect(rendered).not_to include('Discipline')
     expect(rendered).not_to include('Overview')
-    expect(rendered).not_to include('My sections')
+    expect(rendered).not_to include('Sections')
     expect(rendered).not_to include('Homeroom')
     expect_common_links(rendered)
   end
@@ -39,7 +39,7 @@ describe '_navbar_signed_in partial' do
     expect(rendered).not_to include('Tardies')
     expect(rendered).not_to include('Discipline')
     expect(rendered).not_to include('Overview')
-    expect(rendered).not_to include('My sections')
+    expect(rendered).not_to include('Sections')
     expect(rendered).to include('Homeroom')
     expect_common_links(rendered)
   end
@@ -52,7 +52,7 @@ describe '_navbar_signed_in partial' do
     expect(rendered).to include('Tardies')
     expect(rendered).to include('Discipline')
     expect(rendered).to include('Overview')
-    expect(rendered).not_to include('My sections')
+    expect(rendered).not_to include('Sections')
     expect(rendered).not_to include('Homeroom')
     expect_common_links(rendered)
   end
@@ -65,7 +65,7 @@ describe '_navbar_signed_in partial' do
     expect(rendered).not_to include('Tardies')
     expect(rendered).not_to include('Discipline')
     expect(rendered).not_to include('Overview')
-    expect(rendered).to include('My sections')
+    expect(rendered).to include('Sections')
     expect(rendered).not_to include('Homeroom')
     expect_common_links(rendered)
   end


### PR DESCRIPTION
Move `Homeroom` link first in navbar, remove "my" from sections.