### PR TITLE
Sections: Update controller guards, incremental deploy with importer

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -55,11 +55,8 @@ class SectionsController < ApplicationController
   end
 
   def authorized_section(section_id)
-    # Extra layer since we don't yet allow K8 teachers to view sections
-    raise Exceptions::EducatorNotAuthorized unless current_educator.districtwide_access || current_educator.school.is_high_school?
-
     section = Section.find(params[:id])
-    raise Exceptions::EducatorNotAuthorized unless current_educator.is_authorized_for_section(section)
+    raise Exceptions::EducatorNotAuthorized unless authorizer.is_authorized_for_section?(section)
     section
   end
 

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -1,7 +1,7 @@
 class Educator < ApplicationRecord
   devise :ldap_authenticatable_tiny, :rememberable, :trackable, :timeoutable, authentication_keys: [:login_text, :login_code]
 
-  belongs_to  :school, optional: true # districtwide admin often don't have schools assigned
+  belongs_to  :school, optional: true # eg, districtwide admin often don't have schools assigned
   has_one     :homeroom
   has_many    :students, through: :homeroom
   has_many    :educator_section_assignments
@@ -45,26 +45,26 @@ class Educator < ApplicationRecord
     )
   end
 
+  # deprecated
   def is_principal?
     staff_type.try(:downcase) == 'principal'
   end
 
+  # deprecated
   def is_authorized_for_student(student)
     Authorizer.new(self).is_authorized_for_student?(student)
   end
 
+  # deprecated
   def is_authorized_for_school(current_school)
     Authorizer.new(self).is_authorized_for_school?(current_school)
-  end
-
-  def is_authorized_for_section(section)
-    Authorizer.new(self).is_authorized_for_section?(section)
   end
 
   def labels
     EducatorLabel.labels(self)
   end
 
+  # deprecated
   def default_section
     return sections[0] if sections.present?
     raise Exceptions::NoAssignedSections
@@ -74,14 +74,17 @@ class Educator < ApplicationRecord
     grade_level_access.present? && grade_level_access.size > 0
   end
 
+  # deprecated
   def allowed_sections
     Authorizer.new(self).sections
   end
 
+  # deprecated
   def self.to_index
     all.map { |e| [e.id, e.for_index] }.to_h
   end
 
+  # deprecated
   def for_index
     as_json.symbolize_keys.slice(:id, :email, :full_name)
   end


### PR DESCRIPTION
# Who is this PR for?
New Bedford educators

# What does this PR do?
Updates section controller guards to remove special case for Somerville, so it can work in incremental deployment for New Bedford.  Also update temporary importer to allow injecting `file_text` directly for manual test runes.  And mark some `Educator` methods as deprecated that came up in looking at this.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Section

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [ ] Included specs for changes
+ [ ] Manual testing made more sense here