### PR TITLE
Profile: Adding dialog for seeing who has access

### DIFF
--- a/app/assets/javascripts/student_profile/EducatorsWithAccessToStudentDialog.fixture.js
+++ b/app/assets/javascripts/student_profile/EducatorsWithAccessToStudentDialog.fixture.js
@@ -1,0 +1,36 @@
+export default {
+  "with_access_json": [
+    {
+      "educator": {
+        "id": 1,
+        "email": "rich@demo.studentinsights.org",
+        "full_name": "Districtwide, Rich"
+      },
+      "reason": "districtwide"
+    },
+    {
+      "educator": {
+        "id": 5,
+        "email": "laura@demo.studentinsights.org",
+        "full_name": "Principal, Laura"
+      },
+      "reason": "schoolwide"
+    },
+    {
+      "educator": {
+        "id": 6,
+        "email": "sarah@demo.studentinsights.org",
+        "full_name": "Teacher, Sarah"
+      },
+      "reason": "homeroom"
+    },
+    {
+      "educator": {
+        "id": 999999,
+        "email": "uri@demo.studentinsights.org",
+        "full_name": "Disney, Uri"
+      },
+      "reason": "districtwide"
+    }
+  ]
+};

--- a/app/assets/javascripts/student_profile/EducatorsWithAccessToStudentDialog.js
+++ b/app/assets/javascripts/student_profile/EducatorsWithAccessToStudentDialog.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import {apiFetchJson} from '../helpers/apiFetchJson';
+import Educator from '../components/Educator';
+import GenericLoader from '../components/GenericLoader';
+
+
+// Fetchers data and shows list of which educators have access to the student.
+export default class EducatorsWithAccessToStudentDialog extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isShowingList: false
+    };
+    this.fetchJson = this.fetchJson.bind(this);
+    this.onShowClicked = this.onShowClicked.bind(this);
+    this.renderJson = this.renderJson.bind(this);
+  }
+
+  fetchJson() {
+    const {studentId} = this.props;
+    const url = `/api/students/${studentId}/educators_with_access_json`;
+    return apiFetchJson(url);
+  }
+
+  onShowClicked(e) {
+    e.preventDefault();
+    this.setState({isShowingList: true});
+  }
+
+  render() {
+    return (
+      <div className="EducatorsWithAccessToStudentDialog">
+        <GenericLoader
+          promiseFn={this.fetchJson}
+          render={this.renderJson} />
+      </div>
+    );
+  }
+
+  renderJson(json) {
+    const withAccess = json.with_access_json;
+    const countsByReason = _.countBy(withAccess, d => d.reason);
+    const sortedReasons = [
+      'districtwide',
+      'housemaster',
+      'schoolwide',
+      'grade_level',
+      'section',
+      'homeroom'
+    ];
+    const sortedWithAccess = _.orderBy(withAccess, ({educator, reason}) => {
+      return [sortedReasons.indexOf(reason), educator.full_name];
+    });
+    return (
+      <div style={{fontSize: 14}}>
+        <div>
+          {sortedReasons.map(reason => {
+            const count = countsByReason[reason] || 0;
+            if (count === 0) return null;
+            return (
+              <div
+                key={reason}
+                style={{
+                  display: 'inline-block',
+                  textAlign: 'center',
+                  marginRight: 5,
+                  marginBottom: 5,
+                  padding: 10,
+                  border: '1px solid #eee',
+                  background: '#f8f8f8'
+                }}
+              >
+                <div style={{fontWeight: 'bold', marginBottom: 5}}>{reason}</div>
+                <div>{countsByReason[reason]}</div>
+              </div>
+            );
+          })}
+        </div>
+        <div style={{marginTop: 20}}>
+          {this.renderList(sortedWithAccess)}
+        </div>
+      </div>
+    );
+  }
+
+  renderList(sortedWithAccess) {
+    const {isShowingList} = this.state;
+    if (!isShowingList) return <a onClick={this.onShowClicked} href="#">Show list of educators</a>;
+
+    return (
+      <div>
+        {sortedWithAccess.map(({educator, reason}) => {
+          return (
+            <div key={educator.id} style={{display: 'flex'}}>
+              <Educator educator={educator} /> <span style={{marginLeft: 5}}>{reason}</span>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+}
+EducatorsWithAccessToStudentDialog.propTypes = {
+  studentId: PropTypes.number.isRequired
+};

--- a/app/assets/javascripts/student_profile/EducatorsWithAccessToStudentDialog.test.js
+++ b/app/assets/javascripts/student_profile/EducatorsWithAccessToStudentDialog.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {mount} from 'enzyme';
+import fetchMock from 'fetch-mock/es5/client';
+import EducatorsWithAccessToStudentDialog from './EducatorsWithAccessToStudentDialog';
+import fixtureJson from './EducatorsWithAccessToStudentDialog.fixture';
+
+function testProps(props = {}) {
+  return {
+    studentId: 42,
+    ...props
+  };
+}
+
+function testEl(props = {}) {
+  return <EducatorsWithAccessToStudentDialog {...props} />;
+}
+
+beforeEach(() => {
+  fetchMock.restore();
+  fetchMock.get('/api/students/42/educators_with_access_json', fixtureJson);
+});
+
+it('renders without crashing', () => {
+  const props = testProps();
+  const el = document.createElement('div');
+  ReactDOM.render(testEl(props), el);
+});
+
+describe('integration tests', () => {
+  it('renders after fetch', done => {
+    const props = testProps();
+    const wrapper = mount(testEl(props));
+    expect(wrapper.text()).toContain('Loading...');
+
+    setTimeout(() => {
+      expect(wrapper.html()).toContain('Show list of educators');
+      expect(wrapper.text()).toContain('districtwide2');
+      expect(wrapper.text()).toContain('schoolwide1');
+      expect(wrapper.text()).toContain('homeroom1');
+      done();
+    }, 0);
+  });
+});

--- a/app/assets/javascripts/student_profile/LightProfileHeader.js
+++ b/app/assets/javascripts/student_profile/LightProfileHeader.js
@@ -19,7 +19,7 @@ import Homeroom from '../components/Homeroom';
 import InsightsCarousel from './InsightsCarousel';
 import ProfilePdfDialog from './ProfilePdfDialog';
 import LightHeaderSupportBits from './LightHeaderSupportBits';
-
+import EducatorsWithAccessToStudentDialog from './EducatorsWithAccessToStudentDialog';
 
 /*
 UI component for top-line information like the student's name, school,
@@ -235,10 +235,14 @@ export default class LightProfileHeader extends React.Component {
     );
   }
 
+  // icons are from https://material.io/resources/icons 
   renderButtons() {
+    const {currentEducator} = this.props;
+    const showEducatorsWithAccess = (currentEducator.labels.indexOf('enable_viewing_educators_with_access_to_student') !== -1);
     return (
       <div style={{marginLeft: 10, display: 'flex', flexDirection: 'column', justifyContent: 'flex-end'}}>
         {this.renderProfilePdfButton()}
+        {showEducatorsWithAccess && this.renderEducatorsWithAccessButton()}
         {this.renderFullCaseHistoryButton()}
       </div>
     );
@@ -265,6 +269,25 @@ export default class LightProfileHeader extends React.Component {
             style={{backgroundColor: 'white'}}
           />
         }
+      />
+    );
+  }
+
+  renderEducatorsWithAccessButton() {
+    const {student} = this.props;
+    return (
+      <HelpBubble
+        style={{marginLeft: 0}}
+        modalStyle={modalFromRight}
+        teaser={
+          <svg style={styles.svgIcon} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path d="M0 0h24v24H0z" fill="none"/>
+            <path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"/>
+          </svg>
+        }
+        tooltip="Educators with access"
+        title="Educators with access"
+        content={<EducatorsWithAccessToStudentDialog studentId={student.id} />}
       />
     );
   }

--- a/app/assets/javascripts/student_profile/LightProfilePage.test.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.test.js
@@ -203,3 +203,20 @@ describe('inactive overlay', () => {
     expect($(el).text()).toContain('no longer actively enrolled');
   });
 });
+
+describe('buttons', () => {
+  it('shows print PDF and full case history', () => {
+    const props = testPropsForAladdinMouse();
+    const el = testRender(props);
+    expect($(el).html()).toContain('Print PDF');
+    expect($(el).html()).toContain('List all data points');
+  });
+
+  it('can show button for permissions', () => {
+    const props = mergeAtPath(testPropsForAladdinMouse(), ['profileJson', 'currentEducator'], {
+      labels: ['enable_viewing_educators_with_access_to_student']
+    });
+    const el = testRender(props);
+    expect($(el).html()).toContain('Educators with access');
+  });
+});

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -40,7 +40,7 @@ class ProfileController < ApplicationController
 
   def educators_with_access_json
     raise Exceptions::EducatorNotAuthorized unless current_educator.labels.include?('enable_viewing_educators_with_access_to_student')
-    
+
     student = Student.find(params[:id])
     active_educators = Educator.active.includes(:educator_labels, :school, {sections: :course}, {homeroom: [:school, :students]})
 

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -38,6 +38,28 @@ class ProfileController < ApplicationController
     render json: json
   end
 
+  def educators_with_access_json
+    raise Exceptions::EducatorNotAuthorized unless current_educator.labels.include?('enable_viewing_educators_with_access_to_student')
+    
+    student = Student.find(params[:id])
+    active_educators = Educator.active.includes(:educator_labels, :school, {sections: :course}, {homeroom: [:school, :students]})
+
+    with_access = []
+    active_educators.each do |educator|
+      authorizer = Authorizer.new(educator)
+      reason = authorizer.why_authorized_for_student?(student)
+      if reason.present?
+        with_access << {
+          educator: educator.as_json(only: [:id, :email, :full_name]),
+          reason: reason
+        }
+      end
+    end
+    render json: {
+      with_access_json: with_access
+    }
+  end
+
   private
   def authorize!
     student = Student.find(params[:id])

--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -24,6 +24,9 @@ class EducatorLabel < ApplicationRecord
         'enable_reading_benchmark_data_entry', # deprecated
         'enable_reading_debug',
 
+        # profile
+        'enable_viewing_educators_with_access_to_student',
+
         # transition notes
         'k8_counselor',
         'high_school_house_master',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,7 @@ Rails.application.routes.draw do
   # student profile
   get '/api/students/:id/profile_json' => 'profile#json'
   get '/api/students/:id/reader_profile_json' => 'profile#reader_profile_json'
+  get '/api/students/:id/educators_with_access_json' => 'profile#educators_with_access_json'
 
   # transition notes: reading restricted notes (create was deprecated and removed, see `second_transition_note`)
   get '/api/students/:student_id/restricted_transition_note_json' => 'transition_notes#restricted_transition_note_json'

--- a/spec/controllers/district_controller_spec.rb
+++ b/spec/controllers/district_controller_spec.rb
@@ -30,7 +30,8 @@ describe DistrictController, :type => :controller do
             'enable_reading_benchmark_data_entry',
             'profile_enable_minimal_reading_data',
             'enable_equity_experiments',
-            'enable_reading_debug'
+            'enable_reading_debug',
+            'enable_viewing_educators_with_access_to_student'
           ]
         },
        "schools" => [

--- a/spec/controllers/educators_controller_spec.rb
+++ b/spec/controllers/educators_controller_spec.rb
@@ -41,6 +41,7 @@ describe EducatorsController, :type => :controller do
           'profile_enable_minimal_reading_data',
           'enable_equity_experiments',
           'enable_reading_debug',
+          'enable_viewing_educators_with_access_to_student'
         ]
       })
     end

--- a/spec/controllers/ui_controller_spec.rb
+++ b/spec/controllers/ui_controller_spec.rb
@@ -24,7 +24,8 @@ describe UiController, :type => :controller do
             'enable_reading_benchmark_data_entry',
             'profile_enable_minimal_reading_data',
             'enable_equity_experiments',
-            'enable_reading_debug'
+            'enable_reading_debug',
+            'enable_viewing_educators_with_access_to_student'
           ]
         }
       }.deep_stringify_keys)

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -219,7 +219,8 @@ RSpec.describe Educator do
         'enable_reading_benchmark_data_entry',
         'enable_equity_experiments',
         'enable_reading_debug',
-        'profile_enable_minimal_reading_data'
+        'profile_enable_minimal_reading_data',
+        'enable_viewing_educators_with_access_to_student'
       ])
     end
   end

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -121,6 +121,10 @@ class TestPals
       educator: @uri,
       label_key: 'enable_reading_debug'
     })
+    EducatorLabel.create!({
+      educator: @uri,
+      label_key: 'enable_viewing_educators_with_access_to_student'
+    })
     EducatorMultifactorConfig.create!({
       educator: @uri,
       rotp_secret: '4444rrr2vwjqgua2umohlpuzobar4444' # so development and demo have a stable TOTP setup over deploys


### PR DESCRIPTION
# Who is this PR for?
internal team, district project leads

# What problem does this PR fix?
When changes to permissions are made, there's no way for project leads to directly see who has access to an individual student.  Down the line, this is something we'd want to make more visible all around as well, for more distributed review of permissions.

# What does this PR do?
Adds a button for seeing this to the student profile, with minimal UI but a more student-centric perspective than other permissions tools.  Access is controlled by a label, which will only be set for the internal team (making and reviewing permissions change now), and to project leads to help with that and to help debug any permissions-related issues going forward.

# Screenshot (if adding a client-side feature)
<img width="447" alt="Screen Shot 2019-09-26 at 3 24 48 PM" src="https://user-images.githubusercontent.com/1056957/65719961-f56e8580-e074-11e9-88df-f948bdc834dd.png">
<img width="582" alt="Screen Shot 2019-09-26 at 3 24 39 PM" src="https://user-images.githubusercontent.com/1056957/65719964-f7384900-e074-11e9-8998-799cb86310bb.png">
<img width="577" alt="Screen Shot 2019-09-26 at 3 24 42 PM" src="https://user-images.githubusercontent.com/1056957/65719975-fa333980-e074-11e9-93ce-3d8df628937e.png">


# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here