### PR TITLE
Authorization: Remove authorization for sections from Educator, and other unused methods

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -23,7 +23,7 @@ class ProfileController < ApplicationController
       grades_reflection_insights: ProfileInsights.new(student).from_q2_self_reflection.as_json,
       latest_iep_document: student.latest_iep_document.as_json(only: [:id]),
       sections: serialize_student_sections_for_profile(student),
-      current_educator_allowed_sections: current_educator.allowed_sections.map(&:id),
+      current_educator_allowed_sections: authorizer.sections.map(&:id),
       attendance_data: {
         discipline_incidents: discipline_incidents_as_json(student),
         tardies: filtered_events(student.tardies),

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -44,7 +44,7 @@ class SectionsController < ApplicationController
 
     # limit navigator to current school year
     district_school_year = Section.to_district_school_year(SchoolYear.to_school_year(Time.now))
-    sections_for_navigator = current_educator.allowed_sections.includes(:course).where(district_school_year: district_school_year)
+    sections_for_navigator = authorizer.sections.includes(:course).where(district_school_year: district_school_year)
     sections_json = sections_for_navigator.as_json({
       only: [:id, :section_number, :term_local_id],
       methods: [:course_description],

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -74,7 +74,7 @@ class SectionsController < ApplicationController
     raise Exceptions::EducatorNotAuthorized unless current_educator.districtwide_access || current_educator.school.is_high_school?
 
     section = Section.find(params[:id])
-    raise Exceptions::EducatorNotAuthorized unless current_educator.is_authorized_for_section(section)
+    raise Exceptions::EducatorNotAuthorized unless authorizer.is_authorized_for_section?(section)
     section
   end
 

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -1,7 +1,7 @@
 class Educator < ApplicationRecord
   devise :ldap_authenticatable_tiny, :rememberable, :trackable, :timeoutable, authentication_keys: [:login_text, :login_code]
 
-  belongs_to  :school, optional: true # districtwide admin often don't have schools assigned
+  belongs_to  :school, optional: true # eg, districtwide admin often don't have schools assigned
   has_one     :homeroom
   has_many    :students, through: :homeroom
   has_many    :educator_section_assignments
@@ -45,45 +45,26 @@ class Educator < ApplicationRecord
     )
   end
 
-  def is_principal?
-    staff_type.try(:downcase) == 'principal'
-  end
-
-  def is_authorized_for_student(student)
-    Authorizer.new(self).is_authorized_for_student?(student)
-  end
-
-  def is_authorized_for_school(current_school)
-    Authorizer.new(self).is_authorized_for_school?(current_school)
-  end
-
-  def is_authorized_for_section(section)
-    Authorizer.new(self).is_authorized_for_section?(section)
-  end
-
   def labels
     EducatorLabel.labels(self)
   end
 
-  def default_section
-    return sections[0] if sections.present?
-    raise Exceptions::NoAssignedSections
-  end
-
+  # deprecated, migrate to Authorizer
   def has_access_to_grade_levels?
     grade_level_access.present? && grade_level_access.size > 0
   end
 
-  def allowed_sections
-    Authorizer.new(self).sections
+  # deprecated, migrate callers to use the Authorizer class directly
+  def is_authorized_for_student(student)
+    Authorizer.new(self).is_authorized_for_student?(student)
   end
 
+  # deprecated, move to controller or standalone class
   def self.to_index
-    all.map { |e| [e.id, e.for_index] }.to_h
-  end
-
-  def for_index
-    as_json.symbolize_keys.slice(:id, :email, :full_name)
+    all.map do |e|
+      json = e.as_json.symbolize_keys.slice(:id, :email, :full_name)
+      [e.id, json]
+    end.to_h
   end
 
   private

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Authorizer do
 
   # Some specs are migrated over from a different file that didn't
   # use TestPals; so this allows unwinding the TestPals db setup for particular
-  # block of these tests, while migrating test cases into here to verify 
+  # block of these tests, while migrating test cases into here to verify
   # no regressions occurred.
   def destroy_test_pals!
     TeamMembership.all.destroy_all
@@ -34,7 +34,6 @@ RSpec.describe Authorizer do
     Course.all.destroy_all
     School.all.destroy_all
   end
-
 
   it 'sets up test context correctly' do
     expect(School.all.size).to eq 13
@@ -467,7 +466,7 @@ RSpec.describe Authorizer do
     end
   end
 
-  describe '#is_authorized_for_section? (migrated from educator)' do
+  describe '#is_authorized_for_section? (migrated from Educator#allowed_sections)' do
     # These specs are migrated over from a different file that didn't
     # use TestPals; so unwind the TestPals db setup for this block of tests.
     before { destroy_test_pals! }

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -14,6 +14,28 @@ RSpec.describe Authorizer do
     allow(PerDistrict).to receive(:new).and_return(mock_per_district)
   end
 
+  # Some specs are migrated over from a different file that didn't
+  # use TestPals; so this allows unwinding the TestPals db setup for particular
+  # block of these tests, while migrating test cases into here to verify 
+  # no regressions occurred.
+  def destroy_test_pals!
+    TeamMembership.all.destroy_all
+    ImportedForm.all.destroy_all
+    StudentSectionAssignment.all.destroy_all
+    Student.all.destroy_all
+    Homeroom.all.destroy_all
+    CounselorNameMapping.all.destroy_all
+    HouseEducatorMapping.all.destroy_all
+    EducatorSectionAssignment.all.destroy_all
+    EducatorMultifactorConfig.all.destroy_all
+    EducatorLabel.all.destroy_all
+    Educator.all.destroy_all
+    Section.all.destroy_all
+    Course.all.destroy_all
+    School.all.destroy_all
+  end
+
+
   it 'sets up test context correctly' do
     expect(School.all.size).to eq 13
     expect(Homeroom.all.size).to eq 6
@@ -445,6 +467,54 @@ RSpec.describe Authorizer do
     end
   end
 
+  describe '#is_authorized_for_section? (migrated from educator)' do
+    # These specs are migrated over from a different file that didn't
+    # use TestPals; so unwind the TestPals db setup for this block of tests.
+    before { destroy_test_pals! }
+
+    let!(:school) { FactoryBot.create(:healey) }
+    let!(:other_school) { FactoryBot.create(:brown) }
+    let!(:in_school_course) { FactoryBot.create(:course, school: school) }
+    let!(:in_school_section) { FactoryBot.create(:section, course: in_school_course) }
+    let!(:out_of_school_course) { FactoryBot.create(:course, school: other_school)}
+    let!(:out_of_school_section) { FactoryBot.create(:section, course: out_of_school_course) }
+
+    context 'schoolwide_access' do
+      let(:schoolwide_educator) { FactoryBot.create(:educator, school: school, schoolwide_access: true)}
+
+      it 'has access to a section in their school' do
+        expect(Authorizer.new(schoolwide_educator).is_authorized_for_section?(in_school_section)).to be true
+      end
+
+      it 'does not have access to a section outside their school' do
+        expect(Authorizer.new(schoolwide_educator).is_authorized_for_section?(out_of_school_section)).to be false
+      end
+    end
+
+    context 'districtwide_access' do
+      let(:districtwide_educator) { FactoryBot.create(:educator, school: school, districtwide_access: true)}
+
+      it 'has access to a section outside their school' do
+        expect(Authorizer.new(districtwide_educator).is_authorized_for_section?(out_of_school_section)).to be true
+      end
+    end
+
+    context 'regular teacher' do
+      let(:educator) { FactoryBot.create(:educator, school: school) }
+      let!(:other_in_school_section) { FactoryBot.create(:section, course: in_school_course) }
+      let!(:esa) { FactoryBot.create(:educator_section_assignment, educator: educator, section: in_school_section) }
+
+      it 'has access to a section assigned to that educator' do
+        expect(Authorizer.new(educator).is_authorized_for_section?(in_school_section)).to be true
+      end
+
+      it 'does not have access to a section not assigned to that educator' do
+        expect(Authorizer.new(educator).is_authorized_for_section?(other_in_school_section)).to be false
+      end
+
+    end
+  end
+
   describe '#is_authorized_for_section?' do
     let!(:test_section) { pals.shs_tuesday_biology_section }
 
@@ -560,24 +630,9 @@ RSpec.describe Authorizer do
   end
 
   context '#allowed_homerooms_DEPRECATED' do
-    # These specs are migrated over from a differnet file that didn't
+    # These specs are migrated over from a different file that didn't
     # use TestPals; so unwind the TestPals db setup for this block of tests.
-    before do
-      TeamMembership.all.destroy_all
-      ImportedForm.all.destroy_all
-      StudentSectionAssignment.all.destroy_all
-      Student.all.destroy_all
-      Homeroom.all.destroy_all
-      CounselorNameMapping.all.destroy_all
-      HouseEducatorMapping.all.destroy_all
-      EducatorSectionAssignment.all.destroy_all
-      EducatorMultifactorConfig.all.destroy_all
-      EducatorLabel.all.destroy_all
-      Educator.all.destroy_all
-      Section.all.destroy_all
-      Course.all.destroy_all
-      School.all.destroy_all
-    end
+    before { destroy_test_pals! }
 
     def deprecated_method(educator)
       Authorizer.new(educator).allowed_homerooms_DEPRECATED(acknowledge_deprecation: true)

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -164,50 +164,6 @@ RSpec.describe Educator do
     end
   end
 
-  describe '#is_authorized_for_section' do
-    let!(:school) { FactoryBot.create(:healey) }
-    let!(:other_school) { FactoryBot.create(:brown) }
-    let!(:in_school_course) { FactoryBot.create(:course, school: school) }
-    let!(:in_school_section) { FactoryBot.create(:section, course: in_school_course) }
-    let!(:out_of_school_course) { FactoryBot.create(:course, school: other_school)}
-    let!(:out_of_school_section) { FactoryBot.create(:section, course: out_of_school_course) }
-
-    context 'schoolwide_access' do
-      let(:schoolwide_educator) { FactoryBot.create(:educator, school: school, schoolwide_access: true)}
-
-      it 'has access to a section in their school' do
-        expect(schoolwide_educator.is_authorized_for_section(in_school_section)).to be true
-      end
-
-      it 'does not have access to a section outside their school' do
-        expect(schoolwide_educator.is_authorized_for_section(out_of_school_section)).to be false
-      end
-    end
-
-    context 'districtwide_access' do
-      let(:districtwide_educator) { FactoryBot.create(:educator, school: school, districtwide_access: true)}
-
-      it 'has access to a section outside their school' do
-        expect(districtwide_educator.is_authorized_for_section(out_of_school_section)).to be true
-      end
-    end
-
-    context 'regular teacher' do
-      let(:educator) { FactoryBot.create(:educator, school: school) }
-      let!(:other_in_school_section) { FactoryBot.create(:section, course: in_school_course) }
-      let!(:esa) { FactoryBot.create(:educator_section_assignment, educator: educator, section: in_school_section) }
-
-      it 'has access to a section assigned to that educator' do
-        expect(educator.is_authorized_for_section(in_school_section)).to be true
-      end
-
-      it 'does not have access to a section not assigned to that educator' do
-        expect(educator.is_authorized_for_section(other_in_school_section)).to be false
-      end
-
-    end
-  end
-
   describe '#labels' do
     let!(:pals) { TestPals.create! }
     it 'works' do

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -125,45 +125,6 @@ RSpec.describe Educator do
     end
   end
 
-  describe '#allowed_sections' do
-    let!(:school) { FactoryBot.create(:healey) }
-    let!(:other_school) { FactoryBot.create(:brown) }
-    let!(:in_school_course) { FactoryBot.create(:course, school: school) }
-    let!(:in_school_section) { FactoryBot.create(:section, course: in_school_course) }
-    let!(:out_of_school_course) { FactoryBot.create(:course, school: other_school)}
-    let!(:out_of_school_section) { FactoryBot.create(:section, course: out_of_school_course) }
-
-    context 'schoolwide_access' do
-      let(:schoolwide_educator) { FactoryBot.create(:educator, school: school, schoolwide_access: true)}
-      it 'returns all sections in the school' do
-        expect(schoolwide_educator.allowed_sections.sort).to eq [
-          in_school_section
-        ].sort
-      end
-    end
-
-    context 'districtwide_access' do
-      let(:districtwide_educator) { FactoryBot.create(:educator, school: school, districtwide_access: true)}
-      it 'returns all sections in the district' do
-        expect(districtwide_educator.allowed_sections.sort).to eq [
-          in_school_section, out_of_school_section
-        ].sort
-      end
-    end
-
-    context 'regular teacher' do
-      let(:educator) { FactoryBot.create(:educator, school: school) }
-      let!(:other_in_school_section) { FactoryBot.create(:section, course: in_school_course) }
-      let!(:esa) { FactoryBot.create(:educator_section_assignment, educator: educator, section: in_school_section) }
-      let!(:other_esa) { FactoryBot.create(:educator_section_assignment, educator: educator, section: other_in_school_section) }
-      it 'returns all sections assigned to the educator' do
-        expect(educator.allowed_sections.sort).to eq [
-          in_school_section, other_in_school_section
-        ].sort
-      end
-    end
-  end
-
   describe '#labels' do
     let!(:pals) { TestPals.create! }
     it 'works' do


### PR DESCRIPTION
# Who is this PR for?
Working towards part of https://github.com/studentinsights/studentinsights/pull/2636.

# What does this PR do?
Remove authorization methods related to sections from the `Educator` model, as part of centralizing section authorization into `Authorizer`.  In the process, removes up some old unused methods in the `Educator` model.  This was broken off to merge first before more substantive refactors.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Section

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
