### PR TITLE
Home page: Optimize query for authorized students

### DIFF
--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -106,7 +106,9 @@ class Authorizer
       return :districtwide if @educator.districtwide_access?
       # As a performance optimization, this check excludes `dynamic_labels`, since they're a bit more
       # expensive to compute, and here we only need to check one specific label that we know
-      # is static.
+      # is static.  Also, PerfTest shows that although it might seem like moving the env check first would
+      # speed this up by avoiding the labels query, this order is consistently faster when the ENV value
+      # is not set.
       return :housemaster if @educator.labels(exclude_dynamic_labels: true).include?('high_school_house_master') && student.grade == '8' && EnvironmentVariable.is_true('HOUSEMASTERS_AUTHORIZED_FOR_GRADE_8')
 
       return nil if @educator.restricted_to_sped_students && !(student.program_assigned.in? ['Sp Ed', 'SEIP'])

--- a/app/lib/perf_test.rb
+++ b/app/lib/perf_test.rb
@@ -161,7 +161,7 @@ class PerfTest
   def test_educator_ids(percent, options = {})
     seed = options[:seed] || 42
     fixed_educator_ids = options[:fixed_educator_ids] || []
-    all_educator_ids = Educator.all.select(:id).map(&:id)
+    all_educator_ids = Educator.active.select(:id).map(&:id)
     sample_size = percent * all_educator_ids.size
     sample_educator_ids = all_educator_ids.sample(sample_size, random: Random.new(seed))
     (sample_educator_ids + fixed_educator_ids).uniq

--- a/app/lib/perf_test.rb
+++ b/app/lib/perf_test.rb
@@ -19,7 +19,14 @@ class PerfTest
     end
   end
 
-  # Critical path authorization code
+  # May be used in critical path authorization code (see #authorized).
+  def self.labels(percentage, options = {})
+    PerfTest.new.simple(percentage, options) do |educator|
+      educator.labels
+    end
+  end
+
+  # Critical path authorization code (may call #labels).
   def self.authorized(percentage, options = {})
     PerfTest.new.simple(percentage, options) do |educator|
       Authorizer.new(educator).authorized { Student.active }
@@ -78,7 +85,7 @@ class PerfTest
     end
   end
 
-  # Usage for testing the feed
+  # Usage for testing the feed (may call #authorized)
   def self.feed(percentage, options = {})
     timer = PerfTest.new.run_with_tags(percentage, options) do |t, educator|
       time_now = options[:time_now] || Time.at(1521552855)

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -45,8 +45,8 @@ class Educator < ApplicationRecord
     )
   end
 
-  def labels
-    EducatorLabel.labels(self)
+  def labels(options = {})
+    EducatorLabel.labels(self, options)
   end
 
   # deprecated, migrate to Authorizer

--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -50,8 +50,10 @@ class EducatorLabel < ApplicationRecord
 
   # Static labels are set by records in the database.  Dynamic labels are
   # computed at read time here based on some other property of the educator.
-  def self.labels(educator)
+  def self.labels(educator, options = {})
     static_labels = educator.educator_labels.map(&:label_key)
+    return static_labels if options.fetch(:exclude_dynamic_labels, false)
+
     dynamic_labels = self.dynamic_labels_for_educator(educator)
 
     static_labels + dynamic_labels


### PR DESCRIPTION
# Who is this PR for?
all educators


# What does this PR do?
This optimizes `authorized { Student.active }` for educators with section assignments, impacting the home page feed, my students page, and many other parts of the product.

It does this by removing calls to `Educator#labels` that end up doing authorization checks to see if the educator has any sections, in the process of computing dynamic labels.  Since the only labels needs in the authorization method itself are static, optimize the call there to only look at static labels.

I also initially reordered the condition checks related to housemaster authorization; these would run even if the feature was disabled through an env flag.  This actually led to consistently slower p95 values on the `PerfTest`, so I noted it and backed that out.

Data from Somerville, for sample of 5% of educators:
```
> PerfTest.authorized(0.05);nil
before: all_for_educator          median: 911ms   p95: 7290ms
after:  all_for_educator          median: 423ms   p95: 993ms


> PerfTest.feed(0.05);nil
# before:    p50: 739    p95: 3939
# after:     p50: 713    p95: 1486
```

New Bedford will soon be impacted by this change, but for now the speedups only impact Somerville folks.

Separately, after this work and measurement, I noticed the `PerfTest` class defaults to all educators, and so updated that to use `Educator.active` going forward.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Home page
+ [x] My Students
+ [x] Core 

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here