### PR TITLE
Section authorization: Optimize method to make it faster

### DIFF
--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -153,10 +153,14 @@ class Authorizer
     return false unless PerDistrict.new.enabled_sections?
     return true if @educator.districtwide_access?
 
-    return false if @educator.school.present? && @educator.school != section.course.school
+    return false if @educator.school_id.present? && @educator.school_id != section.course.school_id
 
     return true if @educator.schoolwide_access? || @educator.admin?
-    return true if section.in?(@educator.sections)
+    # The `#to_a` is a performance optimization to reduce queries, in loops
+    # with `authorized { Section.all }`.  It results in Rails caching the values
+    # of this query in memory across the repeated calls in the loop.  Taken from
+    # similar optimization in `why_authorized_for_student?`
+    return true if section.in?(@educator.sections.to_a)
     false
   end
 

--- a/app/lib/perf_test.rb
+++ b/app/lib/perf_test.rb
@@ -95,6 +95,22 @@ class PerfTest
     end
   end
 
+  # Part of Section controller, influenced heavily by Authorizer.
+  def self.section_authorization_pattern(percentage, options = {})
+    PerfTest.new.simple(percentage, options) do |educator|
+      authorizer = Authorizer.new(educator)
+      section = educator.sections.sample
+      if section.nil?
+        [[], []]
+      else
+        section_students = authorizer.authorized { section.students.active }
+        authorized_sections = authorized { Section.includes(:course).all }
+        [section_students, authorized_sections]
+      end
+    end
+  end
+
+
   # Usage for testing the feed (may call #authorized)
   def self.feed(percentage, options = {})
     timer = PerfTest.new.run_with_tags(percentage, options) do |t, educator|

--- a/app/lib/perf_test.rb
+++ b/app/lib/perf_test.rb
@@ -62,7 +62,7 @@ class PerfTest
     sample_educator_ids = all_educator_ids.sample(sample_size, random: Random.new(seed))
     (sample_educator_ids + fixed_educator_ids).uniq
   end
-  
+
   def reset!
     ActiveRecord::Base.connection.query_cache.clear
   end
@@ -90,7 +90,6 @@ class PerfTest
     # Rails.configuration.log_level = :debug
     # ActiveRecord::Base.logger = Logger.new(STDOUT)
   end
-
 
   # Helper class to print summary stats like p50, p95
   #
@@ -136,7 +135,6 @@ class PerfTest
       @log.puts msg
     end
   end
-
 
   # Helper class to hold timing data
   class Timer

--- a/app/lib/perf_test.rb
+++ b/app/lib/perf_test.rb
@@ -104,7 +104,7 @@ class PerfTest
         [[], []]
       else
         section_students = authorizer.authorized { section.students.active }
-        authorized_sections = authorized { Section.includes(:course).all }
+        authorized_sections = authorizer.authorized { Section.includes(:course).all }
         [section_students, authorized_sections]
       end
     end

--- a/app/lib/perf_test.rb
+++ b/app/lib/perf_test.rb
@@ -1,162 +1,31 @@
+# For measuring performance of different methods across
+# a sample of Educators.  See `PerfTester` for usage.
+#
+# Example usage:
+#
+#   puts new_perf_test.simple(0.05) do |educator|
+#     do_expensive_thing_for_educator(educator)
+#   end;nil
+#
 class PerfTest
-  # querying and serializing data for absence dashboard at a particular school
-  def self.absences_dashboard(percentage, options = ())
-    school_id = options[:school_id] || School.all.first.id
-    school = School.find(school_id)
-    time_now = Time.at(1536589824)
-    PerfTest.new.simple(percentage, options) do |educator|
-      queries = DashboardQueries.new(educator, time_now: time_now)
-      queries.absence_dashboard_data(school)
-    end
-  end
-
-  def self.levels_shs(percentage, options = {})
-    time_now = options.fetch(:time_now, Time.at(1529067553))
-    school_id = 9
-    PerfTest.new.simple(percentage, options) do |educator|
-      levels = SomervilleHighLevels.new
-      levels.students_with_levels_json(educator, [school_id], time_now)
-    end
-  end
-
-  # May be used in critical path authorization code (see #authorized).
-  def self.labels(percentage, options = {})
-    PerfTest.new.simple(percentage, options) do |educator|
-      educator.labels
-    end
-  end
-
-  # Critical path authorization code (may call #labels).
-  def self.authorized(percentage, options = {})
-    PerfTest.new.simple(percentage, options) do |educator|
-      Authorizer.new(educator).authorized { Student.active }
-    end
-  end
-
-  def self.navbar_links(percentage, options = {})
-    PerfTest.new.simple(percentage, options) do |educator|
-      PathsForEducator.new(educator).navbar_links
-    end
-  end
-
-  def self.authorized_homerooms(percentage, options = {})
-    PerfTest.new.simple(percentage, options) do |educator|
-      Authorizer.new(educator).homerooms
-    end
-  end
-
-  def self.authorized_homerooms_DEPRECATED(percentage, options = {})
-    PerfTest.new.simple(percentage, options) do |educator|
-      Authorizer.new(educator).allowed_homerooms_DEPRECATED(acknowledge_deprecation: true)
-    end
-  end
-
-  # See educators_controller#my_students_json
-  def self.my_students(percentage, options = {})
-    PerfTest.new.simple(percentage, options) do |educator|
-      students = Authorizer.new(educator).authorized { Student.active.includes(:school).to_a }
-      students.as_json({
-        only: [:id, :first_name, :last_name, :house, :counselor, :grade],
-        include: {
-          school: {
-            only: [:id, :name]
-          }
-        }
-      })
-    end
-  end
-
-  # See ClassListQueries.  This was driven by the view in admin/authorization, running this
-  # across all educators.
-  def self.is_relevant_for_educator?(percentage, options = {})
-    PerfTest.new.simple(percentage, options) do |educator|
-      ClassListQueries.new(educator).is_relevant_for_educator?
-    end
-  end
-
-  # For testing the high absences insight
-  def self.high_absences(percentage, options = {})
-    PerfTest.new.simple(percentage, options) do |educator|
-      time_now = options[:time_now] || Time.at(1522779136)
-      time_threshold = time_now - 45.days
-      absences_threshold = 4
-      insight = InsightStudentsWithHighAbsences.new(educator)
-      insight.students_with_high_absences_json(time_now, time_threshold, absences_threshold)
-    end
-  end
-
-  def self.low_grades(percentage, options = {})
-    PerfTest.new.simple(percentage, options) do |educator|
-      time_now = options[:time_now] || Time.at(1522779136)
-      time_threshold = time_now - 45.days
-      grade_threshold = 69
-      insight = InsightStudentsWithLowGrades.new(educator)
-      insight.students_with_low_grades_json(time_now, time_threshold, grade_threshold)
-    end
-  end
-
-  # Part of Section controller, influenced heavily by Authorizer.
-  def self.section_authorization_pattern(percentage, options = {})
-    PerfTest.new.simple(percentage, options) do |educator|
-      authorizer = Authorizer.new(educator)
-      section = educator.sections.sample
-      if section.nil?
-        [[], []]
-      else
-        section_students = authorizer.authorized { section.students.active }
-        authorized_sections = authorizer.authorized { Section.includes(:course).all }
-        [section_students, authorized_sections]
-      end
-    end
-  end
-
-
-  # Usage for testing the feed (may call #authorized)
-  def self.feed(percentage, options = {})
-    timer = PerfTest.new.run_with_tags(percentage, options) do |t, educator|
-      time_now = options[:time_now] || Time.at(1521552855)
-      limit = options[:limit] || 10
-      students = t.measure('students') do
-        Feed.students_for_feed(educator)
-      end
-      feed = Feed.new(students)
-      event_note_cards = t.measure('event_note_cards') do
-        feed.event_note_cards(time_now, limit)
-      end
-      incident_cards = t.measure('incident_cards') do
-        feed.incident_cards(time_now, limit)
-      end
-      birthday_cards = t.measure('birthday_cards') do
-        feed.birthday_cards(time_now, limit, {
-          limit: 3,
-          days_back: 3,
-          days_ahead: 0
-        })
-      end
-      student_voice_cards = t.measure('student_voice_cards') do
-        feed.student_voice_cards(time_now)
-      end
-      t.measure('feed_cards') do
-        feed.merge_sort_and_limit_cards([
-          event_note_cards,
-          birthday_cards,
-          incident_cards,
-          student_voice_cards
-        ], limit)
-      end
-    end
-    pp timer.report
-    timer
+  def initialize(options = {})
+    @log = options.fetch(:log, STDOUT)
   end
 
   # Simplest usage.  Block yields an educator.
   def simple(percentage, options = {}, &block)
-    timer = PerfTest.new.run_with_tags(percentage, options) do |t, educator|
+    timer = self.run_with_tags(percentage, options) do |t, educator|
       block.yield(educator)
     end
-    pp timer.report
-    pp PerfTest::Reporter.new.report(timer.report.group_by {|tuple| tuple[0] })
+    print_timer_and_report(timer)
     timer
+  end
+
+  def print_timer_and_report(timer)
+    log timer.report
+    reporter = PerfTest::Reporter.new(log: @log)
+    log reporter.report(timer.report.group_by {|tuple| tuple[0] })
+    nil
   end
 
   # Generic perftest usage:
@@ -164,26 +33,27 @@ class PerfTest
   #   t.measure('whatever') { do_something_for(educator) }
   #   t.measure('foo') { do_something_else_for(educator) }
   # end;nil
-  # pp timer.report
+  # log timer.report
   def run_with_tags(percentage, options = {}, &block)
-    timer = Timer.new
+    timer = Timer.new(log: @log)
 
-    puts
-    puts
-    puts 'Getting test set...'
+    log
+    log
+    log 'Getting test set...'
     educator_ids = test_educator_ids(percentage, options)
-    puts "Test set includes #{educator_ids.size} educators: [#{educator_ids.sort.join(',')}]"
-    puts 'Done.'
-    puts
-    puts
-    puts 'Starting test run...'
+    log "Test set includes #{educator_ids.size} educators: [#{educator_ids.sort.join(',')}]"
+    log 'Done.'
+    log
+    log
+    log 'Starting test run...'
     run_for_all_educators(timer, educator_ids, &block)
-    puts 'Done.'
-    puts
-    puts
+    log 'Done.'
+    log
+    log
     timer
   end
 
+  private
   def test_educator_ids(percent, options = {})
     seed = options[:seed] || 42
     fixed_educator_ids = options[:fixed_educator_ids] || []
@@ -192,6 +62,35 @@ class PerfTest
     sample_educator_ids = all_educator_ids.sample(sample_size, random: Random.new(seed))
     (sample_educator_ids + fixed_educator_ids).uniq
   end
+  
+  def reset!
+    ActiveRecord::Base.connection.query_cache.clear
+  end
+
+  def run_for_all_educators(t, educator_ids, &block)
+    educator_ids.each do |educator_id|
+      reset!
+      log
+      log "Starting for educator: #{educator_id}..."
+      educator = Educator.find(educator_id)
+      t.measure('all_for_educator') do
+        block.yield(t, educator)
+      end
+    end
+  end
+
+  def log(msg = '')
+    @log.puts msg
+  end
+
+  def debug!
+    # This is dangerous, as it can result in logging sensitive information.
+    # Use with caution, and verify the impact locally first.
+    #
+    # Rails.configuration.log_level = :debug
+    # ActiveRecord::Base.logger = Logger.new(STDOUT)
+  end
+
 
   # Helper class to print summary stats like p50, p95
   #
@@ -205,15 +104,19 @@ class PerfTest
   # or json = JSON.parse(IO.read('runs.json'));nil
   # Reporter.new.report(json)
   class Reporter
+    def initialize(options = {})
+      @log = options.fetch(:log, STDOUT)
+    end
+
     def report(timer_reports_map)
       timer_reports_map.each do |report_key, tuples|
-        puts
-        puts "#{report_key.upcase}, sample size: #{tuples.size}"
+        log
+        log "#{report_key.upcase}, sample size: #{tuples.size}"
         tuples.group_by {|t| t[0]}.each do |key, ts|
           values = ts.map {|t| t[1] }
           p50 = percentile(values, 0.50).round
           p95 = percentile(values, 0.95).round
-          puts "  #{key.ljust(25)}\tmedian: #{p50}ms\t\tp95: #{p95}ms"
+          log "  #{key.ljust(25)}\tmedian: #{p50}ms\t\tp95: #{p95}ms"
         end
       end
       nil
@@ -227,15 +130,22 @@ class PerfTest
       f = (percentile*(values_sorted.length-1)+1).modulo(1)
       return values_sorted[k] + (f * (values_sorted[k+1] - values_sorted[k]))
     end
+
+    private
+    def log(msg = '')
+      @log.puts msg
+    end
   end
+
 
   # Helper class to hold timing data
   class Timer
-    def initialize()
+    def initialize(options = {})
+      @log = options.fetch(:log, STDOUT)
       @measurements = []
     end
 
-    # not attr_reader so it doesn't puts by default (values are large!)
+    # not attr_reader so it doesn't log by default (values are large!)
     def measurements
       @measurements
     end
@@ -243,7 +153,7 @@ class PerfTest
     def measure(tag)
       value = nil
       timing = Benchmark.measure { value = yield }
-      puts tag + timing.to_s
+      log tag + timing.to_s
       @measurements << {tag: tag, timing: timing, value: value}
       value
     end
@@ -255,30 +165,10 @@ class PerfTest
       end
       tuples.sort_by {|t| [t[0], t[1]] }
     end
-  end
 
-  private
-  def debug!
-    # This is dangerous, as it can result in logging sensitive information.
-    # Use with caution, and verify the impact locally first.
-    #
-    # Rails.configuration.log_level = :debug
-    # ActiveRecord::Base.logger = Logger.new(STDOUT)
-  end
-
-  def reset!
-    ActiveRecord::Base.connection.query_cache.clear
-  end
-
-  def run_for_all_educators(t, educator_ids, &block)
-    educator_ids.each do |educator_id|
-      reset!
-      puts
-      puts "Starting for educator: #{educator_id}..."
-      educator = Educator.find(educator_id)
-      t.measure('all_for_educator') do
-        block.yield(t, educator)
-      end
+    private
+    def log(msg = '')
+      @log.puts msg
     end
   end
 end

--- a/app/lib/perf_tester.rb
+++ b/app/lib/perf_tester.rb
@@ -1,0 +1,161 @@
+class PerfTester
+  def initialize(options = {})
+    @options = options
+  end
+
+  # querying and serializing data for absence dashboard at a particular school
+  def absences_dashboard(percentage, options = {})
+    school_id = options[:school_id] || School.all.first.id
+    school = School.find(school_id)
+    time_now = Time.at(1536589824)
+    new_perf_test.simple(percentage, options) do |educator|
+      queries = DashboardQueries.new(educator, time_now: time_now)
+      queries.absence_dashboard_data(school)
+    end
+  end
+
+  def levels_shs(percentage, options = {})
+    time_now = options.fetch(:time_now, Time.at(1529067553))
+    school_id = 9
+    new_perf_test.simple(percentage, options) do |educator|
+      levels = SomervilleHighLevels.new
+      levels.students_with_levels_json(educator, [school_id], time_now)
+    end
+  end
+
+  # May be used in critical path authorization code (see #authorized).
+  def labels(percentage, options = {})
+    new_perf_test.simple(percentage, options) do |educator|
+      educator.labels
+    end
+  end
+
+  # Critical path authorization code (may call #labels).
+  def authorized(percentage, options = {})
+    new_perf_test.simple(percentage, options) do |educator|
+      Authorizer.new(educator).authorized { Student.active }
+    end
+  end
+
+  def navbar_links(percentage, options = {})
+    new_perf_test.simple(percentage, options) do |educator|
+      PathsForEducator.new(educator).navbar_links
+    end
+  end
+
+  def authorized_homerooms(percentage, options = {})
+    new_perf_test.simple(percentage, options) do |educator|
+      Authorizer.new(educator).homerooms
+    end
+  end
+
+  def authorized_homerooms_DEPRECATED(percentage, options = {})
+    new_perf_test.simple(percentage, options) do |educator|
+      Authorizer.new(educator).allowed_homerooms_DEPRECATED(acknowledge_deprecation: true)
+    end
+  end
+
+  # See educators_controller#my_students_json
+  def my_students(percentage, options = {})
+    new_perf_test.simple(percentage, options) do |educator|
+      students = Authorizer.new(educator).authorized { Student.active.includes(:school).to_a }
+      students.as_json({
+        only: [:id, :first_name, :last_name, :house, :counselor, :grade],
+        include: {
+          school: {
+            only: [:id, :name]
+          }
+        }
+      })
+    end
+  end
+
+  # See ClassListQueries.  This was driven by the view in admin/authorization, running this
+  # across all educators.
+  def is_relevant_for_educator?(percentage, options = {})
+    new_perf_test.simple(percentage, options) do |educator|
+      ClassListQueries.new(educator).is_relevant_for_educator?
+    end
+  end
+
+  # For testing the high absences insight
+  def high_absences(percentage, options = {})
+    new_perf_test.simple(percentage, options) do |educator|
+      time_now = options[:time_now] || Time.at(1522779136)
+      time_threshold = time_now - 45.days
+      absences_threshold = 4
+      insight = InsightStudentsWithHighAbsences.new(educator)
+      insight.students_with_high_absences_json(time_now, time_threshold, absences_threshold)
+    end
+  end
+
+  def low_grades(percentage, options = {})
+    new_perf_test.simple(percentage, options) do |educator|
+      time_now = options[:time_now] || Time.at(1522779136)
+      time_threshold = time_now - 45.days
+      grade_threshold = 69
+      insight = InsightStudentsWithLowGrades.new(educator)
+      insight.students_with_low_grades_json(time_now, time_threshold, grade_threshold)
+    end
+  end
+
+  # Part of Section controller, influenced heavily by Authorizer.
+  def section_authorization_pattern(percentage, options = {})
+    new_perf_test.simple(percentage, options) do |educator|
+      authorizer = Authorizer.new(educator)
+      section = educator.sections.sample
+      if section.nil?
+        [[], []]
+      else
+        section_students = authorizer.authorized { section.students.active }
+        authorized_sections = authorizer.authorized { Section.includes(:course).all }
+        [section_students, authorized_sections]
+      end
+    end
+  end
+
+
+  # Usage for testing the feed (may call #authorized)
+  def feed(percentage, options = {})
+    perf_test = new_perf_test()
+    timer = perf_test.run_with_tags(percentage, options) do |t, educator|
+      time_now = options[:time_now] || Time.at(1521552855)
+      limit = options[:limit] || 10
+      students = t.measure('students') do
+        Feed.students_for_feed(educator)
+      end
+      feed = Feed.new(students)
+      event_note_cards = t.measure('event_note_cards') do
+        feed.event_note_cards(time_now, limit)
+      end
+      incident_cards = t.measure('incident_cards') do
+        feed.incident_cards(time_now, limit)
+      end
+      birthday_cards = t.measure('birthday_cards') do
+        feed.birthday_cards(time_now, limit, {
+          limit: 3,
+          days_back: 3,
+          days_ahead: 0
+        })
+      end
+      student_voice_cards = t.measure('student_voice_cards') do
+        feed.student_voice_cards(time_now)
+      end
+      t.measure('feed_cards') do
+        feed.merge_sort_and_limit_cards([
+          event_note_cards,
+          birthday_cards,
+          incident_cards,
+          student_voice_cards
+        ], limit)
+      end
+    end
+    perf_test.print_timer_and_report timer
+    timer
+  end
+
+  private
+  def new_perf_test()
+    PerfTest.new(@options)
+  end
+end

--- a/app/lib/perf_tester.rb
+++ b/app/lib/perf_tester.rb
@@ -114,7 +114,6 @@ class PerfTester
     end
   end
 
-
   # Usage for testing the feed (may call #authorized)
   def feed(percentage, options = {})
     perf_test = new_perf_test()

--- a/spec/lib/perf_tester_spec.rb
+++ b/spec/lib/perf_tester_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+# These are just smoke tests verifying that the methods still
+# can be called and don't regress.  It is not making assertion about
+# actual performance.
+RSpec.describe PerfTester do
+  let!(:pals) { TestPals.create! }
+
+  def create_perf_tester(options = {})
+    log = LogHelper::FakeLog.new
+    perf_tester = PerfTester.new(log: log)
+    [perf_tester, log]
+  end
+
+  def expect_smoke_test_passes_for(method_symbol)
+    tester, log = create_perf_tester()
+    expect { tester.send(method_symbol, 1.0) }.not_to raise_error
+    expect(log.output).to include('Getting test set...')
+    expect(log.output).to include('Starting test run...')
+    expect(log.output).to include('median')
+    expect(log.output).to include('p95')
+    expect(log.output).to include('Done.')
+  end
+
+  it 'measures #absences_dashboard' do
+    expect_smoke_test_passes_for(:absences_dashboard)
+  end
+
+  it 'measures #levels_shs' do
+    expect_smoke_test_passes_for(:levels_shs)
+  end
+
+  it 'measures #labels' do
+    expect_smoke_test_passes_for(:labels)
+  end
+
+  it 'measures #authorized' do
+    expect_smoke_test_passes_for(:authorized)
+  end
+
+  it 'measures #navbar_links' do
+    expect_smoke_test_passes_for(:navbar_links)
+  end
+
+  it 'measures #authorized_homerooms' do
+    expect_smoke_test_passes_for(:authorized_homerooms)
+  end
+
+  it 'measures #authorized_homerooms_DEPRECATED' do
+    expect_smoke_test_passes_for(:authorized_homerooms_DEPRECATED)
+  end
+
+  it 'measures #my_students' do
+    expect_smoke_test_passes_for(:my_students)
+  end
+
+  it 'measures #is_relevant_for_educator?' do
+    expect_smoke_test_passes_for(:is_relevant_for_educator?)
+  end
+
+  it 'measures #high_absences' do
+    expect_smoke_test_passes_for(:high_absences)
+  end
+
+  it 'measures #low_grades' do
+    expect_smoke_test_passes_for(:low_grades)
+  end
+
+  it 'measures #section_authorization_pattern' do
+    expect_smoke_test_passes_for(:section_authorization_pattern)
+  end
+
+  it 'measures #feed' do
+    expect_smoke_test_passes_for(:feed)
+  end
+end


### PR DESCRIPTION
# Who is this PR for?
Educators with section assignments

# What problem does this PR fix?
https://github.com/studentinsights/studentinsights/pull/2654 centralizes section authorization, and makes more use of these methods that previously.  This slowed down the section page for queries like `authorized { Section.all }`.

# What does this PR do?
Adds two optimizations, adapted from `#why_authorized_for_student?`, comparing foreign key values rather than model values to remove that query, and adding a `#to_a` call to the end of the association, which causes Rails to cache the result of that query across calls.  I'm not sure why this influences Rails' caching, but it does and `PerfTests` here show the same thing as with `#why_authorized_for_student?`.

Also adds minimal smoke tests to `PerfTest` methods, just verifying that they still run and don't break.  It does not make assertions about performance.

# Screenshot (if adding a client-side feature)
```
puts PerfTest.section_authorization_pattern(0.01);nil

# before
1%,  median: 1917ms    p95: 2490ms

# after
 1%, median:  417ms    p95:  613ms
 5%, median:    2ms    p95:  511ms
10%, median:    2ms    p95:  518ms
(caveat: distribution is bimodal since some educators don't have sections)
```

# Checklists
*Which features or pages does this PR touch?*
+ [x] Section
+ [x] Authorization

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here