### PR TITLE
Allow import of tardy and absence events in single record

### DIFF
--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -153,8 +153,18 @@ class AttendanceImporter
       return
     end
 
-    # Match with existing record or initialize new one (not saved)
-    # Then mark the record and sync the record from CSV to Insights
+    # Record both events if present in the row
+    if record_class === "both"
+      match_record(row, Absence)
+      match_record(row, Tardy)
+    else
+      match_record(row, record_class)
+    end
+  end
+
+  # Match with existing record or initialize new one (not saved)
+  # Then mark the record and sync the record from CSV to Insights
+  def match_record(row, record_class)
     maybe_matching_record = matching_insights_record_for_row(row, record_class)
     syncer = get_syncer!(record_class)
     syncer.validate_mark_and_sync!(maybe_matching_record)
@@ -189,7 +199,7 @@ class AttendanceImporter
     is_absence = per_district.is_attendance_import_value_truthy?(row[:absence])
     is_tardy = per_district.is_attendance_import_value_truthy?(row[:tardy])
 
-    if is_absence && is_tardy then nil
+    if is_absence && is_tardy then "both"
     elsif is_absence then Absence
     elsif is_tardy then Tardy
     else nil

--- a/app/importers/file_importers/attendance_importer.rb
+++ b/app/importers/file_importers/attendance_importer.rb
@@ -154,7 +154,7 @@ class AttendanceImporter
     end
 
     # Record both events if present in the row
-    if record_class === "both"
+    if record_class == "both"
       match_record(row, Absence)
       match_record(row, Tardy)
     else

--- a/spec/importers/file_importers/attendance_importer_spec.rb
+++ b/spec/importers/file_importers/attendance_importer_spec.rb
@@ -306,24 +306,24 @@ RSpec.describe AttendanceImporter do
   end
 
   describe '#attendance_event_class' do
-    def attendance_event_class(row)
-      make_attendance_importer.send(:attendance_event_class, row)
+    def valid_attendance_event_classes(row)
+      make_attendance_importer.send(:valid_attendance_event_classes, row)
     end
 
     it 'works for absence' do
-      expect(attendance_event_class(make_row(absence: 1))).to eq Absence
+      expect(valid_attendance_event_classes(make_row(absence: 1))).to eq [Absence]
     end
 
     it 'works for tardy' do
-      expect(attendance_event_class(make_row(tardy: 1))).to eq Tardy
+      expect(valid_attendance_event_classes(make_row(tardy: 1))).to eq [Tardy]
     end
 
     it 'returns nil if not absence or tardy' do
-      expect(attendance_event_class(make_row)).to eq nil
+      expect(valid_attendance_event_classes(make_row)).to eq []
     end
 
     it 'returns both if BOTH absence and tardy' do
-      expect(attendance_event_class(make_row(absence: 1, tardy: 1))).to eq "both"
+      expect(valid_attendance_event_classes(make_row(absence: 1, tardy: 1))).to eq [Absence, Tardy]
     end
   end
 end

--- a/spec/importers/file_importers/attendance_importer_spec.rb
+++ b/spec/importers/file_importers/attendance_importer_spec.rb
@@ -81,6 +81,62 @@ RSpec.describe AttendanceImporter do
             }.by 0
           end
         end
+
+        context "row with both absence and tardy (Somerville)" do
+          let(:row) {
+            { event_date: date, local_id: '1', absence: '1', tardy: '1',
+              dismissed: '0', reason: 'Medical', excused: '0', comment: 'Received doctor note.' }
+          }
+
+          it 'creates an absence' do
+              expect {
+                attendance_importer.send(:import_row, row)
+              }.to change {
+                Absence.count
+              }.by 1
+            end
+
+          it 'creates a tardy' do
+              expect {
+                attendance_importer.send(:import_row, row)
+              }.to change {
+                Tardy.count
+              }.by 1
+            end
+
+          it 'sets the right attributes for the absence' do
+            attendance_importer.send(:import_row, row)
+            absence = Absence.first
+
+            expect(absence.dismissed).to eq false
+            expect(absence.reason).to eq 'Medical'
+            expect(absence.excused).to eq false
+            expect(absence.comment).to eq 'Received doctor note.'
+          end
+
+          it 'creates only 1 absence if run twice' do
+            expect {
+              attendance_importer.send(:import_row, row)
+              attendance_importer.send(:import_row, row)
+            }.to change { Absence.count }.by 1
+          end
+
+          it 'increments student absences by 1' do
+            expect {
+              attendance_importer.send(:import_row, row)
+            }.to change {
+              student.reload.absences.size
+            }.by 1
+          end
+
+          it 'increments student tadies by 1' do
+            expect {
+              attendance_importer.send(:import_row, row)
+            }.to change {
+              student.reload.tardies.size
+            }.by 1
+          end
+        end
       end
 
       context 'row with absence (New Bedford)' do
@@ -266,8 +322,8 @@ RSpec.describe AttendanceImporter do
       expect(attendance_event_class(make_row)).to eq nil
     end
 
-    it 'returns nil if BOTH absence and tardy' do
-      expect(attendance_event_class(make_row(absence: 1, tardy: 1))).to eq nil
+    it 'returns both if BOTH absence and tardy' do
+      expect(attendance_event_class(make_row(absence: 1, tardy: 1))).to eq "both"
     end
   end
 end


### PR DESCRIPTION
This addresses #1925 by creating both an absence and a tardy if both exist in the record. 