### PR TITLE
Courses: Add uniqueness index

### DIFF
--- a/db/migrate/20191002170704_indexes_for_courses.rb
+++ b/db/migrate/20191002170704_indexes_for_courses.rb
@@ -1,0 +1,7 @@
+class IndexesForCourses < ActiveRecord::Migration[5.2]
+  def change
+    # Different courses at different schools can have the same course number, but the
+    # combination is unique.
+    add_index :courses, [:course_number, :school_id], unique: true, name: :course_number_unique_within_school
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_01_161158) do
+ActiveRecord::Schema.define(version: 2019_10_02_170704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 2019_10_01_161158) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "school_id", null: false
+    t.index ["course_number", "school_id"], name: "course_number_unique_within_school", unique: true
   end
 
   create_table "delayed_jobs", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
This uniqueness is enforced in a validation that is slow and triggers multiple queries across models; add a uniqueness constraint to to this in the DB, maybe we'll remove the validation later.