### PR TITLE
Authorization: Add separate flag for section-based authorization

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -151,7 +151,7 @@ class PerDistrict
   end
 
   # Note that this may be called in performance-sensitive loops.
-  def should_consider_sections_for_authorization?
+  def should_consider_sections_for_student_level_authorization?
     return false unless self.enabled_sections? # respect global switch
 
     if @district_key == SOMERVILLE || @district_key == DEMO

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -141,10 +141,26 @@ class PerDistrict
   end
 
   # Allow env to override
+  # This is a global kill-switch for the server, as other callers check it (eg, when
+  # using sections for authorization, for showing navbar links, for allowing controller
+  # endpoints).
   def enabled_sections?
     return EnvironmentVariable.is_true('ENABLED_SECTIONS') if ENV.has_key?('ENABLED_SECTIONS')
     return true if [SOMERVILLE, DEMO].include?(@district_key)
     false
+  end
+
+  # Note that this may be called in performance-sensitive loops.
+  def should_consider_sections_for_authorization?
+    return false unless self.enabled_sections? # respect global switch
+
+    if @district_key == SOMERVILLE || @district_key == DEMO
+      true
+    elsif @district_key == NEW_BEDFORD
+      false
+    else
+      false
+    end
   end
 
   # Note that this may be called in performance-sensitive loops.

--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -102,7 +102,7 @@ class Authorizer
   # access.
   def why_authorized_for_student?(student, options = {})
     begin
-      should_consider_sections = options.fetch(:should_consider_sections, PerDistrict.new.should_consider_sections_for_authorization?)
+      should_consider_sections = options.fetch(:should_consider_sections, PerDistrict.new.should_consider_sections_for_student_level_authorization?)
       return :districtwide if @educator.districtwide_access?
       # As a performance optimization, this check excludes `dynamic_labels`, since they're a bit more
       # expensive to compute, and here we only need to check one specific label that we know

--- a/app/lib/authorizer.rb
+++ b/app/lib/authorizer.rb
@@ -102,7 +102,7 @@ class Authorizer
   # access.
   def why_authorized_for_student?(student, options = {})
     begin
-      should_consider_sections = options.fetch(:should_consider_sections, PerDistrict.new.enabled_sections?)
+      should_consider_sections = options.fetch(:should_consider_sections, PerDistrict.new.should_consider_sections_for_authorization?)
       return :districtwide if @educator.districtwide_access?
       # As a performance optimization, this check excludes `dynamic_labels`, since they're a bit more
       # expensive to compute, and here we only need to check one specific label that we know

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe Authorizer do
     allow(PerDistrict).to receive(:new).and_return(mock_per_district)
   end
 
+  def mock_per_district_should_consider_sections_for_student_level_authorization!(value)
+    mock_per_district = PerDistrict.new
+    allow(mock_per_district).to receive(:should_consider_sections_for_student_level_authorization?).and_return(value)
+    allow(PerDistrict).to receive(:new).and_return(mock_per_district)
+  end
+
   # Some specs are migrated over from a different file that didn't
   # use TestPals; so this allows unwinding the TestPals db setup for particular
   # block of these tests, while migrating test cases into here to verify
@@ -229,9 +235,9 @@ RSpec.describe Authorizer do
         end
       end
 
-      context 'when enabled_sections? is false' do
+      context 'when should_consider_sections_for_student_level_authorization? is false' do
         it 'only allows schoolwide, not section-based access' do
-          mock_per_district_enabled_sections!(false)
+          mock_per_district_should_consider_sections_for_student_level_authorization!(false)
           expect(authorized(pals.shs_bill_nye) { Student.all }).to match_array []
           expect(authorized(pals.shs_hugo_art_teacher) { Student.all }).to match_array []
           expect(authorized(pals.shs_jodi) { Student.all }).to match_array [
@@ -709,7 +715,7 @@ RSpec.describe Authorizer do
     end
 
     it 'respects should_consider_sections:true' do
-      mock_per_district_enabled_sections!(false)
+      mock_per_district_should_consider_sections_for_student_level_authorization!(false)
       outcomes = outcomes_for(Educator.all, Student.all, should_consider_sections: true)
       expect(outcomes.map {|outcome| outcome[2]}.uniq).to include(:section)
     end


### PR DESCRIPTION
# Who is this PR for?
developers

# What does this PR do?
Adds a flag to control section-based authorization separately. This way we can enable sections but keep links and authorization unchanged while incrementally deploying and verifying in New Bedford.

Split out from https://github.com/studentinsights/studentinsights/pull/2659.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Core, authorization

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes