### PR TITLE
Remove filename paths from CsvDownloader logging

### DIFF
--- a/app/importers/helpers/csv_downloader.rb
+++ b/app/importers/helpers/csv_downloader.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 # This is a service object that works with importer classes. It factors out
 # shared logic that downloads CSVs and cleans them up before import.
 class CsvDownloader
@@ -10,12 +12,12 @@ class CsvDownloader
   end
 
   def get_data
-    log('Downloading...')
+    log("Downloading remote basename '#{basename}'...")
     file_contents = download_file
     log("file_contents.size: #{file_contents.size}")
 
     if file_contents.size == 0
-      raise "CsvDownloader: size of #{@remote_file_name} is 0 bytes"
+      raise "CsvDownloader: file size is 0 bytes"
     end
 
     log('Transforming...')
@@ -23,13 +25,16 @@ class CsvDownloader
   end
 
   def download_file
-    log("Downloading remote file name: #{@remote_file_name}")
-
     downloaded_file = @client.download_file(@remote_file_name)
     File.read(downloaded_file)
   end
 
   private
+  # Avoid logging full paths of remote file system
+  def basename
+    Pathname.new(@remote_file_name).basename
+  end
+
   def log(msg)
     text = if msg.class == String then msg else JSON.pretty_generate(msg) end
     @log.puts "CsvDownloader: #{text}"

--- a/spec/importers/helpers/csv_downloader_spec.rb
+++ b/spec/importers/helpers/csv_downloader_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe CsvDownloader do
+  it 'avoids logging full filename paths' do
+    log = LogHelper::FakeLog.new
+    transformer = StreamingCsvTransformer.new(log)
+    csv_downloader = CsvDownloader.new({
+      log: log,
+      client: SftpClient.for_x2,
+      remote_file_name: '/pathway/secret/filename.txt',
+      transformer: transformer
+    })
+    allow(csv_downloader).to receive(:download_file).and_return 'foo-file-contents'
+
+    expect(csv_downloader.get_data).to eq transformer
+    expect(log.output).to include("Downloading remote basename 'filename.txt'...")
+  end
+end


### PR DESCRIPTION
No need to be logging these.