### PR TITLE
Maintenance: Tune Rollbar throttling to be stricter

### DIFF
--- a/ui/rollbar.js
+++ b/ui/rollbar.js
@@ -21,7 +21,7 @@ function loadRollbar() {
 
     // throttle, mostly for bugs in browser extensions
     itemsPerMinute: 10,
-    maxItems: 100,
+    maxItems: 25,
     
     autoInstrument: {
       // Limit data we send to Rollbar


### PR DESCRIPTION
Throttling this to stay well under the next billing threshold.  Talk to @kevinrobinson for more about the underlying issue, which is unrelated to this codebase.