### PR TITLE
Attendance importer: Track student not matched separately, add logging and specs

### DIFF
--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -20,10 +20,10 @@ class ImportTask
 
   def connect_transform_import
     begin
-      log("Initializing from options = #{@options.to_json}...")
-
       @record = create_import_record
       @report = create_report
+      log("Initialized from options = #{@options.to_json}...")
+
       log('Starting validation...')
       validate_school_options
       verify_school_definitions!

--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -20,6 +20,8 @@ class ImportTask
 
   def connect_transform_import
     begin
+      log("Initializing from options = #{@options.to_json}...")
+
       @record = create_import_record
       @report = create_report
       log('Starting validation...')


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
There had been some false-positive warnings from importer jobs, and for the attendance job I looked into this more in verifying that https://github.com/studentinsights/studentinsights/pull/2658 had the intended effect.  This is coming from differences across districts in the scope of different exports.

For example, in Bedford the export XML in StudentInsightstudentdef.txt filters by only active students, but the same filter isn't applied to the attendance export.  This means we receive a large number of attendance events for past students.  This was tracked and `RecordSyncer` properly alerted on this being more than we might expect.  But since this is known, this PR updates the attendance importer to track this condition separately.  This PR also adds an integration test for this importer.

We should fix this upstream, which would also reduce the data being exported from districts, but that's work for another time.


# Checklists
*Which features or pages does this PR touch?*
+ [x] Attendance importer

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here