### PR TITLE
Sections: Add dialog link for New Bedford, preserving tabs

### DIFF
--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -329,3 +329,10 @@ export function includeSectionGrade(districtKey) {
   if (districtKey === NEW_BEDFORD) return false;
   return false;
 }
+
+// On the profile, add a link that opens a dialog for sections (vs seeing it as
+// a full tab).
+export function showProfileSectionsDialog(districtKey) {
+  if (districtKey === NEW_BEDFORD) return true;
+  return false;
+}

--- a/app/assets/javascripts/student_profile/LightProfileHeader.js
+++ b/app/assets/javascripts/student_profile/LightProfileHeader.js
@@ -117,7 +117,7 @@ export default class LightProfileHeader extends React.Component {
 
   renderHouseAndGrade() {
     const {districtKey} = this.context;
-    const {student, sections} = this.props;
+    const {student} = this.props;
     const showHouse = (
       supportsHouse(districtKey) &&
       student.house
@@ -394,6 +394,7 @@ LightProfileHeader.propTypes = {
   access: PropTypes.object,
   teams: PropTypes.array.isRequired,
   sections: PropTypes.array.isRequired,
+  currentEducatorAllowedSections: PropTypes.array.isRequired,
   profileInsights: PropTypes.array.isRequired,
   edPlans: PropTypes.arrayOf(PropTypes.object).isRequired,
   renderFullCaseHistory: PropTypes.func.isRequired,

--- a/app/assets/javascripts/student_profile/LightProfileHeader.js
+++ b/app/assets/javascripts/student_profile/LightProfileHeader.js
@@ -6,6 +6,7 @@ import * as Routes from '../helpers/Routes';
 import {
   hasStudentPhotos,
   supportsHouse,
+  showProfileSectionsDialog,
   isHomeroomMeaningful
 } from '../helpers/PerDistrict';
 import HelpBubble, {
@@ -20,6 +21,8 @@ import InsightsCarousel from './InsightsCarousel';
 import ProfilePdfDialog from './ProfilePdfDialog';
 import LightHeaderSupportBits from './LightHeaderSupportBits';
 import EducatorsWithAccessToStudentDialog from './EducatorsWithAccessToStudentDialog';
+import StudentSectionsRoster from './StudentSectionsRoster';
+
 
 /*
 UI component for top-line information like the student's name, school,
@@ -114,7 +117,7 @@ export default class LightProfileHeader extends React.Component {
 
   renderHouseAndGrade() {
     const {districtKey} = this.context;
-    const {student} = this.props;
+    const {student, sections} = this.props;
     const showHouse = (
       supportsHouse(districtKey) &&
       student.house
@@ -124,7 +127,31 @@ export default class LightProfileHeader extends React.Component {
       <div style={styles.subtitleItem}>
         {'Grade ' + student.grade}
         {showHouse && `, ${student.house} house`}
+        {showProfileSectionsDialog(districtKey) && this.renderSectionsDialogLink()}
       </div>
+    );
+  }
+
+  renderSectionsDialogLink() {
+    const {sections, currentEducatorAllowedSections} = this.props;
+    if (sections.length === 0) return;
+
+    return (
+      <span>
+        ,
+        <HelpBubble
+          style={{marginLeft: 5, display: 'inline-block'}}
+          linkStyle={styles.subtitleItem}
+          teaser={sections.length === 1 ? '1 section' : `${sections.length} sections`}
+          modalStyle={modalFromLeft}
+          title="Sections"
+          content={<StudentSectionsRoster
+            includeGrade={false}
+            sections={sections}
+            linkableSections={currentEducatorAllowedSections}
+          />}
+        />
+      </span>
     );
   }
 
@@ -366,6 +393,7 @@ LightProfileHeader.propTypes = {
   activeServices: PropTypes.array.isRequired,
   access: PropTypes.object,
   teams: PropTypes.array.isRequired,
+  sections: PropTypes.array.isRequired,
   profileInsights: PropTypes.array.isRequired,
   edPlans: PropTypes.arrayOf(PropTypes.object).isRequired,
   renderFullCaseHistory: PropTypes.func.isRequired,

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -118,7 +118,9 @@ export default class LightProfilePage extends React.Component {
       profileInsights,
       iepDocument,
       currentEducator,
-      edPlans
+      edPlans,
+      sections,
+      currentEducatorAllowedSections
     } = this.props.profileJson;
     return (
       <LightProfileHeader
@@ -126,6 +128,8 @@ export default class LightProfilePage extends React.Component {
         student={student}
         access={access}
         teams={teams}
+        sections={sections}
+        currentEducatorAllowedSections={currentEducatorAllowedSections}
         iepDocument={iepDocument}
         profileInsights={profileInsights}
         activeServices={feed.services.active}

--- a/app/assets/javascripts/student_profile/LightProfilePage.test.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.test.js
@@ -149,6 +149,26 @@ describe('tabs', () => {
   });
 });
 
+describe('sections link in header', () => {
+  it('is shown for New Bedford', () => {
+    const props = testPropsForAladdinMouse();
+    const el = testRender(props, {districtKey: 'new_bedford'});
+    expect($(el).find('.LightProfileHeader').text()).toContain('1 section');
+  });
+
+  it('is not present for Somerville', () => {
+    const props = testPropsForAladdinMouse();
+    const el = testRender(props, {districtKey: 'somerville'});
+    expect($(el).find('.LightProfileHeader').text()).not.toContain('1 section');
+  });
+
+  it('is not present for Bedford', () => {
+    const props = testPropsForAladdinMouse();
+    const el = testRender(props, {districtKey: 'bedford'});
+    expect($(el).find('.LightProfileHeader').text()).not.toContain('1 section');
+  });
+});
+
 
 it('#latestStar works regardless of initial sort order', () => {
   const nowMoment = toMomentFromTimestamp('2018-08-13T11:03:06.123Z');


### PR DESCRIPTION
Building on https://github.com/studentinsights/studentinsights/pull/2669.

# Who is this PR for?
NB project lead, principals

# What problem does this PR fix?
Adds a link to see student sections on the profile page for NB.  This is different than in SHS, because NB MS students have frequent data from STAR assessments and so the tabs are more valuable than they were originally in SHS, when we changed these to MCAS and collapsed them into one tab to show grades.  NB does not send grades, so this isn't changing the core layout and just adding a minimal link up top.

# What does this PR do?
### link, in header next to grade
<img width="1096" alt="Screen Shot 2019-10-11 at 1 14 10 PM" src="https://user-images.githubusercontent.com/1056957/66671500-2d0b2f00-ec2a-11e9-98e3-41b6b3b415e6.png">

### dialog
<img width="981" alt="Screen Shot 2019-10-11 at 1 13 45 PM" src="https://user-images.githubusercontent.com/1056957/66671518-34cad380-ec2a-11e9-8da9-6181b86f1a98.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here