### PR TITLE
Student meeting importer: Automate import process

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     bourbon (4.3.4)
       sass (~> 3.4)
       thor (~> 0.19)
-    brakeman (4.6.1)
+    brakeman (4.7.0)
     builder (3.2.3)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -414,6 +414,11 @@ class PerDistrict
     @district_key == SOMERVILLE
   end
 
+  # Should we run this import job about student meetings.
+  def student_meeting_importer_enabled?
+    @district_key == SOMERVILLE
+  end
+
   # Should this run as part of import jobs?
   def reading_benchmark_sheets_importer_enabled?
     @district_key == SOMERVILLE

--- a/app/importers/file_importers/file_importer_options.rb
+++ b/app/importers/file_importers/file_importer_options.rb
@@ -59,6 +59,7 @@ class FileImporterOptions
       ],
       'google' => [
         StudentVoiceSurveyImporter,
+        StudentMeetingImporter
         ReadingBenchmarkSheetsImporter
       ],
       'students' => StudentsImporter,
@@ -75,6 +76,7 @@ class FileImporterOptions
       'star_math' => StarMathImporter,
       'star_reading' => StarReadingImporter,
       'student_voice_surveys' => StudentVoiceSurveyImporter,
+      'student_meetings' => StudentMeetingImporter,
       'reading_benchmark_sheets' => ReadingBenchmarkSheetsImporter
     }
   end

--- a/app/importers/file_importers/file_importer_options.rb
+++ b/app/importers/file_importers/file_importer_options.rb
@@ -59,7 +59,7 @@ class FileImporterOptions
       ],
       'google' => [
         StudentVoiceSurveyImporter,
-        StudentMeetingImporter
+        StudentMeetingImporter,
         ReadingBenchmarkSheetsImporter
       ],
       'students' => StudentsImporter,

--- a/app/importers/student_meeting/student_meeting_importer.rb
+++ b/app/importers/student_meeting/student_meeting_importer.rb
@@ -27,21 +27,32 @@ class StudentMeetingImporter
       return
     end
 
+    log("Clearing state...")
+    @survey = nil
+    @syncer = nil
+
     log('Fetching tabs...')
     csv_text = get_csv_text_from_sheet()
     log("Found CSV text with #{csv_text.size} bytes.")
 
     # Read the CSV
-    survey = parse_rows(csv_text)
-    log "reader#stats.to_json: #{survey[:stats].to_json}"
+    @survey = parse_rows(csv_text)
+    log "reader#stats.to_json: #{@survey[:stats].to_json}"
 
     # Translate survey to generic EventNote hashes, and then do an exact sync
     importer = FlatNoteImporter.new(log: @log)
-    hashes_for_notes = importer.generic_hashes_for_notes(note_title, survey[:parsed_rows])
-    syncer = importer.exact_sync_using_note_title(note_title, hashes_for_notes)
-    log("Sync stats.to_json: #{syncer.stats.to_json}")
+    hashes_for_notes = importer.generic_hashes_for_notes(note_title, @survey[:parsed_rows])
+    @syncer = importer.exact_sync_using_note_title(note_title, hashes_for_notes)
+    log("Sync stats.to_json: #{@syncer.stats.to_json}")
 
     log("Done.")
+  end
+
+  def stats
+    {
+      survey: @survey.try(:[], :stats),
+      syncer: @syncer.try(:stats)
+    }
   end
 
   private

--- a/app/importers/student_meeting/student_meeting_importer.rb
+++ b/app/importers/student_meeting/student_meeting_importer.rb
@@ -1,11 +1,68 @@
-# Used on the console to import student meetings.
-#
-# Usage:
-# file_text = <<EOD
-# ...
-# EOD
-# output = StudentMeetingImporter.new.import(file_text);nil
+# For importing student meeting data from Google Sheets (not the form directly).
 class StudentMeetingImporter
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_GOOGLE_DRIVE_SHEET,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      options: [],
+      merge: DataFlow::MERGE_UPDATE_DELETE_UNMARKED,
+      touches: [
+        EventNote.name
+      ],
+      description: 'Import forms from student meetings, from a Google Sheet produced by a particular form'
+    })
+  end
+
+  def initialize(options:)
+    @log = options.fetch(:log, Rails.env.test? ? LogHelper::Redirect.instance.file : STDOUT)
+    @school_year = options.fetch(:school_year, SchoolYear.to_school_year(Time.now))
+    @fetcher = options.fetch(:fetcher, GoogleSheetsFetcher.new(log: @log))
+  end
+
+  def import
+    if !PerDistrict.new.student_meeting_importer_enabled?
+      log('Aborting since not enabled...')
+      return
+    end
+
+    log('Fetching tabs...')
+    csv_text = get_csv_text_from_sheet()
+    log("Found CSV text with #{csv_text.size} bytes.")
+
+    # Read the CSV
+    survey = parse_rows(csv_text)
+    log "reader#stats.to_json: #{survey[:stats].to_json}"
+
+    # Translate survey to generic EventNote hashes, and then do an exact sync
+    importer = FlatNoteImporter.new(log: @log)
+    hashes_for_notes = importer.generic_hashes_for_notes(note_title, survey[:parsed_rows])
+    syncer = importer.exact_sync_using_note_title(note_title, hashes_for_notes)
+    log("Sync stats.to_json: #{@syncer.stats.to_json}")
+
+    log("Done.")
+  end
+
+  private
+  # Scope to school year as conservative strategy for isolation (eg, in case
+  # educator clears out previous year's in sheet).
+  def note_title
+    "NGE/10GE/NEST Student Meeting (#{@school_year}-#{@school_year+1})"
+  end
+
+  def get_csv_from_sheet
+    sheet_id = read_sheet_id_from_env()
+    tabs = @fetcher.get_tabs_from_sheet(sheet_id)
+    raise "unexpected number of tabs found: #{tabs.size}" if tabs.size != 1
+    tabs.first.tab_csv
+  end
+
+  def read_sheet_id_from_env
+    sheet_id = PerDistrict.new.imported_google_folder_ids('student_meeting_importer_sheet_id')
+    raise '#read_sheet_id_from_env found nil' if sheet_id.nil?
+    sheet_id
+  end
+
   # We ran into a crazy bug with Google Forms - the data within a field
   # was inaccurate in the Forms UI (both responses and individual) and in the file from
   # "download CSV" - but if you exported that form into a Google Sheet, you'd see the
@@ -15,43 +72,19 @@ class StudentMeetingImporter
   # So this is written to export the data as a sheet; then download that as a CSV.
   # This matters because the Forms download CSV uses "Username" for the educator email,
   # but when exporting to Sheets it translates that to "Email Address".
-  READER_OPTIONS = {
-    source_key: 'student_meeting',
-    config: {
-      student_local_id: 'Student Local ID Number',
-      educator_email: 'Email Address',
-      timestamp: 'Timestamp',
-      ignore_keys: [
-        'Student Name',
-        'Teacher Name'
-      ]
-    }
-  }
-  def initialize(options = {})
-    @log = options.fetch(:log, Rails.env.test? ? LogHelper::Redirect.instance.file : STDOUT)
-  end
-
-  def import(file_text, options = {})
-    # Read the CSV
-    survey = parse_rows(file_text, options)
-    log "reader#stats: #{survey[:stats]}"
-
-    # Translate survey to generic EventNote hashes, and then do an exact sync
-    importer = FlatNoteImporter.new(log: @log)
-    hashes_for_notes = importer.generic_hashes_for_notes(note_title, survey[:parsed_rows])
-    syncer = importer.exact_sync_using_note_title(note_title, hashes_for_notes)
-    log "syncer#stats: #{syncer.stats}"
-
-    [survey, syncer] # return for debugging
-  end
-
-  private
-  def note_title
-    'NGE/10GE/NEST Student Meeting'
-  end
-
-  def parse_rows(file_text, options = {})
-    reader = SurveyReader.new(file_text, options.merge(READER_OPTIONS))
+  def parse_rows(file_text)
+    reader = SurveyReader.new(file_text, {
+      source_key: 'student_meeting',
+      config: {
+        student_local_id: 'Student Local ID Number',
+        educator_email: 'Email Address',
+        timestamp: 'Timestamp',
+        ignore_keys: [
+          'Student Name',
+          'Teacher Name'
+        ]
+      }
+    })
     reader.parse_rows
   end
 

--- a/spec/importers/file_importers/data_flows_fixture.json
+++ b/spec/importers/file_importers/data_flows_fixture.json
@@ -134,8 +134,15 @@
       "option_school_scope"
     ],
     "description": "STAR Reading scores, imported from vendor"
-  },
-  {
+  }, {
+    "importer": "StudentMeetingImporter",
+    "source": "source_google_drive_sheet",
+    "frequency": "frequency_daily",
+    "merge": "merge_update_delete_unmarked",
+    "touches": ["EventNote"],
+    "options": [],
+    "description": "Import forms from student meetings, from a Google Sheet produced by a particular form"
+  }, {
     "importer": "StudentSectionAssignmentsImporter",
     "source": "source_sis_sftp_csv",
     "frequency": "frequency_daily",

--- a/spec/importers/file_importers/file_importer_options_spec.rb
+++ b/spec/importers/file_importers/file_importer_options_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe FileImporterOptions do
 
     it 'can describe data flows for all importer classes' do
       data_flows = FileImporterOptions.new.all_data_flows
-      expect(data_flows.size).to eq(15)
+      expect(data_flows.size).to eq(16)
       sorted_json = data_flows.as_json.sort_by {|j| j['importer'] }
       fixture_json = JSON.parse(IO.read("#{Rails.root}/spec/importers/file_importers/data_flows_fixture.json"))
       expect(sorted_json).to eq(fixture_json)
@@ -45,6 +45,7 @@ RSpec.describe FileImporterOptions do
         'educator_section_assignments',
         'star_math',
         'star_reading',
+        'student_meetings',
         'ed_plans',
         'ed_plan_accommodations',
         'student_voice_surveys',

--- a/spec/importers/student_meeting/student_meeting_importer_spec.rb
+++ b/spec/importers/student_meeting/student_meeting_importer_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe StudentMeetingImporter do
     [importer, log]
   end
 
-
   describe 'integration test' do
     let!(:pals) { TestPals.create! }
 

--- a/spec/importers/student_meeting/student_meeting_importer_spec.rb
+++ b/spec/importers/student_meeting/student_meeting_importer_spec.rb
@@ -5,11 +5,42 @@ RSpec.describe StudentMeetingImporter do
     IO.read("#{Rails.root}/spec/importers/student_meeting/student_meeting_fixture.csv")
   end
 
+  def create_mock_fetcher_from_map(sheet_id_to_tab_map)
+    mock_fetcher = GoogleSheetsFetcher.new
+    allow(GoogleSheetsFetcher).to receive(:new).and_return(mock_fetcher)
+    sheet_id_to_tab_map.each do |sheet_id, tabs|
+      allow(mock_fetcher).to receive(:get_tabs_from_sheet).with(sheet_id).and_return(tabs)
+    end
+    mock_fetcher
+  end
+
+  def create_importer_with_fixture(mock_sheet_id, file_text)
+    log = LogHelper::FakeLog.new
+    mock_fetcher = create_mock_fetcher_from_map({
+      mock_sheet_id => [GoogleSheetsFetcher::Tab.new({
+        spreadsheet_id: 'student-meeting-sheet',
+        spreadsheet_name: 'NGE/10GE/NEST Student Meeting (Responses)',
+        spreadsheet_url: 'https://example.com/student-meeting-sheet',
+        tab_id: '123456789',
+        tab_name: 'Form responses',
+        tab_csv: file_text
+      })]
+    })
+    importer = StudentMeetingImporter.new(options: {
+      log: log,
+      fetcher: mock_fetcher
+    })
+    allow(importer).to receive(:read_sheet_id_from_env).and_return(mock_sheet_id)
+    [importer, log]
+  end
+
+
   describe 'integration test' do
+    let!(:pals) { TestPals.create! }
+
     it 'works for importing notes' do
-      pals = TestPals.create!
-      importer = StudentMeetingImporter.new
-      survey, syncer = importer.import(fixture_file_text)
+      importer, _ = create_importer_with_fixture('mock_sheet_id_Z', fixture_file_text())
+      importer.import
 
       expect(EventNote.pluck(:event_note_type_id, :is_restricted).uniq).to eq([[304, false]])
       expect(EventNote.all.as_json(only: [:student_id, :educator_id, :text])).to contain_exactly(*[
@@ -23,7 +54,7 @@ RSpec.describe StudentMeetingImporter do
           'text' => include("NGE/10GE/NEST Student Meeting\n\nWhat classes are you doing well in?\nEnglish, History, and Math")
         }
       ])
-      expect(syncer.send(:stats)).to eq({
+      expect(importer.stats[:syncer]).to eq({
         total_sync_calls_count: 2,
         created_rows_count: 2,
         destroyed_records_count: 0,
@@ -38,11 +69,11 @@ RSpec.describe StudentMeetingImporter do
     end
 
     it 'does not update unchanged records from previous import' do
-      pals = TestPals.create!
 
       # first run
-      first_survey, first_syncer = StudentMeetingImporter.new.import(fixture_file_text)
-      expect(first_syncer.send(:stats)).to eq({
+      first_importer, _ = create_importer_with_fixture('mock_sheet_id_Z', fixture_file_text())
+      first_importer.import
+      expect(first_importer.stats[:syncer]).to eq({
         total_sync_calls_count: 2,
         created_rows_count: 2,
         destroyed_records_count: 0,
@@ -58,8 +89,9 @@ RSpec.describe StudentMeetingImporter do
       expect(first_records_json.size).to eq 2
 
       # second run
-      second_survey, second_syncer = StudentMeetingImporter.new.import(fixture_file_text)
-      expect(second_syncer.send(:stats)).to eq({
+      second_importer, _ = create_importer_with_fixture('mock_sheet_id_Z', fixture_file_text())
+      second_importer.import
+      expect(second_importer.stats[:syncer]).to eq({
         total_sync_calls_count: 2,
         created_rows_count: 0,
         destroyed_records_count: 0,
@@ -76,11 +108,11 @@ RSpec.describe StudentMeetingImporter do
     end
 
     it 'does not impact other existing notes' do
-      pals = TestPals.create!
       4.times { FactoryBot.create(:event_note) }
 
-      survey, syncer = StudentMeetingImporter.new.import(fixture_file_text)
-      expect(syncer.send(:stats)).to eq({
+      importer, _ = create_importer_with_fixture('mock_sheet_id_Z', fixture_file_text())
+      importer.import
+      expect(importer.stats[:syncer]).to eq({
         total_sync_calls_count: 2,
         created_rows_count: 2,
         destroyed_records_count: 0,
@@ -96,7 +128,6 @@ RSpec.describe StudentMeetingImporter do
     end
 
     it 'can map email addresses when Google email address does not match Insights email address' do
-      pals = TestPals.create!
       mock_per_district = PerDistrict.new
       allow(mock_per_district).to receive(:google_email_address_mapping).and_return({
         "fatima_google@demo.studentinsights.org" => "fatima@demo.studentinsights.org"
@@ -104,8 +135,9 @@ RSpec.describe StudentMeetingImporter do
       allow(PerDistrict).to receive(:new).and_return(mock_per_district)
 
       file_text = fixture_file_text.split("\n").first + "\n" + '"03/05/2018 08:11:11","fatima_google@demo.studentinsights.org","Amir Solo","Fatima Teacher","2222222211   ","Biology, Spanish","one","two","three","four","five","six","seven"'
-      survey, syncer = StudentMeetingImporter.new.import(file_text)
-      expect(syncer.send(:stats)).to eq({
+      importer, _ = create_importer_with_fixture('mock_sheet_id_z', file_text)
+      importer.import
+      expect(importer.stats[:syncer]).to eq({
         total_sync_calls_count: 1,
         created_rows_count: 1,
         destroyed_records_count: 0,


### PR DESCRIPTION
# Who is this PR for?
SHS students, educators

# What problem does this PR fix?
The importer for the student meeting form is semi-automated, so there's some lag between when the conversation happens, and when it appears in Student Insights.  For HS folks working with many students, this buries the meeting note in the feed.

# What does this PR do?
Updates `StudentMeetingImporter` to use `GoogleSheetsFetcher` and to an importer class included as part of the main import task.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student meeting importer

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here