### PR TITLE
Notes: Add New Bedford SST for taking notes, in table columns, and search

### DIFF
--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -221,7 +221,7 @@ export function takeNotesChoices(districtKey) {
 // about those students?
 export function studentTableEventNoteTypeIds(districtKey, schoolType) {
   if (districtKey === BEDFORD) return [300, 302, 304];
-  if (districtKey === NEW_BEDFORD) return [400];
+  if (districtKey === NEW_BEDFORD) return [400, 300];
   
   const isSomervilleOrDemo = (districtKey === SOMERVILLE || districtKey === DEMO);
   if (isSomervilleOrDemo && schoolType === 'HS') return [300, 305, 306, 307, 308];

--- a/app/assets/javascripts/helpers/PerDistrict.js
+++ b/app/assets/javascripts/helpers/PerDistrict.js
@@ -209,8 +209,8 @@ export function takeNotesChoices(districtKey) {
 
   if (districtKey === NEW_BEDFORD) {
     return {
-      leftEventNoteTypeIds: [400, 302, 304],
-      rightEventNoteTypeIds: []
+      leftEventNoteTypeIds: [400, 300],
+      rightEventNoteTypeIds: [302, 304]
     };
   }
 

--- a/app/assets/javascripts/helpers/PerDistrict.test.js
+++ b/app/assets/javascripts/helpers/PerDistrict.test.js
@@ -21,18 +21,25 @@ it('#sortSchoolSlugsByGrade', () => {
 describe('#studentTableEventNoteTypeIds', () => {
   it('handles somerville HS correctly', () => {
     const eventNoteTypeIds = studentTableEventNoteTypeIds('somerville', 'HS');
-
     expect(eventNoteTypeIds).toEqual([300, 305, 306, 307, 308]);
   });
   it('handles somerville elementary school correctly', () => {
     const eventNoteTypeIds = studentTableEventNoteTypeIds('somerville', 'ESMS');
-
     expect(eventNoteTypeIds).toEqual([300, 301]);
   });
   it('handles somerville Capuano early childhood center correctly', () => {
     const eventNoteTypeIds = studentTableEventNoteTypeIds('somerville', null);
-
     expect(eventNoteTypeIds).toEqual([300, 301]);
+  });
+
+  it('handles new_bedford correctly', () => {
+    const eventNoteTypeIds = studentTableEventNoteTypeIds('new_bedford', null);
+    expect(eventNoteTypeIds).toEqual([400, 300]);
+  });
+
+  it('handles bedford correctly', () => {
+    const eventNoteTypeIds = studentTableEventNoteTypeIds('bedford', null);
+    expect(eventNoteTypeIds).toEqual([300, 302, 304]);
   });
 });
 

--- a/app/assets/javascripts/helpers/PerDistrict.test.js
+++ b/app/assets/javascripts/helpers/PerDistrict.test.js
@@ -42,7 +42,7 @@ describe('#eventNoteTypeIdsForSearch', () => {
   });
 
   it('handles new_bedford', () => {
-    expect(eventNoteTypeIdsForSearch('new_bedford')).toEqual([400, 302, 304]);
+    expect(eventNoteTypeIdsForSearch('new_bedford')).toEqual([400, 300, 302, 304]);
   });
 
   it('handles beford', () => {

--- a/app/assets/javascripts/homeroom/HomeroomTable.test.js
+++ b/app/assets/javascripts/homeroom/HomeroomTable.test.js
@@ -88,6 +88,7 @@ describe('high-level integration test', () => {
       'Name',
       'Photo',
       'Last BBST',
+      'Last SST',
       'Program Assigned',
       'Disability',
       'Level of Need',

--- a/app/assets/javascripts/school_overview/StudentsTable.test.js
+++ b/app/assets/javascripts/school_overview/StudentsTable.test.js
@@ -16,10 +16,11 @@ function testProps(props = {}) {
   };
 }
 
-function testRender(props) {
+function testRender(props, context = {}) {
+  const districtKey = context.districtKey || SOMERVILLE;
   const el = document.createElement('div');
   ReactDOM.render(
-    <PerDistrictContainer districtKey={SOMERVILLE}>
+    <PerDistrictContainer districtKey={districtKey}>
       <StudentsTable {...props} />
     </PerDistrictContainer>
     , el);
@@ -31,7 +32,7 @@ function tableHeaderTexts(el) {
 }
 
 describe('high-level integration test', () => {
-  it('happy path for K8', () => { 
+  it('happy path for Somerville K8', () => { 
     const props = testProps();
     const {el} = testRender(props);
 
@@ -57,7 +58,7 @@ describe('high-level integration test', () => {
     ]);
   });
 
-  it('happy path for HS', () => {
+  it('happy path for Somerville HS', () => {
     const props = testProps({
       school: {
         local_id: 'SHS',
@@ -84,6 +85,57 @@ describe('high-level integration test', () => {
       "STARReading",
       "MCASELA",
       "STARMath",
+      "MCASMath",
+      "DisciplineIncidents",
+      "Absences",
+      "Tardies",
+      "Services",
+      "Program"
+    ]);
+  });
+
+  it('happy path for New Bedford', () => {
+    const props = testProps();
+    const {el} = testRender(props, {districtKey: 'new_bedford'});
+    expect($(el).find('.StudentsTable tbody tr').length).toEqual(25);
+    expect(tableHeaderTexts(el)).toEqual([
+      "Name",
+      "LastBBST",
+      "LastSST",
+      "Grade",
+      "Homeroom",
+      "504plan",
+      "SPEDlevel",
+      "EnglishLearner",
+      "STARReading",
+      "MCASELA",
+      "STARMath",
+      "MCASMath",
+      "DisciplineIncidents",
+      "Absences",
+      "Tardies",
+      "Services",
+      "Program"
+    ]);
+  });
+
+  it('happy path for Bedford', () => {
+    const props = testProps();
+    const {el} = testRender(props, {districtKey: 'bedford'});
+    expect($(el).find('.StudentsTable tbody tr').length).toEqual(25);
+    expect(tableHeaderTexts(el)).toEqual([
+      "Name",
+      "LastSST",
+      "LastParent",
+      "LastOther",
+      "Grade",
+      "Homeroom",
+      "504plan",
+      "SPEDlevel",
+      "EnglishLearner",
+      "STARReading", // should remove, but haven't yet
+      "MCASELA",
+      "STARMath", // should remove, but haven't yet
       "MCASMath",
       "DisciplineIncidents",
       "Absences",

--- a/app/assets/javascripts/section/SectionView.test.js
+++ b/app/assets/javascripts/section/SectionView.test.js
@@ -96,12 +96,13 @@ describe('table headers', () => {
   it('no grades and note types in New Bedford', () => {
     const {el} = testRender(testProps(), {districtKey: 'new_bedford'});
     const headers = $(el).find('.SectionView #roster-header th').toArray().map(el => $(el).text());
-    expect(headers.length).toEqual(17);
+    expect(headers.length).toEqual(18);
     expect(headers.indexOf('Grade')).toEqual(-1);
     expect(headers).toEqual([
       'Name',
       '', // photo
       'Last BBST',
+      'Last SST',
       'Program Assigned',
       'Disability',
       '504 Plan',

--- a/app/assets/javascripts/student_profile/DraftNote.test.js
+++ b/app/assets/javascripts/student_profile/DraftNote.test.js
@@ -115,6 +115,7 @@ describe('buttons for taking notes', () => {
     const {el} = renderTestEl(testProps(), { districtKey: NEW_BEDFORD });
     expect(buttonTexts(el)).toEqual([
       'BBST Meeting',
+      'SST Meeting',
       'Parent conversation',
       'Something else'
     ]);

--- a/app/assets/javascripts/student_profile/__snapshots__/DraftNote.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/DraftNote.test.js.snap
@@ -200,6 +200,34 @@ Array [
                   </button>
                   <button
                     className="btn note-type"
+                    name={300}
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "background": "#eee",
+                        "border": "4px solid white",
+                        "color": "black",
+                        "fontSize": 12,
+                        "marginRight": "1em",
+                        "minWidth": "14em",
+                        "outline": 0,
+                        "padding": 8,
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    SST Meeting
+                  </button>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <button
+                    className="btn note-type"
                     name={302}
                     onClick={[Function]}
                     style={
@@ -239,13 +267,6 @@ Array [
                     Something else
                   </button>
                 </div>
-                <div
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                />
               </div>
             </div>
             <div


### PR DESCRIPTION
# Who is this PR for?
New Bedford MS educators

# What problem does this PR fix?
Some folks in some MS do BBST, some do SST.

# What does this PR do?
Updates the `PerDistrict.js` method to add SST for New Bedford, and then updates the tests.  Also adds some missing coverage on this for the school overview table.

# Screenshot (if adding a client-side feature)
### before
<img width="504" alt="Screen Shot 2019-10-17 at 12 18 13 PM" src="https://user-images.githubusercontent.com/1056957/67028988-56b8d000-f0da-11e9-912f-fbd923ba681d.png">

### after
<img width="512" alt="Screen Shot 2019-10-17 at 12 18 05 PM" src="https://user-images.githubusercontent.com/1056957/67028989-56b8d000-f0da-11e9-962a-93c7fa01e484.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile
+ [x] Homeroom
+ [x] Section
+ [x] School Overview

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage