### PR TITLE
School roster: Add minimal download CSV button

### DIFF
--- a/app/assets/javascripts/components/DownloadIcon.js
+++ b/app/assets/javascripts/components/DownloadIcon.js
@@ -1,5 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-export default function DownloadIcon() {
-  return <svg style={{fill: "#3177c9", opacity: 0.5, cursor: 'pointer'}} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>;
+
+export default function DownloadIcon({style = {}}) {
+  return <svg style={{fill: "#3177c9", opacity: 0.5, cursor: 'pointer', ...style}} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>;
 }
+DownloadIcon.propTypes = {
+  style: PropTypes.object
+};

--- a/app/assets/javascripts/school_overview/SchoolRoster.js
+++ b/app/assets/javascripts/school_overview/SchoolRoster.js
@@ -184,7 +184,6 @@ export default class SchoolRoster extends React.Component {
         </div>
         <div className="summary" style={styles.summary}>
           <SliceButtons
-            schoolId={this.props.school.id}
             students={this.getFilteredStudents()}
             filters={this.state.filters}
             filtersHash={this.filtersHash()}

--- a/app/assets/javascripts/school_overview/SchoolRoster.js
+++ b/app/assets/javascripts/school_overview/SchoolRoster.js
@@ -184,6 +184,7 @@ export default class SchoolRoster extends React.Component {
         </div>
         <div className="summary" style={styles.summary}>
           <SliceButtons
+            schoolId={this.props.school.id}
             students={this.getFilteredStudents()}
             filters={this.state.filters}
             filtersHash={this.filtersHash()}

--- a/app/assets/javascripts/school_overview/SliceButtons.js
+++ b/app/assets/javascripts/school_overview/SliceButtons.js
@@ -68,26 +68,16 @@ export default class SliceButtons extends React.Component {
           }}>
           Link to save these filters
         </a>
-        {this.renderDownloadLink()}
+        {this.renderLocalDownloadLink()}
       </div>
     );
-  }
-
-  renderDownloadLink() {
-    const {schoolId} = this.props;
-    const forceLocalCsvDownload = (window.location.search.indexOf('force_local_csv') !== -1);
-    if (forceLocalCsvDownload) {
-      return this.renderLocalDownloadLink();
-    }
-
-    return <a href={`/schools/${schoolId}/csv`} style={{fontSize: styles.fontSize}}>Download CSV</a>;
   }
 
   // This tracks the modal state on its own rather than using <HelpBubble /> so that it
   // can be lazy about rendering the actual download link (which is expensive) and defer that
   // until the user expresses intent to download.
   // This adds an extra UX step to the download to do that.
-  renderDownloadLink() {
+  renderLocalDownloadLink() {
     const {isDownloadOpen} = this.state;
 
     return (

--- a/app/assets/javascripts/school_overview/SliceButtons.js
+++ b/app/assets/javascripts/school_overview/SliceButtons.js
@@ -113,7 +113,7 @@ export default class SliceButtons extends React.Component {
     const {nowFn} = this.context;
     const {students, filters} = this.props;
     const isFiltered = (filters.length > 0);
-    const {filename, csvText} = filenameAndCsvText(nowFn, students, isFiltered)
+    const {filename, csvText} = filenameAndCsvText(nowFn, students, isFiltered);
 
     return (
       <div style={{fontSize: 14}}>
@@ -156,7 +156,6 @@ export default class SliceButtons extends React.Component {
   }
 }
 SliceButtons.propTypes = {
-  schoolId: PropTypes.number.isRequired,
   students: PropTypes.arrayOf(PropTypes.object).isRequired,
   filters: PropTypes.arrayOf(PropTypes.object).isRequired,
   filtersHash: PropTypes.string.isRequired,

--- a/app/assets/javascripts/school_overview/SliceButtons.js
+++ b/app/assets/javascripts/school_overview/SliceButtons.js
@@ -1,18 +1,25 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactModal from 'react-modal';
 import {styles, colors} from '../helpers/Theme';
-
+import {modalFromRight} from '../components/HelpBubble';
+import DownloadIcon from '../components/DownloadIcon';
+import DownloadCsvLink from '../components/DownloadCsvLink';
 
 // Show the buttons at the bottom of SlicePanels, for
 // clearing the selection, downloading the output, etc.
-class SliceButtons extends React.Component {
+export default class SliceButtons extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {
+      isDownloadOpen: false
+    };
     this.onKeyDown = this.onKeyDown.bind(this);
-    this.onClickDownload = this.onClickDownload.bind(this);
+    this.onDownloadDialogToggled = this.onDownloadDialogToggled.bind(this);
   }
 
   componentDidMount() {
+    ReactModal.setAppElement(document.body);
     $(document).on('keydown', this.onKeyDown);
   }
 
@@ -20,18 +27,15 @@ class SliceButtons extends React.Component {
     $(document).off('keydown', this.onKeyDown);
   }
 
+  onDownloadDialogToggled(e) {
+    e.preventDefault();
+    const {isDownloadOpen} = this.state;
+    this.setState({isDownloadOpen: !isDownloadOpen});
+  }
+
   // Key code 27 is the ESC key
   onKeyDown(e) {
     if (e.keyCode == 27) this.props.clearFilters();
-  }
-
-  // IE hack; see http://msdn.microsoft.com/en-us/library/ie/hh779016.aspx
-  onClickDownload(csvText, filename, e) {
-    if (!window.navigator.msSaveOrOpenBlob) return;
-
-    e.preventDefault();
-    const blob = new Blob([csvText], {type: 'text/csv;charset=utf-8;'});
-    window.navigator.msSaveBlob(blob, filename);
   }
 
   render() {
@@ -58,18 +62,166 @@ class SliceButtons extends React.Component {
           href={this.props.filtersHash}
           target="_blank"
           rel="noopener noreferrer"
-          style={{ fontSize: styles.fontSize }}>
+          style={{
+            fontSize: styles.fontSize,
+            marginRight: 20
+          }}>
           Link to save these filters
         </a>
+        {this.renderDownloadLink()}
       </div>
     );
   }
+
+  renderDownloadLink() {
+    const {schoolId} = this.props;
+    const forceLocalCsvDownload = (window.location.search.indexOf('force_local_csv') !== -1);
+    if (forceLocalCsvDownload) {
+      return this.renderLocalDownloadLink();
+    }
+
+    return <a href={`/schools/${schoolId}/csv`} style={{fontSize: styles.fontSize}}>Download CSV</a>;
+  }
+
+  // This tracks the modal state on its own rather than using <HelpBubble /> so that it
+  // can be lazy about rendering the actual download link (which is expensive) and defer that
+  // until the user expresses intent to download.
+  // This adds an extra UX step to the download to do that.
+  renderDownloadLink() {
+    const {isDownloadOpen} = this.state;
+
+    return (
+      <span>
+        <a
+          style={{
+            display: 'inline-block',
+            verticalAlign: 'middle',
+            marginLeft: 20,
+            fontSize: styles.fontSize
+          }}
+          href="#"
+          onClick={this.onDownloadDialogToggled}>
+          <span style={{verticalAlign: 'middle'}}>
+            Download CSV <DownloadIcon style={{verticalAlign: 'middle'}}/>
+          </span>
+        </a>
+        {isDownloadOpen && (
+          <ReactModal
+            isOpen={true}
+            onRequestClose={this.onDownloadDialogToggled}
+            style={modalFromRight}>
+            {this.renderLinkWithCsvDataInline()}
+          </ReactModal>
+        )}
+      </span>
+    );
+  }
+
+  // This is expensive to render, since it unrolls the whole spreadsheet into a string
+  // and writes it inline to the link.
+  renderLinkWithCsvDataInline() {
+    const {nowFn} = this.context;
+    const {students, filters} = this.props;
+    const isFiltered = (filters.length > 0);
+    const {filename, csvText} = filenameAndCsvText(nowFn, students, isFiltered)
+
+    return (
+      <div style={{fontSize: 14}}>
+        <h1 style={{
+          borderBottom: '1px solid #333',
+          paddingBottom: 10,
+          marginBottom: 20
+        }}>Export as CSV</h1>
+        {this.renderFilterWarningMessage()}
+        <DownloadCsvLink
+          filename={filename}
+          csvText={csvText}
+          style={{
+            paddingLeft: 20,
+            fontSize: styles.fontSize,
+            color: 'white'
+          }}>
+          Download CSV
+        </DownloadCsvLink>
+      </div>
+    );
+  }
+
+  renderFilterWarningMessage() {
+    const {students, filters} = this.props;
+    const messageStyles = { marginBottom: 20};
+    if (filters.length > 0) {
+      return (
+        <div style={{...messageStyles, fontWeight: 'bold', color: 'darkorange'}}>
+          Filters are applied, so this only includes data for {students.length} students.
+        </div>
+      );
+    } else {
+      return (
+        <div style={messageStyles}>
+          This includes data for all {students.length} students.
+        </div>
+      );
+    }
+  }
 }
 SliceButtons.propTypes = {
+  schoolId: PropTypes.number.isRequired,
   students: PropTypes.arrayOf(PropTypes.object).isRequired,
   filters: PropTypes.arrayOf(PropTypes.object).isRequired,
   filtersHash: PropTypes.string.isRequired,
   clearFilters: PropTypes.func.isRequired
 };
+SliceButtons.contextTypes = {
+  nowFn: PropTypes.func.isRequired
+};
 
-export default SliceButtons;
+
+function filenameAndCsvText(nowFn, students, isFiltered) {
+  const header = [
+    'First Name',
+    'Last Name',
+    'Grade',
+    'SPED Level of Need',
+    'Free/Reduced Lunch',
+    'Limited English Proficient',
+    'STAR Reading Percentile',
+    'MCAS ELA Score',
+    'MCAS ELA SGP',
+    'STAR Math Percentile',
+    'MCAS Math Score',
+    'MCAS Math SGP',
+    'Discipline Incidents',
+    'Absences This Year',
+    'Tardies This Year',
+    'Active Services',
+    'Program Assigned',
+    'Homeroom Name',
+  ];
+  const rows = students.map(student => {
+    return [
+      student.first_name,
+      student.last_name,
+      student.grade,
+      student.sped_level_of_need,
+      student.free_reduced_lunch,
+      student.limited_english_proficiency,
+      student.most_recent_star_reading_percentile,
+      student.most_recent_mcas_ela_scaled,
+      student.most_recent_mcas_ela_growth,
+      student.most_recent_star_math_percentile,
+      student.most_recent_mcas_math_scaled,
+      student.most_recent_mcas_math_growth,
+      student.discipline_incidents_count,
+      student.absences_count,
+      student.tardies_count,
+      student.active_services.length,
+      student.program_assigned,
+      student.homeroom_name,
+    ].join(',');
+  });
+  const csvText = [header].concat(rows).join('\n');
+  const now = nowFn();
+  const filename = `SchoolRoster-${isFiltered ? 'filtered' : 'all'}-${now.format('YYYY-MM-DD')}.csv`;
+  return {filename, csvText};
+}

--- a/app/assets/javascripts/school_overview/SliceButtons.test.js
+++ b/app/assets/javascripts/school_overview/SliceButtons.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import {withDefaultNowContext} from '../testing/NowContainer';
 import SliceButtons from './SliceButtons';
 
 function testProps(props = {}) {
@@ -15,6 +16,7 @@ function testProps(props = {}) {
 it('renders without crashing', () => {
   const props = testProps();
   const el = document.createElement('div');
-  ReactDOM.render(<SliceButtons {...props} />, el);
+  ReactDOM.render(withDefaultNowContext(<SliceButtons {...props} />), el);
   expect(el.innerHTML).toContain('Link to save these filters');
+  expect(el.innerHTML).toContain('Download CSV');
 });

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -11,9 +11,47 @@ class SchoolsController < ApplicationController
     render json: overview_json
   end
 
+  # Limit to less fields that districtwide project lead.  Mirrors kinds of things
+  # in UI, but is not exactly the same.
   def csv
     authorized_students = authorized { @school.students.active.to_a }
-    exporter = WideStudentsExporter.new(current_educator)
+    exporter = WideStudentsExporter.new(current_educator, {
+      as_json: {
+        only: [
+          :local_id,
+          :first_name,
+          :last_name,
+          :grade,
+          :program_assigned,
+          :sped_placement,
+          :disability,
+          :sped_level_of_need,
+          :plan_504,
+          :limited_english_proficiency,
+          :ell_entry_dat,
+          :ell_transition_dat,
+          :house,
+          :counselor,
+          :sped_liaison,
+          :date_of_birth,
+          :home_language,
+          :gender,
+          :hispanic_latino,
+          :race,
+          :enrollment_status,
+          :registration_date,
+          :free_reduced_lunch,
+          :most_recent_mcas_ela_performance,
+          :most_recent_mcas_ela_scaled,
+          :most_recent_mcas_ela_growth,
+          :most_recent_mcas_math_performance,
+          :most_recent_mcas_math_scaled,
+          :most_recent_mcas_math_growth,
+          :most_recent_star_reading_percentile,
+          :most_recent_star_math_percentile
+        ]
+      }
+    })
     csv_string = exporter.csv_string(authorized_students)
     filename = "StudentInsights-WideStudentsExport-school_#{@school.slug}-#{Time.now.strftime("%Y-%m-%d")}.csv"
     send_data csv_string, filename: filename, type: 'text/csv', disposition: 'inline'

--- a/app/lib/wide_students_exporter.rb
+++ b/app/lib/wide_students_exporter.rb
@@ -30,12 +30,12 @@ class WideStudentsExporter
   # the same shape for all students it is provided.
   def flat_row_hash(student)
     # Remove some fields by default, these are likely to be misleading.
-    # Allow removing other fields (eg, address) for other uses.
-    except_fields = @options.fetch(:except_fields, [
-      'created_at',
-      'updated_at'
-    ])
-    student_fields = student.as_json.except(*except_fields)
+    # Allow callers to remove other fields (eg, address) for other uses,
+    # to safelist with `only` instead.
+    as_json_options = @options.fetch(:as_json_options, {
+      except: [:created_at, :updated_at]
+    })
+    student_fields = student.as_json(as_json_options)
 
     # optionalin include other fields
     student_fields

--- a/app/lib/wide_students_exporter.rb
+++ b/app/lib/wide_students_exporter.rb
@@ -32,12 +32,12 @@ class WideStudentsExporter
     # Remove some fields by default, these are likely to be misleading.
     # Allow callers to remove other fields (eg, address) for other uses,
     # to safelist with `only` instead.
-    as_json_options = @options.fetch(:as_json_options, {
+    as_json_options = @options.fetch(:as_json, {
       except: [:created_at, :updated_at]
     })
     student_fields = student.as_json(as_json_options)
 
-    # optionalin include other fields
+    # optionally include other fields
     student_fields
       .merge(additional_student_fields(student))
       .merge(service_fields(student))


### PR DESCRIPTION
# Who is this PR for?
New Bedford MS folks

# What problem does this PR fix?
We added this back in 2016 in a particular format as the first way to export to PowerBI, and then removed it in December 2016.  We noticed in January 2018 that it wasn't here anymore, but didn't take action since no one was missing it :)  I think we didn't immediately re-add it since the old way we used in Healey originally wasn't fast enough for a larger school like Normandin.  This past June (#2507) I optimized how this works for a districtwide list, but that was only for project leads so includes things like student address and race that we'd want to scrub from an export on the overview page.

# What does this PR do?
This adds CSV download, deferred to user action.  We'll deploy and see if it works well enough with large schools, or whether we need to swap to the server side.  This doesn't download the exact same data as is shown in the UI; this PR is just aimed at seeing if this works well enough with larger schools.

Also separately updates the server-side export (only exposed to project leads) to use a safelist rather than grabbing all fields on the model.

# Screenshot (if adding a client-side feature)
<img width="565" alt="Screen Shot 2019-10-17 at 4 34 03 PM" src="https://user-images.githubusercontent.com/1056957/67046132-a78df000-f0fd-11e9-87d3-790a1f8cbdb3.png">
<img width="618" alt="Screen Shot 2019-10-17 at 4 34 09 PM" src="https://user-images.githubusercontent.com/1056957/67046142-a957b380-f0fd-11e9-8472-d43e1c13db9b.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] School Overview

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
