### PR TITLE
School scope: Add Pulaski for New Bedford

### DIFF
--- a/config/district_new_bedford.yml
+++ b/config/district_new_bedford.yml
@@ -18,19 +18,14 @@ star_filenames:
 
 
 school_definitions_for_import:
-  - name: John A. Parker
-    slug: parker
-    local_id: '115'
-    school_type: ES
+  - name: Normandin Middle
+    slug: normandin
+    local_id: '410'
+    school_type: MS
 
   - name: Keith Middle
     slug: keith
     local_id: '405'
-    school_type: MS
-
-  - name: Normandin Middle
-    slug: normandin
-    local_id: '410'
     school_type: MS
 
   - name: Roosevelt Middle
@@ -38,13 +33,17 @@ school_definitions_for_import:
     local_id: '415'
     school_type: MS
 
-
-school_definitions_not_yet_used:
   - name: Casimir Pulaski
     slug: pulaski
     local_id: '123'
     school_type: ES
 
+  - name: John A. Parker
+    slug: parker
+    local_id: '115'
+    school_type: ES
+
+school_definitions_not_yet_used:
   - name: James B. Congdon
     slug: congdon
     local_id: '040'


### PR DESCRIPTION
# Who is this PR for?
New Bedford educators

# What problem does this PR fix?
Folks want to pilot in this elementary school, but importing was disabled when we cut them from scope earlier.
# What does this PR do?
Adds them to the default school scope for all importers.


# Checklists
*Which features or pages does this PR touch?*
+ [x] Core, all importers

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here