### PR TITLE
Maintenance: Upgrade to node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "studentinsights",
   "version": "0.1.0",
   "engines": {
-    "node": "^10.13.0"
+    "node": "^12.13.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It's now in long-term support.  The current build setup pins the dev and production node version in `package.json`, but floats to the latest LTS in Travis.  This means that when a new LTS is released, the build fails like this: https://travis-ci.org/studentinsights/studentinsights/jobs/600978116  This seems fine, and a healthy kind of prompt, so keeping it rather than fixing the version in Travis as well.