### PR TITLE
Sports teams: Automate import, revise template, always include in educator contacts

### DIFF
--- a/app/assets/javascripts/student_profile/InsightAboutTeamMembership.js
+++ b/app/assets/javascripts/student_profile/InsightAboutTeamMembership.js
@@ -25,7 +25,10 @@ export default class InsightAboutTeamMembership extends React.Component {
         sourceEl={
           <div>
             <div>with coach {team.coach_text}</div>
-            <div>during the {team.season_key} season</div>
+            {team.active
+              ? <div>this {team.season_key} season</div>
+              : <div>during the {team.school_year_text} {team.season_key} season</div>
+            }
           </div>
         }
       />
@@ -38,6 +41,7 @@ InsightAboutTeamMembership.propTypes = {
     activity_text: PropTypes.string.isRequired,
     season_key: PropTypes.string.isRequired,
     coach_text: PropTypes.string.isRequired,
+    school_year_text: PropTypes.string.isRequired,
     active: PropTypes.bool.isRequired
   }).isRequired
 };

--- a/app/assets/javascripts/student_profile/InsightAboutTeamMembership.js
+++ b/app/assets/javascripts/student_profile/InsightAboutTeamMembership.js
@@ -10,7 +10,6 @@ export default class InsightAboutTeamMembership extends React.Component {
   render() {
     const {insightPayload, firstName} = this.props;
     const team = insightPayload;
-    const isOrWas = team.active ? 'is' : 'was';
     return (
       <InsightQuote
         className="InsightAboutTeamMembership"
@@ -19,7 +18,10 @@ export default class InsightAboutTeamMembership extends React.Component {
             minFontSize={12}
             maxFontSize={42}
             fontSizeStep={6}
-            text={<span>{firstName} {isOrWas} on the <Team team={team} /> team</span>}
+            text={team.active
+              ? <span>{firstName} is on the <Team team={team} /> team</span>
+              : <span>{firstName} was on the <Team team={team} /> team in {team.school_year_text}</span>
+            }
           />
         }
         sourceEl={

--- a/app/assets/javascripts/student_profile/InsightAboutTeamMembership.test.js
+++ b/app/assets/javascripts/student_profile/InsightAboutTeamMembership.test.js
@@ -11,7 +11,8 @@ function testProps(props = {}) {
     insightPayload: {
       activity_text: 'Indoor Track - Girls Varsity',
       season_key: 'winter',
-      coach_text: '2018-19',
+      school_year_text: '2018-19',
+      coach_text: 'Eric Taylor',
       active: true,
     },
     ...props
@@ -34,6 +35,22 @@ it('renders without crashing', () => {
 
 it('snapshots view', () => {
   const props = testProps();
+  const tree = renderer
+    .create(testEl(props))
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('snapshots for last year', () => {
+  const defaultProps = testProps();
+  const props = {
+    ...defaultProps,
+    insightPayload: {
+      ...defaultProps.insightPayload,
+      school_year_text: '2017-18',
+      active: false
+    }
+  };
   const tree = renderer
     .create(testEl(props))
     .toJSON();

--- a/app/assets/javascripts/student_profile/InsightsCarousel.js
+++ b/app/assets/javascripts/student_profile/InsightsCarousel.js
@@ -35,7 +35,7 @@ export default class InsightsCarousel extends React.Component {
 
   resetInterval() {
     this.clearInterval();
-    this.interval = window.setInterval(this.onIntervalTicked, 10000);
+    this.interval = window.setInterval(this.onIntervalTicked, 8000);
   }
 
   // Insights that we know how to render

--- a/app/assets/javascripts/student_profile/LightProfileHeader.js
+++ b/app/assets/javascripts/student_profile/LightProfileHeader.js
@@ -59,10 +59,9 @@ export default class LightProfileHeader extends React.Component {
   }
 
   renderStudentPhotoOrNull() {
-    const {student, teams} = this.props;
+    const {student} = this.props;
     if (!this.hasPhoto()) return null;
     
-    // The teams badges hang over the bottom
     return (
       <div style={{flex: 1, marginLeft: 10, position: 'relative'}}>
         <AutoSizer>
@@ -72,15 +71,26 @@ export default class LightProfileHeader extends React.Component {
               student={student} />
           )}
         </AutoSizer>
-        <div style={{position: 'absolute', bottom: -30, left: 5}}>
-          {teams.map(team => (
-            <TeamIcon
-              key={team.activity_text}
-              style={{fontSize: 20}}
-              team={team}
-            />
-          ))}
-        </div>
+        {this.renderTeamIcons()}
+      </div>
+    );
+  }
+
+  // The teams badges hang over the bottom, styling hack
+  renderTeamIcons() {
+    // disabled for now
+    if (window.location.search.indexOf('teamicons') === -1) return null;
+
+    const {teams} = this.props;
+    return (
+      <div style={{position: 'absolute', bottom: -30, left: 5}}>
+        {teams.map(team => (
+          <TeamIcon
+            key={team.activity_text}
+            style={{fontSize: 20}}
+            team={team}
+          />
+        ))}
       </div>
     );
   }

--- a/app/assets/javascripts/student_profile/__snapshots__/InsightAboutTeamMembership.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/InsightAboutTeamMembership.test.js.snap
@@ -39,9 +39,7 @@ exports[`snapshots for last year 1`] = `
         text={
           <span>
             Mari
-             
-            was
-             on the 
+             was on the 
             <Team
               team={
                 Object {
@@ -53,7 +51,8 @@ exports[`snapshots for last year 1`] = `
                 }
               }
             />
-             team
+             team in 
+            2017-18
           </span>
         }
       />
@@ -131,9 +130,7 @@ exports[`snapshots view 1`] = `
         text={
           <span>
             Mari
-             
-            is
-             on the 
+             is on the 
             <Team
               team={
                 Object {

--- a/app/assets/javascripts/student_profile/__snapshots__/InsightAboutTeamMembership.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/InsightAboutTeamMembership.test.js.snap
@@ -1,5 +1,97 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`snapshots for last year 1`] = `
+<div
+  className="InsightQuote InsightAboutTeamMembership"
+  style={
+    Object {
+      "display": "flex",
+      "flex": 1,
+      "flexDirection": "column",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "display": "flex",
+        "flex": 1,
+        "margin": 20,
+        "marginBottom": 0,
+        "marginTop": 15,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "display": "flex",
+          "flex": 1,
+          "flexDirection": "column",
+          "overflow": "hidden",
+        }
+      }
+    >
+      <mocked-fit-text
+        fontSizeStep={6}
+        maxFontSize={42}
+        minFontSize={12}
+        text={
+          <span>
+            Mari
+             
+            was
+             on the 
+            <Team
+              team={
+                Object {
+                  "active": false,
+                  "activity_text": "Indoor Track - Girls Varsity",
+                  "coach_text": "Eric Taylor",
+                  "school_year_text": "2017-18",
+                  "season_key": "winter",
+                }
+              }
+            />
+             team
+          </span>
+        }
+      />
+    </div>
+  </div>
+  <div
+    style={
+      Object {
+        "alignItems": "flex-end",
+        "display": "flex",
+        "flexDirection": "row",
+        "fontSize": 12,
+        "justifyContent": "space-between",
+        "margin": 20,
+        "marginBottom": 15,
+        "marginTop": 10,
+      }
+    }
+  >
+    <div>
+      <div>
+        <div>
+          with coach 
+          Eric Taylor
+        </div>
+        <div>
+          during the 
+          2017-18
+           
+          winter
+           season
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`snapshots view 1`] = `
 <div
   className="InsightQuote InsightAboutTeamMembership"
@@ -47,7 +139,8 @@ exports[`snapshots view 1`] = `
                 Object {
                   "active": true,
                   "activity_text": "Indoor Track - Girls Varsity",
-                  "coach_text": "2018-19",
+                  "coach_text": "Eric Taylor",
+                  "school_year_text": "2018-19",
                   "season_key": "winter",
                 }
               }
@@ -76,10 +169,10 @@ exports[`snapshots view 1`] = `
       <div>
         <div>
           with coach 
-          2018-19
+          Eric Taylor
         </div>
         <div>
-          during the 
+          this 
           winter
            season
         </div>

--- a/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
@@ -64,27 +64,6 @@ exports[`snapshots works for aladdin grades 1`] = `
             }
           />
         </div>
-        <div
-          style={
-            Object {
-              "bottom": -30,
-              "left": 5,
-              "position": "absolute",
-            }
-          }
-        >
-          <span
-            style={
-              Object {
-                "cursor": "default",
-                "fontSize": 20,
-              }
-            }
-            title="Soccer - Boys JV with Jonathan Fishman"
-          >
-            ⚽
-          </span>
-        </div>
       </div>
     </div>
     <div
@@ -1289,27 +1268,6 @@ exports[`snapshots works for aladdin notes 1`] = `
               }
             }
           />
-        </div>
-        <div
-          style={
-            Object {
-              "bottom": -30,
-              "left": 5,
-              "position": "absolute",
-            }
-          }
-        >
-          <span
-            style={
-              Object {
-                "cursor": "default",
-                "fontSize": 20,
-              }
-            }
-            title="Soccer - Boys JV with Jonathan Fishman"
-          >
-            ⚽
-          </span>
         </div>
       </div>
     </div>
@@ -2665,27 +2623,6 @@ exports[`snapshots works for aladdin testing 1`] = `
             }
           />
         </div>
-        <div
-          style={
-            Object {
-              "bottom": -30,
-              "left": 5,
-              "position": "absolute",
-            }
-          }
-        >
-          <span
-            style={
-              Object {
-                "cursor": "default",
-                "fontSize": 20,
-              }
-            }
-            title="Soccer - Boys JV with Jonathan Fishman"
-          >
-            ⚽
-          </span>
-        </div>
       </div>
     </div>
     <div
@@ -3871,15 +3808,6 @@ exports[`snapshots works for olaf math 1`] = `
             }
           />
         </div>
-        <div
-          style={
-            Object {
-              "bottom": -30,
-              "left": 5,
-              "position": "absolute",
-            }
-          }
-        />
       </div>
     </div>
     <div
@@ -5127,15 +5055,6 @@ exports[`snapshots works for olaf notes 1`] = `
             }
           />
         </div>
-        <div
-          style={
-            Object {
-              "bottom": -30,
-              "left": 5,
-              "position": "absolute",
-            }
-          }
-        />
       </div>
     </div>
     <div
@@ -6454,15 +6373,6 @@ exports[`snapshots works for olaf reading 1`] = `
             }
           />
         </div>
-        <div
-          style={
-            Object {
-              "bottom": -30,
-              "left": 5,
-              "position": "absolute",
-            }
-          }
-        />
       </div>
     </div>
     <div

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -409,6 +409,10 @@ class PerDistrict
     @district_key == SOMERVILLE
   end
 
+  def team_membership_importer_enabled?
+    @district_key == SOMERVILLE
+  end
+  
   # Specifically whether this importer class runs as part of import jobs
   def student_voice_survey_importer_enabled?
     @district_key == SOMERVILLE

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -412,7 +412,7 @@ class PerDistrict
   def team_membership_importer_enabled?
     @district_key == SOMERVILLE
   end
-  
+
   # Specifically whether this importer class runs as part of import jobs
   def student_voice_survey_importer_enabled?
     @district_key == SOMERVILLE

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -141,7 +141,6 @@ class ProfileController < ApplicationController
   end
 
   def teams_json(student)
-    return [] unless ENV.fetch('SHOULD_SHOW_TEAM_ICONS', false)
     student.teams.as_json({
       only: [:activity_text, :coach_text, :season_key, :school_year_text],
       methods: [:active]

--- a/app/importers/team_membership_import/team_membership_importer.rb
+++ b/app/importers/team_membership_import/team_membership_importer.rb
@@ -45,6 +45,8 @@ class TeamMembershipImporter
       log("\n\ntab_id: #{tab.tab_id}, tab.name.first(1): #{tab.tab_name.first(1)}") # minimize logging
       log('Starting loop...')
       StreamingCsvTransformer.from_text(@log, tab.tab_csv).each_with_index do |row, index|
+        # Support multiple header rows to explain to users how to enter data, etc.
+        next if index < @skip_explanation_rows_count
         records << matching_record_for_row(row, index)
       end
       log("Total stats #{records.size} records, #{records.compact.size} non-nil.")
@@ -95,11 +97,6 @@ class TeamMembershipImporter
   end
 
   def matching_record_for_row(row, index)
-    # Support multiple header rows to explain to users how to enter data, etc.
-    if (index) < @skip_explanation_rows_count
-      return nil
-    end
-
     student_id = @matcher.find_student_id(row['LASID'])
     return nil if student_id.nil?
 

--- a/app/importers/team_membership_import/team_membership_importer.rb
+++ b/app/importers/team_membership_import/team_membership_importer.rb
@@ -120,7 +120,6 @@ class TeamMembershipImporter
     record
   end
 
-
   def log(msg)
     text = if msg.class == String then msg else JSON.pretty_generate(msg) end
     @log.puts "TeamMembershipImporter: #{text}"

--- a/app/importers/team_membership_import/team_membership_importer.rb
+++ b/app/importers/team_membership_import/team_membership_importer.rb
@@ -4,84 +4,128 @@
 # importer = TeamMembershipImporter.new(file_text)
 # records = importer.create_from_text!
 class TeamMembershipImporter
-  def initialize(file_text, options = {})
-    @file_text = file_text
-    @log = options.fetch(:log, Rails.env.test? ? LogHelper::Redirect.instance.file : STDOUT)
-    reset_counters!
-  end
-
-  def create_from_text!
-    reset_counters!
-
-    created_records = []
-    columns_map = {
-      activity_text: 'Activity',
-      coach_text: 'Coach',
-      school_year_text: 'School_Year',
-      season_key: 'Season'
-    }
-    create_streaming_csv.each_with_index do |row, index|
-      student_local_id = row['ID'] # lasid
-      maybe_row_attrs = process_row_or_nil(columns_map, student_local_id, row)
-      next if maybe_row_attrs.nil?
-      created_records << TeamMembership.create!(maybe_row_attrs)
-      @created_records_count += 1
-    end
-
-    created_records
-  end
-
-  private
-  def create_streaming_csv
-    csv_transformer = StreamingCsvTransformer.new(@log, {
-      csv_options: { header_converters: nil }
+  def self.data_flow
+    DataFlow.new({
+      importer: self.name,
+      source: DataFlow::SOURCE_GOOGLE_DRIVE_SHEET,
+      frequency: DataFlow::FREQUENCY_DAILY,
+      options: [],
+      merge: DataFlow::MERGE_UPDATE_DELETE_UNMARKED,
+      touches: [
+        TeamMembership.name
+      ],
+      description: 'Import rosters for sports teams at SHS, which educators update via Google Sheets from other registration systems'
     })
-    csv_transformer.transform(@file_text)
   end
 
-  def process_row_or_nil(columns_map, student_local_id, raw_row)
-    missing_column_keys = (columns_map.values - raw_row.to_h.keys)
-    if missing_column_keys.size > 0
-      @invalid_row_columns_count += 1
-      return nil
+  def initialize(options:)
+    @log = options.fetch(:log, Rails.env.test? ? LogHelper::Redirect.instance.file : STDOUT)
+    @school_year = options.fetch(:school_year, SchoolYear.to_school_year(Time.now))
+    @explicit_folder_id = options.fetch(:explicit_folder_id, nil)
+    @skip_explanation_rows_count = options.fetch(:skip_explanation_rows_count, 1)
+    @dry_run = options.fetch(:dry_run, false)
+    @fetcher = options.fetch(:fetcher, GoogleSheetsFetcher.new(log: @log))
+    @matcher = options.fetch(:matcher, ImportMatcher.new)
+    @syncer = options.fetch(:syncer, RecordSyncer.new(log: @log))
+  end
+
+  def import
+    if !PerDistrict.new.team_membership_importer_enabled?
+      log('Aborting since team_membership_importer_enabled? not enabled...')
+      return
     end
 
-    # whitelist attributes for the row, translate to short symbol keys
-    row_attrs = {}
-    columns_map.each do |record_field_name, csv_column_text|
-      row_attrs[record_field_name] = raw_row[csv_column_text]
+    log('Fetching tabs...')
+    tabs = fetch_tabs()
+    log("Found #{tabs.size} tabs.")
+
+    log('Processing each tab...')
+    records = []
+    tabs.each do |tab|
+      log("\n\ntab_id: #{tab.tab_id}, tab.name.first(1): #{tab.tab_name.first(1)}") # minimize logging
+      log('Starting loop...')
+      StreamingCsvTransformer.from_text(@log, tab.tab_csv).each_with_index do |row, index|
+        records << matching_record_for_row(row, index)
+      end
+      log("Total stats #{records.size} records, #{records.compact.size} non-nil.")
+      log('Done loop.')
     end
 
-    # filter out if all responses are empty
-    if row_attrs.values.uniq == ['']
-      @invalid_row_columns_count += 1
-      return nil
+    log('Syncing all rows...')
+    if @dry_run
+      log('skipping, dry_run: true...')
+      return records
     end
 
-    # match student
-    student_id = Student.find_by_local_id(student_local_id).try(:id)
-    if student_id.nil?
-      @invalid_student_local_id_count += 1
-      @invalid_student_local_ids_list << student_local_id
-      return nil
+    records.each {|record| @syncer.validate_mark_and_sync!(record) }
+    if @explicit_folder_id.present?
+      log('Since @explicit_folder_id is present, skipping call to syncer.')
+    else
+      log('Calling #delete_unmarked_records...')
+      @syncer.delete_unmarked_records!(records_within_scope)
     end
-
-    row_attrs.merge(student_id: student_id)
+    log("syncer stats.to_json: #{@syncer.stats.to_json}")
+    log('Done.')
+    nil
   end
 
   def stats
     {
-      created_records_count: @created_records_count,
-      invalid_row_columns_count: @invalid_row_columns_count,
-      invalid_student_local_id_count: @invalid_student_local_id_count,
-      invalid_student_local_ids_list: @invalid_student_local_ids_list
+      matcher: @matcher.stats,
+      syncer: @syncer.stats
     }
   end
 
-  def reset_counters!
-    @created_records_count = 0
-    @invalid_row_columns_count = 0
-    @invalid_student_local_id_count = 0
-    @invalid_student_local_ids_list = []
+  private
+  def fetch_tabs
+    folder_id = @explicit_folder_id.present? ? @explicit_folder_id : read_folder_id_from_env()
+    @fetcher.get_tabs_from_folder(folder_id)
+  end
+
+  def read_folder_id_from_env
+    PerDistrict.new.imported_google_folder_ids('shs_sports_teams_folder_id')
+  end
+
+  # Explicitly scope to specific school year.
+  def records_within_scope
+    if @school_year != 2019
+      raise "aborting because of unexpected school_year; review the syncer scoping closely before running on another year"
+    end
+    TeamMembership.where(school_year_text: '2019-20')
+  end
+
+  def matching_record_for_row(row, index)
+    # Support multiple header rows to explain to users how to enter data, etc.
+    if (index) < @skip_explanation_rows_count
+      return nil
+    end
+
+    student_id = @matcher.find_student_id(row['LASID'])
+    return nil if student_id.nil?
+
+    # translate from 2019-2020 to 2019-20
+    school_year_text = begin
+      school_year = row['school_year'].split('-').first
+      "#{school_year}-#{school_year.last(2).to_i + 1}"
+    rescue => err
+      nil
+    end
+
+    record = TeamMembership.find_or_initialize_by({
+      student_id: student_id,
+      activity_text: row['activity_text'],
+      season_key: row['season'].downcase,
+      school_year_text: school_year_text
+    })
+    record.assign_attributes({
+      coach_text: row['coach_name_text']
+    })
+    record
+  end
+
+
+  def log(msg)
+    text = if msg.class == String then msg else JSON.pretty_generate(msg) end
+    @log.puts "TeamMembershipImporter: #{text}"
   end
 end

--- a/spec/importers/team_membership_import/team_membership_fixture.csv
+++ b/spec/importers/team_membership_import/team_membership_fixture.csv
@@ -1,3 +1,4 @@
-Student_Name,ID,Activity,Coach,Season,School_Year
-"Keonbi, Mari",111222222,Competitive Cheerleading Varsity,Fatima Teacher,fall,2017-18
-"Ren, Kylo",2225555555,Cross Country - Boys Varsity,Jonathan Fishman,fall,2017-18
+LASID,activity_text,coach_name_text,season,school_year
+ex: 111222233,Cross Country - Junior Varsity,Eric Taylor,fall,2019-2020
+111222222,Competitive Cheerleading Varsity,Fatima Teacher,Fall,2017-2018
+2225555555,Cross Country - Boys Varsity,Jonathan Fishman,Fall,2017-2018

--- a/spec/importers/team_membership_import/team_membership_importer_spec.rb
+++ b/spec/importers/team_membership_import/team_membership_importer_spec.rb
@@ -1,21 +1,46 @@
 require 'rails_helper'
 
 RSpec.describe TeamMembershipImporter do
+  def fixture_tabs
+    [GoogleSheetsFetcher::Tab.new({
+      spreadsheet_id: 'test-spreadsheet-id',
+      spreadsheet_name: 'Test Sheet Name',
+      spreadsheet_url: 'https://example.com/foo',
+      tab_id: '123456',
+      tab_name: 'fall',
+      tab_csv: IO.read("#{Rails.root}/spec/importers/team_membership_import/team_membership_fixture.csv")
+    })]
+  end
+
+  def create_mock_fetcher(test_folder_id)
+    mock_fetcher = GoogleSheetsFetcher.new
+    allow(GoogleSheetsFetcher).to receive(:new).and_return(mock_fetcher)
+    allow(mock_fetcher).to receive(:get_tabs_from_folder).with(test_folder_id).and_return(fixture_tabs)
+    mock_fetcher
+  end
+
+  def create_importer(test_folder_id, options = {})
+    log = LogHelper::FakeLog.new
+    fetcher = create_mock_fetcher(test_folder_id)
+    importer = TeamMembershipImporter.new(options: {
+      explicit_folder_id: test_folder_id,
+      log: log,
+      fetcher: fetcher,
+    }.merge(options))
+
+    [importer, log]
+  end
+
   describe 'integration test' do
     it 'works for importing teams for Mari and Kylo' do
       pals = TestPals.create!(skip_team_memberships: true)
       time_now = pals.time_now
-      file_text = IO.read("#{Rails.root}/spec/importers/team_membership_import/team_membership_fixture.csv")
-      importer = TeamMembershipImporter.new(file_text)
-      created_records = importer.create_from_text!
+      importer, log = create_importer('sports-folder-id')
+      importer.import
 
-      expect(created_records.size).to eq 2
-      expect(importer.send(:stats)).to eq({
-        :created_records_count => 2,
-        :invalid_row_columns_count => 0,
-        :invalid_student_local_id_count => 0,
-        :invalid_student_local_ids_list => []
-      })
+      expect(importer.stats[:syncer][:total_sync_calls_count]).to eq(2)
+      expect(importer.stats[:syncer][:created_rows_count]).to eq(2)
+      expect(importer.stats[:syncer][:marked_ids_count]).to eq(2)
       expect(TeamMembership.all.size).to eq 2
       expect(pals.shs_freshman_mari.teams(time_now: time_now).as_json(except: [:id, :created_at, :updated_at])).to eq([{
         'student_id' => pals.shs_freshman_mari.id,


### PR DESCRIPTION
# Who is this PR for?
SHS educators

# What problem does this PR fix?
Updates the sports team membership from last year.

# What does this PR do?
Updates the import process to be automated for the rest of the year (but scoped to only 2019-2020 for now).  Revises the list of educator contacts to always include coaches names (previously it was tied to a feature switch on whether to show icon badges).  Update the text on insights related to teams to make more clear which teams they're active on now and which ones are from past seasons.


# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here