### PR TITLE
Sports teams: Tighten validations, add to main import task, update icons

### DIFF
--- a/app/assets/javascripts/components/Team.js
+++ b/app/assets/javascripts/components/Team.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 
 const TEAM_ICON_MAP = {
   // fall
+  'Cheerleading Fall Varsity': '📣',
   'Competitive Cheerleading Varsity': '📣',
   'Cross Country - Boys Varsity': '👟',
   'Cross Country - Girls Varsity': '👟',

--- a/app/importers/file_importers/file_importer_options.rb
+++ b/app/importers/file_importers/file_importer_options.rb
@@ -77,7 +77,8 @@ class FileImporterOptions
       'star_reading' => StarReadingImporter,
       'student_voice_surveys' => StudentVoiceSurveyImporter,
       'student_meetings' => StudentMeetingImporter,
-      'reading_benchmark_sheets' => ReadingBenchmarkSheetsImporter
+      'reading_benchmark_sheets' => ReadingBenchmarkSheetsImporter,
+      'team_memberships' => TeamMembershipImporter
     }
   end
 
@@ -103,7 +104,8 @@ class FileImporterOptions
       EdPlansImporter => 7,
       EdPlanAccommodationsImporter => 8,
       StudentVoiceSurveyImporter => 9,
-      ReadingBenchmarkSheetsImporter => 10
+      ReadingBenchmarkSheetsImporter => 10,
+      TeamMembershipImporter => 11
     }
   end
 end

--- a/app/lib/profile_insights.rb
+++ b/app/lib/profile_insights.rb
@@ -76,7 +76,9 @@ class ProfileInsights
   end
 
   def about_team_membership
-    @student.teams(time_now: @time_now).map do |team|
+    teams = @student.teams(time_now: @time_now)
+    sorted_teams = teams.sort_by(&:season_sort_key)
+    sorted_teams.map do |team|
       ProfileInsight.new(ABOUT_TEAM_MEMBERSHIP, team.as_json({
         only: [:activity_text, :coach_text, :season_key, :school_year_text],
         methods: [:active]

--- a/app/models/team_membership.rb
+++ b/app/models/team_membership.rb
@@ -7,8 +7,8 @@ class TeamMembership < ApplicationRecord
     with: /\A(20\d\d)-(\d\d)\z/,
     message: 'must be format 2002-03'
   }
-  validates :student, presence: true, uniqueness: {
-    scope: [:activity_text, :school_year_text, :season_key]
+  validates :activity_text, presence: true, uniqueness: {
+    scope: [:student_id, :school_year_text, :season_key]
   }
   validates :season_key, inclusion: { in: ['fall', 'winter', 'spring'] }
 

--- a/app/models/team_membership.rb
+++ b/app/models/team_membership.rb
@@ -1,17 +1,26 @@
 class TeamMembership < ApplicationRecord
   belongs_to :student
 
-  validates :student, presence: true
   validates :activity_text, presence: true, exclusion: { in: ['']}
   validates :coach_text, presence: true, exclusion: { in: ['']}
   validates :school_year_text, presence: true, format: {
     with: /\A(20\d\d)-(\d\d)\z/,
     message: 'must be format 2002-03'
   }
+  validates :student, presence: true, uniqueness: {
+    scope: [:activity_text, :school_year_text, :season_key]
+  }
+  validates :season_key, inclusion: { in: ['fall', 'winter', 'spring'] }
 
   def active(options = {})
     this_season_key, school_year_text = TeamMembership.this_season_and_year(options)
     self.school_year_text == school_year_text && self.season_key == this_season_key.to_s
+  end
+
+  def season_sort_key(options = {})
+    school_year = self.school_year_text.split('-').first.to_i
+    season_number = ['fall', 'winter', 'spring'].index(self.season_key) || 0
+    [school_year, season_number]
   end
 
   def self.active(options = {})

--- a/spec/importers/file_importers/data_flows_fixture.json
+++ b/spec/importers/file_importers/data_flows_fixture.json
@@ -193,8 +193,15 @@
       "option_school_scope"
     ],
     "description": "Student rosters"
-  },
-  {
+  }, {
+    "importer": "TeamMembershipImporter",
+    "source": "source_google_drive_sheet",
+    "frequency": "frequency_daily",
+    "merge": "merge_update_delete_unmarked",
+    "touches": ["TeamMembership"],
+    "options": [],
+    "description": "Import rosters for sports teams at SHS, which educators update via Google Sheets from other registration systems"
+  }, {
     "importer": "X2AssessmentImporter",
     "source": "source_sis_sftp_csv",
     "frequency": "frequency_daily",

--- a/spec/importers/file_importers/file_importer_options_spec.rb
+++ b/spec/importers/file_importers/file_importer_options_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe FileImporterOptions do
 
     it 'can describe data flows for all importer classes' do
       data_flows = FileImporterOptions.new.all_data_flows
-      expect(data_flows.size).to eq(16)
+      expect(data_flows.size).to eq(17)
       sorted_json = data_flows.as_json.sort_by {|j| j['importer'] }
       fixture_json = JSON.parse(IO.read("#{Rails.root}/spec/importers/file_importers/data_flows_fixture.json"))
       expect(sorted_json).to eq(fixture_json)
@@ -49,7 +49,8 @@ RSpec.describe FileImporterOptions do
         'ed_plans',
         'ed_plan_accommodations',
         'student_voice_surveys',
-        'reading_benchmark_sheets'
+        'reading_benchmark_sheets',
+        'team_memberships'
       ])
     end
   end

--- a/spec/models/team_membership_spec.rb
+++ b/spec/models/team_membership_spec.rb
@@ -1,6 +1,50 @@
 require 'rails_helper'
 
 RSpec.describe TeamMembership, type: :model do
+  describe 'validations' do
+    it 'allows only valid season_key values' do
+      pals = TestPals.create!(skip_team_memberships: true)
+      record = TeamMembership.new({
+        student_id: pals.shs_senior_kylo.id,
+        activity_text: 'Hockey',
+        school_year_text: '2017-18',
+        season_key: 'fffffall',
+        coach_text: 'Obi Wan'
+      })
+      record.save
+      expect(record.valid?).to eq false
+      expect(record.errors.details).to eq({
+        :season_key=>[{:error=>:inclusion, :value=>"fffffall"}]
+      })
+    end
+
+    it 'prevents duplicate records by activity, period, student' do
+      pals = TestPals.create!(skip_team_memberships: true)
+      legit = TeamMembership.create!({
+        student_id: pals.shs_senior_kylo.id,
+        activity_text: 'Hockey',
+        school_year_text: '2017-18',
+        season_key: 'winter',
+        coach_text: 'Obi Wan'
+      })
+      legit.save
+      expect(legit.valid?).to eq true
+
+      duplicate = TeamMembership.new({
+        student_id: pals.shs_senior_kylo.id,
+        activity_text: 'Hockey',
+        school_year_text: '2017-18',
+        season_key: 'winter',
+        coach_text: 'Obi Wan'
+      })
+      duplicate.save
+      expect(duplicate.valid?).to eq false
+      expect(duplicate.errors.details).to eq({
+        :activity_text=>[{:error=>:taken, :value=>"Hockey"}]
+      })
+    end
+  end
+
   describe '.active' do
     it 'works' do
       pals = TestPals.create!(skip_team_memberships: true)
@@ -48,6 +92,40 @@ RSpec.describe TeamMembership, type: :model do
       })
       expect(team_membership.valid?).to eq false
       expect(team_membership.errors.messages).to eq(school_year_text: ['must be format 2002-03'])
+    end
+  end
+
+  describe '#season_sort_key' do
+    it 'works' do
+      pals = TestPals.create!(skip_team_memberships: true)
+      teams = [
+        TeamMembership.create!({
+          student_id: pals.shs_senior_kylo.id,
+          activity_text: 'Hockey',
+          school_year_text: '2017-18',
+          season_key: 'winter',
+          coach_text: 'Obi Wan'
+        }),
+        TeamMembership.create!({
+          student_id: pals.shs_senior_kylo.id,
+          activity_text: 'Soccer',
+          school_year_text: '2018-19',
+          season_key: 'fall',
+          coach_text: 'Obi Wan'
+        }),
+        TeamMembership.create!({
+          student_id: pals.shs_senior_kylo.id,
+          activity_text: 'Baseball',
+          school_year_text: '2017-18',
+          season_key: 'spring',
+          coach_text: 'Obi Wan'
+        })
+      ]
+      expect(teams.sort_by(&:season_sort_key).map(&:activity_text)).to eq([
+        'Hockey',
+        'Baseball',
+        'Soccer'
+      ])
     end
   end
 end


### PR DESCRIPTION
# Who is this PR for?
SHS students and educators

# What problem does this PR fix?
Builds on https://github.com/studentinsights/studentinsights/pull/2677, adding the importer to the main importer so it can run each day.  There are some duplicate records from past work.

# What does this PR do?
Offline, I ran a task to clean up the duplicates, and then added these validations and verified they now hold.  This also adds an emoji icon for new name variant.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile
+ [x] Team importer

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here