### PR TITLE
Reflection: Patterns within notes

### DIFF
--- a/app/assets/javascripts/components/BoxCard.js
+++ b/app/assets/javascripts/components/BoxCard.js
@@ -5,11 +5,11 @@ import Card from './Card';
 
 // A visual UI element for a boxy card of information, with a title.
 // Does not have a defined or minimum height; style that in the child element.
-export default function BoxCard({title, children, style, className}) {
+export default function BoxCard({title, children, style = {}, className}) {
   return (
     <Card
       className={`BoxCard ${className || ''}`}
-      style={styles.card}>
+      style={{...styles.card, ...style}}>
       <div style={styles.cardTitle}>{title}</div>
       {children}
     </Card>

--- a/app/assets/javascripts/components/Delay.js
+++ b/app/assets/javascripts/components/Delay.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+
+// Delay rendering of child components with a timer
+// Adapted from https://github.com/chrisshiplet/react-delay
+class Delay extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      waiting: true
+    };
+    this.onDelayDone = this.onDelayDone.bind(this);
+  }
+
+  componentDidMount() {
+    this.timer = setTimeout(this.onDelayDone, this.props.wait);
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.timer);
+  }
+
+  onDelayDone() {
+    const {onDone} = this.props;
+    this.setState({ waiting: false }, () => {
+      if (onDone) onDone();
+    });
+  }
+
+  render() {
+    const {children, placeholder} = this.props;
+    const {waiting} = this.state;
+    if (!waiting) {
+      return children;
+    }
+
+    return placeholder;
+  }
+}
+
+Delay.propTypes = {
+  children: PropTypes.node.isRequired,
+  wait: PropTypes.number.isRequired,
+  placeholder: PropTypes.node,
+  onDone: PropTypes.func
+};
+
+Delay.defaultProps = {
+  wait: 250,
+  placeholder: null
+};
+
+export default Delay;

--- a/app/assets/javascripts/components/Delay.test.js
+++ b/app/assets/javascripts/components/Delay.test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Delay from './Delay';
+
+
+it('renders without crashing', async () => {
+  const div = document.createElement('div');
+  ReactDOM.render(
+    <Delay onEnd={jest.fn()}>
+      hello
+    </Delay>
+    , div);
+});

--- a/app/assets/javascripts/components/WordCloud.js
+++ b/app/assets/javascripts/components/WordCloud.js
@@ -42,12 +42,12 @@ export default class WordCloud extends React.Component {
   }
 
   render() {
-    const {width, height} = this.props;
+    const {width, height, style = {}} = this.props;
     return (
       <canvas
         className="WordCloud"
         ref={el => this.el = el}
-        style={{cursor: 'pointer'}}
+        style={{cursor: 'pointer', ...style}}
         width={width}
         height={height}
       />
@@ -57,7 +57,8 @@ export default class WordCloud extends React.Component {
 WordCloud.propTypes = {
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
-  words: PropTypes.arrayOf(PropTypes.string).isRequired
+  words: PropTypes.arrayOf(PropTypes.string).isRequired,
+  style: PropTypes.object
 };
 
 

--- a/app/assets/javascripts/my_notes/__snapshots__/NotesFeed.test.js.snap
+++ b/app/assets/javascripts/my_notes/__snapshots__/NotesFeed.test.js.snap
@@ -1729,6 +1729,7 @@ exports[`snapshots view with wordcloud 1`] = `
               "display": "flex",
               "flexDirection": "column",
               "margin": 20,
+              "marginTop": 10,
               "padding": 0,
             }
           }

--- a/app/assets/javascripts/reflection/ReflectionOnNotesPage.fixture.js
+++ b/app/assets/javascripts/reflection/ReflectionOnNotesPage.fixture.js
@@ -742,4 +742,4 @@ export default {
       "I met with her about staying after school so she could make them up, or how she could work with her lab partner."
     ]
   }
-}
+};

--- a/app/assets/javascripts/reflection/ReflectionOnNotesPage.fixture.js
+++ b/app/assets/javascripts/reflection/ReflectionOnNotesPage.fixture.js
@@ -1,0 +1,745 @@
+export default {
+  "students": [
+    {
+      "id": 1,
+      "grade": "KF",
+      "first_name": "Garfield",
+      "last_name": "Skywalker",
+      "house": null
+    },
+    {
+      "id": 2,
+      "grade": "8",
+      "first_name": "Ryan",
+      "last_name": "Rodriguez",
+      "house": null
+    },
+    {
+      "id": 3,
+      "grade": "9",
+      "first_name": "Mari",
+      "last_name": "Kenobi",
+      "house": "Beacon"
+    },
+    {
+      "id": 4,
+      "grade": "9",
+      "first_name": "Amir",
+      "last_name": "Solo",
+      "house": "Broadway"
+    },
+    {
+      "id": 5,
+      "grade": "12",
+      "first_name": "Kylo",
+      "last_name": "Ren",
+      "house": "Broadway"
+    },
+    {
+      "id": 6,
+      "grade": "KF",
+      "first_name": "Aladdin",
+      "last_name": "Disney",
+      "house": null
+    },
+    {
+      "id": 10,
+      "grade": "KF",
+      "first_name": "Winnie",
+      "last_name": "Pan",
+      "house": null
+    },
+    {
+      "id": 13,
+      "grade": "KF",
+      "first_name": "Daisy",
+      "last_name": "Duck",
+      "house": null
+    },
+    {
+      "id": 12,
+      "grade": "KF",
+      "first_name": "Aladdin",
+      "last_name": "Skywalker",
+      "house": null
+    },
+    {
+      "id": 14,
+      "grade": "5",
+      "first_name": "Winnie",
+      "last_name": "Duck",
+      "house": null
+    },
+    {
+      "id": 15,
+      "grade": "5",
+      "first_name": "Olaf",
+      "last_name": "Pan",
+      "house": null
+    },
+    {
+      "id": 18,
+      "grade": "5",
+      "first_name": "Aladdin",
+      "last_name": "Poppins",
+      "house": null
+    },
+    {
+      "id": 17,
+      "grade": "5",
+      "first_name": "Chip",
+      "last_name": "Mouse",
+      "house": null
+    },
+    {
+      "id": 20,
+      "grade": "5",
+      "first_name": "Donald",
+      "last_name": "Pan",
+      "house": null
+    },
+    {
+      "id": 21,
+      "grade": "5",
+      "first_name": "Donald",
+      "last_name": "Poppins",
+      "house": null
+    },
+    {
+      "id": 23,
+      "grade": "9",
+      "first_name": "Mickey",
+      "last_name": "Duck",
+      "house": "Beacon"
+    },
+    {
+      "id": 24,
+      "grade": "9",
+      "first_name": "Aladdin",
+      "last_name": "Pan",
+      "house": "Beacon"
+    },
+    {
+      "id": 25,
+      "grade": "9",
+      "first_name": "Elsa",
+      "last_name": "Skywalker",
+      "house": "Broadway"
+    },
+    {
+      "id": 26,
+      "grade": "9",
+      "first_name": "Rapunzel",
+      "last_name": "Mouse",
+      "house": "Broadway"
+    },
+    {
+      "id": 28,
+      "grade": "9",
+      "first_name": "Minnie",
+      "last_name": "Skywalker",
+      "house": "Highland"
+    },
+    {
+      "id": 29,
+      "grade": "9",
+      "first_name": "Olaf",
+      "last_name": "Pan",
+      "house": "Highland"
+    },
+    {
+      "id": 30,
+      "grade": "9",
+      "first_name": "Mowgli",
+      "last_name": "Mouse",
+      "house": "Broadway"
+    },
+    {
+      "id": 32,
+      "grade": "9",
+      "first_name": "Donald",
+      "last_name": "Poppins",
+      "house": "Broadway"
+    },
+    {
+      "id": 27,
+      "grade": "9",
+      "first_name": "Elsa",
+      "last_name": "Poppins",
+      "house": "Broadway"
+    },
+    {
+      "id": 34,
+      "grade": "9",
+      "first_name": "Mickey",
+      "last_name": "White",
+      "house": "Beacon"
+    },
+    {
+      "id": 35,
+      "grade": "9",
+      "first_name": "Mowgli",
+      "last_name": "Kenobi",
+      "house": "Broadway"
+    },
+    {
+      "id": 33,
+      "grade": "9",
+      "first_name": "Daisy",
+      "last_name": "Poppins",
+      "house": "Highland"
+    },
+    {
+      "id": 37,
+      "grade": "9",
+      "first_name": "Aladdin",
+      "last_name": "Poppins",
+      "house": "Broadway"
+    },
+    {
+      "id": 38,
+      "grade": "10",
+      "first_name": "Rapunzel",
+      "last_name": "Skywalker",
+      "house": "Broadway"
+    },
+    {
+      "id": 39,
+      "grade": "10",
+      "first_name": "Mickey",
+      "last_name": "Kenobi",
+      "house": "Highland"
+    },
+    {
+      "id": 41,
+      "grade": "10",
+      "first_name": "Snow",
+      "last_name": "Kenobi",
+      "house": "Highland"
+    },
+    {
+      "id": 42,
+      "grade": "10",
+      "first_name": "Aladdin",
+      "last_name": "Poppins",
+      "house": "Highland"
+    },
+    {
+      "id": 43,
+      "grade": "10",
+      "first_name": "Chip",
+      "last_name": "Disney",
+      "house": "Beacon"
+    },
+    {
+      "id": 44,
+      "grade": "10",
+      "first_name": "Minnie",
+      "last_name": "Kenobi",
+      "house": "Beacon"
+    },
+    {
+      "id": 45,
+      "grade": "10",
+      "first_name": "Daisy",
+      "last_name": "Duck",
+      "house": "Highland"
+    },
+    {
+      "id": 46,
+      "grade": "5",
+      "first_name": "Snow",
+      "last_name": "Disney",
+      "house": null
+    },
+    {
+      "id": 47,
+      "grade": "5",
+      "first_name": "Pocahontas",
+      "last_name": "White",
+      "house": null
+    },
+    {
+      "id": 48,
+      "grade": "5",
+      "first_name": "Chip",
+      "last_name": "White",
+      "house": null
+    },
+    {
+      "id": 49,
+      "grade": "5",
+      "first_name": "Mowgli",
+      "last_name": "Duck",
+      "house": null
+    },
+    {
+      "id": 50,
+      "grade": "5",
+      "first_name": "Donald",
+      "last_name": "Pan",
+      "house": null
+    },
+    {
+      "id": 52,
+      "grade": "5",
+      "first_name": "Minnie",
+      "last_name": "White",
+      "house": null
+    },
+    {
+      "id": 53,
+      "grade": "5",
+      "first_name": "Rapunzel",
+      "last_name": "Pan",
+      "house": null
+    },
+    {
+      "id": 54,
+      "grade": "3",
+      "first_name": "Donald",
+      "last_name": "Poppins",
+      "house": null
+    },
+    {
+      "id": 55,
+      "grade": "3",
+      "first_name": "Daisy",
+      "last_name": "Duck",
+      "house": null
+    },
+    {
+      "id": 56,
+      "grade": "3",
+      "first_name": "Mowgli",
+      "last_name": "Disney",
+      "house": null
+    },
+    {
+      "id": 59,
+      "grade": "3",
+      "first_name": "Snow",
+      "last_name": "Skywalker",
+      "house": null
+    },
+    {
+      "id": 60,
+      "grade": "3",
+      "first_name": "Minnie",
+      "last_name": "Disney",
+      "house": null
+    },
+    {
+      "id": 61,
+      "grade": "3",
+      "first_name": "Olaf",
+      "last_name": "Duck",
+      "house": null
+    },
+    {
+      "id": 63,
+      "grade": "10",
+      "first_name": "Olaf",
+      "last_name": "Mouse",
+      "house": "Elm"
+    },
+    {
+      "id": 65,
+      "grade": "10",
+      "first_name": "Daisy",
+      "last_name": "White",
+      "house": "Highland"
+    },
+    {
+      "id": 66,
+      "grade": "10",
+      "first_name": "Rapunzel",
+      "last_name": "White",
+      "house": "Broadway"
+    },
+    {
+      "id": 68,
+      "grade": "10",
+      "first_name": "Mowgli",
+      "last_name": "Pan",
+      "house": "Elm"
+    },
+    {
+      "id": 105,
+      "grade": "10",
+      "first_name": "Mowgli",
+      "last_name": "Mouse",
+      "house": "Elm"
+    },
+    {
+      "id": 69,
+      "grade": "10",
+      "first_name": "Chip",
+      "last_name": "Mouse",
+      "house": "Broadway"
+    },
+    {
+      "id": 70,
+      "grade": "10",
+      "first_name": "Pluto",
+      "last_name": "Pan",
+      "house": "Beacon"
+    },
+    {
+      "id": 71,
+      "grade": "10",
+      "first_name": "Donald",
+      "last_name": "Poppins",
+      "house": "Elm"
+    },
+    {
+      "id": 72,
+      "grade": "10",
+      "first_name": "Aladdin",
+      "last_name": "White",
+      "house": "Highland"
+    },
+    {
+      "id": 74,
+      "grade": "10",
+      "first_name": "Rapunzel",
+      "last_name": "Pan",
+      "house": "Beacon"
+    },
+    {
+      "id": 75,
+      "grade": "10",
+      "first_name": "Pocahontas",
+      "last_name": "Skywalker",
+      "house": "Beacon"
+    },
+    {
+      "id": 76,
+      "grade": "10",
+      "first_name": "Pluto",
+      "last_name": "Kenobi",
+      "house": "Elm"
+    },
+    {
+      "id": 77,
+      "grade": "10",
+      "first_name": "Winnie",
+      "last_name": "Pan",
+      "house": "Broadway"
+    },
+    {
+      "id": 78,
+      "grade": "10",
+      "first_name": "Daisy",
+      "last_name": "Duck",
+      "house": "Elm"
+    },
+    {
+      "id": 79,
+      "grade": "10",
+      "first_name": "Mickey",
+      "last_name": "Pan",
+      "house": "Beacon"
+    },
+    {
+      "id": 80,
+      "grade": "10",
+      "first_name": "Olaf",
+      "last_name": "Duck",
+      "house": "Broadway"
+    },
+    {
+      "id": 81,
+      "grade": "10",
+      "first_name": "Elsa",
+      "last_name": "Disney",
+      "house": "Highland"
+    },
+    {
+      "id": 82,
+      "grade": "10",
+      "first_name": "Winnie",
+      "last_name": "Disney",
+      "house": "Elm"
+    },
+    {
+      "id": 83,
+      "grade": "10",
+      "first_name": "Chip",
+      "last_name": "Mouse",
+      "house": "Highland"
+    },
+    {
+      "id": 85,
+      "grade": "10",
+      "first_name": "Elsa",
+      "last_name": "White",
+      "house": "Broadway"
+    },
+    {
+      "id": 84,
+      "grade": "10",
+      "first_name": "Aladdin",
+      "last_name": "Duck",
+      "house": "Highland"
+    },
+    {
+      "id": 86,
+      "grade": "10",
+      "first_name": "Olaf",
+      "last_name": "Pan",
+      "house": "Highland"
+    },
+    {
+      "id": 88,
+      "grade": "10",
+      "first_name": "Mickey",
+      "last_name": "Skywalker",
+      "house": "Broadway"
+    },
+    {
+      "id": 89,
+      "grade": "10",
+      "first_name": "Mickey",
+      "last_name": "Mouse",
+      "house": "Highland"
+    },
+    {
+      "id": 90,
+      "grade": "10",
+      "first_name": "Daisy",
+      "last_name": "Mouse",
+      "house": "Beacon"
+    },
+    {
+      "id": 91,
+      "grade": "10",
+      "first_name": "Mickey",
+      "last_name": "Poppins",
+      "house": "Beacon"
+    },
+    {
+      "id": 92,
+      "grade": "10",
+      "first_name": "Donald",
+      "last_name": "Mouse",
+      "house": "Broadway"
+    },
+    {
+      "id": 93,
+      "grade": "10",
+      "first_name": "Mowgli",
+      "last_name": "Mouse",
+      "house": "Beacon"
+    },
+    {
+      "id": 94,
+      "grade": "10",
+      "first_name": "Aladdin",
+      "last_name": "Pan",
+      "house": "Beacon"
+    },
+    {
+      "id": 97,
+      "grade": "10",
+      "first_name": "Elsa",
+      "last_name": "Disney",
+      "house": "Highland"
+    },
+    {
+      "id": 99,
+      "grade": "10",
+      "first_name": "Mowgli",
+      "last_name": "Duck",
+      "house": "Highland"
+    },
+    {
+      "id": 9,
+      "grade": "KF",
+      "first_name": "Chip",
+      "last_name": "Skywalker",
+      "house": null
+    },
+    {
+      "id": 22,
+      "grade": "9",
+      "first_name": "Rapunzel",
+      "last_name": "Pan",
+      "house": "Elm"
+    },
+    {
+      "id": 31,
+      "grade": "9",
+      "first_name": "Pluto",
+      "last_name": "Disney",
+      "house": "Elm"
+    },
+    {
+      "id": 36,
+      "grade": "9",
+      "first_name": "Donald",
+      "last_name": "Kenobi",
+      "house": "Highland"
+    },
+    {
+      "id": 40,
+      "grade": "10",
+      "first_name": "Pluto",
+      "last_name": "Duck",
+      "house": "Broadway"
+    },
+    {
+      "id": 51,
+      "grade": "5",
+      "first_name": "Elsa",
+      "last_name": "Duck",
+      "house": null
+    },
+    {
+      "id": 58,
+      "grade": "3",
+      "first_name": "Pocahontas",
+      "last_name": "Kenobi",
+      "house": null
+    },
+    {
+      "id": 67,
+      "grade": "10",
+      "first_name": "Olaf",
+      "last_name": "Kenobi",
+      "house": "Elm"
+    },
+    {
+      "id": 73,
+      "grade": "10",
+      "first_name": "Snow",
+      "last_name": "Duck",
+      "house": "Beacon"
+    },
+    {
+      "id": 87,
+      "grade": "10",
+      "first_name": "Minnie",
+      "last_name": "Poppins",
+      "house": "Beacon"
+    },
+    {
+      "id": 96,
+      "grade": "10",
+      "first_name": "Mickey",
+      "last_name": "Skywalker",
+      "house": "Elm"
+    },
+    {
+      "id": 100,
+      "grade": "10",
+      "first_name": "Snow",
+      "last_name": "Disney",
+      "house": "Highland"
+    },
+    {
+      "id": 101,
+      "grade": "10",
+      "first_name": "Chip",
+      "last_name": "Mouse",
+      "house": "Highland"
+    },
+    {
+      "id": 102,
+      "grade": "10",
+      "first_name": "Snow",
+      "last_name": "Disney",
+      "house": "Beacon"
+    },
+    {
+      "id": 103,
+      "grade": "10",
+      "first_name": "Snow",
+      "last_name": "Poppins",
+      "house": "Elm"
+    },
+    {
+      "id": 104,
+      "grade": "10",
+      "first_name": "Winnie",
+      "last_name": "Kenobi",
+      "house": "Broadway"
+    },
+    {
+      "id": 106,
+      "grade": "10",
+      "first_name": "Mickey",
+      "last_name": "Disney",
+      "house": "Beacon"
+    },
+    {
+      "id": 107,
+      "grade": "10",
+      "first_name": "Donald",
+      "last_name": "Poppins",
+      "house": "Beacon"
+    },
+    {
+      "id": 108,
+      "grade": "10",
+      "first_name": "Pluto",
+      "last_name": "Skywalker",
+      "house": "Elm"
+    },
+    {
+      "id": 110,
+      "grade": "10",
+      "first_name": "Aladdin",
+      "last_name": "Poppins",
+      "house": "Beacon"
+    },
+    {
+      "id": 111,
+      "grade": "10",
+      "first_name": "Olaf",
+      "last_name": "Skywalker",
+      "house": "Elm"
+    },
+    {
+      "id": 112,
+      "grade": "10",
+      "first_name": "Chip",
+      "last_name": "White",
+      "house": "Highland"
+    },
+    {
+      "id": 113,
+      "grade": "10",
+      "first_name": "Aladdin",
+      "last_name": "Kenobi",
+      "house": "Highland"
+    },
+    {
+      "id": 114,
+      "grade": "10",
+      "first_name": "Chip",
+      "last_name": "Disney",
+      "house": "Beacon"
+    },
+    {
+      "id": 115,
+      "grade": "10",
+      "first_name": "Minnie",
+      "last_name": "Pan",
+      "house": "Beacon"
+    },
+    {
+      "id": 116,
+      "grade": "10",
+      "first_name": "Minnie",
+      "last_name": "Kenobi",
+      "house": "Highland"
+    }
+  ],
+  "segments_by_student_id": {
+    "3": [
+      "Mari is struggling in biology, and has not completed the last two labs.",
+      "I met with her about staying after school so she could make them up, or how she could work with her lab partner."
+    ]
+  }
+}

--- a/app/assets/javascripts/reflection/ReflectionOnNotesPage.js
+++ b/app/assets/javascripts/reflection/ReflectionOnNotesPage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import _ from 'lodash';
 import * as Routes from '../helpers/Routes';
+import StudentPhoto from '../components/StudentPhoto';
 import StudentPhotoCropped from '../components/StudentPhotoCropped';
 import Delay from '../components/Delay';
 import GenericLoader from '../components/GenericLoader';
@@ -77,13 +78,22 @@ export default class ReflectionOnNotesPage extends React.Component {
     return (
       <div key={student.id} style={{display: 'flex', flexDirection: 'row', marginBottom: 50}}>
         <div>
-          <StudentPhotoCropped
-            studentId={student.id}
-            style={{
-              width: 400,
-              height: 400
-            }}
-          />
+          {window.location.search.indexOf('photo') !== -1
+          ? <StudentPhoto
+              student={student}
+              style={{
+                maxWidth: 400,
+                maxHeight: 400
+              }}
+            />
+          : <StudentPhotoCropped
+              studentId={student.id}
+              style={{
+                width: 400,
+                height: 400
+              }}
+            />
+          }
           <div>
             <a href={Routes.studentProfile(student.id)} style={{fontSize: 24, margin: 5}}>
               {student.first_name} {student.last_name}

--- a/app/assets/javascripts/reflection/ReflectionOnNotesPage.js
+++ b/app/assets/javascripts/reflection/ReflectionOnNotesPage.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import _ from 'lodash';
 import * as Routes from '../helpers/Routes';
 import StudentPhotoCropped from '../components/StudentPhotoCropped';
 import Delay from '../components/Delay';
 import GenericLoader from '../components/GenericLoader';
 import {apiFetchJson} from '../helpers/apiFetchJson';
-import {updateGlobalStylesToTakeFullHeight} from '../helpers/globalStylingWorkarounds';
 import SectionHeading from '../components/SectionHeading';
 import BoxCard from '../components/BoxCard';
 import WordCloud from '../components/WordCloud';

--- a/app/assets/javascripts/reflection/ReflectionOnNotesPage.js
+++ b/app/assets/javascripts/reflection/ReflectionOnNotesPage.js
@@ -77,14 +77,11 @@ export default class ReflectionOnNotesPage extends React.Component {
     const words = _.flatMap(segments, segment => segment.split(' '));
     return (
       <div key={student.id} style={{display: 'flex', flexDirection: 'row', marginBottom: 50}}>
-        <div>
+        <div style={{width: 400, marginRight: 10}}>
           {window.location.search.indexOf('photo') !== -1
           ? <StudentPhoto
               student={student}
-              style={{
-                maxWidth: 400,
-                maxHeight: 400
-              }}
+              style={{height: 400}}
             />
           : <StudentPhotoCropped
               studentId={student.id}
@@ -94,8 +91,8 @@ export default class ReflectionOnNotesPage extends React.Component {
               }}
             />
           }
-          <div>
-            <a href={Routes.studentProfile(student.id)} style={{fontSize: 24, margin: 5}}>
+          <div style={{textAlign: 'center'}}>
+            <a href={Routes.studentProfile(student.id)} style={{fontSize: 24, margin: 10}}>
               {student.first_name} {student.last_name}
             </a>
           </div>

--- a/app/assets/javascripts/reflection/ReflectionOnNotesPage.js
+++ b/app/assets/javascripts/reflection/ReflectionOnNotesPage.js
@@ -1,0 +1,134 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import * as Routes from '../helpers/Routes';
+import StudentPhotoCropped from '../components/StudentPhotoCropped';
+import Delay from '../components/Delay';
+import GenericLoader from '../components/GenericLoader';
+import {apiFetchJson} from '../helpers/apiFetchJson';
+import {updateGlobalStylesToTakeFullHeight} from '../helpers/globalStylingWorkarounds';
+import SectionHeading from '../components/SectionHeading';
+import BoxCard from '../components/BoxCard';
+import WordCloud from '../components/WordCloud';
+
+
+// For reflecting on patterns within notes
+export default class ReflectionOnNotesPage extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      n: 10
+    };
+    this.fetchJson = this.fetchJson.bind(this);
+    this.renderJson = this.renderJson.bind(this);
+    this.onClickMore = this.onClickMore.bind(this);
+  }
+
+  fetchJson() {
+    return apiFetchJson('/api/reflection/notes_patterns_json');
+  }
+
+  onClickMore(e) {
+    e.preventDefault();
+    const {n} = this.state;
+    this.setState({n: n + 10});
+  }
+
+  render() {
+    return (
+      <div style={{...styles.flexVertical, margin: 10}}>
+        <SectionHeading>Reflection on notes</SectionHeading>
+        <GenericLoader
+          promiseFn={this.fetchJson}
+          render={this.renderJson}
+        />
+      </div>
+    );
+  }
+
+  renderJson(json) {
+    const {n} = this.state;
+    const students = json.students;
+    const segmentsByStudentId = json.segments_by_student_id;
+    const sortedStudents = _.sortBy(students, student => -1 * (segmentsByStudentId[student.id] || []).length);
+    return (
+      <div style={styles.main}>
+        {this.renderMeta(students, n)}
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+          {sortedStudents.slice(0, n).map((student, studentIndex) => {
+            return this.renderForStudent(student, studentIndex, segmentsByStudentId[student.id] || []);
+          })}
+        </div>
+        {students.length > n && <div><a onClick={this.onClickMore} href="#">More</a></div>}
+      </div>
+    );
+  }
+
+  renderMeta(students, n) {
+    return (
+      <div style={styles.meta}>
+        <div>Students with the most written about them this school year are shown first.</div>
+        <div>Showing first {n} of {students.length} students.</div>
+      </div>
+    );
+  }
+
+  renderForStudent(student, studentIndex, segments) {
+    const words = _.flatMap(segments, segment => segment.split(' '));
+    return (
+      <div key={student.id} style={{display: 'flex', flexDirection: 'row', marginBottom: 50}}>
+        <div>
+          <StudentPhotoCropped
+            studentId={student.id}
+            style={{
+              width: 400,
+              height: 400
+            }}
+          />
+          <div>
+            <a href={Routes.studentProfile(student.id)} style={{fontSize: 24, margin: 5}}>
+              {student.first_name} {student.last_name}
+            </a>
+          </div>
+        </div>
+        <BoxCard
+          style={{
+            margin: 0,
+            minWidth: 400 // prevent jump when loading
+          }}
+          title={`Patterns in ${words.length} words written`}>
+          <Delay wait={studentIndex * 100}> {/* ux, to prioritize drawing top rows first */ }
+            <WordCloud
+              style={{
+                cursor: 'default',
+                height: 400,
+                width: 400
+              }}
+              width={400}
+              height={400}
+              words={words}
+            />
+          </Delay>
+        </BoxCard>
+      </div>
+    );
+  }
+}
+
+const styles = {
+  flexVertical: {
+    display: 'flex',
+    flex: 1,
+    flexDirection: 'column'
+  },
+  main: {
+    fontSize: 14,
+    paddingLeft: 10
+  },
+  meta: {
+    padding: 10,
+    paddingLeft: 0,
+    color: '#999'
+  }
+};

--- a/app/assets/javascripts/reflection/ReflectionOnNotesPage.js
+++ b/app/assets/javascripts/reflection/ReflectionOnNotesPage.js
@@ -79,11 +79,11 @@ export default class ReflectionOnNotesPage extends React.Component {
       <div key={student.id} style={{display: 'flex', flexDirection: 'row', marginBottom: 50}}>
         <div style={{width: 400, marginRight: 10}}>
           {window.location.search.indexOf('photo') !== -1
-          ? <StudentPhoto
+            ? <StudentPhoto
               student={student}
               style={{height: 400}}
             />
-          : <StudentPhotoCropped
+            : <StudentPhotoCropped
               studentId={student.id}
               style={{
                 width: 400,

--- a/app/assets/javascripts/reflection/ReflectionOnNotesPage.test.js
+++ b/app/assets/javascripts/reflection/ReflectionOnNotesPage.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {mount} from 'enzyme';
+import fetchMock from 'fetch-mock/es5/client';
+import {withDefaultNowContext} from '../testing/NowContainer';
+import PerDistrictContainer from '../components/PerDistrictContainer';
+import ReflectionOnNotesPage from './ReflectionOnNotesPage';
+import fixtureJson from './ReflectionOnNotesPage.fixture';
+
+function testProps() {
+  return {};
+}
+
+function testEl(props = {}) {
+  return withDefaultNowContext(
+    <PerDistrictContainer districtKey="somerville">
+      <ReflectionOnNotesPage {...props} />
+    </PerDistrictContainer>
+  );
+}
+
+jest.mock('../components/WordCloud'); // requires real DOM
+
+beforeEach(() => {
+  fetchMock.restore();
+  fetchMock.get('/api/reflection/notes_patterns_json', fixtureJson);
+});
+
+it('renders without crashing', () => {
+  const props = testProps();
+  const el = document.createElement('div');
+  ReactDOM.render(testEl(props), el);
+});
+
+describe('integration tests', () => {
+  it('renders after fetch', done => {
+    const props = testProps();
+    const wrapper = mount(testEl(props));
+    expect(wrapper.text()).toContain('Loading...');
+
+    setTimeout(() => {
+      expect(wrapper.html()).toContain('Reflection on notes');
+      expect($(wrapper.html()).find('.BoxCard').length).toEqual(10);
+      expect($(wrapper.html()).find('.StudentPhotoCropped').length).toEqual(10);
+      expect(wrapper.text()).toContain('More');
+      done();
+    }, 0);
+  });
+});

--- a/app/controllers/reflection_controller.rb
+++ b/app/controllers/reflection_controller.rb
@@ -1,0 +1,43 @@
+class ReflectionController < ApplicationController
+  before_action :ensure_authorized!
+
+  def notes_patterns_json
+    # notes for this school year, for students they work with
+    time_now = Time.now
+    school_year = SchoolYear.to_school_year(time_now)
+    start_of_school_year = SchoolYear.first_day_of_school_for_year(school_year)
+    puts 'time_now:'
+    puts time_now
+    puts 'start_of_school_year:'
+    puts start_of_school_year
+
+    students = authorizer.authorized { Student.active.to_a }
+    event_notes = authorizer.authorized do
+      EventNote
+        .where(student: students.map(&:id))
+        .where(is_restricted: false)
+        .where('recorded_at >= ?', start_of_school_year)
+    end
+
+    # by student, flatten out and segment text
+    notes_by_student_id = event_notes.group_by(&:student_id)
+    segments_by_student_id = {}
+    notes_by_student_id.each do |student_id, event_notes|
+      note_texts = event_notes.map(&:text)
+      segments = note_texts.flat_map do |text|
+        PragmaticSegmenter::Segmenter.new(text: text, language: 'en').segment
+      end
+      segments_by_student_id[student_id] = segments
+    end
+
+    render json: {
+      students: students.as_json(only: [:id, :first_name, :last_name, :grade, :house]),
+      segments_by_student_id: segments_by_student_id
+    }
+  end
+
+  private
+  def ensure_authorized!
+    raise Exceptions::EducatorNotAuthorized unless current_educator.labels.include?('enable_reflection_on_notes_patterns')
+  end
+end

--- a/app/controllers/reflection_controller.rb
+++ b/app/controllers/reflection_controller.rb
@@ -38,6 +38,7 @@ class ReflectionController < ApplicationController
 
   private
   def ensure_authorized!
-    raise Exceptions::EducatorNotAuthorized unless current_educator.labels.include?('enable_reflection_on_notes_patterns')
+    is_authorized = current_educator.labels.include?('enable_reflection_on_notes_patterns') || EnvironmentVariable.is_true('ENABLE_REFLECTION_ON_NOTES_FOR_ALL')
+    raise Exceptions::EducatorNotAuthorized unless is_authorized
   end
 end

--- a/app/importers/star/star_importer.rb
+++ b/app/importers/star/star_importer.rb
@@ -8,6 +8,7 @@ class StarImporter
     @log = options.fetch(:log, nil)
     @invalid_rows_count = 0
     @skipped_from_school_filter = 0
+    @student_id_not_found_count = 0
 
     raise 'missing option: model_class' if @model_class.nil?
     raise 'missing option: remote_file_name' if @remote_file_name.nil?
@@ -38,6 +39,7 @@ class StarImporter
 
       log("skipped #{@invalid_rows_count} invalid rows.")
       log("skipped #{@skipped_from_school_filter} rows because of school filter.")
+      log("skipped #{@student_id_not_found_count} rows because student not found.")
     end
   end
 
@@ -75,7 +77,7 @@ class StarImporter
     student_local_id = row['StudentIdentifier']
     student = Student.find_by_local_id(student_local_id)
     if student.nil?
-      log("skipping, StudentIdentifier not found: #{student_local_id}")
+      @student_id_not_found_count += 1
       return
     end
 

--- a/app/models/educator_label.rb
+++ b/app/models/educator_label.rb
@@ -42,6 +42,7 @@ class EducatorLabel < ApplicationRecord
         'can_upload_student_voice_surveys',
         'should_show_levels_shs_link',
         'enable_searching_notes',
+        'enable_reflection_on_notes_patterns',
         'can_mark_notes_as_restricted',
         'enable_equity_experiments',
         'enable_counselor_meetings_page'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,9 @@ Rails.application.routes.draw do
   # notes search
   get '/api/search_notes/query_json' => 'search_notes#query_json'
 
+  # reflection tools
+  get '/api/reflection/notes_patterns_json' => 'reflection#notes_patterns_json'
+
   # my notes
   get '/api/educators/my_notes_json'=> 'educators#my_notes_json'
 
@@ -157,6 +160,9 @@ Rails.application.routes.draw do
 
   # search notes
   get '/search/notes' => 'ui#ui'
+
+  # reflection tools
+  get '/reflection/notes' => 'ui#ui'
 
   # SHS levels
   get '/levels/:school_id' => 'ui#ui'

--- a/spec/controllers/district_controller_spec.rb
+++ b/spec/controllers/district_controller_spec.rb
@@ -28,6 +28,7 @@ describe DistrictController, :type => :controller do
             'can_upload_student_voice_surveys',
             'should_show_levels_shs_link',
             'enable_reading_benchmark_data_entry',
+            'enable_reflection_on_notes_patterns',
             'profile_enable_minimal_reading_data',
             'enable_equity_experiments',
             'enable_reading_debug',

--- a/spec/controllers/educators_controller_spec.rb
+++ b/spec/controllers/educators_controller_spec.rb
@@ -38,6 +38,7 @@ describe EducatorsController, :type => :controller do
           'can_upload_student_voice_surveys',
           'should_show_levels_shs_link',
           'enable_reading_benchmark_data_entry',
+          'enable_reflection_on_notes_patterns',
           'profile_enable_minimal_reading_data',
           'enable_equity_experiments',
           'enable_reading_debug',

--- a/spec/controllers/reflection_controller_spec.rb
+++ b/spec/controllers/reflection_controller_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+describe ReflectionController, :type => :controller do
+  before { request.env['HTTPS'] = 'on' }
+  let!(:pals) { TestPals.create! }
+
+  describe '#notes_patterns_json' do
+    def get_notes_patterns_json(educator)
+      sign_in(educator)
+      get :notes_patterns_json, params: {
+        format: :json
+      }
+      sign_out(educator)
+      response
+    end
+
+    def enable_for_educator!(educator)
+      EducatorLabel.create!(
+        educator: educator,
+        label_key: 'enable_reflection_on_notes_patterns'
+      )
+    end
+
+    def with_time_frozen(&block)
+      time_now = pals.time_now.utc
+      Timecop.freeze(time_now) do
+        block.call(time_now)
+      end
+    end
+
+    def create_test_note(params = {})
+      FactoryBot.create(:event_note, {
+        student_id: pals.shs_senior_kylo.id,
+        event_note_type: EventNoteType.SST,
+        educator_id: pals.shs_jodi.id,
+        text: 'this is about reading.  he is doing great this semester!',
+        is_restricted: false
+      }.merge(params))
+    end
+
+    it 'works on happy path' do
+      with_time_frozen do |time_now|
+        event_note = create_test_note(recorded_at: time_now - 13.days)
+        response = get_notes_patterns_json(pals.uri)
+        expect(response.status).to eq 200
+        json = JSON.parse(response.body)
+        expect(json.keys).to eq(['students', 'segments_by_student_id'])
+        expect(json['students'].length).to eq(5)
+        expect(json['students'].first.keys).to eq([
+          'id',
+          'grade',
+          'first_name',
+          'last_name',
+          'house'
+        ])
+        expect(json['segments_by_student_id']).to eq({
+          pals.shs_senior_kylo.id.to_s => [
+            "this is about reading.",
+            "he is doing great this semester!"
+          ]
+        })
+      end
+    end
+
+    it 'does not return restricted notes, even if user has access to view' do
+      with_time_frozen do |time_now|
+        event_note = create_test_note({
+          recorded_at: time_now - 13.days,
+          is_restricted: true
+        })
+        response = get_notes_patterns_json(pals.uri)
+        expect(response.status).to eq 200
+        json = JSON.parse(response.body)
+        expect(json['segments_by_student_id']).to eq({})
+      end
+    end
+
+    it 'guards student-level authorization, using Kylo as example' do
+      with_time_frozen do |time_now|
+        create_test_note(recorded_at: time_now - 13.days)
+        unauthorized_educators = Educator.all - [
+          pals.uri,
+          pals.rich_districtwide,
+          pals.shs_harry_housemaster, # schoolwide
+          pals.shs_sofia_counselor, # schoolwide
+          pals.shs_fatima_science_teacher, # schoolwide
+          pals.shs_hugo_art_teacher # in course
+        ]
+        unauthorized_educators.each do |educator|
+          enable_for_educator!(educator)
+          response = get_notes_patterns_json(educator)
+          expect(response.status).to eq 200
+          json = JSON.parse(response.body)
+          expect(json['students'].map {|j| j['id'] }).to_not include(pals.shs_senior_kylo.id)
+          expect(json['segments_by_student_id']).to eq({})
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/ui_controller_spec.rb
+++ b/spec/controllers/ui_controller_spec.rb
@@ -22,6 +22,7 @@ describe UiController, :type => :controller do
             'can_upload_student_voice_surveys',
             'should_show_levels_shs_link',
             'enable_reading_benchmark_data_entry',
+            'enable_reflection_on_notes_patterns',
             'profile_enable_minimal_reading_data',
             'enable_equity_experiments',
             'enable_reading_debug',

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe Educator do
         'can_upload_student_voice_surveys',
         'should_show_levels_shs_link',
         'enable_reading_benchmark_data_entry',
+        'enable_reflection_on_notes_patterns',
         'enable_equity_experiments',
         'enable_reading_debug',
         'profile_enable_minimal_reading_data',

--- a/spec/support/test_pals.rb
+++ b/spec/support/test_pals.rb
@@ -125,6 +125,10 @@ class TestPals
       educator: @uri,
       label_key: 'enable_viewing_educators_with_access_to_student'
     })
+    EducatorLabel.create!({
+      educator: @uri,
+      label_key: 'enable_reflection_on_notes_patterns'
+    })
     EducatorMultifactorConfig.create!({
       educator: @uri,
       rotp_secret: '4444rrr2vwjqgua2umohlpuzobar4444' # so development and demo have a stable TOTP setup over deploys

--- a/ui/App.js
+++ b/ui/App.js
@@ -159,7 +159,7 @@ export default class App extends React.Component {
   }
 
   renderReflectionOnNotes(routeProps) {
-    return <ReflectionOnNotesPage />
+    return <ReflectionOnNotesPage />;
   }
 
   renderMyNotesPage(routeProps) {

--- a/ui/App.js
+++ b/ui/App.js
@@ -13,6 +13,7 @@ import SessionRenewal from '../app/assets/javascripts/components/SessionRenewal'
 import RollbarErrorBoundary from '../app/assets/javascripts/components/RollbarErrorBoundary';
 import HomePage from '../app/assets/javascripts/home/HomePage';
 import SearchNotesPage from '../app/assets/javascripts/search_notes/SearchNotesPage';
+import ReflectionOnNotesPage from '../app/assets/javascripts/reflection/ReflectionOnNotesPage';
 import EducatorPage from '../app/assets/javascripts/educator/EducatorPage';
 import HomeroomPage from '../app/assets/javascripts/homeroom/HomeroomPage';
 import SchoolRosterPage from '../app/assets/javascripts/school_overview/SchoolRosterPage';
@@ -104,6 +105,7 @@ export default class App extends React.Component {
         <Route exact path="/educators/my_sections" render={this.renderMySectionsPage.bind(this)}/>
         <Route exact path="/home" render={this.renderHomePage.bind(this)}/>
         <Route exact path="/search/notes" render={this.renderSearchNotesPage.bind(this)}/>
+        <Route exact path="/reflection/notes" render={this.renderReflectionOnNotes.bind(this)}/>
         <Route exact path="/schools/:id_or_slug" render={this.renderSchoolRosterPage.bind(this)}/>
         <Route exact path="/schools/:id_or_slug/absences" render={this.renderAbsencesPage.bind(this)}/>
         <Route exact path="/schools/:id/tardies" render={this.renderTardiesDashboard.bind(this)}/>
@@ -151,6 +153,16 @@ export default class App extends React.Component {
     const {id, labels} = currentEducator;
     return (
       <SearchNotesPage
+        educatorId={id}
+        educatorLabels={labels} />
+    );
+  }
+
+  renderReflectionOnNotes(routeProps) {
+    const {currentEducator} = this.props;
+    const {id, labels} = currentEducator;
+    return (
+      <ReflectionOnNotesPage
         educatorId={id}
         educatorLabels={labels} />
     );

--- a/ui/App.js
+++ b/ui/App.js
@@ -159,13 +159,7 @@ export default class App extends React.Component {
   }
 
   renderReflectionOnNotes(routeProps) {
-    const {currentEducator} = this.props;
-    const {id, labels} = currentEducator;
-    return (
-      <ReflectionOnNotesPage
-        educatorId={id}
-        educatorLabels={labels} />
-    );
+    return <ReflectionOnNotesPage />
   }
 
   renderMyNotesPage(routeProps) {

--- a/ui/App.test.js
+++ b/ui/App.test.js
@@ -4,6 +4,7 @@ import {NEW_BEDFORD} from '../app/assets/javascripts/helpers/PerDistrict';
 import App from './App';
 import HomePage from '../app/assets/javascripts/home/HomePage';
 import SearchNotesPage from '../app/assets/javascripts/search_notes/SearchNotesPage';
+import ReflectionOnNotesPage from '../app/assets/javascripts/reflection/ReflectionOnNotesPage';
 import EducatorPage from '../app/assets/javascripts/educator/EducatorPage';
 import HomeroomPage from '../app/assets/javascripts/homeroom/HomeroomPage';
 import MyStudentsPage from '../app/assets/javascripts/my_students/MyStudentsPage';
@@ -28,6 +29,7 @@ import {MemoryRouter} from 'react-router-dom';
 
 jest.mock('../app/assets/javascripts/home/HomePage');
 jest.mock('../app/assets/javascripts/search_notes/SearchNotesPage');
+jest.mock('../app/assets/javascripts/reflection/ReflectionOnNotesPage');
 jest.mock('../app/assets/javascripts/educator/EducatorPage');
 jest.mock('../app/assets/javascripts/homeroom/HomeroomPage');
 jest.mock('../app/assets/javascripts/my_students/MyStudentsPage');
@@ -91,6 +93,10 @@ it('renders SearchNotesPage without crashing', () => {
   )).toEqual(true);
 });
 
+it('renders SearchNotesPage without crashing', () => {
+  const wrapper = mount(renderPath('/reflection/notes'));
+  expect(wrapper.contains(<ReflectionOnNotesPage />)).toEqual(true);
+});
 
 it('renders MyStudentsPage without crashing', () => {
   const wrapper = mount(renderPath('/educators/my_students'));


### PR DESCRIPTION
# Who is this PR for?
SHS educators in a workshop, to start

# What does this PR do?
Adds a reflection tool for looking at patterns in how students are written about within Student Insights.  This is still early, but the idea is to center how individual students are talked about (rather than how individual educators write), and to focus on students that are written about the most within Student Insights.  The intention is to help focus ask questions about reflecting whole-child and strengths-based perspectives.  Notes are scoped to student-level authorization, and to the current school year only (anything restricted is excluded, even if the educator would have access in other contexts).

This page is behind a label, and not exposed in the UI right now.  It'll be prototyped in a workshop first before any wider training or release.

# Screenshot (if adding a client-side feature)
(word cloud omitted)

<img width="855" alt="Screen Shot 2019-10-30 at 11 13 27 AM" src="https://user-images.githubusercontent.com/1056957/67871228-61298f80-fb06-11e9-928c-8c107eb9ffaf.png">



# Checklists
*Which features or pages does this PR touch?*
+ [x] Reflection on notes

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here