### PR TITLE
STAR: Fix test time since parsing is dependent on time zones, update v1 parsing to ET

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -96,21 +96,11 @@ class PerDistrict
     end
   end
 
-  # This is pretty old, but especially with the fixed `CDT` string here
-  # could probably be simplified or improved.
+  # Parse in EDT/EST, depending on parse date (probably should be depending on
+  # the date itself.  In earlier iterations this parsing was fixed to CDT.
   def parse_star_date_taken_with_v1_format(datetime_string)
-    day = DateTime.strptime(datetime_string, "%m/%d/%Y")
-    time = Time.strptime("#{datetime_string} CDT", "%m/%d/%Y %H:%M:%S %Z")
-
-    # Merge together data from DateTime and Time because:
-    #  * The Ruby `Time` class handles timezones properly (DateTime has issues)
-    #  * The Ruby `DateTime` class stores dates properly
-    #  * The only way I found to successfully parse and store this data was to
-    #    use both classes and merge the results together
-    DateTime.new(
-      day.year, day.month, day.day,
-      time.hour, time.min, time.sec, time.formatted_offset
-    )
+    eastern_offset = Time.now.in_time_zone('Eastern Time (US & Canada)').formatted_offset
+    DateTime.strptime("#{datetime_string} #{eastern_offset}", '%m/%d/%Y %H:%M:%S %Z')
   end
 
   # Remove microseconds manually, since I can't figure out how to get Ruby

--- a/spec/importers/star/star_math_importer_spec.rb
+++ b/spec/importers/star/star_math_importer_spec.rb
@@ -37,31 +37,35 @@ RSpec.describe StarMathImporter do
     let!(:student) { FactoryBot.create(:student, local_id: '10', school: pals.west) }
 
     it 'works for v2 in somerville' do
-      importer, log = create_mocked_importer(PerDistrict::SOMERVILLE, "#{Rails.root}/spec/importers/star/star_math_v2.csv")
-      importer.import
-      expect(log.output).to include(':processed_rows_count=>1')
-      expect(StarMathResult.all.size).to eq(1)
-      expect(StarMathResult.first.as_json(except: [:id, :created_at, :updated_at])).to eq({
-        "date_taken"=>DateTime.new(2015, 1, 21, 13, 18, 27), # stored in UTC
-        "percentile_rank"=>70,
-        "total_time"=>600,
-        "grade_equivalent"=>"1.00",
-        "student_id"=>student.id
-      })
+      Timecop.freeze(pals.time_now) do
+        importer, log = create_mocked_importer(PerDistrict::SOMERVILLE, "#{Rails.root}/spec/importers/star/star_math_v2.csv")
+        importer.import
+        expect(log.output).to include(':processed_rows_count=>1')
+        expect(StarMathResult.all.size).to eq(1)
+        expect(StarMathResult.first.as_json(except: [:id, :created_at, :updated_at])).to eq({
+          "date_taken"=>DateTime.new(2015, 1, 21, 13, 18, 27), # parsed as EDT/EST, stored in UTC
+          "percentile_rank"=>70,
+          "total_time"=>600,
+          "grade_equivalent"=>"1.00",
+          "student_id"=>student.id
+        })
+      end
     end
 
     it 'works for v1 in new_bedford' do
-      importer, log = create_mocked_importer(PerDistrict::NEW_BEDFORD, "#{Rails.root}/spec/importers/star/star_math_v1.csv")
-      importer.import
-      expect(log.output).to include(':processed_rows_count=>1')
-      expect(StarMathResult.all.size).to eq(1)
-      expect(StarMathResult.first.as_json(except: [:id, :created_at, :updated_at])).to eq({
-        "date_taken"=>DateTime.new(2015, 1, 21, 14, 18, 27), # stored in UTC
-        "percentile_rank"=>70,
-        "total_time"=>600,
-        "grade_equivalent"=>"1.00",
-        "student_id"=>student.id
-      })
+      Timecop.freeze(pals.time_now) do
+        importer, log = create_mocked_importer(PerDistrict::NEW_BEDFORD, "#{Rails.root}/spec/importers/star/star_math_v1.csv")
+        importer.import
+        expect(log.output).to include(':processed_rows_count=>1')
+        expect(StarMathResult.all.size).to eq(1)
+        expect(StarMathResult.first.as_json(except: [:id, :created_at, :updated_at])).to eq({
+          "date_taken"=>DateTime.new(2015, 1, 21, 13, 18, 27), # parsed as EDT/EST, stored in UTC
+          "percentile_rank"=>70,
+          "total_time"=>600,
+          "grade_equivalent"=>"1.00",
+          "student_id"=>student.id
+        })
+      end
     end
 
     it 'handles bad data (v2 as example)' do

--- a/spec/importers/star/star_reading_importer_spec.rb
+++ b/spec/importers/star/star_reading_importer_spec.rb
@@ -37,31 +37,35 @@ RSpec.describe StarReadingImporter do
     let!(:student) { FactoryBot.create(:student, local_id: '10', school: pals.west) }
 
     it 'works for v2 format in somerville' do
-      importer, log = create_mocked_importer(PerDistrict::SOMERVILLE, "#{Rails.root}/spec/importers/star/star_reading_v2.csv")
-      importer.import
-      expect(log.output).to include(':processed_rows_count=>1')
-      expect(StarReadingResult.all.size).to eq(1)
-      expect(StarReadingResult.first.as_json(except: [:id, :created_at, :updated_at])).to eq({
-        "date_taken"=>DateTime.new(2015, 1, 21, 13, 18, 27), # parsed as EDT/EST, stored in UTC
-        "percentile_rank"=>90,
-        "total_time"=>710,
-        "grade_equivalent"=>"1.00",
-        "student_id"=>student.id
-      })
+      Timecop.freeze(pals.time_now) do
+        importer, log = create_mocked_importer(PerDistrict::SOMERVILLE, "#{Rails.root}/spec/importers/star/star_reading_v2.csv")
+        importer.import
+        expect(log.output).to include(':processed_rows_count=>1')
+        expect(StarReadingResult.all.size).to eq(1)
+        expect(StarReadingResult.first.as_json(except: [:id, :created_at, :updated_at])).to eq({
+          "date_taken"=>DateTime.new(2015, 1, 21, 13, 18, 27), # parsed as EDT/EST, stored in UTC
+          "percentile_rank"=>90,
+          "total_time"=>710,
+          "grade_equivalent"=>"1.00",
+          "student_id"=>student.id
+        })
+      end
     end
 
     it 'works for v1 format in new bedford' do
-      importer, log = create_mocked_importer(PerDistrict::NEW_BEDFORD, "#{Rails.root}/spec/importers/star/star_reading_v1.csv")
-      importer.import
-      expect(log.output).to include(':processed_rows_count=>1')
-      expect(StarReadingResult.all.size).to eq(1)
-      expect(StarReadingResult.first.as_json(except: [:id, :created_at, :updated_at])).to eq({
-        "date_taken"=>DateTime.new(2015, 1, 21, 14, 18, 27), # parsed as CDT(?), stored in UTC
-        "percentile_rank"=>90,
-        "total_time"=>710,
-        "grade_equivalent"=>"1.00",
-        "student_id"=>student.id
-      })
+      Timecop.freeze(pals.time_now) do
+        importer, log = create_mocked_importer(PerDistrict::NEW_BEDFORD, "#{Rails.root}/spec/importers/star/star_reading_v1.csv")
+        importer.import
+        expect(log.output).to include(':processed_rows_count=>1')
+        expect(StarReadingResult.all.size).to eq(1)
+        expect(StarReadingResult.first.as_json(except: [:id, :created_at, :updated_at])).to eq({
+          "date_taken"=>DateTime.new(2015, 1, 21, 13, 18, 27), # parsed as EDT/EST, stored in UTC
+          "percentile_rank"=>90,
+          "total_time"=>710,
+          "grade_equivalent"=>"1.00",
+          "student_id"=>student.id
+        })
+      end
     end
 
     it 'skips and logs bad data (v2 as example)' do


### PR DESCRIPTION
# What problem does this PR fix?
Tests change based on timezone, since parsing is dependent on EST/EDT, which helpfully changed this weekend.  Fixing from https://github.com/studentinsights/studentinsights/pull/2688.

# What does this PR do?
Updates tests to fix time.  Also updates v1 parsing to use the same timezone and eastern time expectations.  Previously it was fixed at CDT, which I don't think matches what the vendor is doing.  Paper trail is: https://github.com/studentinsights/studentinsights/pull/1957/commits/7b162f302abbebfb087e660e8f0f2c6b3df18943#diff-0e9359cbb9e678e0c8cebe5808671865R33, https://github.com/studentinsights/studentinsights/pull/1957/commits/71caa90143db3529acffbf4b16a299a68b0a27f1#diff-f371a5d634493de1cbaeb46c77a19048R61 and https://github.com/studentinsights/studentinsights/pull/1957/commits/0b9208ce14ac0a15b93783299e32b7ae466afd7b#r209621059.

# Checklists
*Which features or pages does this PR touch?*
+ [x] STAR importers

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
