### PR TITLE
Maintenance: Update Rollbar Ruby gem and tighten configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     moneta (0.8.1)
-    multi_json (1.13.1)
+    multi_json (1.14.1)
     multipart-post (2.0.0)
     net-ldap (0.16.1)
     net-sftp (2.1.2)
@@ -290,8 +290,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     retriable (3.1.2)
-    rollbar (2.15.5)
-      multi_json
+    rollbar (2.22.1)
     rotp (4.0.2)
       addressable (~> 2.5)
     rqrcode (0.10.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -111,7 +111,6 @@ class ApplicationController < ActionController::Base
   # Called via Rollbar, set in rollbar.rb config.
   # See https://docs.rollbar.com/docs/person-tracking
   def rollbar_anonymized_person_method
-    puts '==> rollbar_anonymized_person_method'
     anonymized_identifier = LogAnonymizer.new.educator_identifier(request)
     AnonymizedPersonForRollbar.new(anonymized_identifier)
   end
@@ -128,7 +127,6 @@ class ApplicationController < ActionController::Base
 
     # Called via Rollbar, set in rollbar.rb config.
     def rollbar_person_anonymized_identifier
-      puts '==> rollbar_person_anonymized_identifier'
       @anonymized_identifier
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -111,6 +111,7 @@ class ApplicationController < ActionController::Base
   # Called via Rollbar, set in rollbar.rb config.
   # See https://docs.rollbar.com/docs/person-tracking
   def rollbar_anonymized_person_method
+    puts '==> rollbar_anonymized_person_method'
     anonymized_identifier = LogAnonymizer.new.educator_identifier(request)
     AnonymizedPersonForRollbar.new(anonymized_identifier)
   end
@@ -127,6 +128,7 @@ class ApplicationController < ActionController::Base
 
     # Called via Rollbar, set in rollbar.rb config.
     def rollbar_person_anonymized_identifier
+      puts '==> rollbar_person_anonymized_identifier'
       @anonymized_identifier
     end
   end

--- a/app/lib/env.rb
+++ b/app/lib/env.rb
@@ -20,6 +20,7 @@ class Env
     default_env['MOCK_LDAP_PASSWORD'] = 'demo-password'
     default_env['AWS_REGION'] = 'us-west-2'
     default_env['ROLLBAR_JS_ACCESS_TOKEN'] = 'foo';
+    default_env['ROLLBAR_ACCESS_TOKEN'] = 'fake_rollbar_access_token';
     default_env['TWILIO_CONFIG_JSON'] = '{"account_sid":"fake-twilio-sid-foo","auth_token":"fake-twilio-auth-token-foo","sending_number":"+15555551234"}'
     default_env['MAILGUN_API_KEY'] = 'fake-mailgun-api-key'
     default_env['MAILGUN_DOMAIN'] = 'fake-mailgun-domain'

--- a/app/lib/log_anonymizer.rb
+++ b/app/lib/log_anonymizer.rb
@@ -1,4 +1,4 @@
-class LogTags
+class LogAnonymizer
   def request_identifier(req)
     "r:#{req.request_id.first(8)}"
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -81,9 +81,9 @@ module SomervilleTeacherTool
 
       # Prepend all log lines with tags for the request, session and educator
       config.log_tags = [
-        ->(req) { LogTags.new.request_identifier(req) },
-        ->(req) { LogTags.new.session_identifier(req) },
-        ->(req) { LogTags.new.educator_identifier(req) }
+        ->(req) { LogAnonymizer.new.request_identifier(req) },
+        ->(req) { LogAnonymizer.new.session_identifier(req) },
+        ->(req) { LogAnonymizer.new.educator_identifier(req) }
       ]
     end
   end

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,20 +1,27 @@
 Rollbar.configure do |config|
+  # Import JS library through the JS build pipeline, not vendored and
+  # injected through the Ruby gem.
+  config.js_enabled = false
+
   # Without configuration, Rollbar is enabled in all environments.
   # To disable in specific environments, set config.enabled=false.
-
   config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
-
   if Rails.env.test? || Rails.env.development? || !EnvironmentVariable.is_true('SHOULD_REPORT_ERRORS')
     config.enabled = false
   end
 
   # By default, Rollbar will try to call the `current_user` controller method
   # to fetch the logged-in user object, and then call that object's `id`,
-  # `username`, and `email` methods to fetch those properties. To customize:
-  # config.person_method = "my_current_user"
-  # config.person_id_method = "my_id"
-  # config.person_username_method = "my_username"
-  # config.person_email_method = "my_email"
+  # `username`, and `email` methods to fetch those properties.
+  # See https://docs.rollbar.com/docs/ruby#section-person-tracking
+  #
+  # We don't want to collect any personally identifiable information about users.
+  # It may be useful to connect error information to error information in logs,
+  # so we send along an obfuscated identifier.
+  config.person_method = 'rollbar_anonymized_person_method'
+  config.person_id_method = 'rollbar_person_anonymized_identifier'
+  config.person_username_method = nil
+  config.person_email_method = nil
 
   # If you want to attach custom data to all exception and message reports,
   # provide a lambda like the following. It should return a hash.
@@ -26,41 +33,20 @@ Rollbar.configure do |config|
 
   # For privacy and security, do not log any parameters to Rollbar other than the URL,
   # since whitelists are hard to maintain accurately as you build things over time.
-  # Similer to filter_parameter_logging.rb.
-  # See https://docs.rollbar.com/docs/ruby#section-scrubbing-items 
-  config.scrub_fields = :scrub_all
-
-  # Add exception class names to the exception_level_filters hash to
-  # change the level that exception is reported at. Note that if an exception
-  # has already been reported and logged the level will need to be changed
-  # via the rollbar interface.
-  # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
-  # 'ignore' will cause the exception to not be reported at all.
-  # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
+  # Similar to filter_parameter_logging.rb.
   #
-  # You can also specify a callable, which will be called with the exception instance.
-  # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
+  # Several config items below default to `true`, this is just being explicit that
+  # we want this particular config in case defaults change later.
+  #
+  # See https://docs.rollbar.com/docs/ruby#section-scrubbing-items 
+  # and https://docs.rollbar.com/docs/ruby#section-managing-sensitive-data 
+  config.scrub_fields = :scrub_all # note that docs say this isn't recursive
+  config.scrub_password = true
+  config.scrub_user = true
+  config.randomize_scrub_length = true
 
-  # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
-  # is not installed)
-  # config.use_async = true
-  # Supply your own async handler:
-  # config.async_handler = Proc.new { |payload|
-  #  Thread.new { Rollbar.process_from_async_handler(payload) }
-  # }
-
-  # Enable asynchronous reporting (using sucker_punch)
-  # config.use_sucker_punch
-
-  # Enable delayed reporting (using Sidekiq)
-  # config.use_sidekiq
-  # You can supply custom Sidekiq options:
-  # config.use_sidekiq 'queue' => 'default'
-
-  # If you run your staging application instance in production environment then
-  # you'll want to override the environment reported by `Rails.env` with an
-  # environment variable like this: `ROLLBAR_ENV=staging`. This is a recommended
-  # setup for Heroku. See:
-  # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
-  # config.environment = Rails.env
+  # We don't want to store IPs in Rollbar, but this information this can be useful
+  # for triangulating security issues, so for now start by anonymizing now that 
+  # this is available.
+  config.anonymize_user_ip = true
 end


### PR DESCRIPTION
More explicitly describe some privacy-related configuration.  Make sure default Rails person tracking is disabled.  Within Rollbar, only store anonymized identifiers and partially anonymized IP addresses, for the purpose of investigating issues.  Retention policy there is 30 days.