### PR TITLE
Maintenance: Upgrade Rollbar.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-select": "^1.2.1",
     "react-test-renderer": "^16.8.6",
     "react-virtualized": "9.20",
-    "rollbar-browser": "^1.9.5",
+    "rollbar": "^2.14.0",
     "uuid": "^3.2.1",
     "whatwg-fetch": "^2.0.3",
     "wordcloud": "^1.1.0"
@@ -83,13 +83,12 @@
     "webpack-merge": "^4.1.0"
   },
   "resolutions": {
-    "handlebars":"^4.4.5",
-    "rollbar-browser/extend": "^3.0.2",
+    "handlebars": "^4.4.5",
     "lodash": "^4.17.14",
     "lodash.mergewith": "^4.6.2",
     "lodash-es": "^4.17.14",
-    "mixin-deep":"^1.3.2",
-    "set-value":"^3.0.1",
-    "eslint-utils":"^1.4.1"
+    "mixin-deep": "^1.3.2",
+    "set-value": "^3.0.1",
+    "eslint-utils": "^1.4.1"
   }
 }

--- a/ui/rollbar.js
+++ b/ui/rollbar.js
@@ -1,4 +1,4 @@
-import rollbar from 'rollbar-browser';
+import rollbar from 'rollbar';
 import {readEnv} from '../app/assets/javascripts/envForJs';
 
 
@@ -12,19 +12,60 @@ if (shouldReportErrors && rollbarJsAccessToken) loadRollbar();
 
 
 // Load and configure the library.  Exports it as a global as well.
+// Example at https://github.com/rollbar/rollbar.js/blob/master/examples/webpack/src/index.js
 function loadRollbar() {
-  window.Rollbar = rollbar.init({
+  window.Rollbar = new rollbar({
+    enabled: true,
     accessToken: readEnv().rollbarJsAccessToken,
     captureUncaught: true,
     captureUnhandledRejections: true,
-    transform: transform,
+    transform: transform, // see note below
 
-    // throttle, mostly for bugs in browser extensions
-    itemsPerMinute: 10,
-    maxItems: 25,
+    // Throttle, mostly for limiting the impact of bugs in browser extensions
+    itemsPerMinute: 5,
+    maxItems: 20,
+    ignoreDuplicateErrors: true,
+
+    // Limit the data we send to Rollbar
+    captureIp: 'anonymize',
+    captureUsername: false,
+    captureEmail: false,
+
+    payload: {
+      person: null // prevent this from being sent, see also `transform`
+    },
+
+    // Nothing should be transmitted automatically and
+    // there shouldn't be any sensitive information in URLs or query
+    // strings.  This is overly defensive, and tries to prevent any Person
+    // information from being sent, even if it does get collected.
+    //
+    // Ideally we would scrub all fields, but the JS client doesn't support
+    // that the way the Ruby client does.
+    scrubFields: [
+      'person',
+      'fingerprint',
+      'id',
+      'currentEducator',
+      'educator',
+      'email',
+      'username'
+    ],
     
+    // We limit the "Telemetry" because of the privacy risk, and
+    // some collection is disabled altogether.  That being said,
+    // this config also defensively disables individual options 
+    // with defaults that are particular concerning for privacy,
+    // also explicitly expresses some config even if it matches
+    // the current default behavior.
+    // For more on Telemetry, see https://docs.rollbar.com/docs/rollbarjs-telemetry
+    scrubTelemetryInputs: true,
+    includeItemsInTelemetry: true,
     autoInstrument: {
-      // Limit data we send to Rollbar
+      // Limit data we send.  Although 
+      // https://github.com/rollbar/rollbar.js/pull/787 recently improved
+      // this, we don't anticipate any debugging value here, so this avoids
+      // the privacy risk.
       log: false,
       dom: false,
       networkResponseHeaders: false,
@@ -40,7 +81,11 @@ function loadRollbar() {
 }
 
 // Add in Rails env info to payload if we're reporting and it exists.
+// This is lazy because the Rollbar code is loaded in parallel with the code
+// that provides `readEnv`.  Reading it lazily on an event avoids having
+// to synchronize that code loading.
 function transform(payload) {
   payload.environment = readEnv().railsEnvironment;
   payload.districtKey = readEnv().districtKey;
+  payload.person = null; // prevent this from being set, overridding the default behavior
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2630,6 +2630,11 @@ async@^2.1.2, async@^2.1.4, async@^2.6.1:
   dependencies:
     lodash "^4.17.11"
 
+async@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.2.1.tgz#a4816a17cd5ff516dfa2c7698a453369b9790de0"
+  integrity sha1-pIFqF81f9RbfosdpikUzabl5DeA=
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -3286,7 +3291,7 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-from@^1.0.0:
+buffer-from@^1.0.0, buffer-from@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -3853,9 +3858,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-console-polyfill@rollbar/console-polyfill#eab6ff9d2b7597fc2f259baa18100556bdb94dbe:
-  version "0.2.3"
-  resolved "https://codeload.github.com/rollbar/console-polyfill/tar.gz/eab6ff9d2b7597fc2f259baa18100556bdb94dbe"
+console-polyfill@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/console-polyfill/-/console-polyfill-0.3.0.tgz#84900902a18c47a5eba932be75fa44d23e8af861"
+  integrity sha512-w+JSDZS7XML43Xnwo2x5O5vxB0ID7T5BdqDtyqT6uiCAX2kZAgcWxNaGqT97tZfSHzfOcvrfsDAodKcJ3UvnXQ==
 
 constants-browserify@^1.0.0:
   version "1.0.0"
@@ -4226,6 +4232,13 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+decache@^3.0.5:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/decache/-/decache-3.1.0.tgz#4f5036fbd6581fcc97237ac3954a244b9536c2da"
+  integrity sha1-T1A2+9ZYH8yXI3rDlUokS5U2wto=
+  dependencies:
+    find "^0.2.4"
 
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
@@ -4677,12 +4690,12 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-error-stack-parser@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-1.3.3.tgz#fada6e3a9cd2b0e080e6d6fc751418649734f35c"
-  integrity sha1-+tpuOpzSsOCA5tb8dRQYZJc081w=
+error-stack-parser@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.4.tgz#a757397dc5d9de973ac9a5d7d4e8ade7cfae9101"
+  integrity sha512-fZ0KkoxSjLFmhW5lHbUT3tLwy3nX1qEzMYo8koY1vrsAco53CMT1djnBSeC/wUjTEZRhZl9iRw7PaMaxfJ4wzQ==
   dependencies:
-    stackframe "^0.3.1"
+    stackframe "^1.1.0"
 
 es-abstract@^1.10.0, es-abstract@^1.11.0, es-abstract@^1.12.0, es-abstract@^1.4.3, es-abstract@^1.5.0, es-abstract@^1.5.1, es-abstract@^1.7.0, es-abstract@^1.9.0:
   version "1.13.0"
@@ -5089,7 +5102,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@3.0.0, extend@^3.0.0, extend@^3.0.2, extend@~3.0.2:
+extend@^3.0.0, extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -5305,6 +5318,13 @@ find-up@^2.0.0, find-up@^2.1.0:
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
+
+find@^0.2.4:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/find/-/find-0.2.9.tgz#4b73f1ff9e56ad91b76e716407fe5ffe6554bb8c"
+  integrity sha1-S3Px/55WrZG3bnFkB/5f/mVUu4w=
+  dependencies:
+    traverse-chain "~0.1.0"
 
 flat-cache@^2.0.1:
   version "2.0.1"
@@ -6381,6 +6401,11 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
+is_js@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/is_js/-/is_js-0.9.0.tgz#0ab94540502ba7afa24c856aa985561669e9c52d"
+  integrity sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0=
+
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -7032,7 +7057,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@~5.0.0, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -7353,6 +7378,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@~2.2.1:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
+  integrity sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=
 
 lunr@^2.3.6:
   version "2.3.6"
@@ -9505,6 +9535,13 @@ replace-ext@1.0.0:
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
   integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
+request-ip@~2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/request-ip/-/request-ip-2.0.2.tgz#deeae6d4af21768497db8cd05fa37143f8f1257e"
+  integrity sha1-3urm1K8hdoSX24zQX6NxQ/jxJX4=
+  dependencies:
+    is_js "^0.9.0"
+
 request-promise-core@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.2.tgz#339f6aababcafdb31c799ff158700336301d3346"
@@ -9653,14 +9690,23 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollbar-browser@^1.9.5:
-  version "1.9.5"
-  resolved "https://registry.yarnpkg.com/rollbar-browser/-/rollbar-browser-1.9.5.tgz#0cb8f6ba998c11da5ca303f74e8bc54bed9e53fa"
-  integrity sha512-dE0Ni8I+Heekl6tRJnK4nlh1nWvS42guHz3ExTkbatzRkIBbM8QWgoqaZxI7gJpaKxu9AgjVRHhwkL8InfVLSQ==
+rollbar@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/rollbar/-/rollbar-2.14.0.tgz#79dfa35e1ac68a78cfab704683b4e92c9cd554a1"
+  integrity sha512-diLV0JFr1TFLzsnf6L8TBvXxHn0bu2pPEHsl48Hy/249XHHOkVhapxWpVMF5im8q9f3J8vXceniGk7HTmct2FA==
   dependencies:
-    console-polyfill rollbar/console-polyfill#eab6ff9d2b7597fc2f259baa18100556bdb94dbe
-    error-stack-parser "1.3.3"
-    extend "3.0.0"
+    async "~1.2.1"
+    buffer-from "~1.1.1"
+    console-polyfill "0.3.0"
+    debug "2.6.9"
+    error-stack-parser "^2.0.4"
+    json-stringify-safe "~5.0.0"
+    lru-cache "~2.2.1"
+    request-ip "~2.0.1"
+    source-map "^0.5.7"
+    uuid "3.0.x"
+  optionalDependencies:
+    decache "^3.0.5"
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"
@@ -10159,10 +10205,10 @@ stack-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
 
-stackframe@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
-  integrity sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=
+stackframe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.1.0.tgz#e3fc2eb912259479c9822f7d1f1ff365bd5cbc83"
+  integrity sha512-Vx6W1Yvy+AM1R/ckVwcHQHV147pTPBKWCRLrXMuPrFVfvBUc3os7PR1QLIWCMhPpRg5eX9ojzbQIMLGBwyLjqg==
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -10641,6 +10687,11 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+traverse-chain@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/traverse-chain/-/traverse-chain-0.1.0.tgz#61dbc2d53b69ff6091a12a168fd7d433107e40f1"
+  integrity sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=
+
 tree-kill@^1.1.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.1.tgz#5398f374e2f292b9dcc7b2e71e30a5c3bb6c743a"
@@ -10945,6 +10996,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@3.0.x:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+  integrity sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=
 
 uuid@^3.2.1, uuid@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
Related to https://github.com/studentinsights/studentinsights/pull/2693, which does this on the Ruby side.  The JS side has a bit more risk as the distribution package has changed (now combined across Node and the browser), and recent versions include several changes in config related to Telemetry and Person tracking which we want to disable here.

Reviewed changes for all versions, and each config option.  To deploy, verifying on demo first.