### PR TITLE
Maintenance: Create DistrictConfigLog to enable more self-serve district maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ _site/
 !/app.json
 !/jest.json
 !/package.json
+!/config/sftp_filenames_development_fixture.json
 !/spec/importers/helpers/data_flows_for_other_importers.json
 !/spec/importers/file_importers/data_flows_fixture.json
 

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -52,8 +52,10 @@ class PerDistrict
     yaml.fetch('star_filenames', {}).fetch(key, fallback)
   end
 
+  # What filenames are district IT staff using when exporting specific
+  # files to SFTP servers?
   def try_sftp_filename(key, fallback = nil)
-    config = DistrictConfigLog.fetch_latest(DistrictConfigLog::SFTP_FILENAMES, {})
+    config = DistrictConfigLog.latest(DistrictConfigLog::SFTP_FILENAMES) || {}
     config.fetch(key, fallback)
   end
 

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -55,8 +55,8 @@ class PerDistrict
   # What filenames are district IT staff using when exporting specific
   # files to SFTP servers?
   def try_sftp_filename(key, fallback = nil)
-    config = DistrictConfigLog.latest(DistrictConfigLog::SFTP_FILENAMES) || {}
-    config.fetch(key, fallback)
+    json = DistrictConfigLog.latest_json(DistrictConfigLog::SFTP_FILENAMES, {})
+    json.fetch(key, fallback)
   end
 
   # This migrates up older formats still in use in New Bedfor

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -48,13 +48,13 @@ class PerDistrict
     yaml.fetch('school_definitions_for_import')
   end
 
-  # Expand basename to full path
-  def try_sftp_filename(key, fallback = nil)
-    yaml.fetch('sftp_filenames', {}).fetch(key, fallback)
-  end
-
   def try_star_filename(key, fallback = nil)
     yaml.fetch('star_filenames', {}).fetch(key, fallback)
+  end
+
+  def try_sftp_filename(key, fallback = nil)
+    config = DistrictConfigLog.fetch_latest(DistrictConfigLog::SFTP_FILENAMES, {})
+    config.fetch(key, fallback)
   end
 
   # This migrates up older formats still in use in New Bedfor

--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -48,6 +48,7 @@ class PerDistrict
     yaml.fetch('school_definitions_for_import')
   end
 
+  # Expand basename to full path
   def try_sftp_filename(key, fallback = nil)
     yaml.fetch('sftp_filenames', {}).fetch(key, fallback)
   end
@@ -483,9 +484,9 @@ class PerDistrict
     @district_key == SOMERVILLE
   end
 
-  def filenames_for_iep_pdf_zips
+  def filenames_for_iep_pdf_zips_ordered_oldest_to_newest
     if @district_key == SOMERVILLE
-      try_sftp_filename('FILENAMES_FOR_IEP_PDF_ZIPS', [])
+      try_sftp_filename('FILENAMES_FOR_IEP_PDF_ZIPS_ORDERED_OLDEST_TO_NEWEST', [])
     else
       []
     end

--- a/app/importers/iep_import/iep_pdf_import_job.rb
+++ b/app/importers/iep_import/iep_pdf_import_job.rb
@@ -31,9 +31,9 @@ class IepPdfImportJob
   # contains several older documents (ie., for a first-time import).
   # It will fail on any errors, log to the console and won't retry.
   def bulk_import!
-    remote_filenames = [ENV.fetch('BULK_IEP_IMPORT_TARGET')]
+    ordered_remote_filenames = [ENV.fetch('BULK_IEP_IMPORT_FILENAMES_FOR_IEP_PDF_ZIPS_ORDERED_OLDEST_TO_NEWEST')]
 
-    import_ieps!(remote_filenames)
+    import_ieps!(ordered_remote_filenames)
   end
 
   # Each ZIP file sent down from EasyIEP has a number at the end, the number
@@ -48,7 +48,7 @@ class IepPdfImportJob
   #
   # Order is important here.
   def nightly_import!
-    import_ieps!(PerDistrict.new.filenames_for_iep_pdf_zips)
+    import_ieps!(PerDistrict.new.filenames_for_iep_pdf_zips_ordered_oldest_to_newest)
   end
 
   private

--- a/app/models/district_config_log.rb
+++ b/app/models/district_config_log.rb
@@ -7,7 +7,41 @@ class DistrictConfigLog < ApplicationRecord
 
   validates :key, inclusion: { in: [SFTP_FILENAMES] }
 
-  def latest(key)
-    where(key: key).order(created_at: :desc).limit(1)
+  def self.latest_json(key, fallback = nil)
+    where(key: key).order(created_at: :desc).limit(1).try(:json) || fallback
+  end
+
+  # These aren't entirely static, but this seeds with
+  # values that are useful for dev and test.
+  def self.seed_for_development_and_test!
+    raise 'only for dev/test!' unless (Rails.env.development? || Rails.env.test?)
+
+    DistrictConfigLog.create!({
+      key: DistrictConfigLog::SFTP_FILENAMES,
+      json: {
+        "FILENAME_FOR_EDUCATORS_IMPORT": "/data/insights-dev-or-test/educators_export.csv",
+        "FILENAME_FOR_STUDENTS_IMPORT": "/data/insights-dev-or-test/students_export.csv",
+        "FILENAME_FOR_BEHAVIOR_IMPORT": "/data/insights-dev-or-test/behavior_export.csv",
+        "FILENAME_FOR_ASSESSMENT_IMPORT": "/data/insights-dev-or-test/assessment_export.csv",
+        "FILENAME_FOR_ATTENDANCE_IMPORT": "/data/insights-dev-or-test/attendance_export.csv",
+        "FILENAME_FOR_STUDENT_AVERAGES_IMPORT": "/data/insights-dev-or-test/student_averages_export.csv",
+        "FILENAME_FOR_COURSE_SECTION_IMPORT": "/data/insights-dev-or-test/courses_sections_export.csv",
+        "FILENAME_FOR_STUDENTS_SECTION_ASSIGNMENT_IMPORT": "/data/insights-dev-or-test/student_section_assignment_export.csv",
+        "FILENAME_FOR_EDUCATOR_SECTION_ASSIGNMENT_IMPORT": "/data/insights-dev-or-test/educator_section_assignment_export.csv",
+        "FILENAME_FOR_ED_PLAN_IMPORT": "/data/insights-dev-or-test/student_ed_plan_export.csv",
+        "FILENAME_FOR_ED_PLAN_ACCOMMODATIONS_IMPORT": "/data/insights-dev-or-test/student_accommodations_export.csv",
+
+        "FILENAME_FOR_PHOTOS_ZIP": "/data/insights-dev-or-test/photos.zip",
+
+        "FILENAMES_FOR_IEP_PDF_ZIPS_ORDERED_OLDEST_TO_NEWEST": [
+          "/data/insights-dev-or-test/student-documents-6.zip",
+          "/data/insights-dev-or-test/student-documents-5.zip",
+          "/data/insights-dev-or-test/student-documents-4.zip",
+          "/data/insights-dev-or-test/student-documents-3.zip",
+          "/data/insights-dev-or-test/student-documents-2.zip",
+          "/data/insights-dev-or-test/student-documents-1.zip"
+        ]
+      }
+    })
   end
 end

--- a/app/models/district_config_log.rb
+++ b/app/models/district_config_log.rb
@@ -1,9 +1,13 @@
+# Stores configuration that folks in the district ideally would manage on their
+# own.  In other words, this shouldn't be config that handles internals about
+# how Student Insights is different across districts, but "district maintenance"
+# that district IT and district project leads could manage.
 class DistrictConfigLog < ApplicationRecord
   SFTP_FILENAMES = 'sftp_filenames'
 
   validates :key, inclusion: { in: [SFTP_FILENAMES] }
 
-  def fetch_latest(key, default = nil)
-    where(key: key).order(created_at: :desc).limit(1) || default
+  def latest(key)
+    where(key: key).order(created_at: :desc).limit(1)
   end
 end

--- a/app/models/district_config_log.rb
+++ b/app/models/district_config_log.rb
@@ -1,0 +1,9 @@
+class DistrictConfigLog < ApplicationRecord
+  SFTP_FILENAMES = 'sftp_filenames'
+
+  validates :key, inclusion: { in: [SFTP_FILENAMES] }
+
+  def fetch_latest(key, default = nil)
+    where(key: key).order(created_at: :desc).limit(1) || default
+  end
+end

--- a/app/models/district_config_log.rb
+++ b/app/models/district_config_log.rb
@@ -8,7 +8,7 @@ class DistrictConfigLog < ApplicationRecord
   validates :key, inclusion: { in: [SFTP_FILENAMES] }
 
   def self.latest_json(key, fallback = nil)
-    where(key: key).order(created_at: :desc).limit(1).try(:json) || fallback
+    where(key: key).order(created_at: :desc).limit(1).try(:first).try(:json) || fallback
   end
 
   # These aren't entirely static, but this seeds with
@@ -18,30 +18,7 @@ class DistrictConfigLog < ApplicationRecord
 
     DistrictConfigLog.create!({
       key: DistrictConfigLog::SFTP_FILENAMES,
-      json: {
-        "FILENAME_FOR_EDUCATORS_IMPORT": "/data/insights-dev-or-test/educators_export.csv",
-        "FILENAME_FOR_STUDENTS_IMPORT": "/data/insights-dev-or-test/students_export.csv",
-        "FILENAME_FOR_BEHAVIOR_IMPORT": "/data/insights-dev-or-test/behavior_export.csv",
-        "FILENAME_FOR_ASSESSMENT_IMPORT": "/data/insights-dev-or-test/assessment_export.csv",
-        "FILENAME_FOR_ATTENDANCE_IMPORT": "/data/insights-dev-or-test/attendance_export.csv",
-        "FILENAME_FOR_STUDENT_AVERAGES_IMPORT": "/data/insights-dev-or-test/student_averages_export.csv",
-        "FILENAME_FOR_COURSE_SECTION_IMPORT": "/data/insights-dev-or-test/courses_sections_export.csv",
-        "FILENAME_FOR_STUDENTS_SECTION_ASSIGNMENT_IMPORT": "/data/insights-dev-or-test/student_section_assignment_export.csv",
-        "FILENAME_FOR_EDUCATOR_SECTION_ASSIGNMENT_IMPORT": "/data/insights-dev-or-test/educator_section_assignment_export.csv",
-        "FILENAME_FOR_ED_PLAN_IMPORT": "/data/insights-dev-or-test/student_ed_plan_export.csv",
-        "FILENAME_FOR_ED_PLAN_ACCOMMODATIONS_IMPORT": "/data/insights-dev-or-test/student_accommodations_export.csv",
-
-        "FILENAME_FOR_PHOTOS_ZIP": "/data/insights-dev-or-test/photos.zip",
-
-        "FILENAMES_FOR_IEP_PDF_ZIPS_ORDERED_OLDEST_TO_NEWEST": [
-          "/data/insights-dev-or-test/student-documents-6.zip",
-          "/data/insights-dev-or-test/student-documents-5.zip",
-          "/data/insights-dev-or-test/student-documents-4.zip",
-          "/data/insights-dev-or-test/student-documents-3.zip",
-          "/data/insights-dev-or-test/student-documents-2.zip",
-          "/data/insights-dev-or-test/student-documents-1.zip"
-        ]
-      }
+      json: JSON.parse(IO.read('config/sftp_filenames_development_fixture.json'))
     })
   end
 end

--- a/config/district_bedford.yml
+++ b/config/district_bedford.yml
@@ -1,14 +1,3 @@
-sftp_filenames:
-  FILENAME_FOR_EDUCATORS_IMPORT:     /home/bedford/data/staff.csv
-  FILENAME_FOR_STUDENTS_IMPORT:      /home/bedford/data/student.csv
-  FILENAME_FOR_BEHAVIOR_IMPORT:      /home/bedford/data/conduct.csv
-  FILENAME_FOR_ATTENDANCE_IMPORT:    /home/bedford/data/attendance.csv
-  FILENAME_FOR_ASSESSMENT_IMPORT:    /home/bedford/data/Assessment.csv
-
-  # student photos snapshot
-  FILENAME_FOR_PHOTOS_ZIP:           /home/bedford/data/Photos.zip
-
-
 school_definitions_for_import:
   - name: Lane Elementary
     local_id: Lane

--- a/config/district_new_bedford.yml
+++ b/config/district_new_bedford.yml
@@ -1,16 +1,3 @@
-sftp_filenames:
-  FILENAME_FOR_EDUCATORS_IMPORT:                    ../newbedford/istaff.csv
-  FILENAME_FOR_STUDENTS_IMPORT:                     ../newbedford/istudent.csv
-  FILENAME_FOR_BEHAVIOR_IMPORT:                     ../newbedford/iconduct.csv
-  FILENAME_FOR_ATTENDANCE_IMPORT:                   ../newbedford/iattendance.csv
-  FILENAME_FOR_ASSESSMENT_IMPORT:                   ../newbedford/iassessments.csv
-  FILENAME_FOR_COURSE_SECTION_IMPORT:               ../newbedford/isections.csv
-  FILENAME_FOR_EDUCATOR_SECTION_ASSIGNMENT_IMPORT:  ../newbedford/isectionstaff.csv
-  FILENAME_FOR_STUDENTS_SECTION_ASSIGNMENT_IMPORT:  ../newbedford/isectionstudent.csv
-
-  # student photos, one-time batch
-  FILENAME_FOR_PHOTOS_ZIP:            /home/newbedford/photos.zip
-
 star_filenames:
   FORMAT_VERSION:                     v1
   FILENAME_FOR_STAR_READING_IMPORT:   SR.csv

--- a/config/district_somerville.yml
+++ b/config/district_somerville.yml
@@ -1,28 +1,3 @@
-sftp_filenames:
-  FILENAME_FOR_EDUCATORS_IMPORT:                    /home/jbreslin/data/educators_export.txt
-  FILENAME_FOR_STUDENTS_IMPORT:                     /home/jbreslin/data/students_export.txt
-  FILENAME_FOR_BEHAVIOR_IMPORT:                     /home/jbreslin/data/behavior_export.txt
-  FILENAME_FOR_ASSESSMENT_IMPORT:                   /home/jbreslin/data/assessment_export.txt
-  FILENAME_FOR_ATTENDANCE_IMPORT:                   /home/jbreslin/data/attendance_export.txt
-  FILENAME_FOR_STUDENT_AVERAGES_IMPORT:             /home/jbreslin/data/student_averages_export.txt
-  FILENAME_FOR_COURSE_SECTION_IMPORT:               /home/jbreslin/data/courses_sections_export.txt
-  FILENAME_FOR_STUDENTS_SECTION_ASSIGNMENT_IMPORT:  /home/jbreslin/data/student_section_assignment_export.txt
-  FILENAME_FOR_EDUCATOR_SECTION_ASSIGNMENT_IMPORT:  /home/jbreslin/data/educator_section_assignment_export.txt
-  FILENAME_FOR_ED_PLAN_IMPORT:                      /home/jbreslin/data/student_ed_plan_export.txt
-  FILENAME_FOR_ED_PLAN_ACCOMMODATIONS_IMPORT:       /home/jbreslin/data/student_accommodations_export.txt
-  
-  # student photos, one-time batch
-  FILENAME_FOR_PHOTOS_ZIP:                          /home/jbreslin/data/photos.zip
-
-  # iep at a glance PDFs
-  FILENAMES_FOR_IEP_PDF_ZIPS:   # order is important here, these need to be oldest > newest
-    - /home/jbreslin/data/student-documents-6.zip
-    - /home/jbreslin/data/student-documents-5.zip
-    - /home/jbreslin/data/student-documents-4.zip
-    - /home/jbreslin/data/student-documents-3.zip
-    - /home/jbreslin/data/student-documents-2.zip
-    - /home/jbreslin/data/student-documents-1.zip
-
 star_filenames:
   FORMAT_VERSION:                                   v2
   FILENAME_FOR_STAR_READING_IMPORT:                 SR_v2.csv

--- a/config/sftp_filenames_development_fixture.json
+++ b/config/sftp_filenames_development_fixture.json
@@ -1,0 +1,24 @@
+{
+  "FILENAME_FOR_EDUCATORS_IMPORT": "/data/insights-dev-or-test/educators_export.csv",
+  "FILENAME_FOR_STUDENTS_IMPORT": "/data/insights-dev-or-test/students_export.csv",
+  "FILENAME_FOR_BEHAVIOR_IMPORT": "/data/insights-dev-or-test/behavior_export.csv",
+  "FILENAME_FOR_ASSESSMENT_IMPORT": "/data/insights-dev-or-test/assessment_export.csv",
+  "FILENAME_FOR_ATTENDANCE_IMPORT": "/data/insights-dev-or-test/attendance_export.csv",
+  "FILENAME_FOR_STUDENT_AVERAGES_IMPORT": "/data/insights-dev-or-test/student_averages_export.csv",
+  "FILENAME_FOR_COURSE_SECTION_IMPORT": "/data/insights-dev-or-test/courses_sections_export.csv",
+  "FILENAME_FOR_STUDENTS_SECTION_ASSIGNMENT_IMPORT": "/data/insights-dev-or-test/student_section_assignment_export.csv",
+  "FILENAME_FOR_EDUCATOR_SECTION_ASSIGNMENT_IMPORT": "/data/insights-dev-or-test/educator_section_assignment_export.csv",
+  "FILENAME_FOR_ED_PLAN_IMPORT": "/data/insights-dev-or-test/student_ed_plan_export.csv",
+  "FILENAME_FOR_ED_PLAN_ACCOMMODATIONS_IMPORT": "/data/insights-dev-or-test/student_accommodations_export.csv",
+
+  "FILENAME_FOR_PHOTOS_ZIP": "/data/insights-dev-or-test/photos.zip",
+
+  "FILENAMES_FOR_IEP_PDF_ZIPS_ORDERED_OLDEST_TO_NEWEST": [
+    "/data/insights-dev-or-test/student-documents-6.zip",
+    "/data/insights-dev-or-test/student-documents-5.zip",
+    "/data/insights-dev-or-test/student-documents-4.zip",
+    "/data/insights-dev-or-test/student-documents-3.zip",
+    "/data/insights-dev-or-test/student-documents-2.zip",
+    "/data/insights-dev-or-test/student-documents-1.zip"
+  ]
+}

--- a/db/migrate/20191106152631_create_district_config_log.rb
+++ b/db/migrate/20191106152631_create_district_config_log.rb
@@ -5,7 +5,7 @@ class CreateDistrictConfigLog < ActiveRecord::Migration[5.2]
       t.json :json, null: false
       t.datetime :created_at, null: false
     end
-    add_index :district_configs, :key
-    add_index :district_configs, :created_at
+    add_index :district_config_logs, :key
+    add_index :district_config_logs, :created_at
   end
 end

--- a/db/migrate/20191106152631_create_district_config_log.rb
+++ b/db/migrate/20191106152631_create_district_config_log.rb
@@ -1,0 +1,11 @@
+class CreateDistrictConfigLog < ActiveRecord::Migration[5.2]
+  def change
+    create_table :district_config_logs do |t|
+      t.string :key, null: false
+      t.json :json, null: false
+      t.datetime :created_at, null: false
+    end
+    add_index :district_configs, :key
+    add_index :district_configs, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_29_151734) do
+ActiveRecord::Schema.define(version: 2019_11_06_152631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -122,6 +122,14 @@ ActiveRecord::Schema.define(version: 2019_10_29_151734) do
     t.boolean "has_exact_time"
     t.integer "student_id", null: false
     t.index ["student_id"], name: "index_discipline_incidents_on_student_id"
+  end
+
+  create_table "district_config_logs", force: :cascade do |t|
+    t.string "key", null: false
+    t.json "json", null: false
+    t.datetime "created_at", null: false
+    t.index ["created_at"], name: "index_district_config_logs_on_created_at"
+    t.index ["key"], name: "index_district_config_logs_on_key"
   end
 
   create_table "ed_plan_accommodations", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,6 +43,9 @@ end
 puts 'Seeding database constants for all districts...'
 DatabaseConstants.new.seed_for_all_districts!
 
+puts 'Seeding generic development DistrictConfigLog...'
+DistrictConfigLog.seed_for_development_and_test!
+
 puts 'Destroying all educators...'
 Educator.destroy_all
 

--- a/db/seeds/database_constants.rb
+++ b/db/seeds/database_constants.rb
@@ -1,10 +1,8 @@
 class DatabaseConstants
-  # Used for initializing the constants in a new database.  This
-  # is factored out of the main seed file so it can be used for
-  # RSpec tests as well.
-  #
-  # These are all specific to the initial Somerville deployment, but
-  # are used for local development as well and relied on in tests.
+  # Used for initializing the constants in a new database in development
+  # or test.  This is factored out of the main seed file so it can be used
+  # for RSpec tests as well.  These could be used as pieces of a new
+  # production deployment as well.
   def seed_for_all_districts!
     Assessment.seed_for_all_districts
     InterventionType.seed_for_all_districts

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,6 +68,7 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
     DatabaseConstants.new.seed_for_all_districts!
+    DistrictConfigLog.seed_for_development_and_test!
     Rack::Attack.cache.store.clear
   end
 


### PR DESCRIPTION
For now, this is moving some district configuration that district IT folks provide out of config code and into the database, where it could be stored, viewed and edited in a more self-serve way.

Concretely, that's done by moving where `PerDistrict` reads from into `DistrictConfigLog`.  It typically expresses differences directly in code, reads from ENV variables, or reads config from files like `district_somerville.yml`.

The idea is that `PerDistrict` reads secrets and info about services from ENV that's controlled by developers, but that other information (eg, URLs for sheets or drive folders being synced, safelists for particular features, etc) should be read from `DistrictConfigLog` where it's a step closer to being exposed to project leads and district IT staff.