### PR TITLE
Security: Remove bcc from LoginChecker

### DIFF
--- a/app/lib/login_checker.rb
+++ b/app/lib/login_checker.rb
@@ -61,7 +61,6 @@ class LoginChecker
     post_data = Net::HTTP.post_form(URI.parse(mailgun_url), {
       :from => "Student Insights <security@studentinsights.org>",
       :to => educator_email,
-      :bcc => 'security@studentinsights.org',
       :subject => "Security alert for #{@canonical_domain}",
       :html => "<html><body><pre style='font: monospace; font-size: 12px;'>#{email_text}</pre>"
     })

--- a/spec/lib/login_checker_spec.rb
+++ b/spec/lib/login_checker_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe LoginChecker do
       expect(Net::HTTP).to receive(:post_form).once.with(URI.parse('https://api:fake-mailgun-api-key@api.mailgun.net/v3/fake-mailgun-domain/messages'), {
         from: 'Student Insights <security@studentinsights.org>',
         to: 'vivian@demo.studentinsights.org',
-        bcc: 'security@studentinsights.org',
         subject: 'Security alert for localhost.studentinsights.org',
         html: anything()
       })


### PR DESCRIPTION
No need for bcc in email, it's tracked other places.