### PR TITLE
STAR: Abort importers if filenames aren't set in config

### DIFF
--- a/app/importers/star/star_math_importer.rb
+++ b/app/importers/star/star_math_importer.rb
@@ -14,15 +14,19 @@ class StarMathImporter
   end
 
   def initialize(options:)
-    @school_scope = options.fetch(:school_scope)
-    @log = options.fetch(:log)
-    @star_importer = StarImporter.new(options: options.merge({
-      model_class: StarMathResult,
-      remote_file_name: PerDistrict.new.try_star_filename('FILENAME_FOR_STAR_MATH_IMPORT')
-    }))
+    @options = options
   end
 
   def import
-    @star_importer.import
+    remote_file_name = PerDistrict.new.try_star_filename('FILENAME_FOR_STAR_MATH_IMPORT')
+    if remote_file_name.nil?
+      log('Aborting, no remote_file_name.')
+      return
+    end
+
+    StarImporter.new(options: @options.merge({
+      model_class: StarMathResult,
+      remote_file_name: remote_file_name
+    })).import
   end
 end

--- a/app/importers/star/star_math_importer.rb
+++ b/app/importers/star/star_math_importer.rb
@@ -15,6 +15,7 @@ class StarMathImporter
 
   def initialize(options:)
     @options = options
+    @log = options.fetch(:log, nil)
   end
 
   def import
@@ -28,5 +29,10 @@ class StarMathImporter
       model_class: StarMathResult,
       remote_file_name: remote_file_name
     })).import
+  end
+
+  def log(msg)
+    text = if msg.class == String then msg else JSON.pretty_generate(msg) end
+    @log.puts "StarMathImporter: #{text}"
   end
 end

--- a/app/importers/star/star_reading_importer.rb
+++ b/app/importers/star/star_reading_importer.rb
@@ -14,16 +14,19 @@ class StarReadingImporter
   end
 
   def initialize(options:)
-    @school_scope = options.fetch(:school_scope)
-    @log = options.fetch(:log)
-    remote_file_name = PerDistrict.new.try_star_filename('FILENAME_FOR_STAR_READING_IMPORT')
-    @star_importer = StarImporter.new(options: options.merge({
-      model_class: StarReadingResult,
-      remote_file_name: remote_file_name
-    }))
+    @options = options
   end
 
   def import
-    @star_importer.import
+    remote_file_name = PerDistrict.new.try_star_filename('FILENAME_FOR_STAR_READING_IMPORT')
+    if remote_file_name.nil?
+      log('Aborting, no remote_file_name.')
+      return
+    end
+
+    StarImporter.new(options: @options.merge({
+      model_class: StarReadingResult,
+      remote_file_name: remote_file_name
+    })).import
   end
 end

--- a/app/importers/star/star_reading_importer.rb
+++ b/app/importers/star/star_reading_importer.rb
@@ -15,6 +15,7 @@ class StarReadingImporter
 
   def initialize(options:)
     @options = options
+    @log = options.fetch(:log, nil)
   end
 
   def import
@@ -28,5 +29,10 @@ class StarReadingImporter
       model_class: StarReadingResult,
       remote_file_name: remote_file_name
     })).import
+  end
+
+  def log(msg)
+    text = if msg.class == String then msg else JSON.pretty_generate(msg) end
+    @log.puts "StarReadingImporter: #{text}"
   end
 end

--- a/spec/importers/star/star_math_importer_spec.rb
+++ b/spec/importers/star/star_math_importer_spec.rb
@@ -84,5 +84,19 @@ RSpec.describe StarMathImporter do
       expect(log.output).to include('skipped 1 rows because of school filter')
       expect(StarMathResult.all.size).to eq(0)
     end
+
+    it 'logs and aborts when config not set (eg, in Bedford)' do
+      mock_per_district = PerDistrict.new(district_key: 'bedford')
+      allow(mock_per_district).to receive(:try_star_filename).and_return(nil)
+      allow(PerDistrict).to receive(:new).and_return(mock_per_district)
+
+      log = LogHelper::FakeLog.new
+      importer = StarMathImporter.new(options: {
+        school_scope: nil,
+        log: log
+      })
+      importer.import
+      expect(log.output).to include 'Aborting, no remote_file_name'
+    end
   end
 end

--- a/spec/importers/star/star_reading_importer_spec.rb
+++ b/spec/importers/star/star_reading_importer_spec.rb
@@ -85,4 +85,18 @@ RSpec.describe StarReadingImporter do
       expect(StarReadingResult.all.size).to eq(0)
     end
   end
+
+  it 'logs and aborts when config not set (eg, in Bedford)' do
+    mock_per_district = PerDistrict.new(district_key: 'bedford')
+    allow(mock_per_district).to receive(:try_star_filename).and_return(nil)
+    allow(PerDistrict).to receive(:new).and_return(mock_per_district)
+
+    log = LogHelper::FakeLog.new
+    importer = StarReadingImporter.new(options: {
+      school_scope: nil,
+      log: log
+    })
+    importer.import
+    expect(log.output).to include 'Aborting, no remote_file_name'
+  end
 end


### PR DESCRIPTION
The check for `remote_file_name` being set is too strict for districts that don't use this; this refactors it to work as expected and adds tests for that.