### PR TITLE
Services: Move filtering of provider suggestions to client, narrow scope of list

### DIFF
--- a/app/assets/javascripts/student_profile/PageContainer.test.js
+++ b/app/assets/javascripts/student_profile/PageContainer.test.js
@@ -119,6 +119,13 @@ const helpers = {
 };
 
 describe('integration tests', () => {
+  beforeEach(() => {
+    fetchMock.restore();
+    fetchMock.get('/api/educators/possible_names_for_service_json', {
+      names: ['Martinez, Pedro', 'Garciaparra, Nomar']
+    });
+  });
+  
   it('renders everything without raising on the happy path', () => {
     const {el} = helpers.renderInto();
     expect($(el).text()).toContain('Pluto Poppins');

--- a/app/assets/javascripts/student_profile/ProvidedByEducatorDropdown.js
+++ b/app/assets/javascripts/student_profile/ProvidedByEducatorDropdown.js
@@ -17,7 +17,7 @@ export default class ProvidedByEducatorDropdown extends React.Component {
   }
 
   componentDidMount() {
-    apiFetchJson('/api/educators/possible_names_for_service')
+    apiFetchJson('/api/educators/possible_names_for_service_json')
       .then(this.initAutoComplete);
   }
 
@@ -42,7 +42,7 @@ export default class ProvidedByEducatorDropdown extends React.Component {
   }
 
   onToggleOpenMenu () {
-    $(this.el).autocomplete("search", "");
+    $(this.el).autocomplete('search', '');
   }
 
   render () {

--- a/app/assets/javascripts/student_profile/ProvidedByEducatorDropdown.js
+++ b/app/assets/javascripts/student_profile/ProvidedByEducatorDropdown.js
@@ -55,11 +55,12 @@ export default class ProvidedByEducatorDropdown extends React.Component {
   }
 
   renderInput () {
+    const {onUserTyping} = this.props;
     return (
       <input
         ref={el => this.el = el}
         className="ProvidedByEducatorDropdown"
-        onChange={this.props.onUserTyping}
+        onChange={e => onUserTyping(e.target.value)}
         placeholder="Last Name, First Name..."
         style={{
           marginTop: 2,
@@ -87,6 +88,5 @@ export default class ProvidedByEducatorDropdown extends React.Component {
 }
 ProvidedByEducatorDropdown.propTypes = {
   onUserTyping: PropTypes.func.isRequired,
-  onUserDropdownSelect: PropTypes.func.isRequired,
-  studentId: PropTypes.number.isRequired
+  onUserDropdownSelect: PropTypes.func.isRequired
 };

--- a/app/assets/javascripts/student_profile/ProvidedByEducatorDropdown.js
+++ b/app/assets/javascripts/student_profile/ProvidedByEducatorDropdown.js
@@ -14,7 +14,6 @@ export default class ProvidedByEducatorDropdown extends React.Component {
     super(props);
     this.initAutoComplete = this.initAutoComplete.bind(this);
     this.onToggleOpenMenu = this.onToggleOpenMenu.bind(this);
-    this.onCloseMenu = this.onCloseMenu.bind(this);
   }
 
   componentDidMount() {
@@ -39,38 +38,11 @@ export default class ProvidedByEducatorDropdown extends React.Component {
       select(event, ui) {
         self.props.onUserDropdownSelect(ui.item.value);
       },
-
-      // // Display what the user is typing first
-      // response(event, ui) {
-      //   if (event.target.value !== "") {
-      //     const currentName = {label: event.target.value,
-      //       value: event.target.value};
-      //     ui.content.unshift(currentName);
-      //   }
-
-      //   // Don't show a duplicate
-      //   for (let i = 1; i < ui.content.length; i++) {
-      //     if (ui.content[i].value === event.target.value)
-      //       ui.content = ui.content.splice(i,1);
-      //   }
-      // },
-
-      open() {
-        $(window.document.body).on('click.closeProvidedByEducatorDropdownMenu', self.onCloseMenu);
-      },
-      close() {
-        $(window.document.body).off('click.closeProvidedByEducatorDropdownMenu', self.onCloseMenu);
-      }
     });
   }
 
-
   onToggleOpenMenu () {
     $(this.el).autocomplete("search", "");
-  }
-
-  onCloseMenu () {
-    $(this.el).autocomplete('close');
   }
 
   render () {

--- a/app/assets/javascripts/student_profile/ProvidedByEducatorDropdown.test.js
+++ b/app/assets/javascripts/student_profile/ProvidedByEducatorDropdown.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import fetchMock from 'fetch-mock/es5/client';
+import changeTextValue from '../testing/changeTextValue';
+import ProvidedByEducatorDropdown from './ProvidedByEducatorDropdown';
+
+function testProps(props = {}) {
+  return {
+    onUserTyping: jest.fn(),
+    onUserDropdownSelect: x => console.log('onUserDropdownSelect', x),
+    ...props
+  };
+}
+
+function testRender(props = {}) {
+  const el = document.createElement('div');
+  ReactDOM.render(<ProvidedByEducatorDropdown {...props} />, el);
+  return el;
+}
+
+beforeEach(() => {
+  fetchMock.restore();
+  fetchMock.get('/api/educators/possible_names_for_service_json', {
+    names: ['Martinez, Pedro', 'Garciaparra, Nomar']
+  });
+});
+
+it('renders without crashing', () => {
+  testRender(testProps());
+});
+
+it('typing callback gets proper value', () => {
+  const props = testProps();
+  const el = testRender(props);
+  changeTextValue($(el).find('input').get(0), 'sar');
+  expect(props.onUserTyping).toHaveBeenCalledWith('sar');
+});

--- a/app/assets/javascripts/student_profile/RecordService.js
+++ b/app/assets/javascripts/student_profile/RecordService.js
@@ -74,8 +74,8 @@ export default class RecordService extends React.Component {
     this.setState({estimatedEndDateText});
   }
 
-  onProvidedByEducatorTyping(event) {
-    this.setState({ providedByEducatorName: event.target.value });
+  onProvidedByEducatorTyping(string) {
+    this.setState({ providedByEducatorName: string });
   }
 
   onProvidedByEducatorDropdownSelect(string) {
@@ -229,7 +229,7 @@ export default class RecordService extends React.Component {
       <ProvidedByEducatorDropdown
         onUserTyping={this.onProvidedByEducatorTyping}
         onUserDropdownSelect={this.onProvidedByEducatorDropdownSelect}
-        studentId={this.props.studentId} />
+      />
     );
   }
 

--- a/app/assets/javascripts/student_profile/RecordService.test.js
+++ b/app/assets/javascripts/student_profile/RecordService.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 import {mount} from 'enzyme';
+import fetchMock from 'fetch-mock/es5/client';
 import PerDistrictContainer from '../components/PerDistrictContainer';
 import {
   studentProfile,
@@ -115,6 +116,13 @@ const helpers = {
     ReactTestUtils.Simulate.click($(el).find('.btn.save').get(0));
   }
 };
+
+beforeEach(() => {
+  fetchMock.restore();
+  fetchMock.get('/api/educators/possible_names_for_service_json', {
+    names: ['Martinez, Pedro', 'Garciaparra, Nomar']
+  });
+});
 
 describe('integration tests', () => {
   it('renders dialog for recording services', () => {

--- a/app/controllers/educators_controller.rb
+++ b/app/controllers/educators_controller.rb
@@ -163,7 +163,7 @@ class EducatorsController < ApplicationController
 
   # Used for picking a name when creating a service, drawing from
   # active educators and from other text values entered previously.
-  def possible_names_for_service
+  def possible_names_for_service_json
     # We assume that the names of most providers are public anyway
     # in many other sources (eg, public staff directory on the web).
     # So while there's no real concern with sharing staff names with

--- a/app/controllers/educators_controller.rb
+++ b/app/controllers/educators_controller.rb
@@ -119,18 +119,6 @@ class EducatorsController < ApplicationController
     render json: json
   end
 
-  # Used for services
-  def names_for_dropdown
-    student = Student.find(params[:id])
-    school = student.school
-
-    if school.nil?
-      render json: [] and return
-    end
-
-    render json: filtered_names(params[:term], school)
-  end
-
   def my_notes_json
     safe_params = params.permit(:batch_size)
     batch_size = safe_params[:batch_size].to_i
@@ -173,22 +161,24 @@ class EducatorsController < ApplicationController
     }
   end
 
-  private
-  def filtered_names(term, school)
-    unfiltered = (school.educator_names_for_services + Service.provider_names).uniq.compact
+  # Used for picking a name when creating a service, drawing from
+  # active educators and from other text values entered previously.
+  def possible_names_for_service
+    # We assume that the names of most providers are public anyway
+    # in many other sources (eg, public staff directory on the web).
+    # So while there's no real concern with sharing staff names with
+    # signed-in educators, this is still defensive and only takes
+    # provider names from services that the educator is authorized to
+    # view.
+    student_ids = authorized { Student.active }.map(&:id)
+    provider_names = Service.active
+      .where(student_id: student_ids)
+      .map(&:provided_by_educator_name)
 
-    return unfiltered.sort_by(&:downcase) if term.nil?  # Handle missing param
-
-    filtered = unfiltered.select do |name|
-      split_name = name.split(', ')   # SIS name format expected
-      split_name.any? { |name_part| match?(term, name_part) } || match?(term, name)
-    end
-
-    return filtered.sort_by(&:downcase)
+    active_educator_names = Educator.active.map(&:full_name)
+    names = (provider_names + active_educator_names).uniq.compact
+    render json: {
+      names: names
+    }
   end
-
-  def match?(term, string_to_test)
-    term.downcase == string_to_test.slice(0, term.length).downcase
-  end
-
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -24,14 +24,4 @@ class School < ApplicationRecord
   def is_high_school?
     school_type == 'HS'
   end
-
-  # deprecated
-  def educators_without_test_account
-    educators.where.not(local_id: 'LDAP')
-  end
-
-  # deprecated
-  def educator_names_for_services
-    educators_without_test_account.pluck(:full_name)
-  end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -28,10 +28,6 @@ class Service < ApplicationRecord
     where('discontinued_at < ?', Time.now)
   end
 
-  def self.provider_names
-    pluck(:provided_by_educator_name)
-  end
-
   def discontinued?
     discontinued_at.present? && (Time.now > discontinued_at)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
   get '/api/educators/my_students_json' => 'educators#my_students_json'
   get '/api/educators/services_json' => 'educators#services_json'
   get '/api/educators/student_searchbar_json' => 'educators#student_searchbar_json'
+  get '/api/educators/possible_names_for_service' => 'educators#possible_names_for_service'
   get '/api/schools/:id/courses' => 'schools#courses_json'
 
   # school leader dashboards
@@ -139,7 +140,6 @@ Rails.application.routes.draw do
   get '/educators/services'=> 'ui#ui'
   get '/educators/reset'=> 'educators#reset_session_clock'
   get '/educators/probe'=> 'educators#probe'
-  get '/educators/services_dropdown/:id' => 'educators#names_for_dropdown'
 
   # error pages
   get 'no_default_page' => 'pages#no_default_page'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
   get '/api/educators/my_students_json' => 'educators#my_students_json'
   get '/api/educators/services_json' => 'educators#services_json'
   get '/api/educators/student_searchbar_json' => 'educators#student_searchbar_json'
-  get '/api/educators/possible_names_for_service' => 'educators#possible_names_for_service'
+  get '/api/educators/possible_names_for_service_json' => 'educators#possible_names_for_service_json'
   get '/api/schools/:id/courses' => 'schools#courses_json'
 
   # school leader dashboards

--- a/spec/controllers/educators_controller_spec.rb
+++ b/spec/controllers/educators_controller_spec.rb
@@ -244,93 +244,103 @@ describe EducatorsController, :type => :controller do
     end
   end
 
-  describe '#names_for_dropdown' do
-    def make_request(student)
+  describe '#possible_names_for_service_json' do
+    let!(:pals) { TestPals.create! }
+
+    def get_possible_names_for_service_json(educator)
+      sign_in(educator)
       request.env['HTTPS'] = 'on'
-      get :names_for_dropdown, params: { format: :json, id: student.id }
+      get :possible_names_for_service_json, params: { format: :json }
+      JSON.parse(response.body)
     end
 
-    context 'authorized' do
-      let(:json) { JSON.parse!(response.body) }
+    def create_test_service!(attrs = {})
+      FactoryBot.create(:service, {
+        provided_by_educator_name: 'Butler, Octavia',
+        recorded_by_educator: pals.healey_laura_principal,
+        discontinued_at: pals.time_now + 3.months,
+        student_id: pals.healey_kindergarten_student.id
+      }.merge(attrs))
+    end
 
-      before(:each) do
-        sign_in FactoryBot.create(:educator)
-        make_request(student)
-      end
+    it 'guards unauthenticated access' do
+      request.env['HTTPS'] = 'on'
+      get :possible_names_for_service_json, params: { format: :json }
+      expect(response.status).to eq(401)
+    end
 
-      context 'student has no school' do
-        let(:student) { FactoryBot.create(:student) }
-        it 'returns an empty array' do
-          expect(json).to eq []
-        end
-      end
+    it 'includes names for active educators (even if not at same school)' do
+      json = get_possible_names_for_service_json(pals.healey_vivian_teacher)
+      expect(json.keys).to eq ['names']
+      expect(json['names']).to match_array [
+        'Disney, Uri',
+        'Districtwide, Rich',
+        'Counselor, Les',
+        'Counselor, Sofia',
+        'Housemaster, Harry',
+        'Principal, Laura',
+        'Teacher, Hugo',
+        'Teacher, Jodi',
+        'Teacher, Marcus',
+        'Teacher, Sarah',
+        'Teacher, Silva',
+        'Teacher, Vivian',
+        'Teacher, Alonso',
+        'Teacher, Bill',
+        'Teacher, Fatima'
+      ]
+    end
 
-      context 'student has school' do
-        let(:student) { FactoryBot.create(:student, school: school) }
+    it 'does not include names for inactive educators' do
+      Timecop.freeze(pals.time_now) do
+        pals.shs_sofia_counselor.update!(missing_from_last_export: true)
 
-        context 'educators at school' do
-          let(:school) { FactoryBot.create(:healey, :with_educator) }
-          it 'returns array of their names' do
-            expect(json).to eq ['Stephenson, Neal']
-          end
-        end
-
-        context 'educators providing services' do
-          let(:school) { FactoryBot.create(:healey) }
-          let!(:service) {
-            FactoryBot.create(:service, provided_by_educator_name: 'Butler, Octavia')
-          }
-
-          it 'returns array of their names' do
-            make_request(student)
-            expect(json).to eq ['Butler, Octavia']
-          end
-        end
-
-        context 'educators at school and providing services' do
-          let(:school) { FactoryBot.create(:healey, :with_educator) }
-          let!(:service) {
-            FactoryBot.create(:service, provided_by_educator_name: 'Butler, Octavia')
-          }
-
-          it 'returns names of both, sorted alphabetically' do
-            make_request(student)
-            expect(json).to eq ['Butler, Octavia', 'Stephenson, Neal']
-          end
-
-          context 'search for "o"' do
-            it 'returns Octavia' do
-              get :names_for_dropdown, params: { format: :json, id: student.id, term: 'o' }
-              expect(json).to eq ['Butler, Octavia']
-            end
-          end
-
-          context 'search for "s"' do
-            it 'returns Stephenson' do
-              get :names_for_dropdown, params: { format: :json, id: student.id, term: 's' }
-              expect(json).to eq ['Stephenson, Neal']
-            end
-          end
-
-        end
-
-        context 'no educators at school or providing services' do
-          let(:school) { FactoryBot.create(:healey) }
-          it 'returns an empty array' do
-            expect(json).to eq []
-          end
-        end
-
+        json = get_possible_names_for_service_json(pals.healey_vivian_teacher)
+        expect(json['names'].size).to eq 14
+        expect(json['names']).not_to include('Couselor, Sofia')
       end
     end
 
-    context 'unauthorized' do
-      it 'returns unauthorized' do
-        make_request(FactoryBot.create(:student))
-        expect(response.status).to eq(401)
+    it 'includes names of service providers from active services for active, authorized students' do
+      Timecop.freeze(pals.time_now) do
+        create_test_service!
+
+        json = get_possible_names_for_service_json(pals.healey_vivian_teacher)
+        expect(json['names'].size).to eq(16)
+        expect(json['names']).to include('Butler, Octavia')
       end
     end
 
+    it 'excludes names of service providers for discontinued services, even if authorized active students' do
+      Timecop.freeze(pals.time_now) do
+        create_test_service!(discontinued_at: pals.time_now - 3.months)
+
+        json = get_possible_names_for_service_json(pals.healey_vivian_teacher)
+        expect(json['names'].size).to eq(15)
+        expect(json['names']).not_to include('Butler, Octavia')
+      end
+    end
+
+    it 'excludes names of service providers for inactive students, even if authorized' do
+      Timecop.freeze(pals.time_now) do
+        create_test_service!
+        pals.healey_kindergarten_student.update!(missing_from_last_export: true)
+
+        json = get_possible_names_for_service_json(pals.healey_vivian_teacher)
+        expect(json['names'].size).to eq(15)
+        expect(json['names']).not_to include('Butler, Octavia')
+      end
+    end
+
+    it 'excludes names of service providers if not authorized for student, even if active service' do
+      Timecop.freeze(pals.time_now) do
+        create_test_service!(student_id: pals.shs_senior_kylo.id)
+
+        json = get_possible_names_for_service_json(pals.healey_vivian_teacher)
+        expect(json['names'].size).to eq(15)
+        expect(json['names']).not_to include('Butler, Octavia')
+      end
+    end
   end
 
   describe '#reset_session_clock' do

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -29,43 +29,43 @@ describe SectionsController, :type => :controller do
     end
 
     it 'works for Fatima as a happy path test case' do
-      expect(response_json_for_get_my_sections_json(pals.shs_fatima_science_teacher)).to eq({
-        "sections"=>[{
-          "id"=>pals.shs_third_period_physics.id,
-          "section_number"=>"SCI-201A",
-          "term_local_id"=>"S1",
-          "schedule"=>"3(M,W,F)",
-          "room_number"=>"306W",
-          "course"=>{
-            "id"=>pals.shs_physics_course.id,
-            "course_number"=>"SCI-201",
-            "course_description"=>"PHYSICS 1",
-            "school"=>{"id"=>pals.shs.id, "name"=>"Somerville High", "local_id"=>"SHS", "slug"=>"shs"}
-          },
-          "educators"=>[{
-            "id"=>pals.shs_fatima_science_teacher.id,
-            "email"=>"fatima@demo.studentinsights.org",
-            "full_name"=>"Teacher, Fatima"
-          }]
-        }, {
-          "id"=>pals.shs_fifth_period_physics.id,
-          "section_number"=>"SCI-201B",
-          "term_local_id"=>"S1",
-          "schedule"=>"5(M,W,F)",
-          "room_number"=>"306W",
-          "course"=>{
-            "id"=>pals.shs_physics_course.id,
-            "course_number"=>"SCI-201",
-            "course_description"=>"PHYSICS 1",
-            "school"=>{"id"=>pals.shs.id, "name"=>"Somerville High", "local_id"=>"SHS", "slug"=>"shs"}
-          },
-          "educators"=>[{
-            "id"=>pals.shs_fatima_science_teacher.id,
-            "email"=>"fatima@demo.studentinsights.org",
-            "full_name"=>"Teacher, Fatima"
-          }]
+      json = response_json_for_get_my_sections_json(pals.shs_fatima_science_teacher)
+      expect(json.keys).to eq(['sections'])
+      expect(json['sections']).to contain_exactly(*[{
+        "id"=>pals.shs_third_period_physics.id,
+        "section_number"=>"SCI-201A",
+        "term_local_id"=>"S1",
+        "schedule"=>"3(M,W,F)",
+        "room_number"=>"306W",
+        "course"=>{
+          "id"=>pals.shs_physics_course.id,
+          "course_number"=>"SCI-201",
+          "course_description"=>"PHYSICS 1",
+          "school"=>{"id"=>pals.shs.id, "name"=>"Somerville High", "local_id"=>"SHS", "slug"=>"shs"}
+        },
+        "educators"=>[{
+          "id"=>pals.shs_fatima_science_teacher.id,
+          "email"=>"fatima@demo.studentinsights.org",
+          "full_name"=>"Teacher, Fatima"
         }]
-      })
+      }, {
+        "id"=>pals.shs_fifth_period_physics.id,
+        "section_number"=>"SCI-201B",
+        "term_local_id"=>"S1",
+        "schedule"=>"5(M,W,F)",
+        "room_number"=>"306W",
+        "course"=>{
+          "id"=>pals.shs_physics_course.id,
+          "course_number"=>"SCI-201",
+          "course_description"=>"PHYSICS 1",
+          "school"=>{"id"=>pals.shs.id, "name"=>"Somerville High", "local_id"=>"SHS", "slug"=>"shs"}
+        },
+        "educators"=>[{
+          "id"=>pals.shs_fatima_science_teacher.id,
+          "email"=>"fatima@demo.studentinsights.org",
+          "full_name"=>"Teacher, Fatima"
+        }]
+      }])
     end
 
     it 'returns nothing for districtwide admin' do

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -27,10 +27,4 @@ FactoryBot.define do
     local_id 'SHS'
     school_type "HS"
   end
-
-  trait :with_educator do
-    after(:create) do |school|
-      school.educators << FactoryBot.create(:educator, full_name: 'Stephenson, Neal')
-    end
-  end
 end


### PR DESCRIPTION
# Who is this PR for?
educators

# What problem does this PR fix?
The service UI has an old autocomplete, and this worked by querying the server on each keystroke, and filtering a list on the server.  That meant unnecessary network chatter, sending user input in the query string (logged in some cases, exposed in some monitoring).  There were bugs in the filtering code on the server, and it didn't scope the query to the student's school like it intended (which we wouldn't want anyway, given the complexity of roles).

# What does this PR do?
Removes the server filtering, but adds scoping to providers for authorized students.  Request the list up front when the UI component is mounted and removes other UI config.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here