### PR TITLE
Rollbar: Allow district_key param from Ruby

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -41,6 +41,7 @@ Rollbar.configure do |config|
   # See https://docs.rollbar.com/docs/ruby#section-scrubbing-items 
   # and https://docs.rollbar.com/docs/ruby#section-managing-sensitive-data 
   config.scrub_fields = :scrub_all # note that docs say this isn't recursive
+  config.scrub_whitelist = [:district_key]
   config.scrub_password = true
   config.scrub_user = true
   config.randomize_scrub_length = true


### PR DESCRIPTION
Behavior change related to https://github.com/studentinsights/studentinsights/pull/2693; this used to be allowed but scrubbing is more comprehensive, so `district_key` is getting scrubbed when we do still want it.