### PR TITLE
STAR: Update config to read from export SFTP box instead of vendor

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -52,6 +52,32 @@ class PerDistrict
     yaml.fetch('star_filenames', {}).fetch(key, fallback)
   end
 
+  # Connect to the STAR SFTP site, or SFTP export box used
+  # for SIS.  This migration happened because of specific
+  # configuration issues.
+  def client_for_star_importer
+    if @district_key == SOMERVILLE
+      SftpClient.for_star
+    elsif @district_key == NEW_BEDFORD
+      SftpClient.for_x2
+    else
+      raise_not_handled!
+    end
+  end
+
+  # Depending on the client, we read the config from different places.
+  # Over time, we should move more of this into `DistrictConfigLog`, which
+  # removes friction on different places config is expressed.
+  def remote_filename_for_star
+    if @district_key == SOMERVILLE
+      self.try_star_filename('FILENAME_FOR_STAR_ZIP_FILE')
+    elsif @district_key == NEW_BEDFORD
+      self.try_sftp_filename('FILENAME_FOR_STAR_ZIP_FILE')
+    else
+      nil
+    end
+  end
+
   # What filenames are district IT staff using when exporting specific
   # files to SFTP servers?
   def try_sftp_filename(key, fallback = nil)

--- a/app/importers/star/star_importer.rb
+++ b/app/importers/star/star_importer.rb
@@ -44,11 +44,11 @@ class StarImporter
   end
 
   def client
-    SftpClient.for_star
+    PerDistrict.new.client_for_star_importer
   end
 
   def zip_file_name
-    PerDistrict.new.try_star_filename('FILENAME_FOR_STAR_ZIP_FILE')
+    PerDistrict.new.remote_filename_for_star
   end
 
   def data_transformer

--- a/config/district_new_bedford.yml
+++ b/config/district_new_bedford.yml
@@ -1,8 +1,6 @@
 star_filenames:
-  FORMAT_VERSION:                     v1
   FILENAME_FOR_STAR_READING_IMPORT:   SR.csv
   FILENAME_FOR_STAR_MATH_IMPORT:      SM.csv
-  FILENAME_FOR_STAR_ZIP_FILE:         New Bedford Public Schools.zip
 
 
 school_definitions_for_import:

--- a/config/district_somerville.yml
+++ b/config/district_somerville.yml
@@ -1,5 +1,4 @@
 star_filenames:
-  FORMAT_VERSION:                                   v2
   FILENAME_FOR_STAR_READING_IMPORT:                 SR_v2.csv
   FILENAME_FOR_STAR_MATH_IMPORT:                    SM_v2.csv
   FILENAME_FOR_STAR_ZIP_FILE:                       Somerville Public Schools.zip

--- a/spec/importers/star/star_reading_importer_spec.rb
+++ b/spec/importers/star/star_reading_importer_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe StarReadingImporter do
-  def create_mocked_importer(district_key, local_fixture_filename, options = {})
-    mock_for_fixture!(district_key, local_fixture_filename)
+  def create_test_importer!(options = {})
     log = LogHelper::FakeLog.new
     importer = StarReadingImporter.new(options: {
       school_scope: nil,
@@ -11,24 +10,36 @@ RSpec.describe StarReadingImporter do
     [importer, log]
   end
 
-  def mock_for_fixture!(district_key, local_fixture_filename)
-    # mock config
+  # config read from two places
+  def mock_sis_sftp!(district_key, local_fixture_filename)
     mock_per_district = PerDistrict.new(district_key: district_key)
+    allow(mock_per_district).to receive(:try_sftp_filename).with('FILENAME_FOR_STAR_ZIP_FILE').and_return('star.zip')
     allow(mock_per_district).to receive(:try_star_filename).with('FILENAME_FOR_STAR_READING_IMPORT').and_return('file.csv')
-    allow(mock_per_district).to receive(:try_star_filename).with('FILENAME_FOR_STAR_ZIP_FILE').and_return('star.zip')
     allow(PerDistrict).to receive(:new).and_return(mock_per_district)
 
-    # zip fixture
+    mock_sftp_connection!(:for_x2, local_fixture_filename)
+  end
+
+  def mock_star_sftp!(district_key, local_fixture_filename)
+    mock_per_district = PerDistrict.new(district_key: district_key)
+    allow(mock_per_district).to receive(:try_star_filename).with('FILENAME_FOR_STAR_ZIP_FILE').and_return('star.zip')
+    allow(mock_per_district).to receive(:try_star_filename).with('FILENAME_FOR_STAR_READING_IMPORT').and_return('file.csv')
+    allow(PerDistrict).to receive(:new).and_return(mock_per_district)
+
+    mock_sftp_connection!(:for_star, local_fixture_filename)
+  end
+
+  # mock connection and zip download
+  def mock_sftp_connection!(method_name, local_fixture_filename)
     zipped_fixture = Tempfile.new('zipped').tap do |zip|
       Zip::File.open(zip, Zip::File::CREATE) do |zipfile|
         zipfile.add('file.csv', local_fixture_filename)
       end
     end
 
-    # mock zip download
     mock_client = SftpClient.new
     allow(mock_client).to receive(:download_file).with('star.zip').and_return(zipped_fixture)
-    allow(SftpClient).to receive(:for_star).and_return(mock_client)
+    allow(SftpClient).to receive(method_name).and_return(mock_client)
     nil
   end
 
@@ -38,7 +49,8 @@ RSpec.describe StarReadingImporter do
 
     it 'works for v2 format in somerville' do
       Timecop.freeze(pals.time_now) do
-        importer, log = create_mocked_importer(PerDistrict::SOMERVILLE, "#{Rails.root}/spec/importers/star/star_reading_v2.csv")
+        mock_star_sftp!(PerDistrict::SOMERVILLE, "#{Rails.root}/spec/importers/star/star_reading_v2.csv")
+        importer, log = create_test_importer!
         importer.import
         expect(log.output).to include(':processed_rows_count=>1')
         expect(StarReadingResult.all.size).to eq(1)
@@ -52,9 +64,10 @@ RSpec.describe StarReadingImporter do
       end
     end
 
-    it 'works for v1 format in new bedford' do
+    it 'works for v1 format in new bedford, via SFTP box for SIS' do
       Timecop.freeze(pals.time_now) do
-        importer, log = create_mocked_importer(PerDistrict::NEW_BEDFORD, "#{Rails.root}/spec/importers/star/star_reading_v1.csv")
+        mock_sis_sftp!(PerDistrict::NEW_BEDFORD, "#{Rails.root}/spec/importers/star/star_reading_v1.csv")
+        importer, log = create_test_importer!
         importer.import
         expect(log.output).to include(':processed_rows_count=>1')
         expect(StarReadingResult.all.size).to eq(1)
@@ -69,7 +82,8 @@ RSpec.describe StarReadingImporter do
     end
 
     it 'skips and logs bad data (v2 as example)' do
-      importer, log = create_mocked_importer(PerDistrict::SOMERVILLE, "#{Rails.root}/spec/importers/star/star_reading_v2_invalid.csv")
+      mock_star_sftp!(PerDistrict::SOMERVILLE, "#{Rails.root}/spec/importers/star/star_reading_v2_invalid.csv")
+      importer, log = create_test_importer!
       importer.import
       expect(log.output).to include('error: ["Percentile rank too high"]')
       expect(log.output).to include('skipped 1 invalid rows')
@@ -77,7 +91,8 @@ RSpec.describe StarReadingImporter do
     end
 
     it 'supports school filter (v2 as example)' do
-      importer, log = create_mocked_importer(PerDistrict::SOMERVILLE, "#{Rails.root}/spec/importers/star/star_reading_v2.csv", {
+      mock_star_sftp!(PerDistrict::SOMERVILLE, "#{Rails.root}/spec/importers/star/star_reading_v2.csv")
+      importer, log = create_test_importer!({
         school_scope: ['SHS']
       })
       importer.import


### PR DESCRIPTION
# Who is this PR for?
New Bedford MS educators

# What problem does this PR fix?
IT pals in New Bedford are having issues with the STAR setup, either upstream or in working with other vendors.  They wanted to work around, so replicated the STAR export themselves.

# What does this PR do?
Parameterizes the `StarImporter` classes with methods for getting different clients, and reading config from different places.  The New Bedford setup uses this to connect to the SFTP export box rather than STAR directly, and reads the config (which is more sensitive) from `DistrictConfigLog` instead of yaml in source.

# Checklists
*Which features or pages does this PR touch?*
+ [x] STAR importers

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here