### PR TITLE
Support language dropdown for Levels page in demo

### DIFF
--- a/app/assets/javascripts/helpers/language.js
+++ b/app/assets/javascripts/helpers/language.js
@@ -107,7 +107,9 @@ export function prettyEnglishProficiencyText(districtKey, limitedEnglishProficie
 
 // For use in Select dropdowns
 export function englishProficiencyOptions(districtKey) {
-  if (districtKey !== SOMERVILLE) throw new Error(`unsupported districtKey: ${districtKey}`);
+  if (districtKey !== SOMERVILLE || districtKey !== DEMO) {
+    throw new Error(`unsupported districtKey: ${districtKey}`);
+  }
   
   const districtMap = LANGUAGE_MAPS_BY_DISTRICT_KEY[districtKey];
   return [{ value: ALL, label: 'All' }].concat(Object.keys(districtMap).map(value => {


### PR DESCRIPTION
The parsing for language-related fields is the same for Somerville and Demo, except for this one method.  This fixes it, which raises on the levels page in demo.