### PR TITLE
Notes: Fix to resizing text area when longer than screen height

### DIFF
--- a/app/assets/javascripts/components/ResizingTextArea.js
+++ b/app/assets/javascripts/components/ResizingTextArea.js
@@ -42,12 +42,14 @@ export default class ResizingTextArea extends React.Component {
     // purposes of sizing.  This limits the impact to when there is a trailing
     // newline, and the last character is about to wrap.
     this.span.textContent = this.el.textContent + '#';
-    // console.log('>> resize', this.el.style.height, '.', this.el.offsetHeight, this.el.scrollHeight, '|', this.span.style.height, '.', this.span.offsetHeight, this.span.scrollHeight);
+
+    // debugging
+    debugLog('>> resize', this.el.style.height, '.', this.el.offsetHeight, this.el.scrollHeight, '|', this.span.style.height, '.', this.span.offsetHeight, this.span.scrollHeight);
 
     // simple, just set `height` if it's not big enough
     const needsToExpand = (this.el.offsetHeight < this.el.scrollHeight);
     if (needsToExpand) {
-      // console.log('  expand!', this.el.scrollHeight);
+      debugLog('  expand!', this.el.scrollHeight);
       this.el.style.height = this.el.scrollHeight + 'px';
       return;
     }
@@ -55,19 +57,22 @@ export default class ResizingTextArea extends React.Component {
     // needs span to measure once `height` is set the first time
     const needsToContract = (this.el.scrollHeight > this.span.scrollHeight);
     if (needsToContract) {
-      // console.log('  contract!', this.span.scrollHeight);
+      debugLog('  contract!', this.span.scrollHeight);
       this.el.style.height = this.span.scrollHeight + 'px';
       return;
     }
   }
 
   render() {
+    const {style = {}, containerStyle = {}} = this.props;
     return (
-      <div className="ResizingTextArea" style={{position: 'relative'}}>
+      <div
+        className="ResizingTextArea"
+        style={{...containerStyle, position: 'relative'}}>
         <span
           ref={el => this.span = el}
           style={{
-            ...this.props.style, // eg, margins
+            ...style, // eg, margins
             pointerEvents: 'none', 
             position: 'absolute',
             top: 0,
@@ -86,10 +91,11 @@ export default class ResizingTextArea extends React.Component {
           }} 
         />
         <textarea
+          className="ResizingTextArea-textarea"
           ref={el => this.el = el}
           {...this.props}
           // to debug visually, do something like this:
-          // style={{...this.props.style, outline: '1px solid blue'}}
+          // style={{...style, outline: '1px solid blue'}}
         />
       </div>
     );
@@ -97,5 +103,17 @@ export default class ResizingTextArea extends React.Component {
 }
 ResizingTextArea.propTypes = {
   value: PropTypes.string,
-  style: PropTypes.object
+  style: PropTypes.object,
+  containerStyle: PropTypes.object
 };
+
+
+
+function debugLog(...debugMsgs) {
+  // const debugEl = document.createElement('pre');
+  // debugEl.textContent = debugMsgs.join('  ');
+  // debugEl.style['border-top'] = '1px solid #ccc';
+  // debugEl.style['margin-top'] = '10px';
+  // document.body.appendChild(debugEl);
+  // console.log(...debugMsgs);
+}

--- a/app/assets/javascripts/components/ResizingTextArea.js
+++ b/app/assets/javascripts/components/ResizingTextArea.js
@@ -42,12 +42,12 @@ export default class ResizingTextArea extends React.Component {
     // purposes of sizing.  This limits the impact to when there is a trailing
     // newline, and the last character is about to wrap.
     this.span.textContent = this.el.textContent + '#';
-    console.log('>> resize', this.el.style.height, '.', this.el.offsetHeight, this.el.scrollHeight, '|', this.span.style.height, '.', this.span.offsetHeight, this.span.scrollHeight);
+    // console.log('>> resize', this.el.style.height, '.', this.el.offsetHeight, this.el.scrollHeight, '|', this.span.style.height, '.', this.span.offsetHeight, this.span.scrollHeight);
 
     // simple, just set `height` if it's not big enough
     const needsToExpand = (this.el.offsetHeight < this.el.scrollHeight);
     if (needsToExpand) {
-       console.log('  expand!', this.el.scrollHeight);
+      // console.log('  expand!', this.el.scrollHeight);
       this.el.style.height = this.el.scrollHeight + 'px';
       return;
     }
@@ -55,7 +55,7 @@ export default class ResizingTextArea extends React.Component {
     // needs span to measure once `height` is set the first time
     const needsToContract = (this.el.scrollHeight > this.span.scrollHeight);
     if (needsToContract) {
-       console.log('  contract!', this.span.scrollHeight);
+      // console.log('  contract!', this.span.scrollHeight);
       this.el.style.height = this.span.scrollHeight + 'px';
       return;
     }

--- a/app/assets/javascripts/components/ResizingTextArea.js
+++ b/app/assets/javascripts/components/ResizingTextArea.js
@@ -19,7 +19,7 @@ export default class ResizingTextArea extends React.Component {
   }
 
   // This component is fragile to changes; verify changes across browsers and
-  // with these test cases below.
+  // with these test cases below.  See also the story.
   //
   // Cases:
   // - on load, resizes to show all text
@@ -41,23 +41,28 @@ export default class ResizingTextArea extends React.Component {
     // This hacks around, and always appends a character to the hidden span for the
     // purposes of sizing.  This limits the impact to when there is a trailing
     // newline, and the last character is about to wrap.
-    this.span.textContent = this.el.textContent + '#';
+    // if (this.el.textContent.slice(-1) === '\n') {
+    // this.el.textContent = this.el.textContent + '\n';
+    // }
+    this.span.textContent = this.el.textContent + '\n#';
 
     // debugging
-    debugLog('>> resize', this.el.style.height, '.', this.el.offsetHeight, this.el.scrollHeight, '|', this.span.style.height, '.', this.span.offsetHeight, this.span.scrollHeight);
+    // debugLog('>> resize', this.el.style.height, '.', this.el.offsetHeight, this.el.scrollHeight, '|', this.span.style.height, '.', this.span.offsetHeight, this.span.scrollHeight);
 
     // simple, just set `height` if it's not big enough
-    const needsToExpand = (this.el.offsetHeight < this.el.scrollHeight);
+    const needsToExpand = (this.el.offsetHeight < this.span.scrollHeight);
     if (needsToExpand) {
-      debugLog('  expand!', this.el.scrollHeight);
-      this.el.style.height = this.el.scrollHeight + 'px';
+      // debugLog('  expand!', this.span.scrollHeight);
+      // debugLog('this.el.scrollTop', this.el.scrollTop);
+      this.el.style.height = this.span.scrollHeight + 'px';
       return;
     }
 
     // needs span to measure once `height` is set the first time
     const needsToContract = (this.el.scrollHeight > this.span.scrollHeight);
     if (needsToContract) {
-      debugLog('  contract!', this.span.scrollHeight);
+      // debugLog('  contract!', this.span.scrollHeight);
+      // debugLog('this.el.scrollTop', this.el.scrollTop);
       this.el.style.height = this.span.scrollHeight + 'px';
       return;
     }
@@ -108,12 +113,29 @@ ResizingTextArea.propTypes = {
 };
 
 
-
+// For working around when in IE11 in a VM, when using the console
+// or debugger tools can be prohibitively slow.
 function debugLog(...debugMsgs) {
-  // const debugEl = document.createElement('pre');
-  // debugEl.textContent = debugMsgs.join('  ');
-  // debugEl.style['border-top'] = '1px solid #ccc';
-  // debugEl.style['margin-top'] = '10px';
-  // document.body.appendChild(debugEl);
-  // console.log(...debugMsgs);
+  let containerEl = document.querySelector('.ResizingTextArea-debug');
+  if (!containerEl) {
+    containerEl = document.createElement('div');
+    containerEl.classList.add('ResizingTextArea-debug');
+    containerEl.style['z-index'] = 999;
+    containerEl.style['position'] = 'fixed';
+    containerEl.style['top'] = '50px';
+    containerEl.style['right'] = '10px';
+    containerEl.style['bottom'] = '50px';
+    containerEl.style['width'] = '400px';
+    containerEl.style['background'] = 'white';
+    containerEl.style['overflow-y'] = 'scroll';
+    containerEl.style['border'] = '1px solid black';
+    containerEl.style['padding'] = '10px';
+    document.body.appendChild(containerEl);
+  }
+  const debugEl = document.createElement('pre');
+  debugEl.textContent = debugMsgs.join('  ');
+  debugEl.style['border-top'] = '1px solid #ccc';
+  debugEl.style['margin-top'] = '10px';
+  containerEl.insertBefore(debugEl, containerEl.children[0]);
+  console.log(...debugMsgs);
 }

--- a/app/assets/javascripts/components/ResizingTextArea.js
+++ b/app/assets/javascripts/components/ResizingTextArea.js
@@ -18,24 +18,84 @@ export default class ResizingTextArea extends React.Component {
     }
   }
 
+  // This component is fragile to changes; verify changes across browsers and
+  // with these test cases below.
+  //
+  // Cases:
+  // - on load, resizes to show all text
+  // - on wrap or enter, expands height without jumping focus or scroll
+  // - on remove lines, contracts height
+  // - no unexpected losing focus or jumping scroll when expanding/contracting
+  // - works when trailing newline
+  // - across browsers to IE11
+  //
+  // More helpful bits in:
+  // - https://stackoverflow.com/questions/454202/creating-a-textarea-with-auto-resize
+  // - https://stackoverflow.com/questions/3341496/how-to-get-the-height-of-the-text-inside-of-a-textarea
   resize() {
-    if (this.el) {
-      this.el.style.height = (this.el.scrollHeight) + 'px;';
-      this.el.style.height = 'auto';
-      this.el.style.height = (this.el.scrollHeight) + 'px';
+    if (!this.el) return;
+    if (!this.span) return;
+
+    // There's some unexpected sizing behavior with trailing newlines, where the
+    // size of the span does not include the height for the trailing newline.
+    // This hacks around, and always appends a character to the hidden span for the
+    // purposes of sizing.  This limits the impact to when there is a trailing
+    // newline, and the last character is about to wrap.
+    this.span.textContent = this.el.textContent + '#';
+    console.log('>> resize', this.el.style.height, '.', this.el.offsetHeight, this.el.scrollHeight, '|', this.span.style.height, '.', this.span.offsetHeight, this.span.scrollHeight);
+
+    // simple, just set `height` if it's not big enough
+    const needsToExpand = (this.el.offsetHeight < this.el.scrollHeight);
+    if (needsToExpand) {
+       console.log('  expand!', this.el.scrollHeight);
+      this.el.style.height = this.el.scrollHeight + 'px';
+      return;
+    }
+
+    // needs span to measure once `height` is set the first time
+    const needsToContract = (this.el.scrollHeight > this.span.scrollHeight);
+    if (needsToContract) {
+       console.log('  contract!', this.span.scrollHeight);
+      this.el.style.height = this.span.scrollHeight + 'px';
+      return;
     }
   }
 
   render() {
     return (
-      <textarea
-        className="ResizingTextArea"
-        ref={el => this.el = el}
-        {...this.props}
-      />
+      <div className="ResizingTextArea" style={{position: 'relative'}}>
+        <span
+          ref={el => this.span = el}
+          style={{
+            ...this.props.style, // eg, margins
+            pointerEvents: 'none', 
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            zIndex: -1,
+            opacity: 0,
+
+            // to debug visually, do something like this:
+            // zIndex: 1,
+            // opacity: 0.5,
+            // color: 'red',
+            // outline: '1px solid red'
+          }} 
+        />
+        <textarea
+          ref={el => this.el = el}
+          {...this.props}
+          // to debug visually, do something like this:
+          // style={{...this.props.style, outline: '1px solid blue'}}
+        />
+      </div>
     );
   }
 }
 ResizingTextArea.propTypes = {
-  value: PropTypes.string
+  value: PropTypes.string,
+  style: PropTypes.object
 };

--- a/app/assets/javascripts/components/ResizingTextArea.js
+++ b/app/assets/javascripts/components/ResizingTextArea.js
@@ -115,27 +115,27 @@ ResizingTextArea.propTypes = {
 
 // For working around when in IE11 in a VM, when using the console
 // or debugger tools can be prohibitively slow.
-function debugLog(...debugMsgs) {
-  let containerEl = document.querySelector('.ResizingTextArea-debug');
-  if (!containerEl) {
-    containerEl = document.createElement('div');
-    containerEl.classList.add('ResizingTextArea-debug');
-    containerEl.style['z-index'] = 999;
-    containerEl.style['position'] = 'fixed';
-    containerEl.style['top'] = '50px';
-    containerEl.style['right'] = '10px';
-    containerEl.style['bottom'] = '50px';
-    containerEl.style['width'] = '400px';
-    containerEl.style['background'] = 'white';
-    containerEl.style['overflow-y'] = 'scroll';
-    containerEl.style['border'] = '1px solid black';
-    containerEl.style['padding'] = '10px';
-    document.body.appendChild(containerEl);
-  }
-  const debugEl = document.createElement('pre');
-  debugEl.textContent = debugMsgs.join('  ');
-  debugEl.style['border-top'] = '1px solid #ccc';
-  debugEl.style['margin-top'] = '10px';
-  containerEl.insertBefore(debugEl, containerEl.children[0]);
-  console.log(...debugMsgs);
-}
+// function debugLog(...debugMsgs) {
+//   let containerEl = document.querySelector('.ResizingTextArea-debug');
+//   if (!containerEl) {
+//     containerEl = document.createElement('div');
+//     containerEl.classList.add('ResizingTextArea-debug');
+//     containerEl.style['z-index'] = 999;
+//     containerEl.style['position'] = 'fixed';
+//     containerEl.style['top'] = '50px';
+//     containerEl.style['right'] = '10px';
+//     containerEl.style['bottom'] = '50px';
+//     containerEl.style['width'] = '400px';
+//     containerEl.style['background'] = 'white';
+//     containerEl.style['overflow-y'] = 'scroll';
+//     containerEl.style['border'] = '1px solid black';
+//     containerEl.style['padding'] = '10px';
+//     document.body.appendChild(containerEl);
+//   }
+//   const debugEl = document.createElement('pre');
+//   debugEl.textContent = debugMsgs.join('  ');
+//   debugEl.style['border-top'] = '1px solid #ccc';
+//   debugEl.style['margin-top'] = '10px';
+//   containerEl.insertBefore(debugEl, containerEl.children[0]);
+//   console.log(...debugMsgs);
+// }

--- a/app/assets/javascripts/components/ResizingTextArea.story.js
+++ b/app/assets/javascripts/components/ResizingTextArea.story.js
@@ -52,7 +52,7 @@ storiesOf('components/ResizingTextArea', module) // eslint-disable-line no-undef
             <li>interactive: after transitions, scroll down on long text.  when editing, scroll should not jump at all</li>
             <li>interactive: after transitions, delete chunk of long text.  textarea should contract, with no unexpected scroll or cursor jumps.</li>
             <li>interactive: after transitions, enter text with trailing newline, then add one word per line, should not see flicker</li>
-            <li>interactive: after transitions, type text on a line, shouldn't see any vertical jitter from scrolling</li>
+            <li>interactive: after transitions, type text on a line, should not see any vertical jitter from scrolling</li>
           </ol>
         </p>
         <div style={{display: 'flex', flexDirection: 'row'}}>

--- a/app/assets/javascripts/components/ResizingTextArea.story.js
+++ b/app/assets/javascripts/components/ResizingTextArea.story.js
@@ -1,0 +1,70 @@
+import React, {useState, useEffect} from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import {storiesOf} from '@storybook/react';
+import ResizingTextArea from './ResizingTextArea';
+
+function TestCase({defaultText}) {
+  const [text, setText] = useState(defaultText);
+  useEffect(() => {
+    setTimeout(() => setText(text + ' ...ok...\nwait...'), 2000);
+    setTimeout(() => setText('short...'), 4000);
+    setTimeout(() => setText(text + '\n\ngoodbye!'), 6000);
+  }, []);
+  const props = {
+    value: text,
+    onChange: e => setText(e.target.value),
+    containerStyle: {
+      fontSize: 14
+    },
+    style: {
+      outline: '1px solid black',
+      fontSize: 14,
+      width: 300,
+      border: 0,
+      padding: 0,
+      margin: 0
+    }
+  };
+  return <ResizingTextArea {...props} />;
+}
+TestCase.propTypes = {
+  defaultText: PropTypes.string.isRequired
+};
+
+const longText = _.repeat('This is a really long sentence with many different clauses saying many, many important things.\n\n', 20);
+
+
+storiesOf('components/ResizingTextArea', module) // eslint-disable-line no-undef
+  .add('all', () => {
+    return (
+      <div>
+        <h2>test cases</h2>
+        <p>
+          This cannot be tested in jest because jsdom does not have a layout engine.  So this is to
+          help with manual testing across browsers.
+
+          Try:
+          <ol>
+            <li>passive: load, and watch it add text and expand to fit, remove text and contract, then add and expand again</li>
+            <li>passive: confirm above works with edge cases like trailing newline</li>
+            <li>interactive: load, scroll all the way down.  after first transition, screen should stay scrolled down until transition to short text.</li>
+            <li>interactive: after transitions, scroll down on long text.  when editing, scroll should not jump at all</li>
+            <li>interactive: after transitions, delete chunk of long text.  textarea should contract, with no unexpected scroll or cursor jumps.</li>
+          </ol>
+        </p>
+        <div style={{display: 'flex', flexDirection: 'row'}}>
+          <div style={{flex: 1}}>
+            <div style={{padding: 10}}><TestCase defaultText={`hello1`} /></div>
+            <div style={{padding: 10}}><TestCase defaultText={`hello world`} /></div>
+            <div style={{padding: 10}}><TestCase defaultText={`hello\nworld`} /></div>
+            <div style={{padding: 10}}><TestCase defaultText={`hello\nworld\n`} /></div>
+            <div style={{padding: 10}}><TestCase defaultText={`hello\nworld\nwith\nresizing`} /></div>
+          </div>
+          <div style={{flex: 1}}>
+            <div style={{padding: 10}}><TestCase defaultText={longText} /></div>
+          </div>
+        </div>
+      </div>
+    );
+  });

--- a/app/assets/javascripts/components/ResizingTextArea.story.js
+++ b/app/assets/javascripts/components/ResizingTextArea.story.js
@@ -51,6 +51,8 @@ storiesOf('components/ResizingTextArea', module) // eslint-disable-line no-undef
             <li>interactive: load, scroll all the way down.  after first transition, screen should stay scrolled down until transition to short text.</li>
             <li>interactive: after transitions, scroll down on long text.  when editing, scroll should not jump at all</li>
             <li>interactive: after transitions, delete chunk of long text.  textarea should contract, with no unexpected scroll or cursor jumps.</li>
+            <li>interactive: after transitions, enter text with trailing newline, then add one word per line, should not see flicker</li>
+            <li>interactive: after transitions, type text on a line, shouldn't see any vertical jitter from scrolling</li>
           </ol>
         </p>
         <div style={{display: 'flex', flexDirection: 'row'}}>

--- a/app/assets/javascripts/components/ResizingTextArea.test.js
+++ b/app/assets/javascripts/components/ResizingTextArea.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ResizingTextArea from './ResizingTextArea';
+
+function testProps(props) {
+  return {
+    value: "hello",
+    onChange: jest.fn(),
+    ...props
+  };
+}
+
+it('renders without crashing', () => {
+  const el = document.createElement('div');
+  ReactDOM.render(<ResizingTextArea {...testProps()} />, el);
+  expect(el.textContent).toContain('hello');
+});
+
+
+// more meaningful tests would be challenging because there's no layout
+// engine in jsdom

--- a/app/assets/javascripts/student_profile/NoteCard.test.js
+++ b/app/assets/javascripts/student_profile/NoteCard.test.js
@@ -83,12 +83,12 @@ function testRender(props) {
 }
 
 function editNoteText(el, text) {
-  const $text = $(el).find('.ResizingTextArea');
+  const $text = $(el).find('.ResizingTextArea-textarea');
   changeTextValue($text.get(0), text);
 }
 
 function getNoteHTML(el) {
-  return $(el).find('.ResizingTextArea').html();
+  return $(el).find('.ResizingTextArea-textarea').html();
 }
 
 

--- a/app/assets/javascripts/student_profile/PageContainer.test.js
+++ b/app/assets/javascripts/student_profile/PageContainer.test.js
@@ -105,7 +105,7 @@ const helpers = {
 
   editNoteText(el, noteIndex, uiParams) {
     const $noteCard = $(el).find('.NotesList .NoteShell').eq(noteIndex);
-    const $text = $noteCard.find('.ResizingTextArea');
+    const $text = $noteCard.find('.ResizingTextArea-textarea');
     changeTextValue($text.get(0), uiParams.text);
   },
 

--- a/app/assets/javascripts/student_profile/__snapshots__/NoteCard.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/NoteCard.test.js.snap
@@ -7,27 +7,61 @@ exports[`snapshots can render substanceOnly so callers can use their own frame 1
   <div
     className="EditableNoteText"
   >
-    <textarea
+    <div
       className="ResizingTextArea"
-      onChange={[Function]}
       style={
         Object {
-          "border": 0,
-          "borderRadius": 3,
-          "fontFamily": "'Open Sans', sans-serif",
-          "fontSize": 14,
-          "marginTop": 5,
-          "outline": "1px solid transparent",
-          "overflowX": "hidden",
-          "padding": 0,
-          "resize": "none",
-          "whiteSpace": "pre-wrap",
-          "width": "100%",
-          "wordBreak": "break-word",
+          "position": "relative",
         }
       }
-      value="hello"
-    />
+    >
+      <span
+        style={
+          Object {
+            "border": 0,
+            "borderRadius": 3,
+            "fontFamily": "'Open Sans', sans-serif",
+            "fontSize": 14,
+            "left": 0,
+            "marginTop": 5,
+            "opacity": 0,
+            "outline": "1px solid transparent",
+            "overflowX": "hidden",
+            "padding": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "resize": "none",
+            "right": 0,
+            "top": 0,
+            "whiteSpace": "pre-wrap",
+            "width": "100%",
+            "wordBreak": "break-word",
+            "zIndex": -1,
+          }
+        }
+      />
+      <textarea
+        className="ResizingTextArea-textarea"
+        onChange={[Function]}
+        style={
+          Object {
+            "border": 0,
+            "borderRadius": 3,
+            "fontFamily": "'Open Sans', sans-serif",
+            "fontSize": 14,
+            "marginTop": 5,
+            "outline": "1px solid transparent",
+            "overflowX": "hidden",
+            "padding": 0,
+            "resize": "none",
+            "whiteSpace": "pre-wrap",
+            "width": "100%",
+            "wordBreak": "break-word",
+          }
+        }
+        value="hello"
+      />
+    </div>
   </div>
   <div
     style={
@@ -146,27 +180,61 @@ Array [
           <div
             className="EditableNoteText"
           >
-            <textarea
+            <div
               className="ResizingTextArea"
-              onChange={[Function]}
               style={
                 Object {
-                  "border": 0,
-                  "borderRadius": 3,
-                  "fontFamily": "'Open Sans', sans-serif",
-                  "fontSize": 14,
-                  "marginTop": 5,
-                  "outline": "1px solid transparent",
-                  "overflowX": "hidden",
-                  "padding": 0,
-                  "resize": "none",
-                  "whiteSpace": "pre-wrap",
-                  "width": "100%",
-                  "wordBreak": "break-word",
+                  "position": "relative",
                 }
               }
-              value="hello!"
-            />
+            >
+              <span
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "left": 0,
+                    "marginTop": 5,
+                    "opacity": 0,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "resize": "none",
+                    "right": 0,
+                    "top": 0,
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                    "zIndex": -1,
+                  }
+                }
+              />
+              <textarea
+                className="ResizingTextArea-textarea"
+                onChange={[Function]}
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "marginTop": 5,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "resize": "none",
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                  }
+                }
+                value="hello!"
+              />
+            </div>
           </div>
           <div
             style={
@@ -931,27 +999,61 @@ Array [
           <div
             className="EditableNoteText"
           >
-            <textarea
+            <div
               className="ResizingTextArea"
-              onChange={[Function]}
               style={
                 Object {
-                  "border": 0,
-                  "borderRadius": 3,
-                  "fontFamily": "'Open Sans', sans-serif",
-                  "fontSize": 14,
-                  "marginTop": 5,
-                  "outline": "1px solid transparent",
-                  "overflowX": "hidden",
-                  "padding": 0,
-                  "resize": "none",
-                  "whiteSpace": "pre-wrap",
-                  "width": "100%",
-                  "wordBreak": "break-word",
+                  "position": "relative",
                 }
               }
-              value="hello!"
-            />
+            >
+              <span
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "left": 0,
+                    "marginTop": 5,
+                    "opacity": 0,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "resize": "none",
+                    "right": 0,
+                    "top": 0,
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                    "zIndex": -1,
+                  }
+                }
+              />
+              <textarea
+                className="ResizingTextArea-textarea"
+                onChange={[Function]}
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "marginTop": 5,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "resize": "none",
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                  }
+                }
+                value="hello!"
+              />
+            </div>
           </div>
           <div
             style={
@@ -1069,27 +1171,61 @@ Array [
           <div
             className="EditableNoteText"
           >
-            <textarea
+            <div
               className="ResizingTextArea"
-              onChange={[Function]}
               style={
                 Object {
-                  "border": 0,
-                  "borderRadius": 3,
-                  "fontFamily": "'Open Sans', sans-serif",
-                  "fontSize": 14,
-                  "marginTop": 5,
-                  "outline": "1px solid transparent",
-                  "overflowX": "hidden",
-                  "padding": 0,
-                  "resize": "none",
-                  "whiteSpace": "pre-wrap",
-                  "width": "100%",
-                  "wordBreak": "break-word",
+                  "position": "relative",
                 }
               }
-              value="hello!"
-            />
+            >
+              <span
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "left": 0,
+                    "marginTop": 5,
+                    "opacity": 0,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "resize": "none",
+                    "right": 0,
+                    "top": 0,
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                    "zIndex": -1,
+                  }
+                }
+              />
+              <textarea
+                className="ResizingTextArea-textarea"
+                onChange={[Function]}
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "marginTop": 5,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "resize": "none",
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                  }
+                }
+                value="hello!"
+              />
+            </div>
           </div>
           <div
             style={
@@ -1211,27 +1347,61 @@ Array [
           <div
             className="EditableNoteText"
           >
-            <textarea
+            <div
               className="ResizingTextArea"
-              onChange={[Function]}
               style={
                 Object {
-                  "border": 0,
-                  "borderRadius": 3,
-                  "fontFamily": "'Open Sans', sans-serif",
-                  "fontSize": 14,
-                  "marginTop": 5,
-                  "outline": "1px solid transparent",
-                  "overflowX": "hidden",
-                  "padding": 0,
-                  "resize": "none",
-                  "whiteSpace": "pre-wrap",
-                  "width": "100%",
-                  "wordBreak": "break-word",
+                  "position": "relative",
                 }
               }
-              value="hello!"
-            />
+            >
+              <span
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "left": 0,
+                    "marginTop": 5,
+                    "opacity": 0,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "resize": "none",
+                    "right": 0,
+                    "top": 0,
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                    "zIndex": -1,
+                  }
+                }
+              />
+              <textarea
+                className="ResizingTextArea-textarea"
+                onChange={[Function]}
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "marginTop": 5,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "resize": "none",
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                  }
+                }
+                value="hello!"
+              />
+            </div>
           </div>
           <div
             style={
@@ -1353,27 +1523,61 @@ Array [
           <div
             className="EditableNoteText"
           >
-            <textarea
+            <div
               className="ResizingTextArea"
-              onChange={[Function]}
               style={
                 Object {
-                  "border": 0,
-                  "borderRadius": 3,
-                  "fontFamily": "'Open Sans', sans-serif",
-                  "fontSize": 14,
-                  "marginTop": 5,
-                  "outline": "1px solid transparent",
-                  "overflowX": "hidden",
-                  "padding": 0,
-                  "resize": "none",
-                  "whiteSpace": "pre-wrap",
-                  "width": "100%",
-                  "wordBreak": "break-word",
+                  "position": "relative",
                 }
               }
-              value="hello!"
-            />
+            >
+              <span
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "left": 0,
+                    "marginTop": 5,
+                    "opacity": 0,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "resize": "none",
+                    "right": 0,
+                    "top": 0,
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                    "zIndex": -1,
+                  }
+                }
+              />
+              <textarea
+                className="ResizingTextArea-textarea"
+                onChange={[Function]}
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "marginTop": 5,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "resize": "none",
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                  }
+                }
+                value="hello!"
+              />
+            </div>
           </div>
           <div
             style={
@@ -1520,27 +1724,61 @@ Array [
           <div
             className="EditableNoteText"
           >
-            <textarea
+            <div
               className="ResizingTextArea"
-              onChange={[Function]}
               style={
                 Object {
-                  "border": 0,
-                  "borderRadius": 3,
-                  "fontFamily": "'Open Sans', sans-serif",
-                  "fontSize": 14,
-                  "marginTop": 5,
-                  "outline": "1px solid transparent",
-                  "overflowX": "hidden",
-                  "padding": 0,
-                  "resize": "none",
-                  "whiteSpace": "pre-wrap",
-                  "width": "100%",
-                  "wordBreak": "break-word",
+                  "position": "relative",
                 }
               }
-              value="hello!"
-            />
+            >
+              <span
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "left": 0,
+                    "marginTop": 5,
+                    "opacity": 0,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "resize": "none",
+                    "right": 0,
+                    "top": 0,
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                    "zIndex": -1,
+                  }
+                }
+              />
+              <textarea
+                className="ResizingTextArea-textarea"
+                onChange={[Function]}
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "marginTop": 5,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "resize": "none",
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                  }
+                }
+                value="hello!"
+              />
+            </div>
           </div>
           <div
             style={
@@ -1702,27 +1940,61 @@ Array [
           <div
             className="EditableNoteText"
           >
-            <textarea
+            <div
               className="ResizingTextArea"
-              onChange={[Function]}
               style={
                 Object {
-                  "border": 0,
-                  "borderRadius": 3,
-                  "fontFamily": "'Open Sans', sans-serif",
-                  "fontSize": 14,
-                  "marginTop": 5,
-                  "outline": "1px solid transparent",
-                  "overflowX": "hidden",
-                  "padding": 0,
-                  "resize": "none",
-                  "whiteSpace": "pre-wrap",
-                  "width": "100%",
-                  "wordBreak": "break-word",
+                  "position": "relative",
                 }
               }
-              value="hello!"
-            />
+            >
+              <span
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "left": 0,
+                    "marginTop": 5,
+                    "opacity": 0,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "resize": "none",
+                    "right": 0,
+                    "top": 0,
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                    "zIndex": -1,
+                  }
+                }
+              />
+              <textarea
+                className="ResizingTextArea-textarea"
+                onChange={[Function]}
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "marginTop": 5,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "resize": "none",
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                  }
+                }
+                value="hello!"
+              />
+            </div>
           </div>
           <div
             style={
@@ -1841,27 +2113,61 @@ Array [
           <div
             className="EditableNoteText"
           >
-            <textarea
+            <div
               className="ResizingTextArea"
-              onChange={[Function]}
               style={
                 Object {
-                  "border": 0,
-                  "borderRadius": 3,
-                  "fontFamily": "'Open Sans', sans-serif",
-                  "fontSize": 14,
-                  "marginTop": 5,
-                  "outline": "1px solid transparent",
-                  "overflowX": "hidden",
-                  "padding": 0,
-                  "resize": "none",
-                  "whiteSpace": "pre-wrap",
-                  "width": "100%",
-                  "wordBreak": "break-word",
+                  "position": "relative",
                 }
               }
-              value="hello!"
-            />
+            >
+              <span
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "left": 0,
+                    "marginTop": 5,
+                    "opacity": 0,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "resize": "none",
+                    "right": 0,
+                    "top": 0,
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                    "zIndex": -1,
+                  }
+                }
+              />
+              <textarea
+                className="ResizingTextArea-textarea"
+                onChange={[Function]}
+                style={
+                  Object {
+                    "border": 0,
+                    "borderRadius": 3,
+                    "fontFamily": "'Open Sans', sans-serif",
+                    "fontSize": 14,
+                    "marginTop": 5,
+                    "outline": "1px solid transparent",
+                    "overflowX": "hidden",
+                    "padding": 0,
+                    "resize": "none",
+                    "whiteSpace": "pre-wrap",
+                    "width": "100%",
+                    "wordBreak": "break-word",
+                  }
+                }
+                value="hello!"
+              />
+            </div>
           </div>
           <div
             style={

--- a/ui/config/.storybook/config.js
+++ b/ui/config/.storybook/config.js
@@ -14,6 +14,7 @@ function loadStories() {
   require('../../../app/assets/javascripts/components/FitText.story');
   require('../../../app/assets/javascripts/components/NoteBadge.story');
   require('../../../app/assets/javascripts/components/ReactSelect.story');
+  require('../../../app/assets/javascripts/components/ResizingTextArea.story');
   require('../../../app/assets/javascripts/components/Stack.story');
 
   // home


### PR DESCRIPTION
# Who is this PR for?
educators, driven from one style of MTSS meeting

# What problem does this PR fix?
When editing a note that is taller than the screen height, the 'resizing' bit of `ResizingTextArea` can lead to the page layout jumping, which can end up scrolling to the top of the textarea so that the cursor and focus isn't visible on the screen anymore.

# What does this PR do?
Updates the resizing code to use a different method.  Previously it set the element height to `auto`, waited for it to size, and then set the height to that value.  Now it uses a separate hidden element to compute the sizing, and then sizes the `textarea` to match.

This also adds notes on test cases, and leaves some styles for visual debugging.  Actual tests cases would be tough since jest/jsdom don't do actual text layout.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here