### PR TITLE
Notes: Update CSS for hover and ResizingTextArea, add more comments

### DIFF
--- a/app/assets/javascripts/components/ResizingTextArea.js
+++ b/app/assets/javascripts/components/ResizingTextArea.js
@@ -28,6 +28,12 @@ export default class ResizingTextArea extends React.Component {
   // - no unexpected losing focus or jumping scroll when expanding/contracting
   // - works when trailing newline
   // - across browsers to IE11
+  // 
+  // Also:
+  // - when testing in the app, the behavior is different based on some
+  //   other state I can't track down (window scroll history?).  this
+  //   means you can experience  different behavior when editing an existing
+  //   note, creating one from new and then editing, etc.
   //
   // More helpful bits in:
   // - https://stackoverflow.com/questions/454202/creating-a-textarea-with-auto-resize

--- a/app/assets/stylesheets/components/EditableNoteText.css
+++ b/app/assets/stylesheets/components/EditableNoteText.css
@@ -1,4 +1,4 @@
-.EditableNoteText .ResizingTextArea {
+.EditableNoteText .ResizingTextArea .ResizingTextArea-textarea {
   &:focus,
   &:hover {
     outline-color: #e5e5e5 !important; /* overrides inline style */


### PR DESCRIPTION
Style regression on https://github.com/studentinsights/studentinsights/pull/2719; the hover and active CSS styles broke when changing the CSS class names and structure with the hidden element.  This fixes that and also adds in some comments on manual testing.