### PR TITLE
Import records: Fix bug blocking districtwide users not set as admin in SIS

### DIFF
--- a/app/controllers/import_records_controller.rb
+++ b/app/controllers/import_records_controller.rb
@@ -1,6 +1,6 @@
 class ImportRecordsController < ApplicationController
   include ActionView::Helpers::DateHelper
-  before_action :ensure_districtwide_access!
+  before_action :ensure_project_lead!
 
   def import_records_json
     recent_records = ImportRecord.order(created_at: :desc).take(25)
@@ -12,8 +12,8 @@ class ImportRecordsController < ApplicationController
   end
 
   private
-  def ensure_districtwide_access!
-    raise Exceptions::EducatorNotAuthorized unless current_educator.districtwide_access?
+  def ensure_project_lead!
+    raise Exceptions::EducatorNotAuthorized unless current_educator.can_set_districtwide_access?
   end
 
   def import_record_for_page(import_record)

--- a/app/controllers/import_records_controller.rb
+++ b/app/controllers/import_records_controller.rb
@@ -1,13 +1,6 @@
 class ImportRecordsController < ApplicationController
-  # Authentication by default inherited from ApplicationController.
-  before_action :authorize_for_districtwide_access_admin # Extra authentication layer
   include ActionView::Helpers::DateHelper
-
-  def authorize_for_districtwide_access_admin
-    unless current_educator.admin? && current_educator.districtwide_access?
-      render json: { error: "You don't have the correct authorization." }
-    end
-  end
+  before_action :ensure_districtwide_access!
 
   def import_records_json
     recent_records = ImportRecord.order(created_at: :desc).take(25)
@@ -19,6 +12,9 @@ class ImportRecordsController < ApplicationController
   end
 
   private
+  def ensure_districtwide_access!
+    raise Exceptions::EducatorNotAuthorized unless current_educator.districtwide_access?
+  end
 
   def import_record_for_page(import_record)
     if import_record.completed?

--- a/spec/controllers/import_records_controller_spec.rb
+++ b/spec/controllers/import_records_controller_spec.rb
@@ -5,79 +5,75 @@ RSpec.describe ImportRecordsController, type: :controller do
   describe '#import_records_json' do
     def make_request
       request.env['HTTPS'] = 'on'
-      get :import_records_json
+      get :import_records_json, params: {
+        format: :json
+      }
     end
 
-    context 'educator signed in' do
+    it 'guards access if not signed in' do
+      make_request
+      expect(response.status).to eq 401
+    end
+
+    it 'guards access if districtwide_access: false' do
+      educator = FactoryBot.create(:educator, districtwide_access: false, admin: true)
+      sign_in(educator)   
+      make_request
+      expect(response.status).to eq 403
+    end
+
+    context 'educator signed in, with districwide access' do
 
       before { sign_in(educator) }
 
-      context 'educator w districtwide access' do
-        let(:educator) {
-          FactoryBot.create(:educator, districtwide_access: true, admin: true)
+      let(:educator) {
+        FactoryBot.create(:educator, districtwide_access: true, admin: false)
+      }
+
+      context 'no import records' do
+        it 'can access the page' do
+          make_request
+          expect(response).to be_successful
+          expect(JSON.parse(response.body)).to eq({
+            "import_records" => []
+          })
+        end
+      end
+
+      context 'completed import record' do
+        let!(:import_record) {
+          ImportRecord.create!(
+            time_started: Time.now - 4.hours,
+            time_ended: Time.now - 2.hours,
+            importer_timing_json: "Super useful JSON...",
+            task_options_json: "Super useful JSON...",
+            log: "Super useful text..."
+          )
         }
 
-        context 'no import records' do
-          it 'can access the page' do
-            make_request
-            expect(response).to be_successful
-            expect(JSON.parse(response.body)).to eq({
-              "import_records" => []
-            })
-          end
+        it 'can access the page' do
+          make_request
+          expect(response).to be_successful
+          expect(JSON.parse(response.body)["import_records"].size).to eq 1
         end
+      end
 
-        context 'completed import record' do
-          let!(:import_record) {
-            ImportRecord.create!(
-              time_started: Time.now - 4.hours,
-              time_ended: Time.now - 2.hours,
-              importer_timing_json: "Super useful JSON...",
-              task_options_json: "Super useful JSON...",
-              log: "Super useful text..."
-            )
-          }
+      context 'import record that did not complete' do
+        let!(:import_record) {
+          ImportRecord.create!(
+            time_started: Time.now - 4.hours,
+            importer_timing_json: "Super useful JSON...",
+            task_options_json: "Super useful JSON...",
+            log: "Super useful text..."
+          )
+        }
 
-          it 'can access the page' do
-            make_request
-            expect(response).to be_successful
-            expect(JSON.parse(response.body)["import_records"].size).to eq 1
-          end
-        end
-
-        context 'import record that did not complete' do
-          let!(:import_record) {
-            ImportRecord.create!(
-              time_started: Time.now - 4.hours,
-              importer_timing_json: "Super useful JSON...",
-              task_options_json: "Super useful JSON...",
-              log: "Super useful text..."
-            )
-          }
-
-          it 'can access the page' do
-            make_request
-            expect(response).to be_successful
-            expect(JSON.parse(response.body)["import_records"].size).to eq 1
-          end
-        end
-
-        context 'educator w/o districtwide access' do
-          let(:educator) { FactoryBot.create(:educator) }
-          it 'cannot access the page; gets redirected' do
-            make_request
-            expect(JSON.parse(response.body)).to eq({ "error" => "You don't have the correct authorization." })
-          end
+        it 'can access the page' do
+          make_request
+          expect(response).to be_successful
+          expect(JSON.parse(response.body)["import_records"].size).to eq 1
         end
       end
     end
-
-    context 'not signed in' do
-      it 'redirects' do
-        make_request
-        expect(response).to redirect_to(new_educator_session_url)
-      end
-    end
-
   end
 end

--- a/spec/controllers/import_records_controller_spec.rb
+++ b/spec/controllers/import_records_controller_spec.rb
@@ -15,19 +15,27 @@ RSpec.describe ImportRecordsController, type: :controller do
       expect(response.status).to eq 401
     end
 
-    it 'guards access if districtwide_access: false' do
-      educator = FactoryBot.create(:educator, districtwide_access: false, admin: true)
+    it 'guards access if can_set_districtwide_access:false' do
+      educator = FactoryBot.create(:educator, {
+        can_set_districtwide_access: false,
+        districtwide_access: true,
+        admin: true
+      })
       sign_in(educator)   
       make_request
       expect(response.status).to eq 403
     end
 
-    context 'educator signed in, with districwide access' do
+    context 'educator signed in, with can_set_districtwide_access:true even if admin:false' do
 
       before { sign_in(educator) }
 
       let(:educator) {
-        FactoryBot.create(:educator, districtwide_access: true, admin: false)
+        FactoryBot.create(:educator, {
+          can_set_districtwide_access: true,
+          districtwide_access: true,
+          admin: false
+        })
       }
 
       context 'no import records' do


### PR DESCRIPTION
# Who is this PR for?
one project lead

# What problem does this PR fix?
Some project leads, or other folks with districtwide access, were incorrectly being blocked from accessing some the "SIS import history" tool.  This could happen if they didn't have the `admin` field also set upstream in the SIS at the time of the first account import.

# What does this PR do?
Updates to gate this to project leads only.  UI code already does that.

# Checklists
*Which features or pages does this PR touch?*
+ [x] District page

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
