### PR TITLE
Monitoring: Review and safelist some fields for alerting

### DIFF
--- a/app/importers/helpers/record_syncer.rb
+++ b/app/importers/helpers/record_syncer.rb
@@ -203,8 +203,8 @@ class RecordSyncer
     # create distinct Rollbar issues
     msg = "RecordSyncer#notify! in #{district_key} for #{@notification_tag}"
     Rollbar.error(msg, nil, {
-      alerts: alerts,
-      caller: caller
+      rollbar_safelist_alerts: alerts,
+      rollbar_safelist_caller: caller
     })
   end
 

--- a/app/importers/iep_import/iep_storer.rb
+++ b/app/importers/iep_import/iep_storer.rb
@@ -114,7 +114,7 @@ class IepStorer
       log("    could not create IepDocument record for student_id: ##{student.id}...")
       log("    orphan file up in S3: #{s3_filename}")
       log("    IepDocument model errors: #{iep_document.errors.try(:details).try(:keys).inspect}")
-      Rollbar.error('IepStorer#create_iep_document_record', error, { student_id: student.id })
+      Rollbar.error("IepStorer#create_iep_document_record raised for student.id: #{student.id}", error)
       nil
     end
   end

--- a/app/importers/import_task.rb
+++ b/app/importers/import_task.rb
@@ -137,8 +137,7 @@ class ImportTask
 
         message = "ImportTask#import_all_the_data caught an error from #{file_import_class.name} and aborted that import task, but is continuing the job..."
         log(message)
-        extra_info =  { "importer" => file_importer.class.name }
-        Rollbar.error(message, error, extra_info)
+        Rollbar.error(message, error)
       end
 
       timing_data[:end_time] = Time.current

--- a/app/importers/photo_import/photo_storer.rb
+++ b/app/importers/photo_import/photo_storer.rb
@@ -81,7 +81,7 @@ class PhotoStorer
       @logger.error("    could not create StudentPhoto record for student_id: ##{student.id}...")
       @logger.error("    orphan Photo up in S3: #{s3_filename}")
       @logger.error("    StudentPhoto model errors: #{student_photo.errors.try(:details).try(:keys).inspect}")
-      Rollbar.error('PhotoStorer#create_student_photo_record', error, { student_id: student.id })
+      Rollbar.error("PhotoStorer#create_student_photo_record raised for student.id: #{student.id}", error)
       nil
     end
   end

--- a/app/importers/precompute/precompute_student_hashes_job.rb
+++ b/app/importers/precompute/precompute_student_hashes_job.rb
@@ -61,7 +61,7 @@ class PrecomputeStudentHashesJob < Struct.new :log
         authorized_students_digest: authorized_students_digest
       )
     rescue => error
-      Rollbar.error('PrecomputeStudentHashesJob#create_document!', error, { key: key })
+      Rollbar.error("PrecomputeStudentHashesJob#create_document! failed for key: #{key}", error)
       log.puts "create_document! failed for key: #{key}"
       nil
     end

--- a/app/lib/consistent_timing.rb
+++ b/app/lib/consistent_timing.rb
@@ -16,8 +16,7 @@ class ConsistentTiming
     begin
       return_value = block.call()
     rescue => err
-      Rollbar.error('ConsistentTiming#measure_timing_only caught an error', err: err)
-      Rollbar.error(err)
+      Rollbar.error('ConsistentTiming#measure_timing_only caught an error', err)
       return_value = nil
     end
     end_milliseconds = read_monotonic_milliseconds()
@@ -29,7 +28,9 @@ class ConsistentTiming
   def wait_for_milliseconds_or_alert(milliseconds_to_wait)
     return sleep(milliseconds_to_wait/1000.0) if milliseconds_to_wait > 0
 
-    Rollbar.warn('ConsistentTiming#wait_for_milliseconds_or_alert was negative', milliseconds_to_wait: milliseconds_to_wait)
+    Rollbar.warn('ConsistentTiming#wait_for_milliseconds_or_alert was negative', {
+      rollbar_safelist_milliseconds_to_wait: milliseconds_to_wait
+    })
   end
 
   def read_monotonic_milliseconds

--- a/app/lib/login_checker.rb
+++ b/app/lib/login_checker.rb
@@ -29,9 +29,9 @@ class LoginChecker
     # alert developer
     with_isolation do
       Rollbar.warn('LoginChecker#warn_if_suspicious', {
-        flags: flags,
-        warning_id: warning_id,
-        time_now: @time_now.to_i
+        rollbar_safelist_login_flags: flags,
+        rollbar_safelist_warning_id: warning_id,
+        rollbar_safelist_time_now: @time_now.to_i
       })
     end
 
@@ -46,11 +46,7 @@ class LoginChecker
     begin
       block.call()
     rescue => err
-      Rollbar.error('LoginChecker#with_isolation rescued', {
-        error_class: err.class.name,
-        error_message: err.message,
-        error_backtrace: err.backtrace
-      })
+      Rollbar.error("LoginChecker#with_isolation rescued", err)
     end
     nil
   end
@@ -68,8 +64,8 @@ class LoginChecker
     # Alert if post to Mailgun failed
     if post_data.code.to_i != 200
       Rollbar.error("LoginChecker#send_email_to_user! failed with post_data.code: #{post_data.code}", {
-        warning_id: warning_id,
-        time_now: @time_now.to_i
+        rollbar_safelist_warning_id: warning_id,
+        rollbar_safelist_time_now: @time_now.to_i
       })
     end
     nil

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -108,7 +108,9 @@ class Rack::Attack
       matching_route = begin Rails.application.routes.recognize_path(req.path) rescue nil end
       is_root_page = (req.path == '/' || req.path.start_with?('/?'))
       if matching_route.present? && !is_root_page
-        Rollbar.error('Rack::Attack req/datacenter rule matched a specific URL', datacenter_name: datacenter_name)
+        Rollbar.error('Rack::Attack req/datacenter rule matched a specific URL', {
+          rollbar_safelist_datacenter_name: datacenter_name
+        })
       end
       true
     end

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -41,7 +41,16 @@ Rollbar.configure do |config|
   # See https://docs.rollbar.com/docs/ruby#section-scrubbing-items 
   # and https://docs.rollbar.com/docs/ruby#section-managing-sensitive-data 
   config.scrub_fields = :scrub_all # note that docs say this isn't recursive
-  config.scrub_whitelist = [:district_key]
+  config.scrub_whitelist = [
+    :district_key,
+    :rollbar_safelist_alerts,
+    :rollbar_safelist_caller,
+    :rollbar_safelist_datacenter_name,
+    :rollbar_safelist_milliseconds_to_wait,
+    :rollbar_safelist_login_flags,
+    :rollbar_safelist_warning_id,
+    :rollbar_safelist_time_now
+  ]
   config.scrub_password = true
   config.scrub_user = true
   config.randomize_scrub_length = true

--- a/spec/features/login_timing_feature_spec.rb
+++ b/spec/features/login_timing_feature_spec.rb
@@ -53,7 +53,7 @@ describe 'login timing', type: :feature do
     it 'tolerates and warns' do
       allow(Rollbar).to receive(:warn)
       expect(Rollbar).to receive(:warn).once.with('ConsistentTiming#wait_for_milliseconds_or_alert was negative', {
-        milliseconds_to_wait: anything
+        rollbar_safelist_milliseconds_to_wait: anything
       })
 
       login, password = [pals.shs_jodi.email, 'wrong-password']

--- a/spec/features/rack_attack_feature_spec.rb
+++ b/spec/features/rack_attack_feature_spec.rb
@@ -107,7 +107,9 @@ describe 'Rack::Attack respects example development config', type: :feature do
 
       # additional error alert, because URL matches valid route
       allow(Rollbar).to receive(:error)
-      expect(Rollbar).to receive(:error).once.with('Rack::Attack req/datacenter rule matched a specific URL', datacenter_name: 'Amazon AWS')
+      expect(Rollbar).to receive(:error).once.with('Rack::Attack req/datacenter rule matched a specific URL', {
+        rollbar_safelist_datacenter_name: 'Amazon AWS'
+      })
 
       allow(Rollbar).to receive(:warn)
       expect(Rollbar).to receive(:warn).once.with('Rack::Attack matched `blocklist req/datacenter`')

--- a/spec/importers/helpers/record_syncer_spec.rb
+++ b/spec/importers/helpers/record_syncer_spec.rb
@@ -324,8 +324,8 @@ RSpec.describe RecordSyncer do
 
     it 'includes district_key and notification_tag when logging and reporting to Rollbar' do
       expect(Rollbar).to receive(:error).with('RecordSyncer#notify! in somerville for AttendanceImporter', nil, {
-        alerts: [{key: :invalid_rows_count, count: 30, percentage: 0.30}],
-        caller: a_kind_of(Array)
+        rollbar_safelist_alerts: [{key: :invalid_rows_count, count: 30, percentage: 0.30}],
+        rollbar_safelist_caller: a_kind_of(Array)
       })
       _, log, _ = test_alerting_for([
         70.times.map { create_test_absence! },
@@ -336,11 +336,11 @@ RSpec.describe RecordSyncer do
 
     it 'calls Rollbar when alerting exceeds thresholds' do
       expect(Rollbar).to receive(:error).with('RecordSyncer#notify! in somerville for default', nil, {
-        alerts: [
+        rollbar_safelist_alerts: [
           {key: :invalid_rows_count, count: 17, percentage: 0.17},
           {key: :created_rows_count, count: 13, percentage: 0.13}
         ],
-        caller: a_kind_of(Array)
+        rollbar_safelist_caller: a_kind_of(Array)
       })
 
       # Should trigger on so many invalid and so many newly created

--- a/spec/lib/consistent_timing_spec.rb
+++ b/spec/lib/consistent_timing_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'ConsistentTiming' do
 
     it 'alerts when it cannot enforce timing' do
       expect(Rollbar).to receive(:warn).once.with('ConsistentTiming#wait_for_milliseconds_or_alert was negative', {
-        milliseconds_to_wait: anything
+        rollbar_safelist_milliseconds_to_wait: anything
       })
 
       start_clock = read_clock()
@@ -26,8 +26,7 @@ RSpec.describe 'ConsistentTiming' do
 
   describe '#measure_timing_only' do
     it 'enforces timing even when exception raised, and alerts' do
-      expect(Rollbar).to receive(:error).with('ConsistentTiming#measure_timing_only caught an error', err: Exceptions::InvalidConfiguration)
-      expect(Rollbar).to receive(:error).with(Exceptions::InvalidConfiguration)
+      expect(Rollbar).to receive(:error).with('ConsistentTiming#measure_timing_only caught an error', Exceptions::InvalidConfiguration)
       start_clock = read_clock()
       expect(ConsistentTiming.new.enforce_timing(500) { raise Exceptions::InvalidConfiguration }).to eq nil
       end_clock = read_clock()

--- a/spec/lib/ldap_authenticatable_tiny_spec.rb
+++ b/spec/lib/ldap_authenticatable_tiny_spec.rb
@@ -409,9 +409,9 @@ RSpec.describe 'LdapAuthenticatableTiny' do
       pals.healey_laura_principal.update!(created_at: pals.time_now - 32.days)
       allow(Rollbar).to receive(:warn)
       expect(Rollbar).to receive(:warn).once.with('LoginChecker#warn_if_suspicious', {
-        flags: [:first_login_month_after_creation],
-        warning_id: anything(),
-        time_now: anything()
+        rollbar_safelist_login_flags: [:first_login_month_after_creation],
+        rollbar_safelist_warning_id: anything(),
+        rollbar_safelist_time_now: anything()
       })
 
       strategy = mock_authenticate_with_laura!(true)
@@ -426,9 +426,9 @@ RSpec.describe 'LdapAuthenticatableTiny' do
       })
       allow(Rollbar).to receive(:warn)
       expect(Rollbar).to receive(:warn).once.with("LoginChecker#warn_if_suspicious", {
-        flags: [:first_login_after_six_months],
-        warning_id: anything(),
-        time_now: anything()
+        rollbar_safelist_login_flags: [:first_login_after_six_months],
+        rollbar_safelist_warning_id: anything(),
+        rollbar_safelist_time_now: anything()
       })
 
       strategy = mock_authenticate_with_laura!(true)

--- a/spec/lib/login_checker_spec.rb
+++ b/spec/lib/login_checker_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe LoginChecker do
 
     allow(Rollbar).to receive(:warn)
     expect(Rollbar).to receive(:warn).once.with('LoginChecker#warn_if_suspicious', {
-      flags: [:first_login_after_six_months],
-      warning_id: anything(),
-      time_now: pals.time_now.to_i
+      rollbar_safelist_login_flags: [:first_login_after_six_months],
+      rollbar_safelist_warning_id: anything(),
+      rollbar_safelist_time_now: pals.time_now.to_i
     })
 
     expect(test_checker().warn_if_suspicious).to eq [:first_login_after_six_months]
@@ -31,20 +31,16 @@ RSpec.describe LoginChecker do
 
     allow(Rollbar).to receive(:warn)
     expect(Rollbar).to receive(:warn).once.with('LoginChecker#warn_if_suspicious', {
-      flags: [:first_login_month_after_creation],
-      warning_id: anything(),
-      time_now: pals.time_now.to_i
+      rollbar_safelist_login_flags: [:first_login_month_after_creation],
+      rollbar_safelist_warning_id: anything(),
+      rollbar_safelist_time_now: pals.time_now.to_i
     })
     expect(test_checker().warn_if_suspicious).to eq [:first_login_month_after_creation]
   end
 
   it '#with_isolation works' do
     allow(Rollbar).to receive(:error)
-    expect(Rollbar).to receive(:error).once.with('LoginChecker#with_isolation rescued', {
-      error_class: 'RuntimeError',
-      error_message: 'something broke!',
-      error_backtrace: anything()
-    })
+    expect(Rollbar).to receive(:error).once.with('LoginChecker#with_isolation rescued', anything())
     checker = test_checker()
     checker.warn_if_suspicious
 


### PR DESCRIPTION
Relax a few more fields being sent to Rollbar, from scrubbing all in https://github.com/studentinsights/studentinsights/pull/2693.  These all use key names that are hopefully narrow as well as triggers for developers about sensitivity, so that we can keep scrubbing-by-default.