### PR TITLE
Testing: Update CoverageChecker to notice when file names change

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -15,6 +15,8 @@ class Educator < ApplicationRecord
 
   validates :email, presence: true, uniqueness: true, case_sensitive: false
   validates :login_name, presence: true, uniqueness: true, case_sensitive: false
+
+  validate :validate_admin_gets_access_to_all_students
   validate :validate_grade_level
 
   VALID_GRADES = [ 'PK', 'KF', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12' ].freeze
@@ -63,6 +65,15 @@ class Educator < ApplicationRecord
   end
 
   private
+  # TODO(kr) deprecated, see offline
+  def validate_admin_gets_access_to_all_students
+    has_access_to_all_students = (
+      restricted_to_sped_students == false &&
+      restricted_to_english_language_learners == false
+    )
+    errors.add(:admin, "needs access to all students") if admin? && !has_access_to_all_students
+  end
+
   def validate_grade_level
     if grade_level_access.nil?
       errors.add(:grade_level_access, "cannot be nil") if grade_level_access.nil?

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -66,8 +66,8 @@ class Educator < ApplicationRecord
   def validate_grade_level
     if grade_level_access.nil?
       errors.add(:grade_level_access, "cannot be nil") if grade_level_access.nil?
-    elsif grade_level_access.any? { |grade| !grade.instance_of?(String) }
-      errors.add(:grade_level_access, "should be an array of strings")
+    elsif grade_level_access.class != Array
+      errors.add(:grade_level_access, "should be an array, containing strings")
     elsif grade_level_access.any? { |grade| !(GradeLevels::ORDERED_GRADE_LEVELS.include?(grade)) }
       errors.add(:grade_level_access, "invalid grade")
     elsif grade_level_access.uniq.size != grade_level_access.size

--- a/spec/coverage_bot.yml
+++ b/spec/coverage_bot.yml
@@ -1,15 +1,18 @@
 # See rails_helpers.rb and coverage_checker.rb
 # This is our own file, which we use to fail the build if specific files fall do not have 100% test coverage.
 check_test_coverage_for_files:
-  - app/model/educator.rb
+  - app/models/educator.rb
 
   - app/lib/authorizer.rb
+  - app/lib/authorized_dispatcher.rb
   - app/lib/ldap_authenticator.rb
   - app/lib/multifactor_authenticator.rb
-  
+  - app/lib/masquerade.rb
+
   - config/initializers/ldap_authenticatable_tiny.rb
   - lib/devise/models/ldap_authenticatable_tiny.rb
   - lib/devise/strategies/ldap_authenticatable_tiny.rb
-
   - app/controllers/educators/sessions_controller.rb
   - app/controllers/multifactor_controller.rb
+
+  

--- a/spec/coverage_bot.yml
+++ b/spec/coverage_bot.yml
@@ -4,7 +4,10 @@ check_test_coverage_for_files:
   - app/lib/authorizer.rb
   - app/lib/ldap_authenticator.rb
   - app/lib/multifactor_authenticator.rb
-  - lib/ldap_authenticatable_tiny/model.rb
-  - lib/ldap_authenticatable_tiny/strategy.rb
+  
+  - config/initializers/ldap_authenticatable_tiny.rb
+  - lib/devise/models/ldap_authenticatable_tiny.rb
+  - lib/devise/strategies/ldap_authenticatable_tiny.rb
+
   - app/controllers/educators/sessions_controller.rb
   - app/controllers/multifactor_controller.rb

--- a/spec/coverage_bot.yml
+++ b/spec/coverage_bot.yml
@@ -14,5 +14,3 @@ check_test_coverage_for_files:
   - lib/devise/strategies/ldap_authenticatable_tiny.rb
   - app/controllers/educators/sessions_controller.rb
   - app/controllers/multifactor_controller.rb
-
-  

--- a/spec/coverage_bot.yml
+++ b/spec/coverage_bot.yml
@@ -1,6 +1,8 @@
 # See rails_helpers.rb and coverage_checker.rb
 # This is our own file, which we use to fail the build if specific files fall do not have 100% test coverage.
 check_test_coverage_for_files:
+  - app/model/educator.rb
+
   - app/lib/authorizer.rb
   - app/lib/ldap_authenticator.rb
   - app/lib/multifactor_authenticator.rb

--- a/spec/features/login_timing_feature_spec.rb
+++ b/spec/features/login_timing_feature_spec.rb
@@ -5,10 +5,6 @@ describe 'login timing', type: :feature do
   let!(:pals) { TestPals.create! }
   before(:each) { LoginTests.reset_rack_attack! }
 
-  def sample_educator(seed)
-    Educator.all.sample(random: Random.new(seed))
-  end
-
   # simulate a really slow response from an LDAP #bind
   def mock_slow_ldap_bind!(username, password, delay_milliseconds)
     slow_mock_ldap = MockLdap.new({

--- a/spec/importers/helpers/import_matcher_spec.rb
+++ b/spec/importers/helpers/import_matcher_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ImportMatcher do
-  def make_log
-    LogHelper::FakeLog.new
-  end
-
   describe '#parse_sheets_est_timestamp' do
     it 'works when EST (+5)' do
       Timecop.freeze(Time.parse('2019-01-30 12:22:02 -0000')) do

--- a/spec/importers/helpers/sftp_client_spec.rb
+++ b/spec/importers/helpers/sftp_client_spec.rb
@@ -11,13 +11,6 @@ RSpec.describe SftpClient do
     allow(ENV).to receive(:[]).with('STAR_SFTP_PASSWORD').and_return "sftp-password"
   end
 
-  def mock_net_sftp_for_x2!
-    expect(Net::SFTP).to receive(:start).with("sis.x2.com", "sis-user", { :key_data=>"sis-key" }) do |&block|
-      block.call(instance_double(Net::SFTP::Session))
-    end
-    nil
-  end
-
   describe '.for_x2' do
     before { mock_env_for_x2 }
     it 'configures the sftp client for X2' do

--- a/spec/lib/authorizer_spec.rb
+++ b/spec/lib/authorizer_spec.rb
@@ -109,12 +109,9 @@ RSpec.describe Authorizer do
         # one of these educators should raise an error about a missing
         # attribute.
         expect do
-          authorized(Educator.select(*some_fields).find(pals.uri.id)) { students }
-          authorized(Educator.select(*some_fields).find(pals.healey_vivian_teacher.id)) { students }
-          authorized(Educator.select(*some_fields).find(pals.healey_ell_teacher.id)) { students }
-          authorized(Educator.select(*some_fields).find(pals.healey_sped_teacher.id)) { students }
-          authorized(Educator.select(*some_fields).find(pals.shs_bill_nye.id)) { students }
-          authorized(Educator.select(*some_fields).find(pals.shs_sofia_counselor.id)) { students }
+          Educator.all.shuffle.each do |educator|
+            authorized(Educator.select(*some_fields).find(educator.id)) { students }
+          end
         end.to raise_error(ActiveModel::MissingAttributeError)
       end
     end
@@ -664,14 +661,6 @@ RSpec.describe Authorizer do
   end
 
   describe '#why_authorized_for_student?' do
-    def why_authorized_map(educator, students)
-      authorizer = Authorizer.new(educator)
-      students.reduce({}) do |map, student|
-        reason = authorizer.why_authorized_for_student?(student)
-        if reason then map.merge([student.id] => reason) else map end
-      end
-    end
-
     def outcomes_for(educators, students, options = {})
       outcomes = []
       educators.each do |educator|

--- a/spec/models/class_list_spec.rb
+++ b/spec/models/class_list_spec.rb
@@ -12,14 +12,6 @@ RSpec.describe ClassList do
     }.merge(params))
   end
 
-  def revise_class_list(class_list, educator, params = {})
-    revised_class_list = clas_list.dup
-    revised_class_list.update!({
-      revised_by_principal_educator_id: educator.id,
-    }.merge(params))
-    revised_class_list
-  end
-
   let!(:pals) { TestPals.create! }
 
   describe 'presence validations' do

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Educator do
 
     it 'requires grade_level_access to be valid GRADE_LEVEL values' do
       educator = FactoryBot.build(:educator)
-      educator.grade_level_access = ['14']
+      educator.grade_level_access = ['3', '14']
       educator.valid?
       expect(educator.errors.details).to eq(grade_level_access: [{:error=>"invalid grade"}])
     end
@@ -56,6 +56,20 @@ RSpec.describe Educator do
       educator.grade_level_access = ['2', '2']
       educator.valid?
       expect(educator.errors.details).to eq(grade_level_access: [{:error=>"duplicate values"}])
+    end
+
+    it 'requires grade_level_access to be an array' do
+      educator = FactoryBot.build(:educator)
+      educator.grade_level_access = false
+      educator.valid?
+      expect(educator.errors.details).to eq(grade_level_access: [{:error=>"should be an array, containing strings"}])
+    end
+
+    it 'requires grade_level_access to be present' do
+      educator = FactoryBot.build(:educator)
+      educator.grade_level_access = nil
+      educator.valid?
+      expect(educator.errors.details).to eq(grade_level_access: [{:error=>"cannot be nil"}])
     end
   end
 

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -121,6 +121,27 @@ RSpec.describe Educator do
     it 'requires email' do
       expect(FactoryBot.build(:educator, email: nil)).to be_invalid
     end
+
+    it 'requires grade_level_access to be an array of strings' do
+      educator = FactoryBot.build(:educator)
+      educator.grade_level_access = [3]
+      educator.valid?
+      expect(educator.errors.details).to eq(foo: 'bar')
+    end
+
+    it 'requires grade_level_access to be valid GRADE_LEVEL values' do
+      educator = FactoryBot.build(:educator)
+      educator.grade_level_access = ['14']
+      educator.valid?
+      expect(educator.errors.details).to eq(foo: 'nooo')
+    end
+
+    it 'requires grade_level_access to have unique values' do
+      educator = FactoryBot.build(:educator)
+      educator.grade_level_access = ['2', '2']
+      educator.valid?
+      expect(educator.errors.details).to eq(foo: 'nooop')
+    end
   end
 
   describe '#labels' do

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -29,22 +29,7 @@ RSpec.describe Educator do
     expect(FactoryBot.build(:educator, school: nil)).to be_valid
   end
 
-  describe '#admin_gets_access_to_all_students' do
-    context 'admin with access to all students' do
-      let(:admin) { FactoryBot.build(:educator, :admin) }
-      it 'is valid' do
-        expect(admin).to be_valid
-      end
-    end
-    context 'admin without access to all students' do
-      let(:admin) { FactoryBot.build(:educator, :admin, restricted_to_sped_students: true) }
-      it 'is invalid' do
-        expect(admin).to be_invalid
-      end
-    end
-  end
-
-  describe 'grade level access' do
+  describe 'grade_level_access' do
     context 'mix of strings and not strings' do
       let(:educator) { FactoryBot.create(:educator, grade_level_access: ['3', 4]) }
       it 'is coerced into an array of strings' do
@@ -55,7 +40,22 @@ RSpec.describe Educator do
       let(:educator) { FactoryBot.create(:educator, grade_level_access: [3, 4]) }
       it 'is coerced into an array of strings' do
         expect(educator.grade_level_access).to eq ["3", "4"]
+        expect(educator.valid?).to eq true
       end
+    end
+
+    it 'requires grade_level_access to be valid GRADE_LEVEL values' do
+      educator = FactoryBot.build(:educator)
+      educator.grade_level_access = ['14']
+      educator.valid?
+      expect(educator.errors.details).to eq(grade_level_access: [{:error=>"invalid grade"}])
+    end
+
+    it 'requires grade_level_access to have unique values' do
+      educator = FactoryBot.build(:educator)
+      educator.grade_level_access = ['2', '2']
+      educator.valid?
+      expect(educator.errors.details).to eq(grade_level_access: [{:error=>"duplicate values"}])
     end
   end
 
@@ -120,27 +120,6 @@ RSpec.describe Educator do
   describe 'validations' do
     it 'requires email' do
       expect(FactoryBot.build(:educator, email: nil)).to be_invalid
-    end
-
-    it 'requires grade_level_access to be an array of strings' do
-      educator = FactoryBot.build(:educator)
-      educator.grade_level_access = [3]
-      educator.valid?
-      expect(educator.errors.details).to eq(foo: 'bar')
-    end
-
-    it 'requires grade_level_access to be valid GRADE_LEVEL values' do
-      educator = FactoryBot.build(:educator)
-      educator.grade_level_access = ['14']
-      educator.valid?
-      expect(educator.errors.details).to eq(foo: 'nooo')
-    end
-
-    it 'requires grade_level_access to have unique values' do
-      educator = FactoryBot.build(:educator)
-      educator.grade_level_access = ['2', '2']
-      educator.valid?
-      expect(educator.errors.details).to eq(foo: 'nooop')
     end
   end
 

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -135,6 +135,21 @@ RSpec.describe Educator do
     it 'requires email' do
       expect(FactoryBot.build(:educator, email: nil)).to be_invalid
     end
+
+    describe 'when "restriction" fields are interpreted as limitations on "admin"' do
+      context 'admin with access to all students' do
+        let(:admin) { FactoryBot.build(:educator, :admin) }
+        it 'is valid' do
+          expect(admin).to be_valid
+        end
+      end
+      context 'admin without access to all students' do
+        let(:admin) { FactoryBot.build(:educator, :admin, restricted_to_sped_students: true) }
+        it 'is invalid' do
+          expect(admin).to be_invalid
+        end
+      end
+    end
   end
 
   describe '#labels' do

--- a/spec/support/coverage_checker.rb
+++ b/spec/support/coverage_checker.rb
@@ -41,7 +41,7 @@ class CoverageChecker
       files_to_check.any? {|file_to_check| file.filename.ends_with?(file_to_check)}
     end
     if files_matching_filter.length < files_to_check.size
-      puts "CoverageChecker: Only found #{files_matching_filter.size} files, but there were #{files_to_check} patterns listed in the config.  Exiting with error status #{MISSING_FILES_STATUS_CODE}"
+      puts "CoverageChecker: Only found #{files_matching_filter.size} files, but there were #{files_to_check.length} patterns listed in the config.  Exiting with error status #{MISSING_FILES_STATUS_CODE}"
       Kernel.exit MISSING_FILES_STATUS_CODE
     end
   end

--- a/spec/support/coverage_checker.rb
+++ b/spec/support/coverage_checker.rb
@@ -29,6 +29,7 @@ class CoverageChecker
         "#{file.filename} - #{file.covered_percent.round}%"
       end
       puts " - " + file_lines.join("\n - ")
+      puts "\n\nERROR from CoverageChecker\n\n"
       puts "CoverageChecker: Exiting with error status #{ERROR_STATUS_CODE}"
       Kernel.exit ERROR_STATUS_CODE
     end
@@ -41,6 +42,7 @@ class CoverageChecker
       files_to_check.any? {|file_to_check| file.filename.ends_with?(file_to_check)}
     end
     if files_matching_filter.length < files_to_check.size
+      puts "\n\nERROR from CoverageChecker\n\n"
       puts "CoverageChecker: Only found #{files_matching_filter.size} files, but there were #{files_to_check.length} patterns listed in the config.  Exiting with error status #{MISSING_FILES_STATUS_CODE}"
       Kernel.exit MISSING_FILES_STATUS_CODE
     end

--- a/spec/support/coverage_checker.rb
+++ b/spec/support/coverage_checker.rb
@@ -46,5 +46,6 @@ class CoverageChecker
       puts "CoverageChecker: Only found #{files_matching_filter.size} files, but there were #{files_to_check.length} patterns listed in the config.  Exiting with error status #{MISSING_FILES_STATUS_CODE}"
       Kernel.exit MISSING_FILES_STATUS_CODE
     end
+    files_matching_filter
   end
 end

--- a/spec/support/coverage_checker.rb
+++ b/spec/support/coverage_checker.rb
@@ -1,5 +1,6 @@
 class CoverageChecker
   ERROR_STATUS_CODE = 172
+  MISSING_FILES_STATUS_CODE = 173
 
   # By default, only run this on full test runs (eg, in Travis) or when explicitly asked.
   # In the common development case where you only run a subset of tests, this will have
@@ -28,7 +29,7 @@ class CoverageChecker
         "#{file.filename} - #{file.covered_percent.round}%"
       end
       puts " - " + file_lines.join("\n - ")
-      puts "CoverageChecked: Exiting with error status #{ERROR_STATUS_CODE}"
+      puts "CoverageChecker: Exiting with error status #{ERROR_STATUS_CODE}"
       Kernel.exit ERROR_STATUS_CODE
     end
   end
@@ -36,8 +37,12 @@ class CoverageChecker
   def filtered_files(files)
     config_file = File.open(File.join(Rails.root, 'spec', 'coverage_bot.yml'))
     files_to_check = YAML.load(config_file)['check_test_coverage_for_files']
-    files.select do |file|
+    files_matching_filter = files.select do |file|
       files_to_check.any? {|file_to_check| file.filename.ends_with?(file_to_check)}
+    end
+    if files_matching_filter.length < files_to_check.size
+      puts "CoverageChecker: Only found #{files_matching_filter.size} files, but there were #{files_to_check} patterns listed in the config.  Exiting with error status #{MISSING_FILES_STATUS_CODE}"
+      Kernel.exit MISSING_FILES_STATUS_CODE
     end
   end
 end


### PR DESCRIPTION
I noticed that `CoverageChecker` wasn't failing, even though some of the file names it referenced were renamed a little while back (eg, in the Rails 6 change https://github.com/studentinsights/studentinsights/pull/2679 with updating the locations of the Devise plugin files).

This updates it so that it fails if it can't find all files specified, adds two other files, and does some cleanup to remove dead spec code that I noticed poking around after a full coverage run.

EDIT: backed out one of the validation cleanups, needs more investigation.