### PR TITLE
Fix student pdf dates

### DIFF
--- a/app/assets/javascripts/student_profile/ProfilePdfDialog.js
+++ b/app/assets/javascripts/student_profile/ProfilePdfDialog.js
@@ -31,20 +31,20 @@ export default class ProfilePdfDialog extends React.Component {
 
   filterFromDateForQuery() {
     const {filterFromDateText} = this.state;
-    return this.formatDateTextForRails(filterFromDateText);
+    return this.formatDateText(filterFromDateText);
   }
 
   filterToDateForQuery() {
     const {filterToDateText} = this.state;
-    return this.formatDateTextForRails(filterToDateText);
+    return this.formatDateText(filterToDateText);
   }
 
-  // Normalize input date text into format Rails expects, tolerating empty string as null.
+  // Normalize input date text into format Rails expects
   // If the date is not valid, an error will be raised.
-  formatDateTextForRails(dateText) {
+  formatDateText(dateText) {
     const moment = toMoment(dateText);
     if (!moment.isValid()) throw new Error('invalid date: ' + dateText);
-    return moment.format('YYYY-MM-DD');
+    return moment.format('MM/DD/YYYY');
   }
 
   // Both dates need to be valid

--- a/app/assets/javascripts/student_profile/ProfilePdfDialog.js
+++ b/app/assets/javascripts/student_profile/ProfilePdfDialog.js
@@ -7,6 +7,7 @@ import {
   toSchoolYear,
   firstDayOfSchool
 } from '../helpers/schoolYear';
+import {toMoment} from '../helpers/toMoment';
 
 
 // Render options for downloading a profile PDF
@@ -17,8 +18,8 @@ export default class ProfilePdfDialog extends React.Component {
     const nowMoment = context.nowFn();
     this.state = {
       includeRestrictedNotes: false,
-      filterFromDate: firstDayOfSchool(toSchoolYear(nowMoment)-1),
-      filterToDate: nowMoment
+      filterFromDateText: firstDayOfSchool(toSchoolYear(nowMoment)-1).format('MM/DD/YYYY'),
+      filterToDateText: nowMoment.format('MM/DD/YYYY')
     };
 
     this.checkboxContainerEl = null;
@@ -29,15 +30,28 @@ export default class ProfilePdfDialog extends React.Component {
   }
 
   filterFromDateForQuery() {
-    const {filterFromDate} = this.state;
-
-    return filterFromDate.format('MM/DD/YYYY');
+    const {filterFromDateText} = this.state;
+    return this.formatDateTextForRails(filterFromDateText);
   }
 
   filterToDateForQuery() {
-    const {filterToDate} = this.state;
+    const {filterToDateText} = this.state;
+    return this.formatDateTextForRails(filterToDateText);
+  }
 
-    return filterToDate.format('MM/DD/YYYY');
+  // Normalize input date text into format Rails expects, tolerating empty string as null.
+  // If the date is not valid, an error will be raised.
+  formatDateTextForRails(dateText) {
+    const moment = toMoment(dateText);
+    if (!moment.isValid()) throw new Error('invalid date: ' + dateText);
+    return moment.format('YYYY-MM-DD');
+  }
+
+  // Both dates need to be valid
+  areDatesValid() {
+    const {filterFromDateText, filterToDateText} = this.state;
+    if (!toMoment(filterFromDateText).isValid() || !toMoment(filterToDateText).isValid() ) return false;
+    return true;
   }
 
   studentReportURL() {
@@ -60,16 +74,12 @@ export default class ProfilePdfDialog extends React.Component {
     this.setState({includeRestrictedNotes: e.target.checked});
   }
 
-  onFilterFromDateChanged(dateText) {
-    const textMoment = moment.utc(dateText, 'MM/DD/YYYY');
-    const updatedMoment = (textMoment.isValid()) ? textMoment : null;
-    this.setState({ filterFromDate: updatedMoment });
+  onFilterFromDateChanged(filterFromDateText) {
+    this.setState({filterFromDateText});
   }
 
-  onFilterToDateChanged(dateText) {
-    const textMoment = moment.utc(dateText, 'MM/DD/YYYY');
-    const updatedMoment = (textMoment.isValid()) ? textMoment : null;
-    this.setState({ filterToDate: updatedMoment });
+  onFilterToDateChanged(filterToDateText) {
+    this.setState({filterToDateText});
   }
 
   onClickGenerateStudentReport(event) {
@@ -80,6 +90,7 @@ export default class ProfilePdfDialog extends React.Component {
   render() {
     const {allowRestrictedNotes, showTitle, style} = this.props;
     const {includeRestrictedNotes} = this.state;
+    const areDatesValid = this.areDatesValid();
 
     return (
       <div className="ProfilePdfDialog" style={{...styles.root, ...style}}>
@@ -119,7 +130,7 @@ export default class ProfilePdfDialog extends React.Component {
                 datepicker: styles.datepickerContainer,
                 input: styles.datepickerInput
               }}
-              value={this.state.filterFromDate.format('MM/DD/YYYY')}
+              value={this.state.filterFromDateText}
               onChange={this.onFilterFromDateChanged}
               datepickerOptions={{
                 showOn: 'both',
@@ -134,7 +145,7 @@ export default class ProfilePdfDialog extends React.Component {
                 datepicker: styles.datepickerContainer,
                 input: styles.datepickerInput
               }}
-              value={this.state.filterToDate.format('MM/DD/YYYY')}
+              value={this.state.filterToDateText}
               onChange={this.onFilterToDateChanged}
               datepickerOptions={{
                 showOn: 'both',
@@ -142,10 +153,14 @@ export default class ProfilePdfDialog extends React.Component {
                 minDate: undefined
               }} />
           </div>
+          <div style={{height: '2em'}}>
+            {!this.areDatesValid() && <div className="RecordService-warning" style={styles.invalidDate}>Choose a valid date (end date is optional)</div>}
+          </div>
         </div>
         <div style={{display: 'flex', justifyContent: 'flex-end'}}>
           <button
-            style={styles.studentReportButton}
+            style={{background: (areDatesValid) ? undefined : '#ccc'}}
+            disabled={!areDatesValid}
             className="btn btn-warning"
             onClick={this.onClickGenerateStudentReport}>
             Generate Student Report

--- a/app/assets/javascripts/student_profile/ProfilePdfDialog.js
+++ b/app/assets/javascripts/student_profile/ProfilePdfDialog.js
@@ -18,7 +18,7 @@ export default class ProfilePdfDialog extends React.Component {
     this.state = {
       includeRestrictedNotes: false,
       filterFromDateText: firstDayOfSchool(toSchoolYear(nowMoment)-1).format('MM/DD/YYYY'),
-      filterToDateText: nowMoment.format('MM/DD/YYYY')
+      filterToDateText: nowMoment.add(1, 'days').format('MM/DD/YYYY')
     };
 
     this.checkboxContainerEl = null;
@@ -154,12 +154,12 @@ export default class ProfilePdfDialog extends React.Component {
               }} />
           </div>
           <div style={{height: '2em'}}>
-            {!this.areDatesValid() && <div className="PdfDialogue-warning" style={styles.invalidDate}>Choose a valid date</div>}
+            {!areDatesValid && <div className="PdfDialogue-warning" style={styles.invalidDate}>Choose a valid date</div>}
           </div>
         </div>
         <div style={{display: 'flex', justifyContent: 'flex-end'}}>
           <button
-            style={{background: (areDatesValid) ? undefined : '#ccc'}}
+            style={{...styles.studentReportButton, ...{background: (areDatesValid) ? undefined : '#ccc'}}}
             disabled={!areDatesValid}
             className="btn btn-warning"
             onClick={this.onClickGenerateStudentReport}>
@@ -255,5 +255,9 @@ const styles = {
   studentReportButton: {
     fontSize: 12,
     margin: 0
+  },
+  invalidDate: {
+    color: 'red',
+    padding: 5
   }
 };

--- a/app/assets/javascripts/student_profile/ProfilePdfDialog.js
+++ b/app/assets/javascripts/student_profile/ProfilePdfDialog.js
@@ -155,7 +155,7 @@ export default class ProfilePdfDialog extends React.Component {
               }} />
           </div>
           <div style={{height: '2em'}}>
-            {!this.areDatesValid() && <div className="RecordService-warning" style={styles.invalidDate}>Choose a valid date</div>}
+            {!this.areDatesValid() && <div className="PdfDialogue-warning" style={styles.invalidDate}>Choose a valid date</div>}
           </div>
         </div>
         <div style={{display: 'flex', justifyContent: 'flex-end'}}>

--- a/app/assets/javascripts/student_profile/ProfilePdfDialog.js
+++ b/app/assets/javascripts/student_profile/ProfilePdfDialog.js
@@ -51,6 +51,7 @@ export default class ProfilePdfDialog extends React.Component {
   areDatesValid() {
     const {filterFromDateText, filterToDateText} = this.state;
     if (!toMoment(filterFromDateText).isValid() || !toMoment(filterToDateText).isValid() ) return false;
+    if (toMoment(filterToDateText).isBefore(toMoment(filterFromDateText))) return false;
     return true;
   }
 
@@ -154,7 +155,7 @@ export default class ProfilePdfDialog extends React.Component {
               }} />
           </div>
           <div style={{height: '2em'}}>
-            {!this.areDatesValid() && <div className="RecordService-warning" style={styles.invalidDate}>Choose a valid date (end date is optional)</div>}
+            {!this.areDatesValid() && <div className="RecordService-warning" style={styles.invalidDate}>Choose a valid date</div>}
           </div>
         </div>
         <div style={{display: 'flex', justifyContent: 'flex-end'}}>

--- a/app/assets/javascripts/student_profile/ProfilePdfDialog.js
+++ b/app/assets/javascripts/student_profile/ProfilePdfDialog.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
 import qs from 'query-string';
 import Datepicker from '../components/Datepicker';
 import {

--- a/app/assets/javascripts/student_profile/ProfilePdfDialog.test.js
+++ b/app/assets/javascripts/student_profile/ProfilePdfDialog.test.js
@@ -97,13 +97,13 @@ describe('PDF', () => {
   it('creates download URL in correct format', () => {
     const context = testContext();
     const wrapper = mount(<ProfilePdfDialog {...testProps()} />, {context});
-    expect(wrapper.instance().studentReportURL()).toEqual('/students/42/student_report.pdf?from_date=08%2F15%2F2016&include_restricted_notes=false&sections=notes%2Cservices%2Cattendance%2Cdiscipline_incidents%2Cassessments&to_date=03%2F13%2F2018');
+    expect(wrapper.instance().studentReportURL()).toEqual('/students/42/student_report.pdf?from_date=08%2F15%2F2016&include_restricted_notes=false&sections=notes%2Cservices%2Cattendance%2Cdiscipline_incidents%2Cassessments&to_date=03%2F14%2F2018');
   });
 
   it('creates download URL in correct format with include_restricted_notes', () => {
     const context = testContext();
     const wrapper = mount(<ProfilePdfDialog {...testProps()} />, {context});
     wrapper.setState({includeRestrictedNotes: true});
-    expect(wrapper.instance().studentReportURL()).toEqual('/students/42/student_report.pdf?from_date=08%2F15%2F2016&include_restricted_notes=true&sections=notes%2Cservices%2Cattendance%2Cdiscipline_incidents%2Cassessments&to_date=03%2F13%2F2018');
+    expect(wrapper.instance().studentReportURL()).toEqual('/students/42/student_report.pdf?from_date=08%2F15%2F2016&include_restricted_notes=true&sections=notes%2Cservices%2Cattendance%2Cdiscipline_incidents%2Cassessments&to_date=03%2F14%2F2018');
   });
 });

--- a/app/assets/javascripts/student_profile/ProfilePdfDialog.test.js
+++ b/app/assets/javascripts/student_profile/ProfilePdfDialog.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import renderer from 'react-test-renderer';
+import ReactTestUtils from 'react-dom/test-utils';
 import {mount} from 'enzyme';
 import {withDefaultNowContext, testContext} from '../testing/NowContainer';
 import ProfilePdfDialog from './ProfilePdfDialog';
@@ -19,10 +20,69 @@ function testEl(props = {}) {
   return withDefaultNowContext(<ProfilePdfDialog {...props} />);
 }
 
+const helpers = {
+  findStartDateInput(el) {
+    return $(el).find('.datepicker').get(0);
+  },
+
+  findEndDateInput(el) {
+    return $(el).find('.datepicker').get(1);
+  },
+
+  simulateStartDateChange(el, text) {
+    const inputEl = helpers.findStartDateInput(el);
+    return ReactTestUtils.Simulate.change(inputEl, {target: {value: text}});
+  },
+
+  simulateEndDateChange(el, text) {
+    const inputEl = helpers.findEndDateInput(el);
+    return ReactTestUtils.Simulate.change(inputEl, {target: {value: text}});
+  },
+
+  findGenerateReportButton(el) {
+    return $(el).find('.btn.btn-warning');
+  },
+
+  isWarningMessageShown(el) {
+    return $(el).find('.PdfDialogue-warning').text() === 'Choose a valid date';
+  },
+};
+
 it('renders without crashing', () => {
   const el = document.createElement('div');
   const props = testProps();
   ReactDOM.render(testEl(props), el);
+});
+
+describe('date validation', () => {
+  it('shows warning on invalid start date', () => {
+    const el = document.createElement('div');
+    const props = testProps();
+    ReactDOM.render(testEl(props), el);
+    helpers.simulateStartDateChange(el, '1/2/3/4');
+    expect(helpers.isWarningMessageShown(el)).toEqual(true);
+  });
+  it('disables the generate report button when start date is invalid', () => {
+    const el = document.createElement('div');
+    const props = testProps();
+    ReactDOM.render(testEl(props), el);
+    helpers.simulateStartDateChange(el, '1/not a date');
+    expect(helpers.findGenerateReportButton(el).attr('disabled')).toEqual('disabled');
+  });
+  it('shows warning on invalid end date', () => {
+    const el = document.createElement('div');
+    const props = testProps();
+    ReactDOM.render(testEl(props), el);
+    helpers.simulateEndDateChange(el, '1/not a date');
+    expect(helpers.isWarningMessageShown(el)).toEqual(true);
+  });
+  it('disables the generate report button when end date is invalid', () => {
+    const el = document.createElement('div');
+    const props = testProps();
+    ReactDOM.render(testEl(props), el);
+    helpers.simulateEndDateChange(el, '1/not a date');
+    expect(helpers.findGenerateReportButton(el).attr('disabled')).toEqual('disabled');
+  });
 });
 
 it('snapshots view', () => {

--- a/app/assets/javascripts/student_profile/__snapshots__/ProfilePdfDialog.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/ProfilePdfDialog.test.js.snap
@@ -356,6 +356,13 @@ exports[`snapshots view 1`] = `
         />
       </div>
     </div>
+    <div
+      style={
+        Object {
+          "height": "2em",
+        }
+      }
+    />
   </div>
   <div
     style={
@@ -367,11 +374,11 @@ exports[`snapshots view 1`] = `
   >
     <button
       className="btn btn-warning"
+      disabled={false}
       onClick={[Function]}
       style={
         Object {
-          "fontSize": 12,
-          "margin": 0,
+          "background": undefined,
         }
       }
     >

--- a/app/assets/javascripts/student_profile/__snapshots__/ProfilePdfDialog.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/ProfilePdfDialog.test.js.snap
@@ -352,7 +352,7 @@ exports[`snapshots view 1`] = `
               "width": "8em",
             }
           }
-          value="03/13/2018"
+          value="03/14/2018"
         />
       </div>
     </div>
@@ -379,6 +379,8 @@ exports[`snapshots view 1`] = `
       style={
         Object {
           "background": undefined,
+          "fontSize": 12,
+          "margin": 0,
         }
       }
     >


### PR DESCRIPTION
# Who is this PR for?

Educators

# What problem does this PR fix?

cf #2685 in the student profile pdf report attempting to type in the date picker doesn't change the date and can produce an error.

# What does this PR do?

Allows input in the date picker boxes, disables the report and shows an error message when dates are invalid. 

# Screenshot (if adding a client-side feature)

![pdf_generation](https://user-images.githubusercontent.com/638809/70719110-65c59400-1cbf-11ea-8410-abfe76bab62d.gif)

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here