### PR TITLE
Login: Adjust drift_behind for MFA verification

### DIFF
--- a/app/lib/multifactor_authenticator.rb
+++ b/app/lib/multifactor_authenticator.rb
@@ -23,11 +23,12 @@ class MultifactorAuthenticator
     return false unless is_multifactor_enabled?
 
     # Check the code, enforcing that it comes after the last verification, but
-    # allowing 15 seconds of drift if the code hasn't been used yet.
+    # allowing n seconds of drift if the code hasn't been used yet.
+    drift_behind = 30 # check tests to see impact of tuning this
     totp = create_totp!
     verified_password_timestamp = totp.verify(login_code, {
       after: multifactor_config.last_verification_at,
-      drift_behind: 15
+      drift_behind: drift_behind
     })
     return false if verified_password_timestamp.nil?
 


### PR DESCRIPTION
# Who is this PR for?
project leads; internal testing of verification via email

# What does this PR do?
Adjusts the `drift_behind` to match the time window (ie, `s=1` in TOTP terms).

# Checklists
*Which features or pages does this PR touch?*
+ [x] Login

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here