### PR TITLE
Maintenance: Update apiFetchJson to reject on non-20x status codes

### DIFF
--- a/app/assets/javascripts/helpers/apiFetchJson.js
+++ b/app/assets/javascripts/helpers/apiFetchJson.js
@@ -12,8 +12,25 @@ export function apiFetch(url, options = {}) {
 }
 
 
+// Return JSON either way, but fail the Promise on
+// an unexpected status code.  This is optimized for
+// the happy path.
+//
+// Requests can fail because authorization expires (eg,
+// open the laptop hours later, click a link before the probe
+// check runs).
+const ACCEPTABLE_STATUS_CODES = [200, 201];
+function parseJson(response) {
+  return response.json().then(json => {
+    if (ACCEPTABLE_STATUS_CODES.indexOf(response.status) === -1) {
+      return Promise.reject(json);
+    }
+    return json;
+  });
+}
+
 export function apiFetchJson(url) {
-  return apiFetch(url).then(response => response.json());
+  return apiFetch(url).then(parseJson);
 }
 
 // This relies on a Rails CSRF token being rendered on the page

--- a/app/assets/javascripts/helpers/apiFetchJson.test.js
+++ b/app/assets/javascripts/helpers/apiFetchJson.test.js
@@ -34,6 +34,28 @@ it('#apiFetchJson', done => {
   });
 });
 
+it('#apiFetchJson parses non-20x responses, rejecting Promise', done => {
+  fetchMock.get('/test-url', {
+    status: 403,
+    body: {json_error: 'msg' }
+  });
+
+  apiFetchJson('/test-url', { queryFoo: 'bar' }).catch(json => {
+    expect(fetchMock.calls()).toEqual([[
+      '/test-url',
+      {
+        "credentials": "same-origin",
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET"
+      }
+    ]]);
+    expect(json).toEqual({json_error: 'msg'});
+    done();
+  });
+});
+
 
 it('#apiPostJson', done => {
   fetchMock.post('/test-url', { responseFoo: 'baz' });


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
We sometimes get false-positive monitoring alerts about JS errors when folks click into stale pages after authorization has expired.  This can happen when a user wakes their computer after say an hour of inactivity, and they click before the probe has a chance to notice they've been signed out.

In that case, if they take some action on the page that makes an API call, the server will return say a 403.  But `apiFetchJson` passes through the JSON ignoring the status code.

# What does this PR do?
In the simplest common case, we want a naive `apiFetchJson` to reject if the response is not 200, so this adds that in.  Callers can always fetch in different ways for other use cases, and they still get access to the response JSON either way (which typically indicates more error info).

# Checklists
*Which features or pages does this PR touch?*
+ [x] Core 
+ [x] eg, Home page

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here