### PR TITLE
Reading: Update importer to better tolerate unmatched student ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,8 +72,8 @@ _site/
 !/spec/importers/file_importers/data_flows_fixture.json
 
 *.csv
-!spec/fixtures/*.csv
-!spec/importers/*.csv
+!spec/fixtures/**/*.csv
+!spec/importers/**/*.csv
 
 *.sql
 !/x2_export/sql/*.sql

--- a/spec/importers/reading/mega_reading_processor_fixture_unknown_student.csv
+++ b/spec/importers/reading/mega_reading_processor_fixture_unknown_student.csv
@@ -1,0 +1,6 @@
+student_local_id,student_last_names_first_names,source_url,,K / FALL / LNF,K / FALL / Instructional needs,K / WINTER / FSF,K / WINTER / LNF,K / WINTER / PSF,K / WINTER / Instructional needs,K / WINTER / F&P Level English,K / WINTER / F&P Level Spanish,K / SPRING / LNF,K / SPRING / PSF,K / SPRING / NWF CLS,K / SPRING / NWF WWR,K / SPRING / Instructional needs,K / SPRING / F&P Level English,K / SPRING / F&P Level Spanish,K / SPRING / LAS Links Speaking,K / SPRING / LAS Links Listening,
+Kindergarten students,,,Fall,,,Winter,,,,,,Spring,,,,,,,,,
+"Student
+LASID","Student
+Last names, first names",Source URL,FSF,LNF,Instructional needs,FSF,LNF,PSF,Instructional needs, F&P English Instructional level, F&P Spanish Instructional level,LNF,PSF,NWF CLS,NWF WWR,Instructional needs, F&P English Instructional level, F&P Spanish Instructional level,LAS Links Speaking,LAS Links Listening,"Add any other columns you want here, or make new tabs for other data."
+999,"Skywalker, Rey",,1,1,,25,18,9,,AA,AA,35,28,25,0,,AA,AA,1,1,

--- a/spec/importers/reading/mega_reading_processor_spec.rb
+++ b/spec/importers/reading/mega_reading_processor_spec.rb
@@ -66,23 +66,29 @@ RSpec.describe MegaReadingProcessor do
         {"educator_id" => pals.uri.id, "benchmark_school_year" => 2018, "student_id" => donald.id, "benchmark_grade"=>"KF", "benchmark_period_key"=>"spring", "benchmark_assessment_key"=>"las_links_listening", "json"=>{"value" => "2" }}
       ])
       expect(stats).to eq({
+        :valid_rows_count => 28,
         :valid_data_points_count => 28,
         :valid_student_names_count => 2,
         :blank_student_name_count => 0,
         :invalid_student_name_count => 0,
-        :invalid_student_names_list_size => 0,
         :missing_data_point_because_student_moved_school => 0,
-        :blank_data_points_count => 6,
-        :matcher => {
-          :valid_rows_count=>28,
-          :invalid_rows_count=>0,
-          :invalid_student_local_ids_size=>0,
-          :invalid_educator_emails_size=>0,
-          :invalid_educator_last_names_size=>0,
-          :invalid_educator_logins_size=>0,
-          :invalid_course_numbers=>[],
-          :invalid_sep_oids=>[]
-        }
+        :blank_data_points_count => 6
+      })
+    end
+
+    it 'can handle failing to match a student' do
+      fixture_file = IO.read("#{Rails.root}/spec/importers/reading/mega_reading_processor_fixture_unknown_student.csv")
+      processor = MegaReadingProcessor.new(pals.uri.id, 2018, include_benchmark_grade: true)
+      rows, stats = processor.process(fixture_file)
+      expect(rows.size).to eq 0
+      expect(stats).to eq({
+        :valid_rows_count => 0,
+        :valid_data_points_count => 0,
+        :valid_student_names_count => 0,
+        :blank_student_name_count => 0,
+        :invalid_student_name_count => 1,
+        :missing_data_point_because_student_moved_school => 0,
+        :blank_data_points_count => 0
       })
     end
   end


### PR DESCRIPTION
# Who is this PR for?
K5 reading teachers, specialists, literacy coaches, folks in MTSS

# What problem does this PR fix?
There was a bug in a path of the reading importer where it was handling unexpected student id values, and this hadn't come up before since that path hadn't been exercised in production yet.

# What does this PR do?
This fixes the bug so it can tick the failure and continue on, and adds a test case for it.  This doesn't add an automated loop to flag these or circle back, which we may want to add later as we automate and smooth more of the loops and flows here.

It also removes the use of `ImporterMatcher` in this class, since the class uses some other logic for matching students, and so the matcher class it wasn't being used directly anymore except for ticking valid rows.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Reading importer

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
