### PR TITLE
STAR: Update config for importers to allow disabling importers

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -48,6 +48,22 @@ class PerDistrict
     yaml.fetch('school_definitions_for_import')
   end
 
+  # Should we be running the import?  This lets us keep other config in
+  # place when temporarily disabling to resolve issues, etc.
+  def is_star_import_enabled
+    if @district_key == SOMERVILLE
+      true
+    elsif @district_key == NEW_BEDFORD
+      false # upstream data quality issue
+    elsif @district_key == BEDFORD
+      false # never enabled
+    elsif @district_key == DEMO
+      true # allow exercising in test
+    else
+      raise_not_handled!
+    end
+  end
+
   def try_star_filename(key, fallback = nil)
     yaml.fetch('star_filenames', {}).fetch(key, fallback)
   end

--- a/app/importers/star/star_math_importer.rb
+++ b/app/importers/star/star_math_importer.rb
@@ -19,12 +19,12 @@ class StarMathImporter
   end
 
   def import
-    remote_file_name = PerDistrict.new.try_star_filename('FILENAME_FOR_STAR_MATH_IMPORT')
-    if remote_file_name.nil?
-      log('Aborting, no remote_file_name.')
+    if !PerDistrict.new.is_star_import_enabled()
+      log('Aborting, is_star_import_enabled=false.')
       return
     end
 
+    remote_file_name = PerDistrict.new.try_star_filename('FILENAME_FOR_STAR_MATH_IMPORT')
     StarImporter.new(options: @options.merge({
       model_class: StarMathResult,
       remote_file_name: remote_file_name

--- a/app/importers/star/star_reading_importer.rb
+++ b/app/importers/star/star_reading_importer.rb
@@ -19,12 +19,12 @@ class StarReadingImporter
   end
 
   def import
-    remote_file_name = PerDistrict.new.try_star_filename('FILENAME_FOR_STAR_READING_IMPORT')
-    if remote_file_name.nil?
-      log('Aborting, no remote_file_name.')
+    if !PerDistrict.new.is_star_import_enabled()
+      log('Aborting, is_star_import_enabled=false.')
       return
     end
 
+    remote_file_name = PerDistrict.new.try_star_filename('FILENAME_FOR_STAR_READING_IMPORT')
     StarImporter.new(options: @options.merge({
       model_class: StarReadingResult,
       remote_file_name: remote_file_name

--- a/spec/importers/star/star_math_importer_spec.rb
+++ b/spec/importers/star/star_math_importer_spec.rb
@@ -64,9 +64,13 @@ RSpec.describe StarMathImporter do
       end
     end
 
-    it 'works for v1 in new_bedford, via SFTP box for SIS' do
+    it 'when new_bedford is enabled, it works for v1, via SFTP box for SIS' do
       Timecop.freeze(pals.time_now) do
         mock_sis_sftp!(PerDistrict::NEW_BEDFORD, "#{Rails.root}/spec/importers/star/star_math_v1.csv")
+        # mock that new_bedford is enabled, to exercise this test code
+        # even if it has been temporarily disabled
+        allow(PerDistrict.new).to receive(:is_star_import_enabled).and_return(true)
+
         importer, log = create_test_importer!()
         importer.import
         expect(log.output).to include(':processed_rows_count=>1')
@@ -100,7 +104,7 @@ RSpec.describe StarMathImporter do
       expect(StarMathResult.all.size).to eq(0)
     end
 
-    it 'logs and aborts when config not set (eg, in Bedford)' do
+    it 'logs and aborts when not enabled (eg, in Bedford)' do
       mock_per_district = PerDistrict.new(district_key: 'bedford')
       allow(mock_per_district).to receive(:try_star_filename).and_return(nil)
       allow(PerDistrict).to receive(:new).and_return(mock_per_district)
@@ -111,7 +115,7 @@ RSpec.describe StarMathImporter do
         log: log
       })
       importer.import
-      expect(log.output).to include 'Aborting, no remote_file_name'
+      expect(log.output).to include 'Aborting, is_star_import_enabled=false'
     end
   end
 end


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
When there are upstream data quality issues, if we want to pause the STAR importers to avoid false-positive monitoring alerts, we have to remove the config values.  This isn't ideal since then we need to remember or record them somewhere.

# What does this PR do?
Adds `PerDistrict#is_star_import_enabled` so that config can remain in place, and we can just flip this switch if we need to globally disable while resolving issues upstream that might take a few days.

# Checklists
*Which features or pages does this PR touch?*
+ [x] STAR importers

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
