### PR TITLE
Educators importer: Track missing email or login_name separately and skip

### DIFF
--- a/spec/importers/file_importers/educators_importer_spec.rb
+++ b/spec/importers/file_importers/educators_importer_spec.rb
@@ -115,6 +115,22 @@ RSpec.describe EducatorsImporter do
       expect(log.output).to include('@skipped_from_school_filter: 0')
       expect(log.output).to include('@included_because_in_whitelist_count: 1')
     end
+
+    it 'counts ignored_because_login_or_email_missing_count when login_name missing, not as nil' do
+      importer = make_educators_importer()
+      allow(importer).to receive(:download_csv).and_return([make_test_row(login_name: '')])
+      importer.import
+      expect(log.output).to include('@ignored_because_login_or_email_missing_count: 1')
+      expect(log.output).to_not include(':passed_nil_record_count=>1')
+    end
+
+    it 'counts ignored_because_login_or_email_missing_count when email missing, not as nil' do
+      importer = make_educators_importer()
+      allow(importer).to receive(:download_csv).and_return([make_test_row(login_name: '')])
+      importer.import
+      expect(log.output).to include('@ignored_because_login_or_email_missing_count: 1')
+      expect(log.output).to_not include(':passed_nil_record_count=>1')
+    end
   end
 
   describe 'works for login_name and email across districts' do


### PR DESCRIPTION
# Who is this PR for?
developers

# What problem does this PR fix?
Some district SIS scripts include educator records without `login_name` or `email`.  This can happen for enough records that it leads to `RecordSyncer` alerting on it with its simple check for percentage of records that are missing or invalid or changed.  Those alerts are false positives.

# What does this PR do?
Track missing `email` or `login_name` separately instead of passing it to `RecordSyncer`.  This logs the counts, and avoids including those records in `RecordSyncer`'s stats or alerts.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Educators importer

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
