### PR TITLE
Educators importer: Skip trying to match homerooms when none set 

### DIFF
--- a/app/importers/file_importers/educators_importer.rb
+++ b/app/importers/file_importers/educators_importer.rb
@@ -64,7 +64,8 @@ class EducatorsImporter
     log("Educator RecordSyncer#stats: #{@educator_syncer.stats}")
     log("@missing_from_last_export_count: #{@missing_from_last_export_count}")
 
-    # Preserve Homeroom records that aren't exported any more as well.
+    # Preserve Homeroom records that aren't exported any more as well, or
+    # are no longer referenced by any educators.
     # This doesn't mark them though and leaves them untouched.
     log('For Homeroom, skipping the call to  RecordSyncer#delete_unmarked_records, to preserve references to older Homeroom records.')
     log("Homeroom RecordSyncer#stats: #{@homeroom_syncer.stats}")
@@ -152,7 +153,7 @@ class EducatorsImporter
     end
 
     # No homeroom for educator
-    if !row[:homeroom]
+    if !row.has_key?(:homeroom) || row[:homeroom].nil? || row[:homeroom] == ''
       @ignored_no_homeroom_count += 1
       return nil
     end

--- a/spec/importers/file_importers/educators_importer_spec.rb
+++ b/spec/importers/file_importers/educators_importer_spec.rb
@@ -131,6 +131,14 @@ RSpec.describe EducatorsImporter do
       expect(log.output).to include('@ignored_because_login_or_email_missing_count: 1')
       expect(log.output).to_not include(':passed_nil_record_count=>1')
     end
+
+    it 'counts ignored_no_homeroom_count and does not try to sync homeroom if no value set' do
+      importer = make_educators_importer()
+      allow(importer).to receive(:download_csv).and_return([make_test_row(homeroom: '')])
+      importer.import
+      expect(log.output).to include('@ignored_no_homeroom_count: 1')
+      expect(log.output).to_not include(':passed_nil_record_count=>1')
+    end
   end
 
   describe 'works for login_name and email across districts' do

--- a/spec/importers/file_importers/educators_importer_spec.rb
+++ b/spec/importers/file_importers/educators_importer_spec.rb
@@ -137,7 +137,6 @@ RSpec.describe EducatorsImporter do
       allow(importer).to receive(:download_csv).and_return([make_test_row(homeroom: '')])
       importer.import
       expect(log.output).to include('@ignored_no_homeroom_count: 1')
-      expect(log.output).to_not include(':passed_nil_record_count=>1')
     end
   end
 


### PR DESCRIPTION
Follow-on to https://github.com/studentinsights/studentinsights/pull/2745, prevent attempting to match a homeroom record if the value is empty.  This essentially just cleans up the metrics printed in logs, since matching on those empty homerooms would always fail as expected.