### PR TITLE
Reading: Fix letter naming tab, show more metadata when no information

### DIFF
--- a/app/assets/javascripts/reader_profile_january/GenericDibelsTab.js
+++ b/app/assets/javascripts/reader_profile_january/GenericDibelsTab.js
@@ -2,16 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import tabProptypes from './tabPropTypes';
 import {mostRecentDataPoint, shouldHighlight} from './dibelsParsing';
-import {Tab} from './Tabs';
+import {Tab, NoInformation} from './Tabs';
 
 
 export default class GenericDibelsTab extends React.Component {
   render() {
     const {nowFn} = this.context;
     const {style, onClick, student, readerJson, tabText, benchmarkAssessmentKey} = this.props;
-    
     const dataPoint = mostRecentDataPoint(readerJson, benchmarkAssessmentKey);
-    if (!dataPoint) return null;
+    if (!dataPoint) {
+      return <NoInformation />;
+    }
+    
     const isOrange = shouldHighlight(dataPoint, student.grade, nowFn());
     return (
       <Tab

--- a/app/assets/javascripts/reader_profile_january/GenericDibelsView.js
+++ b/app/assets/javascripts/reader_profile_january/GenericDibelsView.js
@@ -45,6 +45,7 @@ GenericDibelsView.contextTypes = {
 
 
 function materialsFileKeys(dataPoint, gradeNow, nowMoment, urls) {
+  if (dataPoint === null || dataPoint === undefined) return [];
   const gradeThen = adjustedGrade(dataPoint.benchmark_school_year, gradeNow, nowMoment);
   const materialKey = [gradeThen, dataPoint.benchmark_period_key].join('-');
   return _.compact([urls[materialKey]]);

--- a/app/assets/javascripts/reader_profile_january/LetterNamingFluencyView.js
+++ b/app/assets/javascripts/reader_profile_january/LetterNamingFluencyView.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import expandedViewPropTypes from './expandedViewPropTypes';
-import {DIBELS_FSF} from '../reading/thresholds';
+import {DIBELS_LNF} from '../reading/thresholds';
 import {PHONICS_FLUENCY} from './instructionalStrategies';
 import GenericDibelsView from './GenericDibelsView';
 
@@ -10,7 +10,7 @@ export default function LetterNamingFluencyView(props) {
     <GenericDibelsView
       {...props}
       titleText="Letter naming fluency"
-      benchmarkAssessmentKey={DIBELS_FSF}
+      benchmarkAssessmentKey={DIBELS_LNF}
       categoryKey={PHONICS_FLUENCY}
       urls={MATERIAL_URLS}
     />

--- a/app/assets/javascripts/reader_profile_january/ReaderProfileJanuary.testSetup.js
+++ b/app/assets/javascripts/reader_profile_january/ReaderProfileJanuary.testSetup.js
@@ -156,6 +156,18 @@ function studentCases(nowString) {
   const benchmarkDataPoints = allBenchmarks(nowString);
   return [
     testProps({
+      student: {
+        id: 12,
+        first_name: 'Nikhil',
+        grade: 'KF'
+      },
+      readerJson: {
+        ...defaultProps.readerJson,
+        benchmark_data_points: []
+      }
+    }),
+
+    testProps({
       readerJson: {
         ...defaultProps.readerJson,
         benchmark_data_points: benchmarkDataPoints

--- a/app/assets/javascripts/reader_profile_january/__snapshots__/ReaderProfileJanuary.test.js.snap
+++ b/app/assets/javascripts/reader_profile_january/__snapshots__/ReaderProfileJanuary.test.js.snap
@@ -37,6 +37,309 @@ exports[`snapshots views across all testRuns 1`] = `
       }
     >
       <h2>
+        Nikhil
+        , 
+        KF
+      </h2>
+      <div
+        style={
+          Object {
+            "border": "1px solid #333",
+            "width": 1000,
+          }
+        }
+      >
+        <div
+          className="ReaderProfileJanuary"
+          style={
+            Object {
+              "marginBottom": 40,
+            }
+          }
+        >
+          <div
+            onClick={[Function]}
+            style={
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "margin": 10,
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 16,
+                    "fontWeight": "bold",
+                    "height": "3em",
+                    "justifyContent": "flex-start",
+                    "lineHeight": "1.2em",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Student experience
+              </div>
+              <div
+                style={Object {}}
+              >
+                <div
+                  className="Tab"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#f8f8f8",
+                      "border": "1px solid #f8f8f8",
+                      "borderRadius": 1,
+                      "color": "#999",
+                      "cursor": "default",
+                      "display": "flex",
+                      "height": "3em",
+                      "justifyContent": "flex-start",
+                      "margin": 5,
+                      "marginLeft": 0,
+                      "marginRight": 10,
+                      "opacity": 0.5,
+                      "padding": 5,
+                      "paddingLeft": 10,
+                    }
+                  }
+                >
+                  Ask teacher
+                </div>
+              </div>
+            </div>
+            <div
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 16,
+                    "fontWeight": "bold",
+                    "height": "3em",
+                    "justifyContent": "flex-start",
+                    "lineHeight": "1.2em",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Oral language
+              </div>
+              <div
+                style={Object {}}
+              >
+                <div
+                  className="Tab"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#f8f8f8",
+                      "border": "1px solid #f8f8f8",
+                      "borderRadius": 1,
+                      "color": "#999",
+                      "cursor": "default",
+                      "display": "flex",
+                      "height": "3em",
+                      "justifyContent": "flex-start",
+                      "margin": 5,
+                      "marginLeft": 0,
+                      "marginRight": 10,
+                      "opacity": 0.5,
+                      "padding": 5,
+                      "paddingLeft": 10,
+                    }
+                  }
+                >
+                  Ask teacher
+                </div>
+              </div>
+            </div>
+            <div
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 16,
+                    "fontWeight": "bold",
+                    "height": "3em",
+                    "justifyContent": "flex-start",
+                    "lineHeight": "1.2em",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Phonological Awareness
+              </div>
+              <div
+                style={Object {}}
+              >
+                <div
+                  className="Tab"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#f8f8f8",
+                      "border": "1px solid #f8f8f8",
+                      "borderRadius": 1,
+                      "color": "#999",
+                      "cursor": "default",
+                      "display": "flex",
+                      "height": "3em",
+                      "justifyContent": "flex-start",
+                      "margin": 5,
+                      "marginLeft": 0,
+                      "marginRight": 10,
+                      "opacity": 0.5,
+                      "padding": 5,
+                      "paddingLeft": 10,
+                    }
+                  }
+                >
+                  Ask teacher
+                </div>
+                <div
+                  className="Tab"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#f8f8f8",
+                      "border": "1px solid #f8f8f8",
+                      "borderRadius": 1,
+                      "color": "#999",
+                      "cursor": "default",
+                      "display": "flex",
+                      "height": "3em",
+                      "justifyContent": "flex-start",
+                      "margin": 5,
+                      "marginLeft": 0,
+                      "marginRight": 10,
+                      "opacity": 0.5,
+                      "padding": 5,
+                      "paddingLeft": 10,
+                    }
+                  }
+                >
+                  Ask teacher
+                </div>
+              </div>
+            </div>
+            <div
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 16,
+                    "fontWeight": "bold",
+                    "height": "3em",
+                    "justifyContent": "flex-start",
+                    "lineHeight": "1.2em",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Phonics Fluency
+              </div>
+              <div
+                style={Object {}}
+              >
+                <div
+                  className="Tab"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#f8f8f8",
+                      "border": "1px solid #f8f8f8",
+                      "borderRadius": 1,
+                      "color": "#999",
+                      "cursor": "default",
+                      "display": "flex",
+                      "height": "3em",
+                      "justifyContent": "flex-start",
+                      "margin": 5,
+                      "marginLeft": 0,
+                      "marginRight": 10,
+                      "opacity": 0.5,
+                      "padding": 5,
+                      "paddingLeft": 10,
+                    }
+                  }
+                >
+                  Ask teacher
+                </div>
+              </div>
+            </div>
+            <div
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 16,
+                    "fontWeight": "bold",
+                    "height": "3em",
+                    "justifyContent": "flex-start",
+                    "lineHeight": "1.2em",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Comprehension
+              </div>
+              <div
+                style={Object {}}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      style={
+        Object {
+          "marginBottom": 20,
+          "marginRight": 20,
+        }
+      }
+    >
+      <h2>
         Mari
         , 
         KF
@@ -1374,6 +1677,309 @@ exports[`snapshots views across all testRuns 1`] = `
       }
     >
       <h2>
+        Nikhil
+        , 
+        KF
+      </h2>
+      <div
+        style={
+          Object {
+            "border": "1px solid #333",
+            "width": 1000,
+          }
+        }
+      >
+        <div
+          className="ReaderProfileJanuary"
+          style={
+            Object {
+              "marginBottom": 40,
+            }
+          }
+        >
+          <div
+            onClick={[Function]}
+            style={
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "margin": 10,
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 16,
+                    "fontWeight": "bold",
+                    "height": "3em",
+                    "justifyContent": "flex-start",
+                    "lineHeight": "1.2em",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Student experience
+              </div>
+              <div
+                style={Object {}}
+              >
+                <div
+                  className="Tab"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#f8f8f8",
+                      "border": "1px solid #f8f8f8",
+                      "borderRadius": 1,
+                      "color": "#999",
+                      "cursor": "default",
+                      "display": "flex",
+                      "height": "3em",
+                      "justifyContent": "flex-start",
+                      "margin": 5,
+                      "marginLeft": 0,
+                      "marginRight": 10,
+                      "opacity": 0.5,
+                      "padding": 5,
+                      "paddingLeft": 10,
+                    }
+                  }
+                >
+                  Ask teacher
+                </div>
+              </div>
+            </div>
+            <div
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 16,
+                    "fontWeight": "bold",
+                    "height": "3em",
+                    "justifyContent": "flex-start",
+                    "lineHeight": "1.2em",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Oral language
+              </div>
+              <div
+                style={Object {}}
+              >
+                <div
+                  className="Tab"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#f8f8f8",
+                      "border": "1px solid #f8f8f8",
+                      "borderRadius": 1,
+                      "color": "#999",
+                      "cursor": "default",
+                      "display": "flex",
+                      "height": "3em",
+                      "justifyContent": "flex-start",
+                      "margin": 5,
+                      "marginLeft": 0,
+                      "marginRight": 10,
+                      "opacity": 0.5,
+                      "padding": 5,
+                      "paddingLeft": 10,
+                    }
+                  }
+                >
+                  Ask teacher
+                </div>
+              </div>
+            </div>
+            <div
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 16,
+                    "fontWeight": "bold",
+                    "height": "3em",
+                    "justifyContent": "flex-start",
+                    "lineHeight": "1.2em",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Phonological Awareness
+              </div>
+              <div
+                style={Object {}}
+              >
+                <div
+                  className="Tab"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#f8f8f8",
+                      "border": "1px solid #f8f8f8",
+                      "borderRadius": 1,
+                      "color": "#999",
+                      "cursor": "default",
+                      "display": "flex",
+                      "height": "3em",
+                      "justifyContent": "flex-start",
+                      "margin": 5,
+                      "marginLeft": 0,
+                      "marginRight": 10,
+                      "opacity": 0.5,
+                      "padding": 5,
+                      "paddingLeft": 10,
+                    }
+                  }
+                >
+                  Ask teacher
+                </div>
+                <div
+                  className="Tab"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#f8f8f8",
+                      "border": "1px solid #f8f8f8",
+                      "borderRadius": 1,
+                      "color": "#999",
+                      "cursor": "default",
+                      "display": "flex",
+                      "height": "3em",
+                      "justifyContent": "flex-start",
+                      "margin": 5,
+                      "marginLeft": 0,
+                      "marginRight": 10,
+                      "opacity": 0.5,
+                      "padding": 5,
+                      "paddingLeft": 10,
+                    }
+                  }
+                >
+                  Ask teacher
+                </div>
+              </div>
+            </div>
+            <div
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 16,
+                    "fontWeight": "bold",
+                    "height": "3em",
+                    "justifyContent": "flex-start",
+                    "lineHeight": "1.2em",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Phonics Fluency
+              </div>
+              <div
+                style={Object {}}
+              >
+                <div
+                  className="Tab"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#f8f8f8",
+                      "border": "1px solid #f8f8f8",
+                      "borderRadius": 1,
+                      "color": "#999",
+                      "cursor": "default",
+                      "display": "flex",
+                      "height": "3em",
+                      "justifyContent": "flex-start",
+                      "margin": 5,
+                      "marginLeft": 0,
+                      "marginRight": 10,
+                      "opacity": 0.5,
+                      "padding": 5,
+                      "paddingLeft": 10,
+                    }
+                  }
+                >
+                  Ask teacher
+                </div>
+              </div>
+            </div>
+            <div
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 16,
+                    "fontWeight": "bold",
+                    "height": "3em",
+                    "justifyContent": "flex-start",
+                    "lineHeight": "1.2em",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Comprehension
+              </div>
+              <div
+                style={Object {}}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      style={
+        Object {
+          "marginBottom": 20,
+          "marginRight": 20,
+        }
+      }
+    >
+      <h2>
         Mari
         , 
         KF
@@ -2702,6 +3308,309 @@ exports[`snapshots views across all testRuns 1`] = `
       on 
       5/15/2018
     </h4>
+    <div
+      style={
+        Object {
+          "marginBottom": 20,
+          "marginRight": 20,
+        }
+      }
+    >
+      <h2>
+        Nikhil
+        , 
+        KF
+      </h2>
+      <div
+        style={
+          Object {
+            "border": "1px solid #333",
+            "width": 1000,
+          }
+        }
+      >
+        <div
+          className="ReaderProfileJanuary"
+          style={
+            Object {
+              "marginBottom": 40,
+            }
+          }
+        >
+          <div
+            onClick={[Function]}
+            style={
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "margin": 10,
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 16,
+                    "fontWeight": "bold",
+                    "height": "3em",
+                    "justifyContent": "flex-start",
+                    "lineHeight": "1.2em",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Student experience
+              </div>
+              <div
+                style={Object {}}
+              >
+                <div
+                  className="Tab"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#f8f8f8",
+                      "border": "1px solid #f8f8f8",
+                      "borderRadius": 1,
+                      "color": "#999",
+                      "cursor": "default",
+                      "display": "flex",
+                      "height": "3em",
+                      "justifyContent": "flex-start",
+                      "margin": 5,
+                      "marginLeft": 0,
+                      "marginRight": 10,
+                      "opacity": 0.5,
+                      "padding": 5,
+                      "paddingLeft": 10,
+                    }
+                  }
+                >
+                  Ask teacher
+                </div>
+              </div>
+            </div>
+            <div
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 16,
+                    "fontWeight": "bold",
+                    "height": "3em",
+                    "justifyContent": "flex-start",
+                    "lineHeight": "1.2em",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Oral language
+              </div>
+              <div
+                style={Object {}}
+              >
+                <div
+                  className="Tab"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#f8f8f8",
+                      "border": "1px solid #f8f8f8",
+                      "borderRadius": 1,
+                      "color": "#999",
+                      "cursor": "default",
+                      "display": "flex",
+                      "height": "3em",
+                      "justifyContent": "flex-start",
+                      "margin": 5,
+                      "marginLeft": 0,
+                      "marginRight": 10,
+                      "opacity": 0.5,
+                      "padding": 5,
+                      "paddingLeft": 10,
+                    }
+                  }
+                >
+                  Ask teacher
+                </div>
+              </div>
+            </div>
+            <div
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 16,
+                    "fontWeight": "bold",
+                    "height": "3em",
+                    "justifyContent": "flex-start",
+                    "lineHeight": "1.2em",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Phonological Awareness
+              </div>
+              <div
+                style={Object {}}
+              >
+                <div
+                  className="Tab"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#f8f8f8",
+                      "border": "1px solid #f8f8f8",
+                      "borderRadius": 1,
+                      "color": "#999",
+                      "cursor": "default",
+                      "display": "flex",
+                      "height": "3em",
+                      "justifyContent": "flex-start",
+                      "margin": 5,
+                      "marginLeft": 0,
+                      "marginRight": 10,
+                      "opacity": 0.5,
+                      "padding": 5,
+                      "paddingLeft": 10,
+                    }
+                  }
+                >
+                  Ask teacher
+                </div>
+                <div
+                  className="Tab"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#f8f8f8",
+                      "border": "1px solid #f8f8f8",
+                      "borderRadius": 1,
+                      "color": "#999",
+                      "cursor": "default",
+                      "display": "flex",
+                      "height": "3em",
+                      "justifyContent": "flex-start",
+                      "margin": 5,
+                      "marginLeft": 0,
+                      "marginRight": 10,
+                      "opacity": 0.5,
+                      "padding": 5,
+                      "paddingLeft": 10,
+                    }
+                  }
+                >
+                  Ask teacher
+                </div>
+              </div>
+            </div>
+            <div
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 16,
+                    "fontWeight": "bold",
+                    "height": "3em",
+                    "justifyContent": "flex-start",
+                    "lineHeight": "1.2em",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Phonics Fluency
+              </div>
+              <div
+                style={Object {}}
+              >
+                <div
+                  className="Tab"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#f8f8f8",
+                      "border": "1px solid #f8f8f8",
+                      "borderRadius": 1,
+                      "color": "#999",
+                      "cursor": "default",
+                      "display": "flex",
+                      "height": "3em",
+                      "justifyContent": "flex-start",
+                      "margin": 5,
+                      "marginLeft": 0,
+                      "marginRight": 10,
+                      "opacity": 0.5,
+                      "padding": 5,
+                      "paddingLeft": 10,
+                    }
+                  }
+                >
+                  Ask teacher
+                </div>
+              </div>
+            </div>
+            <div
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "flex-end",
+                    "display": "flex",
+                    "fontSize": 16,
+                    "fontWeight": "bold",
+                    "height": "3em",
+                    "justifyContent": "flex-start",
+                    "lineHeight": "1.2em",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                Comprehension
+              </div>
+              <div
+                style={Object {}}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
     <div
       style={
         Object {


### PR DESCRIPTION
Follow-on to https://github.com/studentinsights/studentinsights/pull/2748.

Fixes a bug with the wrong assessment key for letter naming fluency, and adds test case covering a scenario that would have revealed that bug.  Also makes some updates for how no information is handled.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
