### PR TITLE
Reading: Add coloring to history view, for validating data 

### DIFF
--- a/app/assets/javascripts/reader_profile_january/BoxChart.js
+++ b/app/assets/javascripts/reader_profile_january/BoxChart.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import chroma from 'chroma-js';
 import {previousGrade, gradeText} from '../helpers/gradeText';
 import {toSchoolYear} from '../helpers/schoolYear';
 import {benchmarkPeriodToMoment} from '../reading/readingData';
-import {shouldHighlight} from './dibelsParsing';
-import {ORANGE, GREEN, PRESENT, BLANK} from './colors';
+import {boxStyle} from './colors';
 
 
 export default class BoxChart extends React.Component {
@@ -60,7 +58,7 @@ function YearBox(props) {
         {benchmarkPeriodKeys.map((benchmarkPeriodKey, index) => {
           const dataPoint = ds[index];
           const valueEl = dataPoint ? dataPoint.json.value : null;
-          const style = pickStyle(dataPoint, gradeThen);
+          const style = boxStyle(dataPoint, gradeThen, styles.box);
           return (
             <div key={benchmarkPeriodKey} style={style} title={valueEl}>
               {benchmarkPeriodKey}
@@ -77,37 +75,6 @@ YearBox.propTypes = {
   gradeThen: PropTypes.string.isRequired,
   sortedDataPoints: PropTypes.array.isRequired
 };
-
-
-function pickStyle(dataPoint, gradeThen) {
-  // no data
-  if (!dataPoint) {
-    return boxStyle(BLANK);
-  }
-
-  // data, but how should we color it?
-  const isOrange = shouldHighlight(dataPoint, gradeThen);
-  if (isOrange === true) {
-    return boxStyle(ORANGE);
-  }
-  if (isOrange === false) {
-    return boxStyle(GREEN);
-  }
-
-  // value, but no thresholds
-  return boxStyle(PRESENT);
-}
-
-
-function boxStyle(color) {
-  return {
-    ...styles.box,
-    background: color,
-    outline: `1px solid ${chroma(color).darken().hex()}`,
-    color: chroma(color).darken().darken().hex()
-  };
-}
-
 
 const styles = {
   years: {

--- a/app/assets/javascripts/reader_profile_january/DebugReadingScheduleGrid.js
+++ b/app/assets/javascripts/reader_profile_january/DebugReadingScheduleGrid.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import HelpBubble from '../components/HelpBubble';
 import {adjustedGrade} from '../helpers/gradeText';
 import ReadingScheduleGrid from '../reading/ReadingScheduleGrid';
-
+import {boxStyle} from './colors';
 
 export default class DebugReadingScheduleGrid extends React.Component {
   render() {
@@ -14,7 +14,7 @@ export default class DebugReadingScheduleGrid extends React.Component {
         linkStyle={{color: '#ccc', padding: 10}}
         title="Debug Reading Schedule Grid"
         content={<ReadingScheduleGrid renderCellFn={(...params) => renderCellFn(readerJson, gradeNow, nowFn(), ...params)} />}
-        teaser='debug'
+        teaser='history'
       />
     );
   }
@@ -28,18 +28,29 @@ DebugReadingScheduleGrid.contextTypes = {
 };
 
 
-function renderCellFn(readerJson, gradeNow, nowMoment, benchmarkAssessmentKey, grade, benchmarkPeriodKey) {
-  const dataPoints = (readerJson.benchmark_data_points || []).filter(d => {
-    if (d.benchmark_assessment_key !== benchmarkAssessmentKey) return false;
-    if (d.benchmark_period_key !== benchmarkPeriodKey) return false;
-    const gradeThen = adjustedGrade(d.benchmark_school_year, gradeNow, nowMoment);
-    if (gradeThen !== grade) return false;
-    return true;
-  });
-
+export function renderCellFn(readerJson, gradeNow, nowMoment, benchmarkAssessmentKey, grade, benchmarkPeriodKey) {
+  const dataPoints = readerJson.benchmark_data_points || [];
   return (
     <div key={[grade, benchmarkAssessmentKey].join('-')} style={{color: '#666', textAlign: 'center', height: 80}}>
-      {dataPoints.map((d, index) => <div key={index} style={{margin: 10}}>{d.json.value}</div>)}
+      {dataPoints.map((d, index) => {
+        if (d.benchmark_assessment_key !== benchmarkAssessmentKey) return null;
+        if (d.benchmark_period_key !== benchmarkPeriodKey) return null;
+        const gradeThen = adjustedGrade(d.benchmark_school_year, gradeNow, nowMoment);
+        if (gradeThen !== grade) return null;
+        const style = boxStyle(d, gradeThen, styles.box);
+        return <div key={index} style={style}>{d.json.value}</div>;
+      })}
     </div>
   );
 }
+
+const styles = {
+  box: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '2em',
+    height: '2em',
+    cursor: 'default'
+  }
+};

--- a/app/assets/javascripts/reader_profile_january/DebugReadingScheduleGrid.test.js
+++ b/app/assets/javascripts/reader_profile_january/DebugReadingScheduleGrid.test.js
@@ -2,15 +2,16 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import renderer from 'react-test-renderer';
 import {withNowContext} from '../testing/NowContainer';
+import {toMomentFromTimestamp} from '../helpers/toMoment';
 import PerDistrictContainer from '../components/PerDistrictContainer';
-import BoxChart from './BoxChart';
+import {renderCellFn} from './DebugReadingScheduleGrid';
+import ReadingScheduleGrid from '../reading/ReadingScheduleGrid';
 
 
 // this test data is only correct shape, but not semantically meaningful
 export function testProps(props = {}) {
   return {
     gradeNow: '1',
-    benchmarkAssessmentKey: 'f_and_p_english',
     readerJson: {
       access: {},
       services: [],
@@ -23,10 +24,14 @@ export function testProps(props = {}) {
   };
 }
 
+// simulate this to test the full render
 export function testRender(props = {}) {
-  return withNowContext('2020-01-03T14:36:34.501Z',
+  const {readerJson, gradeNow} = props;
+  const nowString = '2020-01-03T14:36:34.501Z';
+  const nowMoment = toMomentFromTimestamp(nowString);
+  return withNowContext(nowString,
     <PerDistrictContainer districtKey="somerville">
-      <BoxChart {...props} />
+      <ReadingScheduleGrid renderCellFn={(...params) => renderCellFn(readerJson, gradeNow, nowMoment, ...params)} />
     </PerDistrictContainer>
   );
 }

--- a/app/assets/javascripts/reader_profile_january/__snapshots__/DebugReadingScheduleGrid.test.js.snap
+++ b/app/assets/javascripts/reader_profile_january/__snapshots__/DebugReadingScheduleGrid.test.js.snap
@@ -1,0 +1,2524 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshots 1`] = `
+<div
+  className="ReadingScheduleGrid"
+>
+  <table
+    style={
+      Object {
+        "fontSize": 12,
+        "margin": 10,
+        "width": "100%",
+      }
+    }
+  >
+    <thead>
+      <tr>
+        <th>
+          <span
+            style={Object {}}
+          >
+             
+          </span>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            KF
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            fall
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            KF
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            winter
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            KF
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            spring
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            1
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            fall
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            1
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            winter
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            1
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            spring
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            2
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            fall
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            2
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            winter
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            2
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            spring
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            3
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            fall
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            3
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            winter
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            3
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            spring
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            4
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            fall
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            4
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            winter
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            4
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            spring
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            5
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            fall
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            5
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            winter
+          </div>
+        </th>
+        <th
+          style={
+            Object {
+              "textAlign": "center",
+              "width": 40,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            5
+          </div>
+          <div
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            spring
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          FSF, First sound fluency
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          LNF, Letter naming fluency
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          PSF, Phonemic segmentation fluency
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          NWF-CLS, Nonsense word fluency
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          NWF-WWR, Nonsense word fluency
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          ORF words/minute
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          ORF accuracy
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          F&P English
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "background": "rgb(147, 196, 125)",
+                  "color": "#366525",
+                  "cursor": "default",
+                  "display": "flex",
+                  "height": "2em",
+                  "justifyContent": "center",
+                  "outline": "1px solid #649350",
+                  "width": "2em",
+                }
+              }
+            >
+              AA
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "background": "orange",
+                  "color": "#904a00",
+                  "cursor": "default",
+                  "display": "flex",
+                  "height": "2em",
+                  "justifyContent": "center",
+                  "outline": "1px solid #c67600",
+                  "width": "2em",
+                }
+              }
+            >
+              B
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "background": "rgb(147, 196, 125)",
+                  "color": "#366525",
+                  "cursor": "default",
+                  "display": "flex",
+                  "height": "2em",
+                  "justifyContent": "center",
+                  "outline": "1px solid #649350",
+                  "width": "2em",
+                }
+              }
+            >
+              E
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "background": "#ccc",
+                  "color": "#6d6d6d",
+                  "cursor": "default",
+                  "display": "flex",
+                  "height": "2em",
+                  "justifyContent": "center",
+                  "outline": "1px solid #9b9b9b",
+                  "width": "2em",
+                }
+              }
+            >
+              F
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "background": "rgb(147, 196, 125)",
+                  "color": "#366525",
+                  "cursor": "default",
+                  "display": "flex",
+                  "height": "2em",
+                  "justifyContent": "center",
+                  "outline": "1px solid #649350",
+                  "width": "2em",
+                }
+              }
+            >
+              L
+            </div>
+          </div>
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+      </tr>
+      <tr>
+        <td
+          style={
+            Object {
+              "marginwhiteSpace": "normal",
+              "paddingBottom": 20,
+              "paddingRight": 10,
+              "verticalAlign": "top",
+              "width": 80,
+            }
+          }
+        >
+          F&P Spanish
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+        <td>
+          <div
+            style={
+              Object {
+                "color": "#666",
+                "height": 80,
+                "textAlign": "center",
+              }
+            }
+          />
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/app/assets/javascripts/reader_profile_january/__snapshots__/ReaderProfileJanuary.test.js.snap
+++ b/app/assets/javascripts/reader_profile_january/__snapshots__/ReaderProfileJanuary.test.js.snap
@@ -4223,7 +4223,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -8469,7 +8469,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -12850,7 +12850,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -17229,7 +17229,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -21564,7 +21564,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -25729,7 +25729,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -29871,7 +29871,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -34092,7 +34092,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -38347,7 +38347,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -42727,7 +42727,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -47106,7 +47106,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -51441,7 +51441,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -55606,7 +55606,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -59748,7 +59748,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -63969,7 +63969,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -68224,7 +68224,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -72604,7 +72604,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -76983,7 +76983,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -81318,7 +81318,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -85483,7 +85483,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -89625,7 +89625,7 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -90018,7 +90018,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -90401,7 +90401,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -90806,7 +90806,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -91209,7 +91209,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -91568,7 +91568,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -91927,7 +91927,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -92263,7 +92263,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -92643,7 +92643,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -93024,7 +93024,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -93428,7 +93428,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -93831,7 +93831,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -94190,7 +94190,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -94549,7 +94549,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -94885,7 +94885,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -95265,7 +95265,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -95646,7 +95646,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -96050,7 +96050,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -96453,7 +96453,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -96812,7 +96812,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -97171,7 +97171,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>
@@ -97507,7 +97507,7 @@ exports[`snapshots views across all testRuns 1`] = `
                   }
                 }
               >
-                debug
+                history
               </a>
             </div>
           </div>

--- a/app/assets/javascripts/reader_profile_january/colors.js
+++ b/app/assets/javascripts/reader_profile_january/colors.js
@@ -1,4 +1,38 @@
+import chroma from 'chroma-js';
+import {shouldHighlight} from './dibelsParsing';
+
+
 export const ORANGE = 'orange';
 export const GREEN = 'rgb(147, 196, 125)';
 export const PRESENT = '#ccc';
 export const BLANK = '#f8f8f8';
+
+
+export function boxStyle(dataPoint, gradeThen, style = {}) {
+  // no data
+  if (!dataPoint) {
+    return createBoxStyle(BLANK, style);
+  }
+
+  // data, but how should we color it?
+  const isOrange = shouldHighlight(dataPoint, gradeThen);
+  if (isOrange === true) {
+    return createBoxStyle(ORANGE, style);
+  }
+  if (isOrange === false) {
+    return createBoxStyle(GREEN, style);
+  }
+
+  // value, but no thresholds
+  return createBoxStyle(PRESENT, style);
+}
+
+
+function createBoxStyle(color, style = {}) {
+  return {
+    background: color,
+    outline: `1px solid ${chroma(color).darken().hex()}`,
+    color: chroma(color).darken().darken().hex(),
+    ...style
+  };
+}


### PR DESCRIPTION
Building on https://github.com/studentinsights/studentinsights/pull/2755

# What does this PR do?
- Adds color from https://github.com/studentinsights/studentinsights/pull/2755 to the 'debug' grid, for easier validating of data
- Rename the link from of "debug" to "history" to better reflect what its showing

# Screenshot (if adding a client-side feature)
<img width="607" alt="Screen Shot 2020-01-30 at 4 06 42 PM" src="https://user-images.githubusercontent.com/1056957/73491315-59cf8780-437c-11ea-8a37-42bc7bbd1be0.png">


# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here