### PR TITLE
Maintenance: Update eslintrc to restore no-console

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,13 +23,14 @@
     "indent": ["error", 2],
     "semi": ["error", "always"],
     "comma-dangle": ["error", "only-multiline"],
+    "no-alert": "error",
+    "no-console": "error",
     "no-unused-vars": ["error", {
       "args": "none"
     }],
     "no-use-before-define": "off",
     "eol-last": "off",
     "react/prefer-stateless-function": "off",
-    "react/prefer-es6-class": "off",
     "react/sort-comp": ["error", {
       order: [
         'static-methods',

--- a/app/assets/javascripts/class_lists/ClassListCreatorPage.js
+++ b/app/assets/javascripts/class_lists/ClassListCreatorPage.js
@@ -483,7 +483,7 @@ export default class ClassListCreatorPage extends React.Component {
 
   onSubmitClicked() {
     const confirmMessage = "Are you sure?  You won't be able to make any changes after submitting.";
-    if (!window.confirm(confirmMessage)) return;
+    if (!window.confirm(confirmMessage)) return; // eslint-disable-line no-alert
 
     // This updates the UI locally to disable editing and mark as submitted.
     // When that state change is done, we also force saving, since

--- a/app/assets/javascripts/class_lists/ExportList.js
+++ b/app/assets/javascripts/class_lists/ExportList.js
@@ -57,7 +57,7 @@ export default class ExportList extends React.Component {
     const {principalTeacherNamesByRoom, onPrincipalTeacherNamesByRoomChanged} = this.props;
     const teacherName = (option === null) ? '' : option.name;
     if ((teacherName !== '') && _.includes(principalTeacherNamesByRoom, teacherName)) {
-      return alert('Duplicate teacher name.');
+      return alert('Duplicate teacher name.'); // eslint-disable-line no-alert
     }
     onPrincipalTeacherNamesByRoomChanged({
       ...principalTeacherNamesByRoom,

--- a/app/assets/javascripts/components/NotifyAboutError.js
+++ b/app/assets/javascripts/components/NotifyAboutError.js
@@ -13,8 +13,8 @@ export default class NotifyAboutError extends React.Component {
 
   rollbarErrorFn(msg, ...params) {
     if (this.props.rollbarErrorFn) return this.props.rollbarErrorFn(msg, ...params);
-    if (window.Rollbar.error) return window.Rollbar.error(msg, ...params);
-    console.error('NotifyAboutError#rollbarErrorFn could not find function for reporting error:', msg, ...params);
+    if (window.Rollbar && window.Rollbar.error) return window.Rollbar.error(msg, ...params);
+    console.error('NotifyAboutError#rollbarErrorFn could not find function for reporting error:', msg, ...params); // eslint-disable-line no-console
   }
 
   render() {

--- a/app/assets/javascripts/components/RollbarErrorBoundary.js
+++ b/app/assets/javascripts/components/RollbarErrorBoundary.js
@@ -36,8 +36,8 @@ export default class RollbarErrorBoundary extends React.Component {
   // Read more at https://stackoverflow.com/questions/18391212/is-it-not-possible-to-stringify-an-error-using-json-stringify
   rollbarErrorFn(msg, ...params) {
     if (this.props.rollbarErrorFn) return this.props.rollbarErrorFn(msg, ...params);
-    if (window.Rollbar.error) return window.Rollbar.error(msg, ...params);
-    console.error('RollbarErrorBoundary#rollbarErrorFn could not find function for reporting error:', msg, ...params);
+    if (window.Rollbar && window.Rollbar.error) return window.Rollbar.error(msg, ...params);
+    console.error('RollbarErrorBoundary#rollbarErrorFn could not find function for reporting error:', msg, ...params); // eslint-disable-line no-console
   }
 
   render() {

--- a/app/assets/javascripts/components/WordCloud.js
+++ b/app/assets/javascripts/components/WordCloud.js
@@ -38,7 +38,7 @@ export default class WordCloud extends React.Component {
   }
 
   onClick(e) {
-    alert(`The word "${e[0]}" appears ${e[1]} times.`);
+    alert(`The word "${e[0]}" appears ${e[1]} times.`); // eslint-disable-line no-alert
   }
 
   render() {

--- a/app/assets/javascripts/feed/MutableFeedView.js
+++ b/app/assets/javascripts/feed/MutableFeedView.js
@@ -30,11 +30,15 @@ export default class MutableFeedView extends React.Component {
 
   onClickMarkRestricted(eventNoteId, e) {
     e.preventDefault();
-    if (!confirm("Marking this note as restricted will protect the student's privacy,\nwhile also limiting which educators can access this information.\n\nIf you need to undo this, you can email help@studentinsights.org.\n\nContinue?")) return;
+    const confirmationMsg = "Marking this note as restricted will protect the student's privacy,\nwhile also limiting which educators can access this information.\n\nIf you need to undo this, you can email help@studentinsights.org.\n\nContinue?";
+    if (!confirm(confirmationMsg)) { // eslint-disable-line no-alert
+      return;
+    }
 
     // Make server request optimistically
+    const errorMsg = 'There was an error trying to update the note, and help@studentinsights.org has been sent a notification.';
     apiPutJson(`/api/event_notes/${eventNoteId}/mark_as_restricted`)
-      .catch(err => alert('There was an error trying to update the note, and help@studentinsights.org has been sent a notification.'));
+      .catch(err => alert(errorMsg)); // eslint-disable-line no-alert
 
     // Remove from UI now
     const {feedCards} = this.state;

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -54,7 +54,7 @@ export default class LightProfilePage extends React.Component {
     const {isTakingNotes} = this.state;
 
     if (isTakingNotes) {
-      const shouldDiscardNote = confirm("You have a note in progress.\n\nDiscard that note?");
+      const shouldDiscardNote = confirm("You have a note in progress.\n\nDiscard that note?"); // eslint-disable-line no-alert
       if (!shouldDiscardNote) return;
     }
     

--- a/app/assets/javascripts/student_profile/NoteCard.js
+++ b/app/assets/javascripts/student_profile/NoteCard.js
@@ -43,7 +43,7 @@ export default class NoteCard extends React.Component {
   // No feedback, fire and forget
   onDeleteAttachmentClicked(eventNoteAttachmentId, e) {
     e.preventDefault();
-    if (!confirm('Remove this link?')) return;
+    if (!confirm('Remove this link?')) return; // eslint-disable-line no-alert
     this.props.onEventNoteAttachmentDeleted(eventNoteAttachmentId);
   }
 

--- a/app/assets/javascripts/student_profile/ProvidedByEducatorDropdown.test.js
+++ b/app/assets/javascripts/student_profile/ProvidedByEducatorDropdown.test.js
@@ -7,7 +7,7 @@ import ProvidedByEducatorDropdown from './ProvidedByEducatorDropdown';
 function testProps(props = {}) {
   return {
     onUserTyping: jest.fn(),
-    onUserDropdownSelect: x => console.log('onUserDropdownSelect', x),
+    onUserDropdownSelect: jest.fn(),
     ...props
   };
 }

--- a/app/assets/javascripts/student_profile/SecondTransitionNoteDialog.js
+++ b/app/assets/javascripts/student_profile/SecondTransitionNoteDialog.js
@@ -63,7 +63,7 @@ export default class SecondTransitionNoteDialog extends React.Component {
     // Warn about pending changes
     const {isDirty, pending, failed} = bridge;
     if (isDirty || pending.length > 0 || failed.length > 0) {
-      if (!confirm('You have unsaved changes, discard them?')) return;
+      if (!confirm('You have unsaved changes, discard them?')) return; // eslint-disable-line no-alert
     }
     const {onClose} = this.props;
     onClose();

--- a/app/assets/javascripts/student_voice_survey_uploads/StudentVoiceSurveyUploadForm.js
+++ b/app/assets/javascripts/student_voice_survey_uploads/StudentVoiceSurveyUploadForm.js
@@ -46,13 +46,13 @@ export default class StudentVoiceSurveyUploadForm extends React.Component {
       uploadState: null
     });
     onUploadDone();
-    alert("Done!\n\n" + JSON.stringify(json, null, 2));
+    alert("Done!\n\n" + JSON.stringify(json, null, 2)); // eslint-disable-line no-alert
   }
 
   onUploadFailed(err) {
     const {onUploadDone} = this.props;
     onUploadDone();
-    alert("The upload failed.\n\n" + JSON.stringify(err, null, 2));
+    alert("The upload failed.\n\n" + JSON.stringify(err, null, 2)); // eslint-disable-line no-alert
   }
 
   render() {

--- a/ui/freeze.js
+++ b/ui/freeze.js
@@ -14,5 +14,5 @@
 try {
   Object.freeze(Object.prototype);
 } catch (err) {
-  console.error('Object.freeze(Object.prototype) failed', err);
+  console.error('Object.freeze(Object.prototype) failed', err); // eslint-disable-line no-console
 }


### PR DESCRIPTION
Removing `no-console` was a breaking change in `eslint:recommended` for eslint 6, and so introduced in https://github.com/studentinsights/studentinsights/pull/2759.  This adds it to our config, along with `no-alert` for good measure.  It separately removes `react/prefer-es6-class: off` since we migrated that previously and no longer need to relax it.

EDIT: Also mark current uses for confirm and alert (for some edge case UX situations not worth improving at the moment).