### PR TITLE
EXPERIMENT: Update Travis to bundle install --deployment, verify mismatches are caught

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_install:
   - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then gem install bundler; fi
 
 install:
-  - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle install --retry=3; fi
+  - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle install --retry=3 --deployment; fi
   - if [[ $TRAVIS_TEST_SUITE == "js" ]]; then . $HOME/.nvm/nvm.sh; fi
   - if [[ $TRAVIS_TEST_SUITE == "js" ]]; then nvm install --lts; fi
   - if [[ $TRAVIS_TEST_SUITE == "js" ]]; then nvm use --lts; fi

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'jquery-ui-rails', '~> 6.0.1'
 gem 'rails', '~> 6.0.0'
 gem 'sass-rails', '~> 5.0'
 gem 'sprockets'
-gem 'thor'
 gem 'uglifier', '>= 1.3.0'
 
 # rails plugins or patches


### PR DESCRIPTION
**This isn't intended to be merged**

In https://github.com/studentinsights/studentinsights/pull/2762 the build passed but deploy failed because the Gemfile didn't match the Gemfile.lock.  We should catch this in CI not at deploy time, so this makes an attempt at that, and mistakenly removes a gem to see if now the Travis build will fail.

**This isn't intended to be merged**