### PR TITLE
Maintenance: Fail build when mismatch between Gemfile and Gemfile.lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_install:
   - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then gem install bundler; fi
 
 install:
-  - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle install --retry=3; fi
+  - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle install --retry=3 --deployment; fi
   - if [[ $TRAVIS_TEST_SUITE == "js" ]]; then . $HOME/.nvm/nvm.sh; fi
   - if [[ $TRAVIS_TEST_SUITE == "js" ]]; then nvm install --lts; fi
   - if [[ $TRAVIS_TEST_SUITE == "js" ]]; then nvm use --lts; fi


### PR DESCRIPTION
Follow-on to https://github.com/studentinsights/studentinsights/pull/2763/files, changing Travis script to fail build on Gemfile / Gemfile.lock mismatches, since these will (correctly) fail the deploy and we should catch this sooner.