### PR TITLE
Maintenance: Fix call to bundle audit in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ install:
 script:
   # dependency audits
   - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle exec ruby-audit check; fi
-  - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle exec bundle audit check --update; fi
+  - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle exec bundle-audit check --update; fi
   - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle exec rails_best_practices -c config/rails_best_practices.yml; fi
   
   # This DATABASE_URL assumes '' for the host is set in database.yml,

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ install:
 script:
   # dependency audits
   - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle exec ruby-audit check; fi
-  - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle audit check --update; fi
+  - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle exec bundle audit check --update; fi
   - if [[ $TRAVIS_TEST_SUITE == "ruby" ]]; then bundle exec rails_best_practices -c config/rails_best_practices.yml; fi
   
   # This DATABASE_URL assumes '' for the host is set in database.yml,


### PR DESCRIPTION
Guessing this is related to https://github.com/studentinsights/studentinsights/pull/2764; seems like this line should have always been scoped by `bundle exec` (eg, https://github.com/rubysec/bundler-audit/issues/191#issuecomment-396675002)