### PR TITLE
Reading: Fix images of Phoneme Segmentation Fluency materials

### DIFF
--- a/app/assets/javascripts/reader_profile_january/PhonemeSegmentationFluencyView.js
+++ b/app/assets/javascripts/reader_profile_january/PhonemeSegmentationFluencyView.js
@@ -19,9 +19,9 @@ export default function PhonemeSegmentationFluencyView(props) {
 PhonemeSegmentationFluencyView.propTypes = expandedViewPropTypes;
 
 const MATERIAL_URLS = {
-  'KF-winter': 'PhonemeSegmentationFluency-KF-winter',
-  'KF-spring': 'PhonemeSegmentationFluency-KF-spring',
-  '1-fall': 'PhonemeSegmentationFluency-1-fall'
+  'KF-winter': ['PhonemeSegmentationFluency-KF-winter'],
+  'KF-spring': ['PhonemeSegmentationFluency-KF-spring'],
+  '1-fall': ['PhonemeSegmentationFluency-1-fall']
 };
 
 

--- a/app/assets/javascripts/reader_profile_january/__snapshots__/ReaderProfileJanuary.test.js.snap
+++ b/app/assets/javascripts/reader_profile_january/__snapshots__/ReaderProfileJanuary.test.js.snap
@@ -11855,48 +11855,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-1-fall.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-1-fall"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -16305,48 +16272,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-1-fall.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-1-fall"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -20756,48 +20690,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-1-fall.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-1-fall"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -25173,48 +25074,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-1-fall.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-1-fall"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -29431,48 +29299,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-1-fall.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-1-fall"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -38012,48 +37847,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-KF-winter.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-KF-winter"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -42361,48 +42163,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-1-fall.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-1-fall"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -46856,48 +46625,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-1-fall.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-1-fall"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -51307,48 +51043,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-1-fall.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-1-fall"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -55724,48 +55427,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-1-fall.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-1-fall"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -59982,48 +59652,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-1-fall.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-1-fall"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -68563,48 +68200,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-KF-spring.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-KF-spring"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -72912,48 +72516,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-1-fall.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-1-fall"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -77407,48 +76978,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-1-fall.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-1-fall"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -81858,48 +81396,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-1-fall.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-1-fall"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -86275,48 +85780,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-1-fall.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-1-fall"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -90533,48 +90005,15 @@ exports[`snapshots across all testRuns, even when all views are expanded 1`] = `
                     >
                       <img
                         className="MaterialImage"
-                        src="/img/reading/P.jpg"
+                        src="/img/reading/PhonemeSegmentationFluency-1-fall.jpg"
                         style={
                           Object {
                             "border": "1px solid #ccc",
                           }
                         }
-                        title="P"
+                        title="PhonemeSegmentationFluency-1-fall"
                         width="100%"
                       />
-                      <div
-                        style={
-                          Object {
-                            "display": "flex",
-                            "justifyContent": "space-between",
-                          }
-                        }
-                      >
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ◄
-                        </div>
-                        <div
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "color": "#aaa",
-                              "cursor": "pointer",
-                              "fontSize": 12,
-                            }
-                          }
-                        >
-                          ►
-                        </div>
-                      </div>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
This didn't get migrated when the carousel changed to support multiple images.