### PR TITLE
Maintenance: Simplify SFTP client params after bug

### DIFF
--- a/app/importers/helpers/sftp_client.rb
+++ b/app/importers/helpers/sftp_client.rb
@@ -1,11 +1,10 @@
 require 'fileutils'
 
 # These are keys into ENV
-class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password, :env_key_data, :options
+class SftpClient < Struct.new :env_host, :env_user, :env_password, :env_key_data, :options
 
-  def self.for_x2(override_env = nil, options = {})
+  def self.for_x2(options = {})
     new(
-      override_env,
       'SIS_SFTP_HOST',
       'SIS_SFTP_USER',
       nil,
@@ -14,9 +13,8 @@ class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password
     )
   end
 
-  def self.for_star(override_env = nil, options = {})
+  def self.for_star(options = {})
     new(
-      override_env,
       'STAR_SFTP_HOST',
       'STAR_SFTP_USER',
       'STAR_SFTP_PASSWORD',
@@ -86,8 +84,6 @@ class SftpClient < Struct.new :override_env, :env_host, :env_user, :env_password
   def env(key)
     if key.nil?
       nil
-    elsif override_env.present?
-      override_env[key]
     else
       ENV[key]
     end

--- a/app/importers/iep_import/iep_pdf_import_job.rb
+++ b/app/importers/iep_import/iep_pdf_import_job.rb
@@ -124,7 +124,7 @@ class IepPdfImportJob
   def download(remote_filename)
     # Expect and allow more stale files than typical, since these
     # are rotated each day for a week.
-    sftp_client = SftpClient.for_x2(nil, {
+    sftp_client = SftpClient.for_x2({
       modified_within_n_days: 10,
       unsafe_local_download_folder: absolute_local_download_path
     })

--- a/spec/importers/helpers/sftp_client_spec.rb
+++ b/spec/importers/helpers/sftp_client_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe SftpClient do
       contents = "name,pitch_name,rating\npedro,change up,awesome"
       mock_download_file_and_lstat!(remote_filename_path, contents, time_now - 2.hours) do
         mock_env_for_x2()
-        client = SftpClient.for_x2(nil, time_now: time_now)
+        client = SftpClient.for_x2(time_now: time_now)
         file = client.download_file(remote_filename_path)
         expect(IO.read(file)).to eq(contents)
       end
@@ -76,7 +76,7 @@ RSpec.describe SftpClient do
       contents = "name,pitch_name,rating\npedro,change up,awesome"
       mock_download_file_and_lstat!(remote_filename_path, contents, time_now - 2.hours) do
         mock_env_for_x2()
-        client = SftpClient.for_x2(nil, time_now: time_now)
+        client = SftpClient.for_x2(time_now: time_now)
         file = client.download_file(remote_filename_path)
         expect(File.basename(file)).to eq 'assessment.csv'
         expect(file.path.ends_with?('tmp/data_download/assessment.csv')).to eq true
@@ -92,7 +92,7 @@ RSpec.describe SftpClient do
       contents = "name,pitch_name,rating\npedro,change up,awesome"
       mock_download_file_and_lstat!(remote_filename_path, contents, mtime) do
         mock_env_for_x2()
-        client = SftpClient.for_x2(nil, time_now: time_now)
+        client = SftpClient.for_x2(time_now: time_now)
         file = client.download_file(remote_filename_path)
         expect(IO.read(file)).to eq(contents)
       end
@@ -106,7 +106,7 @@ RSpec.describe SftpClient do
       contents = "name,pitch_name,rating\npedro,change up,awesome"
       mock_download_file_and_lstat!(remote_filename_path, contents, mtime) do
         mock_env_for_x2()
-        client = SftpClient.for_x2(nil, {
+        client = SftpClient.for_x2({
           time_now: time_now,
           modified_within_n_days: 7
         })


### PR DESCRIPTION
In https://github.com/studentinsights/studentinsights/pull/2768 and https://github.com/studentinsights/studentinsights/pull/2769, there were bugs since the params for this call are a atypical, and end-to-end tests mocked that configuration.  We could improve that, but this simplifies the root problem of having to pass a nil `override_env` param before other config, especially since `override_env` is never used anywhere :)