### PR TITLE
Patch/bedford special education edge cases

### DIFF
--- a/app/assets/javascripts/helpers/specialEducation.test.js
+++ b/app/assets/javascripts/helpers/specialEducation.test.js
@@ -181,3 +181,30 @@ describe('#prettyIepTextForSpecialEducationStudent', () => {
     })).toEqual('IEP');
   });
 });
+
+
+describe('Bedford test cases', () => {
+  it('works for test case a', () => {
+    const a = {
+      program_assigned: 'Not Enrolled',
+      sped_placement: 'Not special ed',
+      disability: 'Developmental Delay',
+      sped_level_of_need: 'Low (2 hours or less)'
+    };
+    expect(hasActiveIep(a)).toEqual(true);
+    expect(prettyProgramOrPlacementText(a)).toEqual(null);
+    expect(prettyIepTextForSpecialEducationStudent(a)).toEqual('IEP for Developmental Delay');
+  });
+
+  it('works for test case b', () => {
+    const b = {
+      program_assigned: 'Not Enrolled',
+      sped_placement: 'Exited this year',
+      disability: 'Specific Learning',
+      sped_level_of_need: 'Moderate'
+    };
+    expect(hasActiveIep(b)).toEqual(true);
+    expect(prettyProgramOrPlacementText(b)).toEqual('Exited this year');
+    expect(prettyIepTextForSpecialEducationStudent(b)).toEqual('Exited SPED this year');
+  });
+});


### PR DESCRIPTION
# Who is this PR for?
MTSS facilitators, reading specialists, literacy coaches, K5 classroom teachers

# What does this PR do?
This is a first cut at the F&P materials.  It adds in some materials for levels A&B only, and adds a different way to choose materials.  For other screeners, these are standardized based on the student's grade and time of year, but the F&P protocol is based on moving up from their previous level, so students in the same cohort might be reading different materials.  This means these materials reflect what the student's instructional level is (while others show "what was assessed").

No work here to optimize images yet, there's a bunch more so punting that until we want to do this, then we can compress or shrink them all down in one shot.

# Screenshot (if adding a client-side feature)
<img width="1049" alt="Screen Shot 2020-02-27 at 4 12 09 PM" src="https://user-images.githubusercontent.com/1056957/75487490-74e1e700-597c-11ea-8e87-9070c59f8571.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here