### PR TITLE
Maintenance: Update rbnacl to resolve ffi deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'twilio-ruby'
 ### standalone libraries
 # security
 gem 'ipcat'
-gem 'rbnacl'
+gem 'rbnacl', '~> 7.1.1'
 gem 'rotp'
 gem 'rqrcode'
 gem 'zxcvbn-js', require: 'zxcvbn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,7 +298,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rbnacl (7.1.0)
+    rbnacl (7.1.1)
       ffi
     regexp_parser (1.6.0)
     representable (3.0.4)
@@ -459,7 +459,7 @@ DEPENDENCIES
   rails (~> 6.0.0)
   rails-controller-testing
   rails_best_practices
-  rbnacl
+  rbnacl (~> 7.1.1)
   rollbar
   rotp
   rqrcode


### PR DESCRIPTION
Follow-on to https://github.com/studentinsights/studentinsights/pull/2781, which was an automated security patch.  It seems the automated patch updated unrelated gems, and while I reviewed the changelog for administrate, I didn't didn't notice the diff updated a bunch of unrelated packages.

One of the changes was to update ffi, which led to this deprecation warning when running tests or deploying:

```[DEPRECATION] Struct layout is already defined for class RbNaCl::HMAC::State. Redefinition as in /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rbnacl-7.1.0/lib/rbnacl/hmac/sha512.rb:105:in `<class:State>' will be disallowed in ffi-2.0.
```

So this bumps `rbnacl` to resolve that ([changelog](https://github.com/RubyCrypto/rbnacl/blob/master/CHANGES.md)).