### PR TITLE
Maintenance: Remove sass and bourbon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'bootsnap', require: false
 gem 'jquery-rails'
 gem 'jquery-ui-rails', '~> 6.0.1'
 gem 'rails', '6.0.1'
-gem 'sass-rails', '~> 5.0'
 gem 'sprockets'
 gem 'thor'
 gem 'uglifier', '>= 1.3.0'
@@ -74,7 +73,6 @@ end
 # local development or test-only tools
 group :development, :test do
   gem 'better_errors'
-  gem 'bourbon', '~> 4.3.2'
   gem 'capybara'
   gem 'database_cleaner'
   gem 'listen'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,9 +96,6 @@ GEM
       rack (>= 0.9.0)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
-    bourbon (4.3.4)
-      sass (~> 3.4)
-      thor (~> 0.19)
     brakeman (4.8.0)
     builder (3.2.4)
     bundler-audit (0.6.1)
@@ -346,17 +343,6 @@ GEM
     ruby_audit (1.2.0)
       bundler-audit (~> 0.6.0)
     rubyzip (1.3.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.1.0)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
     sassc (2.2.1)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -424,7 +410,6 @@ DEPENDENCIES
   aws-sdk (~> 2)
   better_errors
   bootsnap
-  bourbon (~> 4.3.2)
   brakeman
   bundler-audit
   capybara
@@ -466,7 +451,6 @@ DEPENDENCIES
   rubocop (~> 0.75.0)
   ruby_audit
   rubyzip (~> 1.3.0)
-  sass-rails (~> 5.0)
   secure_headers
   simplecov
   spring


### PR DESCRIPTION
https://github.com/studentinsights/studentinsights/pull/2783 ended up reaching a threshold for slug size in Heroku (see https://devcenter.heroku.com/articles/slug-compiler#slug-size).

To start I tried cleaning the remote repo (per https://thoughtbot.com/blog/how-to-reduce-a-large-heroku-compiled-slug-size) but that didn't change the size.  It did purge the build cache though, which revealed a deprecation notice about `sass-ruby`.  That led me to looking at the Gemfile for `sass-rails` and `bourbon`.  Neither are needed, since `sprockets` pulls in `sassc` are we haven't been using bourbon for a while either.  So this removes those gems, which should also reduce the slug size.

There are plenty of other ways to reduce the slug size too, but cleaning up these stale gems is an improvement anyway.