### PR TITLE
Maintenance: Update AWS SDK to v3, limit to only S3 client 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'rack-attack'
 gem 'secure_headers'
 
 # services
-gem 'aws-sdk', '~> 2'
+gem 'aws-sdk-s3', '~> 1'
 gem 'dalli' # memcached for rack::attack
 gem 'google-api-client', "~> 0.28.7"
 gem 'net-ldap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,13 +80,19 @@ GEM
     autoprefixer-rails (9.7.4)
       execjs
     aws-eventstream (1.0.3)
-    aws-sdk (2.11.463)
-      aws-sdk-resources (= 2.11.463)
-    aws-sdk-core (2.11.463)
-      aws-sigv4 (~> 1.0)
+    aws-partitions (1.285.0)
+    aws-sdk-core (3.91.1)
+      aws-eventstream (~> 1.0, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.463)
-      aws-sdk-core (= 2.11.463)
+    aws-sdk-kms (1.30.0)
+      aws-sdk-core (~> 3, >= 3.71.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.61.1)
+      aws-sdk-core (~> 3, >= 3.83.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.1)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.13)
@@ -407,7 +413,7 @@ PLATFORMS
 DEPENDENCIES
   administrate (~> 0.13.0)
   authtrail
-  aws-sdk (~> 2)
+  aws-sdk-s3 (~> 1)
   better_errors
   bootsnap
   brakeman

--- a/app/lib/env.rb
+++ b/app/lib/env.rb
@@ -19,6 +19,9 @@ class Env
     default_env['USE_MOCK_LDAP'] = 'true'
     default_env['MOCK_LDAP_PASSWORD'] = 'demo-password'
     default_env['AWS_REGION'] = 'us-west-2'
+    default_env['AWS_ACCESS_KEY_ID'] = 'fake-dev-aws-access-key-id'
+    default_env['AWS_SECRET_ACCESS_KEY'] = 'fake-dev-aws-secret-access-key'
+    default_env['AWS_SDK_CONFIG_OPT_OUT'] = 'true' # don't ever read config from disk (read it only from ENV variables)
     default_env['ROLLBAR_JS_ACCESS_TOKEN'] = 'foo';
     default_env['ROLLBAR_ACCESS_TOKEN'] = 'fake_rollbar_access_token';
     default_env['TWILIO_CONFIG_JSON'] = '{"account_sid":"fake-twilio-sid-foo","auth_token":"fake-twilio-auth-token-foo","sending_number":"+15555551234"}'


### PR DESCRIPTION
On top of https://github.com/studentinsights/studentinsights/pull/2784.

This is from a deprecation warning via email, and from looking at https://github.com/aws/aws-sdk-ruby/blob/master/V3_UPGRADING_GUIDE.md  No impact expected, other than that we can now pull in only the S3 client and not the rest of the AWS SDK.  So incidentally this should also reduce the slug size.

EDIT: turns out that there's a change in how credentials are read across versions, and the S3 client checks that config is present in the constructor.  Some tests use the real client, and then mock calls to it, but those now fail since the constructor raises that there is no config.

In development, this SDK behavior is a bit dangerous and not what we want.  If if there was local config or credentials in `~/.aws` the SDK would read that from disk, which is why these tests didn't fail when run locally.  It's dangerous because it's possible that test bugs could lead to exercising stale credentials a developer left on disk from doing unrelated work on the AWS CLI (even for a different project).  We never want this to be possible, so this adds `AWS_SDK_CONFIG_OPT_OUT`.

It also adds fake values to the ENV for keys and secrets in dev and test, so that the constructor doesn't raise and we can mock and test.  It looks like the SDK may now have more first-class ways to stub it that are baked in (eg https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ClientStubs.html) but this PR didn't look more deeply into that.