### PR TITLE
Reading: Fix bug in STAR highlighting for reading tab only

### DIFF
--- a/app/assets/javascripts/reader_profile_january/StarReadingTab.js
+++ b/app/assets/javascripts/reader_profile_january/StarReadingTab.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
+import {toMomentFromTimestamp} from '../helpers/toMoment';
 import {shouldHighlight} from '../helpers/star';
 import tabProptypes from './tabPropTypes';
 import {Tab, NoInformation} from './Tabs';
@@ -13,7 +14,8 @@ export default class StarReadingTab extends React.Component {
       return <NoInformation />;
     }
     
-    const mostRecent = _.last(starPercentiles);
+    const sortedPercentiles = _.sortBy(starPercentiles, starJson => toMomentFromTimestamp(starJson.date_taken).valueOf());
+    const mostRecent = _.last(sortedPercentiles);
     const isOrange = shouldHighlight(mostRecent.percentile_rank);
     return (
       <Tab

--- a/app/assets/javascripts/reader_profile_january/StarReadingTab.story.js
+++ b/app/assets/javascripts/reader_profile_january/StarReadingTab.story.js
@@ -1,0 +1,16 @@
+import {storiesOf} from '@storybook/react';
+import {action} from '@storybook/addon-actions';
+import {testProps, testRender} from './StarReadingTab.test';
+
+
+function storyProps(props = {}) {
+  return {
+    ...testProps(),
+    onClick: action('onClick'),
+    ...props
+  };
+}
+
+
+storiesOf('reader_profile_january/StarReadingTab', module) // eslint-disable-line no-undef
+  .add('default', () => testRender(storyProps()));

--- a/app/assets/javascripts/reader_profile_january/StarReadingTab.test.js
+++ b/app/assets/javascripts/reader_profile_january/StarReadingTab.test.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import renderer from 'react-test-renderer';
+import {withNowContext} from '../testing/NowContainer';
+import PerDistrictContainer from '../components/PerDistrictContainer';
+import StarReadingTab from './StarReadingTab';
+
+
+// in spring of KF, looking back at fall and winter scores
+const TEST_NOW_STRING = '2018-05-15T11:03:06.123Z';
+
+export function testProps(props = {}) {
+  return {
+    onClick: jest.fn(),
+    student: {
+      id: 123,
+      first_name: 'Amir',
+      grade: '3'
+    },
+    readerJson: {
+      access: {},
+      services: [],
+      iep_contents: null,
+      feed_cards: [],
+      current_school_year: 2017,
+      reading_chart_data: {
+        star_series_reading_percentile: [{
+          "percentile_rank": 40,
+          "total_time": 1569,
+          "grade_equivalent": "2.80",
+          "date_taken": "2017-10-13T00:00:00.000Z"
+        }, {
+          "percentile_rank": 29,
+          "total_time": 1178,
+          "grade_equivalent": "2.25",
+          "date_taken": "2017-05-11T00:00:00.000Z"
+        }]
+      },
+      benchmark_data_points: []
+    },
+    ...props
+  };
+}
+
+export function testRender(props = {}) {
+  return (
+    withNowContext(TEST_NOW_STRING, (
+      <PerDistrictContainer districtKey="somerville">
+        <StarReadingTab {...props} />
+      </PerDistrictContainer>
+    ))
+  );
+}
+
+it('renders without crashing', () => {
+  const el = document.createElement('div');
+  ReactDOM.render(testRender(testProps()), el);
+});
+
+
+it('snapshots', () => {
+  const tree = renderer.create(testRender(testProps())).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/assets/javascripts/reader_profile_january/StarReadingView.js
+++ b/app/assets/javascripts/reader_profile_january/StarReadingView.js
@@ -90,7 +90,6 @@ export default class StarReadingView extends React.Component {
     const gradeThen = adjustedGrade(schoolYear, student.grade, nowFn());
     const captionEl = `${gradeText(gradeThen)}, ${schoolYear}`;
     const periodEls = mostRecentStarForPeriods.map((maybeStar, index) => {
-
       const maybePercentile = maybeStar ? maybeStar.percentile_rank : null;
       const isOrange = shouldHighlight(maybePercentile);
       const boxColor = pickBoxColor(maybePercentile, isOrange);

--- a/app/assets/javascripts/reader_profile_january/__snapshots__/StarReadingTab.test.js.snap
+++ b/app/assets/javascripts/reader_profile_january/__snapshots__/StarReadingTab.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshots 1`] = `
+<div
+  className="Tab"
+  onClick={[MockFunction]}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "rgb(147, 196, 125)",
+      "border": "1px solid #f8f8f8",
+      "borderRadius": 1,
+      "cursor": "pointer",
+      "display": "flex",
+      "height": "3em",
+      "justifyContent": "flex-start",
+      "margin": 5,
+      "marginLeft": 0,
+      "marginRight": 10,
+      "padding": 5,
+      "paddingLeft": 10,
+    }
+  }
+>
+  STAR Reading
+</div>
+`;

--- a/ui/config/.storybook/config.js
+++ b/ui/config/.storybook/config.js
@@ -42,6 +42,7 @@ function loadStories() {
   // reader profile (june, january)
   require('../../../app/assets/javascripts/reader_profile/ReaderProfileJune.story');
   require('../../../app/assets/javascripts/reader_profile_january/ReaderProfileJanuary.story');
+  require('../../../app/assets/javascripts/reader_profile_january/StarReadingTab.story');
   require('../../../app/assets/javascripts/reader_profile_january/StarReadingView.story');
   require('../../../app/assets/javascripts/reader_profile_january/FirstSoundFluencyView.story');
   require('../../../app/assets/javascripts/reader_profile_january/FAndPEnglishView.story');


### PR DESCRIPTION
# Who is this PR for?
K5 reading folks

# What problem does this PR fix?
There was a bug in the STAR Reading tab highlighting (but not the view or other charts).  See screenshot below.

# What does this PR do?
Fixes the bug; the percentile data points need to be sorted first.

# Screenshot (if adding a client-side feature)
### before
<img width="229" alt="Screen Shot 2020-03-26 at 1 27 50 PM" src="https://user-images.githubusercontent.com/1056957/77680165-f1f78080-6f69-11ea-9407-04ad3a822d29.png">

### after
<img width="195" alt="Screen Shot 2020-03-26 at 1 52 37 PM" src="https://user-images.githubusercontent.com/1056957/77680169-f459da80-6f69-11ea-9c85-a58afcace478.png">
# Checklists
*Which features or pages does this PR touch?*
+ [x] Reader profile


*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here