### PR TITLE
Reading: Fix UI bug with edge case for lowest score in cohort

### DIFF
--- a/app/assets/javascripts/reader_profile_january/BenchmarkCohortChart.js
+++ b/app/assets/javascripts/reader_profile_january/BenchmarkCohortChart.js
@@ -58,8 +58,9 @@ export default class BenchmarkCohortChart extends React.Component {
     const {schoolYear, benchmarkPeriodKey} = boxParams;
     const whenKey = [schoolYear, benchmarkPeriodKey].join('-');
     const cell = json.cells[whenKey];
-    const pText = cell && cell.stats.p ? percentileWithSuffix(cell.stats.p) : null;
-    const tooltipText = (cell && cell.stats.p) ? [
+    const hasValue = (cell && cell.stats.p !== null && cell.stats.p !== undefined);
+    const pText =  (hasValue) ? percentileWithSuffix(cell.stats.p) : null;
+    const tooltipText = (hasValue) ? [
       'Within the school, at that grade level:',
       `  ${padFormatStudentsHave(cell.stats.n_higher, 3)} a higher score`,
       `  ${padFormatStudentsHave(cell.stats.n_equal, 3)} the same score`,

--- a/app/assets/javascripts/reader_profile_january/BenchmarkCohortChart.test.js
+++ b/app/assets/javascripts/reader_profile_january/BenchmarkCohortChart.test.js
@@ -16,7 +16,7 @@ export function mockFetch() {
       '2018-winter': { value: 101, stats: { p: 20, n_lower: 1, n_equal: 0, n_higher: 4 } },
       '2018-spring': { value: 101, stats: { p: 40, n_lower: 2, n_equal: 0, n_higher: 3 } },
       '2019-fall':   { value: 132, stats: { p: 60, n_lower: 2, n_equal: 2, n_higher: 1 } },
-      '2019-winter': { value: 132, stats: { p: 40, n_lower: 2, n_equal: 0, n_higher: 3 } },
+      '2019-winter': { value: 132, stats: { p: 40, n_lower: 0, n_equal: 0, n_higher: 5 } }, // 0th percentile edge case
     }
   });
 }

--- a/app/assets/javascripts/reader_profile_january/__snapshots__/BenchmarkCohortChart.test.js.snap
+++ b/app/assets/javascripts/reader_profile_january/__snapshots__/BenchmarkCohortChart.test.js.snap
@@ -164,9 +164,9 @@ A score of \\"132\\" is in the 60th percentile"
               }
             }
             title="Within the school, at that grade level:
-  3	 students have a higher score
+  5	 students have a higher score
   0	 students have the same score
-  2	 students have a lower score
+  0	 students have a lower score
 
 A score of \\"132\\" is in the 40th percentile"
           >


### PR DESCRIPTION
# Who is this PR for?
K5 reading folks

# What problem does this PR fix?
If the student had the lowest score in their cohort, nothing would be shown in the comparison chart.

<img width="380" alt="Screen Shot 2020-04-03 at 1 30 08 PM" src="https://user-images.githubusercontent.com/1056957/78390383-76718100-75b2-11ea-8c76-e6fd7edd85ce.png">


# What does this PR do?
Fixes the bug to not use `x && y` since 0 is falsy but to check it isn't undefined or null.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Reader profile


*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
