### PR TITLE
Add stricter timeouts to GitHub CI jobs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,6 +10,8 @@ jobs:
   # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
   js_build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     steps:
     - uses: actions/checkout@v2    
 
@@ -62,6 +64,7 @@ jobs:
   # Postgres setup based on https://help.github.com/en/actions/configuring-and-managing-workflows/creating-postgresql-service-containers
   ruby_build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     services:
       postgres:
@@ -156,6 +159,7 @@ jobs:
   rspec_coverage_enforcer:
     needs: ruby_build
     runs-on: ubuntu-latest
+    timeout-minutes: 2
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Follow-on to https://github.com/studentinsights/studentinsights/pull/2801, just being conservative in case, since this has been a problem for us in smaller ways, and other folks in related issues report tasks hanging for hours.