### PR TITLE
Reading: Highlight current time in reading grids

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       rack (>= 0.9.0)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
-    brakeman (4.8.0)
+    brakeman (4.8.1)
     builder (3.2.4)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)

--- a/app/assets/javascripts/reader_profile_january/DebugReadingScheduleGrid.js
+++ b/app/assets/javascripts/reader_profile_january/DebugReadingScheduleGrid.js
@@ -11,6 +11,7 @@ export default class DebugReadingScheduleGrid extends React.Component {
     const {readerJson, gradeNow} = this.props;
     return (
       <ReadingScheduleGrid
+        gradeNow={gradeNow}
         renderCellFn={(...params) => renderCellFn(readerJson, gradeNow, nowFn(), ...params)}
       />
     );

--- a/app/assets/javascripts/reader_profile_january/ReaderProfileJanuary.js
+++ b/app/assets/javascripts/reader_profile_january/ReaderProfileJanuary.js
@@ -58,24 +58,27 @@ export default class ReaderProfileJanuary extends React.Component {
 
   renderHistoryAndThresholds() {
     const {readerJson, student} = this.props;
+    const gradeNow = student.grade;
     return (
       <div style={styles.debug}>
         <HelpBubble
           teaser='history'
+          modalStyle={styles.modalStyle}
           linkStyle={styles.debugLink}
           title="Debug Reading Schedule Grid"
           content={
             <DebugReadingScheduleGrid
               readerJson={readerJson}
-              gradeNow={student.grade}
+              gradeNow={gradeNow}
             />
           }
         />
         <HelpBubble
           teaser='thresholds'
+          modalStyle={styles.modalStyle}
           linkStyle={styles.debugLink}
           title="Reading: Thresholds and Benchmarks"
-          content={<ReadingThresholdsGrid />}
+          content={<ReadingThresholdsGrid gradeNow={gradeNow} />}
         />
       </div>
     );
@@ -211,6 +214,11 @@ const styles = {
   debugLink: {
     color: '#ccc',
     paddingRight: 10
+  },
+  modalStyle: {
+    overlay: {
+      zIndex: 10
+    }
   }
 };
 

--- a/app/assets/javascripts/reader_profile_january/__snapshots__/DebugReadingScheduleGrid.test.js.snap
+++ b/app/assets/javascripts/reader_profile_january/__snapshots__/DebugReadingScheduleGrid.test.js.snap
@@ -134,6 +134,10 @@ exports[`snapshots 1`] = `
         <th
           style={
             Object {
+              "background": "#f8f8f8",
+              "borderLeft": "1px solid #ccc",
+              "borderRight": "1px solid #ccc",
+              "borderTop": "1px solid #ccc",
               "textAlign": "center",
               "width": 40,
             }
@@ -619,6 +623,9 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "background": "#f8f8f8",
+              "borderLeft": "1px solid #ccc",
+              "borderRight": "1px solid #ccc",
               "paddingBottom": 10,
               "paddingTop": 10,
             }
@@ -1004,6 +1011,9 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "background": "#f8f8f8",
+              "borderLeft": "1px solid #ccc",
+              "borderRight": "1px solid #ccc",
               "paddingBottom": 10,
               "paddingTop": 10,
             }
@@ -1389,6 +1399,9 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "background": "#f8f8f8",
+              "borderLeft": "1px solid #ccc",
+              "borderRight": "1px solid #ccc",
               "paddingBottom": 10,
               "paddingTop": 10,
             }
@@ -1774,6 +1787,9 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "background": "#f8f8f8",
+              "borderLeft": "1px solid #ccc",
+              "borderRight": "1px solid #ccc",
               "paddingBottom": 10,
               "paddingTop": 10,
             }
@@ -2159,6 +2175,9 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "background": "#f8f8f8",
+              "borderLeft": "1px solid #ccc",
+              "borderRight": "1px solid #ccc",
               "paddingBottom": 10,
               "paddingTop": 10,
             }
@@ -2544,6 +2563,9 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "background": "#f8f8f8",
+              "borderLeft": "1px solid #ccc",
+              "borderRight": "1px solid #ccc",
               "paddingBottom": 10,
               "paddingTop": 10,
             }
@@ -2929,6 +2951,9 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "background": "#f8f8f8",
+              "borderLeft": "1px solid #ccc",
+              "borderRight": "1px solid #ccc",
               "paddingBottom": 10,
               "paddingTop": 10,
             }
@@ -3446,6 +3471,9 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "background": "#f8f8f8",
+              "borderLeft": "1px solid #ccc",
+              "borderRight": "1px solid #ccc",
               "paddingBottom": 10,
               "paddingTop": 10,
             }
@@ -3864,6 +3892,10 @@ exports[`snapshots 1`] = `
         <td
           style={
             Object {
+              "background": "#f8f8f8",
+              "borderBottom": "1px solid #ccc",
+              "borderLeft": "1px solid #ccc",
+              "borderRight": "1px solid #ccc",
               "paddingBottom": 10,
               "paddingTop": 10,
             }

--- a/app/assets/javascripts/reading/ReadingScheduleGrid.js
+++ b/app/assets/javascripts/reading/ReadingScheduleGrid.js
@@ -21,6 +21,7 @@ export default class ReadingScheduleGrid extends React.Component {
   cellForNow() {
     const {gradeNow} = this.props;
     const {nowFn} = this.context;
+    if (!gradeNow || !nowFn) return null;
     const nowMoment = nowFn();
     const benchmarkPeriodKeyNow = benchmarkPeriodKeyFor(nowMoment);
     return [gradeNow, benchmarkPeriodKeyNow];
@@ -85,11 +86,11 @@ export default class ReadingScheduleGrid extends React.Component {
   }
 }
 ReadingScheduleGrid.propTypes = {
-  gradeNow: PropTypes.string.isRequired,
-  renderCellFn: PropTypes.func.isRequired
+  renderCellFn: PropTypes.func.isRequired,
+  gradeNow: PropTypes.string
 };
 ReadingScheduleGrid.contextTypes = {
-  nowFn: PropTypes.func.isRequired
+  nowFn: PropTypes.func
 };
 
 

--- a/app/assets/javascripts/reading/ReadingScheduleGrid.js
+++ b/app/assets/javascripts/reading/ReadingScheduleGrid.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import Nbsp from '../components/Nbsp';
 import {prettyDibelsText} from '../reading/readingData';
+import {benchmarkPeriodKeyFor} from '../reading/readingData';
 import {
   DIBELS_DORF_WPM,
   DIBELS_DORF_ACC,
@@ -17,36 +18,57 @@ import {
 
 
 export default class ReadingScheduleGrid extends React.Component {
+  cellForNow() {
+    const {gradeNow} = this.props;
+    const {nowFn} = this.context;
+    const nowMoment = nowFn();
+    const benchmarkPeriodKeyNow = benchmarkPeriodKeyFor(nowMoment);
+    return [gradeNow, benchmarkPeriodKeyNow];
+  }
+
   render() {
     const {benchmarkAssessmentKeys, grades, benchmarkPeriodKeys} = gridParams();
     const cells = _.flatMap(grades, grade => benchmarkPeriodKeys.map(periodKey => [grade, periodKey]));
 
+    // highlight where student is now
+    const cellForNow = this.cellForNow();
     return (
       <div className="ReadingScheduleGrid">
         <table style={styles.table}>
           <thead>
             <tr>
               <th><Nbsp /></th>
-              {cells.map(cell => (
-                <th style={{textAlign: 'center', width: 40}} key={cell.join('-')}>
-                  <div style={{width: 40}}>{cell[0]}</div>
-                  <div style={{width: 40}}>{cell[1]}</div>
-                </th>
-              ))}
+              {cells.map(cell => {
+                const nowStyle = (_.isEqual(cell, cellForNow))
+                  ? {...styles.nowCellStyle, borderTop: styles.nowCellStyle.borderLeft}
+                  : null;
+                return (
+                  <th style={{...styles.headerCell, ...nowStyle}} key={cell.join('-')}>
+                    <div style={{width: 40}}>{cell[0]}</div>
+                    <div style={{width: 40}}>{cell[1]}</div>
+                  </th>
+                );
+              })}
             </tr>
           </thead>
           <tbody>
-            {benchmarkAssessmentKeys.map(benchmarkAssessmentKey => {          
+            {benchmarkAssessmentKeys.map((benchmarkAssessmentKey, rowIndex) => {          
               return (
                 <tr key={benchmarkAssessmentKey} style={styles.row}>
                   <td style={styles.labelCell}>
                     {prettyDibelsText(benchmarkAssessmentKey)}
                   </td>
-                  {cells.map(cell => (
-                    <td key={cell.join('-')} style={styles.cell}>
-                      {this.renderCell(cell, benchmarkAssessmentKey)}
-                    </td>
-                  ))}
+                  {cells.map(cell => {
+                    const nowStyle = (_.isEqual(cell, cellForNow)) ? styles.nowCellStyle : null;
+                    const nowStyleWithBorder = (nowStyle && rowIndex === benchmarkAssessmentKeys.length - 1)
+                      ? {...nowStyle, borderBottom: nowStyle.borderLeft}
+                      : nowStyle;
+                    return (
+                      <td key={cell.join('-')} style={{...styles.cell, ...nowStyleWithBorder}}>
+                        {this.renderCell(cell, benchmarkAssessmentKey)}
+                      </td>
+                    );
+                  })}
                 </tr>
               );
             })}
@@ -63,7 +85,11 @@ export default class ReadingScheduleGrid extends React.Component {
   }
 }
 ReadingScheduleGrid.propTypes = {
+  gradeNow: PropTypes.string.isRequired,
   renderCellFn: PropTypes.func.isRequired
+};
+ReadingScheduleGrid.contextTypes = {
+  nowFn: PropTypes.func.isRequired
 };
 
 
@@ -73,6 +99,10 @@ const styles = {
     fontSize: 12,
     width: '100%',
     borderCollapse: 'collapse'
+  },
+  headerCell: {
+    textAlign: 'center',
+    width: 40
   },
   labelCell: {
     width: 80,
@@ -91,6 +121,11 @@ const styles = {
     borderTop: '1px solid #ccc',
     paddingBottom: 10,
     paddingTop: 10
+  },
+  nowCellStyle: {
+    background: '#f8f8f8',
+    borderLeft: '1px solid #ccc',
+    borderRight: '1px solid #ccc'
   }
 };
 

--- a/app/assets/javascripts/reading_debug/ReadingThresholdsPage.js
+++ b/app/assets/javascripts/reading_debug/ReadingThresholdsPage.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Nbsp from '../components/Nbsp';
 import SectionHeading from '../components/SectionHeading';
 import {computeMids} from '../reading/readingData';
@@ -50,9 +51,12 @@ const styles = {
 };
 
 
-export function ReadingThresholdsGrid() {
-  return <ReadingScheduleGrid renderCellFn={renderCellFn} />;
+export function ReadingThresholdsGrid({gradeNow}) {
+  return <ReadingScheduleGrid renderCellFn={renderCellFn} gradeNow={gradeNow} />;
 }
+ReadingThresholdsGrid.propTypes = {
+  gradeNow: PropTypes.string.isRequired
+};
 
 
 function renderCellFn(benchmarkAssessmentKey, grade, benchmarkPeriodKey) {

--- a/app/assets/javascripts/reading_debug/ReadingThresholdsPage.js
+++ b/app/assets/javascripts/reading_debug/ReadingThresholdsPage.js
@@ -55,7 +55,7 @@ export function ReadingThresholdsGrid({gradeNow}) {
   return <ReadingScheduleGrid renderCellFn={renderCellFn} gradeNow={gradeNow} />;
 }
 ReadingThresholdsGrid.propTypes = {
-  gradeNow: PropTypes.string.isRequired
+  gradeNow: PropTypes.string
 };
 
 


### PR DESCRIPTION
# Who is this PR for?
K5 teachers, internal validation

# What problem does this PR fix?
On the reader profile, it's not immediately clear where "now" is when looking at reading benchmark thresholds or history for a particular student.  Separately, this fixes a UI bug with the z-index for these modals when box charts are open.

# What does this PR do?
Adds in that highlighting for these two uses of the reading grid.  The overall "thresholds" are unchanged.

# Screenshot (if adding a client-side feature)
bug:
![image](https://user-images.githubusercontent.com/1056957/78796138-ed789200-7983-11ea-9338-063532c548ef.png)

unchanged:
<img width="712" alt="Screen Shot 2020-04-08 at 10 24 46 AM" src="https://user-images.githubusercontent.com/1056957/78795782-675c4b80-7983-11ea-83b3-38c0f7cbd6a8.png">

on profile for particular student:
<img width="553" alt="Screen Shot 2020-04-08 at 10 07 43 AM" src="https://user-images.githubusercontent.com/1056957/78795873-8824a100-7983-11ea-8ebf-4b69996afd3b.png">

<img width="965" alt="Screen Shot 2020-04-08 at 10 07 29 AM" src="https://user-images.githubusercontent.com/1056957/78795855-7f33cf80-7983-11ea-9c67-9d5c2889fbd5.png">


# Checklists
*Which features or pages does this PR touch?*
+ [x] Reader profile
+ [x] Reading thresholds page

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Manual testing made more sense here