### PR TITLE
Maintenance: Fork wkhtmltopdf to remove unneeded binaries and reduce slug size

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,8 +50,9 @@ gem 'rqrcode'
 gem 'zxcvbn-js', require: 'zxcvbn'
 
 # generating pdfs
+# See https://github.com/zakird/wkhtmltopdf_binary_gem/issues/55#issuecomment-552930066
+gem 'wkhtmltopdf-binary', :git => 'https://github.com/studentinsights/wkhtmltopdf_binary_gem.git'
 gem 'wicked_pdf'
-gem 'wkhtmltopdf-binary'
 
 # text processing (eg, IEP PDFs)
 gem 'pdf-reader'

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'zxcvbn-js', require: 'zxcvbn'
 
 # generating pdfs
 # See https://github.com/zakird/wkhtmltopdf_binary_gem/issues/55#issuecomment-552930066
+# Driven by https://help.heroku.com/KUFMEES1/my-slug-size-is-too-large-how-can-i-make-it-smaller
 gem 'wkhtmltopdf-binary', :git => 'https://github.com/studentinsights/wkhtmltopdf_binary_gem.git'
 gem 'wicked_pdf'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/studentinsights/wkhtmltopdf_binary_gem.git
+  revision: 940d708fdafa4d7ef6c6338ed7aaf44e8e0157fc
+  specs:
+    wkhtmltopdf-binary (0.12.5.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -400,7 +406,6 @@ GEM
     websocket-extensions (0.1.4)
     wicked_pdf (2.0.1)
       activesupport
-    wkhtmltopdf-binary (0.12.5.4)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.3.0)
@@ -466,7 +471,7 @@ DEPENDENCIES
   twilio-ruby
   uglifier (>= 1.3.0)
   wicked_pdf
-  wkhtmltopdf-binary
+  wkhtmltopdf-binary!
   zxcvbn-js
 
 RUBY VERSION


### PR DESCRIPTION
Heroku has a slug size limit, and we ran into it a few weeks ago.  I figured it was from checking in large image assets related to reading, but turns out it was also driven by updating the `wkhtmltopdf-binary` gem.

That gem bundles up binaries for `wkhtmltopdf` on different platforms, and in that release it increased its coverage for more OS versions, which meant the size of the gem increased ~5x to almost 300MB, which is already at the soft limit for slug size just on its own.  On a dyno:

```
$ du -sh vendor/bundle/ruby/2.6.0/gems/* | sort -hr
288M	vendor/bundle/ruby/2.6.0/gems/wkhtmltopdf-binary-0.12.5.4
```

This PR adds comments to that issue upstream in the Gemfile, and swaps to a fork of the gem that limits the binaries to only Ubuntu 18 and OSX, which is all we need for this project.  That lets us keep the same developer setup and not add any other config complexity, while reducing the slug size by 100s of MB so we can deploy again.

For posterity, I also tried dropping in `rposborne/wkhtmltopdf-heroku` but it didn't just work, so instead of investigating that I switched to forking.