### PR TITLE
Maintenance: Update Rollbar handling in local dev, for manual testing

### DIFF
--- a/app/assets/javascripts/components/SessionRenewal.js
+++ b/app/assets/javascripts/components/SessionRenewal.js
@@ -47,8 +47,14 @@ export default class SessionRenewal extends React.Component {
     const {warnFn} = this.props;
     if (warnFn) return warnFn(msg, err);
 
-    console.info && console.info(msg, err); // eslint-disable-line
-    window.Rollbar.info && window.Rollbar.info(msg, err);
+    if (window.Rollbar && window.Rollbar.info) {
+      window.Rollbar.info(msg, err);
+    } else {
+      // This fallback shouldn't happen, since the Rollbar reporting API should be mocked in 
+      // local development.  But in case that fails or the lib fails to load, at least log t
+      // the console so we know.
+      console.log('window.Rollbar not found', msg, err); // eslint-disable-line
+    }
   }
 
   shouldWarn() {

--- a/ui/rollbar.js
+++ b/ui/rollbar.js
@@ -22,6 +22,7 @@ function reportToMockRollbar(type, ...params) {
 // Minimal reporting API for local development.
 function writeToConsoleInsteadOfRollbar() {
   window.Rollbar = {
+    isRollbarMocked: true,
     info: reportToMockRollbar.bind('info'),
     warn: reportToMockRollbar.bind('warn'),
     error: reportToMockRollbar.bind('error')

--- a/ui/rollbar.js
+++ b/ui/rollbar.js
@@ -8,8 +8,25 @@ const {
   shouldReportErrors,
   rollbarJsAccessToken,
 } = readEnv();
-if (shouldReportErrors && rollbarJsAccessToken) loadRollbar();
+if (shouldReportErrors && rollbarJsAccessToken) {
+  loadRollbar();
+} else {
+  writeToConsoleInsteadOfRollbar();
+}
 
+function reportToMockRollbar(type, ...params) {
+  console.log('Rollbar disabled.', type, ...params); // eslint-disable-line no-console
+}
+
+
+// Minimal reporting API for local development.
+function writeToConsoleInsteadOfRollbar() {
+  window.Rollbar = {
+    info: reportToMockRollbar.bind('info'),
+    warn: reportToMockRollbar.bind('warn'),
+    error: reportToMockRollbar.bind('error')
+  };
+}
 
 // Load and configure the library.  Exports it as a global as well.
 // Example at https://github.com/rollbar/rollbar.js/blob/master/examples/webpack/src/index.js


### PR DESCRIPTION
# Who is this PR for?
This is for developers, trying to validate some edge cases locally.

# What problem does this PR fix?
Rollbar just wasn't provided locally, and there was a place in `<SessionRenewal />` that didn't guard for this and would raise.  This would only happen in local development.

# What does this PR do?
Updates the code setting up Rollbar to provide mock reporting functions if it doesn't load.  These just log to the console.  This way if other call sites don't guard properly local development still works.

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here