### PR TITLE
Maintenance: Fix administrate pages from config bug

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,9 +1,14 @@
 // This is the entrypoint for the Rails asset pipeline, and is new
 // as part of Sprockets 4.0.  See https://github.com/rails/sprockets/blob/master/UPGRADING.md#manifestjs
-//
+
+
 // Most JS is built separately, and most styles are defined in JS, but this
 // is the entry point for some older code still processed by the asset pipeline.
-//
 //= link_tree ../images
 //= link application.js
 //= link application.css
+
+// This is required for the `administrate` gem to work correctly, which
+// provides some of the `admin` routes, controllers and views.`
+//= link administrate/application.js
+//= link administrate/application.css

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -10,5 +10,6 @@
 
 // This is required for the `administrate` gem to work correctly, which
 // provides some of the `admin` routes, controllers and views.`
+// See https://github.com/thoughtbot/administrate/pull/1452
 //= link administrate/application.js
 //= link administrate/application.css


### PR DESCRIPTION
# Who is this PR for?
project leads

# What problem does this PR fix?
The administrate admin pages for adjusting educator permissions were broken, probably in https://github.com/studentinsights/studentinsights/pull/2781.  I'm not sure how this got through so long, especially when there was a fair bit of manual testing to validate the gem update and other related gem updates around that time.

There was an authorization smoke test for these routes, but those didn't notice they were getting back Rails error pages.  This is the second consecutive time bumping administrate has broken these routes and we haven't caught it until a fair bit afterward (eg, https://github.com/studentinsights/studentinsights/pull/2722).

# What does this PR do?
Updates the authorization smoke test to explicitly check for Rails error pages, and fixes the root config problem, with comments referencing the upstream issue in administrate about the underlying change in Sprockets 4 that led to the config change.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Project lead admin permissions pages

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
z+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here