### PR TITLE
Reading: Soft-release reader profile, with framing copy in front

### DIFF
--- a/app/assets/javascripts/reader_profile_january/ReaderProfileJanuaryPage.js
+++ b/app/assets/javascripts/reader_profile_january/ReaderProfileJanuaryPage.js
@@ -12,19 +12,53 @@ import {readInstructionalStrategies} from './instructionalStrategies';
 // both to render their tabs in the overview, and also
 // to render the expanded view.
 export default class ReaderProfileJanuaryPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasClicked: false
+    };
+    this.onClick = this.onClick.bind(this);
+  }
+  
+  onClick(e) {
+    e.preventDefault();
+    this.setState({hasClicked: true});
+  }
+
   render() {
-    const {student} = this.props;
-    const url = `/api/students/${student.id}/reader_profile_json`;
+    const {hasClicked} = this.state;
 
     return (
       <RollbarErrorBoundary debugKey="ReaderProfileJanuaryPage">
         <div className="ReaderProfileJanuaryPage">
-          <SectionHeading>Reader Profile, v4 January</SectionHeading>
-          <GenericLoader
-            promiseFn={() => apiFetchJson(url)}
-            render={json => this.renderJson(json)} />
+          <SectionHeading>Reader Profile</SectionHeading>
+          {hasClicked ? this.renderSubstance() : this.renderMessage()}
         </div>
       </RollbarErrorBoundary>
+    );
+  }
+
+  renderMessage() {
+    const {student} = this.props;
+    return (
+      <div style={{padding: 0, margin: 10}}>
+        <div style={{display: 'flex', alignItems: 'flex-start', marginTop: 20, lineHeight: '1.5em'}}>
+          <div style={{flex: 1, marginRight: 20}}>Reader profiles aim to help facilitate problem-solving discussions around what actions or steps in the classroom or school can help students thrive in as readers.</div>
+          <div style={{flex: 1, marginRight: 20}}>Our profiles build from left to right, starting with how students see themselves as a reader, their oral language, and then moving to phonological awareness, phonics, and comprehension.</div>
+          <div style={{flex: 1, marginRight: 20}}>As we view the profile, we are also looking for what strengths the students have that we can leverage as we help the student to grow as a reader.</div>          
+        </div>
+        <button style={{marginTop: 20}} className="btn btn-primary" onClick={this.onClick}>{`${student.first_name}'s profile`}</button>
+      </div>
+    );
+  }
+
+  renderSubstance() {
+    const {student} = this.props;
+    const url = `/api/students/${student.id}/reader_profile_json`;
+    return (
+      <GenericLoader
+        promiseFn={() => apiFetchJson(url)}
+        render={json => this.renderJson(json)} />
     );
   }
 
@@ -44,6 +78,7 @@ export default class ReaderProfileJanuaryPage extends React.Component {
 ReaderProfileJanuaryPage.propTypes = {
   student: PropTypes.shape({
     id: PropTypes.number.isRequired,
+    first_name: PropTypes.string.isRequired,
     grade: PropTypes.any.isRequired
   }).isRequired
 };

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -533,7 +533,7 @@ export default class LightProfilePage extends React.Component {
     const allowReaderProfile = (allGradeLevels.indexOf(student.grade) <= allGradeLevels.indexOf('5'));
     const showMinimalReadingData = currentEducator.labels.indexOf('profile_enable_minimal_reading_data') !== -1;
     const showReaderProfileJune = currentEducator.labels.indexOf('enable_reader_profile_june') !== -1;
-    const showReaderProfileJanuary = true;
+    const showReaderProfileJanuary = true; // see https://github.com/studentinsights/studentinsights/pull/2814
     const showReaderProfileSection = (allowReaderProfile && (showMinimalReadingData || showReaderProfileJune || showReaderProfileJanuary));
     return (!showReaderProfileSection) ? null : (
       <div>

--- a/app/assets/javascripts/student_profile/LightProfilePage.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.js
@@ -533,7 +533,7 @@ export default class LightProfilePage extends React.Component {
     const allowReaderProfile = (allGradeLevels.indexOf(student.grade) <= allGradeLevels.indexOf('5'));
     const showMinimalReadingData = currentEducator.labels.indexOf('profile_enable_minimal_reading_data') !== -1;
     const showReaderProfileJune = currentEducator.labels.indexOf('enable_reader_profile_june') !== -1;
-    const showReaderProfileJanuary = currentEducator.labels.indexOf('enable_reader_profile_january') !== -1;
+    const showReaderProfileJanuary = true;
     const showReaderProfileSection = (allowReaderProfile && (showMinimalReadingData || showReaderProfileJune || showReaderProfileJanuary));
     return (!showReaderProfileSection) ? null : (
       <div>

--- a/app/assets/javascripts/student_profile/LightProfilePage.test.js
+++ b/app/assets/javascripts/student_profile/LightProfilePage.test.js
@@ -274,7 +274,7 @@ describe('reader profile', () => {
     });
   });
 
-  it('shows nothing for 3rd grade student without labels', () => {
+  it('shows January profile for 3rd grade student without labels', () => {
     let props = testPropsForAladdinMouse();
     props = mergeAtPath(props, ['profileJson', 'student'], {grade: '3'});
     props = {...props, selectedColumnKey: 'reading'};
@@ -283,15 +283,12 @@ describe('reader profile', () => {
     expect(findReaderProfiles(el)).toEqual({
       deprecated: false,
       june: false,
-      january: false
+      january: true
     });
   });
   
-  it('shows January profile when label set, PK grade student', () => {
+  it('shows January profile without label being set, PK grade student', () => {
     let props = testPropsForAladdinMouse();
-    props = mergeAtPath(props, ['profileJson', 'currentEducator'], {
-      labels: ['enable_reader_profile_january']
-    });
     props = mergeAtPath(props, ['profileJson', 'student'], {grade: 'PK'});
     props = {...props, selectedColumnKey: 'reading'};
 
@@ -303,13 +300,12 @@ describe('reader profile', () => {
     });
   });
 
-  it('shows both profiles when both labels set, 5th grade student', () => {
+  it('shows both profiles when June label is set, 5th grade student', () => {
     let props = testPropsForAladdinMouse();
     props = mergeAtPath(props, ['profileJson', 'currentEducator'], {
       labels: [
         'profile_enable_minimal_reading_data',
-        'enable_reader_profile_june',
-        'enable_reader_profile_january'
+        'enable_reader_profile_june'
       ]
     });
     props = mergeAtPath(props, ['profileJson', 'student'], {grade: '5'});

--- a/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
+++ b/app/assets/javascripts/student_profile/__snapshots__/LightProfilePage.test.js.snap
@@ -7329,6 +7329,70 @@ exports[`snapshots works for olaf reading 1`] = `
     <div
       className="ElaDetails"
     >
+      <div>
+        <div>
+          <mocked-reader-profile-january-page
+            student={
+              Object {
+                "absences_count": 2,
+                "counselor": null,
+                "created_at": "2018-06-14T14:18:24.281Z",
+                "date_of_birth": "2009-02-27T00:00:00.000Z",
+                "disability": null,
+                "discipline_incidents_count": 1,
+                "enrollment_status": "Active",
+                "first_name": "Olaf",
+                "free_reduced_lunch": "Free Lunch",
+                "gender": "M",
+                "grade": "5",
+                "has_photo": true,
+                "hispanic_latino": false,
+                "home_language": "Haitian-Creole",
+                "homeroom": Object {
+                  "educator": Object {
+                    "email": "sarah@demo.studentinsights.org",
+                    "full_name": "Teacher, Sarah",
+                    "id": 6,
+                  },
+                  "id": 2,
+                  "name": "HEA 500",
+                },
+                "homeroom_id": 2,
+                "house": null,
+                "id": 16,
+                "last_name": "White",
+                "limited_english_proficiency": "Limited",
+                "local_id": "000556",
+                "most_recent_mcas_ela_growth": 77,
+                "most_recent_mcas_ela_performance": "Meeting Expectations",
+                "most_recent_mcas_ela_scaled": 526,
+                "most_recent_mcas_math_growth": 11,
+                "most_recent_mcas_math_performance": "Partially Meeting",
+                "most_recent_mcas_math_scaled": 549,
+                "most_recent_star_math_percentile": 34,
+                "most_recent_star_reading_percentile": 60,
+                "plan_504": "Not 504",
+                "primary_email": "student@example.com",
+                "primary_phone": "999-999-9999 C-Mom",
+                "program_assigned": "Reg Ed",
+                "race": "White",
+                "registration_date": null,
+                "restricted_notes_count": 0,
+                "school_id": 2,
+                "school_name": "Arthur D Healey",
+                "school_type": "ESMS",
+                "sped_level_of_need": null,
+                "sped_liaison": null,
+                "sped_placement": null,
+                "state_id": null,
+                "student_address": null,
+                "tardies_count": 1,
+                "updated_at": "2018-06-14T14:19:23.112Z",
+              }
+            }
+          />
+        </div>
+      </div>
       <div
         className="DetailsSection"
         style={


### PR DESCRIPTION
# Who is this PR for?
primarily for expanding the scope of validation and testing by projects leads (eg, with literacy coaches, reading specialists, classroom teachers)

# What problem does this PR fix?
The reader profile could be enabled individually with a feature switch, but we want to open this up a bit more.

# What does this PR do?
Because of coronavirus, the release and rollout this will likely happen outside of the PD structures that we'd initially been working towards.  So the work on framing the intention and how this connects to problem solving (versus framing centered on "data" or "graphs")  will have to get started in a lighter and more organic way.

This adds framing copy up front, with a "click to view" so that folks discovering this on their own get something minimal that hopefully helps with setting the frame and expectations.

# Screenshot (if adding a client-side feature)
<img width="992" alt="Screen Shot 2020-05-07 at 10 39 07 AM" src="https://user-images.githubusercontent.com/1056957/81308405-bb745180-904f-11ea-90ee-12a0167700ea.png">

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile


*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here