### PR TITLE
Class lists: Allow enabling authorization but hiding link for all

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -199,6 +199,16 @@ class PerDistrict
     end
   end
 
+  # Controls whether link is visible
+  def show_link_for_class_lists?
+    if @district_key == SOMERVILLE || @district_key == DEMO
+      EnvironmentVariable.is_true('SHOW_LINK_FOR_CLASS_LISTS')
+    else
+      false
+    end
+  end
+
+  # Controls authorization
   def enabled_class_lists?
     if @district_key == SOMERVILLE || @district_key == DEMO
       EnvironmentVariable.is_true('ENABLE_CLASS_LISTS')

--- a/app/lib/env.rb
+++ b/app/lib/env.rb
@@ -29,6 +29,8 @@ class Env
     default_env['MAILGUN_DOMAIN'] = 'fake-mailgun-domain'
 
     # feature switches
+    ENV['ENABLE_CLASS_LISTS'] = 'true'
+    ENV['SHOW_LINK_FOR_CLASS_LISTS'] = 'true'
     default_env['ENABLE_COUNSELOR_BASED_FEED'] = 'true'
     default_env['ENABLE_HOUSEMASTER_BASED_FEED'] = 'true'
     default_env['ENABLE_SECTION_BASED_FEED'] = 'true'

--- a/app/lib/paths_for_educator.rb
+++ b/app/lib/paths_for_educator.rb
@@ -8,7 +8,7 @@ class PathsForEducator
   def navbar_links
     links = {}
 
-    if PerDistrict.new.enabled_class_lists? && ClassListQueries.new(@educator).is_relevant_for_educator?
+    if PerDistrict.new.enabled_class_lists? && PerDistrict.new.show_link_for_class_lists? && ClassListQueries.new(@educator).is_relevant_for_educator?
       links[:classlists] = '/classlists'
     end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,5 @@
 Rails.application.configure do
   Env.set_for_development_and_test!
-  ENV['ENABLE_CLASS_LISTS'] = 'true'
   ENV['USE_PLACEHOLDER_STUDENT_PHOTO'] = 'true'
   ENV['USE_PLACEHOLDER_IEP_DOCUMENT'] = 'true'
   ENV['CONSISTENT_TIMING_FOR_LOGIN_IN_MILLISECONDS'] = '2000'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -2,7 +2,6 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
   # Set env variables
   Env.set_for_development_and_test!
-  ENV['ENABLE_CLASS_LISTS'] = 'true'
 
   config.secret_key_base = SecureRandom.hex(64)
 

--- a/spec/lib/paths_for_educator_spec.rb
+++ b/spec/lib/paths_for_educator_spec.rb
@@ -14,6 +14,19 @@ RSpec.describe PathsForEducator do
   end
 
   describe '#navbar_links' do
+    context 'when SHOW_LINK_FOR_CLASS_LISTS disabled' do
+      before { @show_link_for_class_lists = ENV['SHOW_LINK_FOR_CLASS_LISTS'] }
+      before { ENV['SHOW_LINK_FOR_CLASS_LISTS'] = nil }
+      after { ENV['SHOW_LINK_FOR_CLASS_LISTS'] = @show_link_for_class_lists }
+
+      it 'does not show link to /classlists' do
+        expect(navbar_links(pals.uri)).to eq({
+          district: '/district',
+          levels_shs: '/levels/shs'
+        })
+      end
+    end
+
     context 'when ENABLE_CLASS_LISTS disabled' do
       before { @enable_class_lists = ENV['ENABLE_CLASS_LISTS'] }
       before { ENV['ENABLE_CLASS_LISTS'] = nil }


### PR DESCRIPTION
Supporting different way of piloting for this year; enables for all but without links, which is done individually out of band.