### PR TITLE
Project leads: Add page for reviewing educator labels

### DIFF
--- a/app/assets/javascripts/district_overview/DistrictOverviewPage.js
+++ b/app/assets/javascripts/district_overview/DistrictOverviewPage.js
@@ -100,12 +100,17 @@ export class DistrictOverviewPageView extends React.Component {
           <ul style={styles.plainList}>
             <li>
               <a href="/admin/authorization" style={styles.link}>
-               Educator permissions: overview
+               Educators: Permissions overview
               </a>
             </li>
             <li>
               <a href="/admin" style={styles.link}>
-               Adjust educator permissions
+               Educators: Adjust permissions
+              </a>
+            </li>
+            <li>
+              <a href="/admin/authorization" style={styles.link}>
+               Educators: Review labels
               </a>
             </li>
           </ul>

--- a/app/assets/javascripts/district_overview/__snapshots__/DistrictOverviewPage.test.js.snap
+++ b/app/assets/javascripts/district_overview/__snapshots__/DistrictOverviewPage.test.js.snap
@@ -491,7 +491,7 @@ exports[`DistrictOverviewPageView pure snapshot when \`enable_equity_experiments
                   }
                 }
               >
-                Educator permissions: overview
+                Educators: Permissions overview
               </a>
             </li>
             <li>
@@ -503,7 +503,19 @@ exports[`DistrictOverviewPageView pure snapshot when \`enable_equity_experiments
                   }
                 }
               >
-                Adjust educator permissions
+                Educators: Adjust permissions
+              </a>
+            </li>
+            <li>
+              <a
+                href="/admin/authorization"
+                style={
+                  Object {
+                    "fontSize": 14,
+                  }
+                }
+              >
+                Educators: Review labels
               </a>
             </li>
           </ul>
@@ -1429,7 +1441,7 @@ exports[`DistrictOverviewPageView pure snapshot when \`enable_reading_debug\` la
                   }
                 }
               >
-                Educator permissions: overview
+                Educators: Permissions overview
               </a>
             </li>
             <li>
@@ -1441,7 +1453,19 @@ exports[`DistrictOverviewPageView pure snapshot when \`enable_reading_debug\` la
                   }
                 }
               >
-                Adjust educator permissions
+                Educators: Adjust permissions
+              </a>
+            </li>
+            <li>
+              <a
+                href="/admin/authorization"
+                style={
+                  Object {
+                    "fontSize": 14,
+                  }
+                }
+              >
+                Educators: Review labels
               </a>
             </li>
           </ul>
@@ -2216,7 +2240,7 @@ exports[`DistrictOverviewPageView pure snapshot, without work board 1`] = `
                   }
                 }
               >
-                Educator permissions: overview
+                Educators: Permissions overview
               </a>
             </li>
             <li>
@@ -2228,7 +2252,19 @@ exports[`DistrictOverviewPageView pure snapshot, without work board 1`] = `
                   }
                 }
               >
-                Adjust educator permissions
+                Educators: Adjust permissions
+              </a>
+            </li>
+            <li>
+              <a
+                href="/admin/authorization"
+                style={
+                  Object {
+                    "fontSize": 14,
+                  }
+                }
+              >
+                Educators: Review labels
               </a>
             </li>
           </ul>

--- a/app/assets/stylesheets/administrate.scss
+++ b/app/assets/stylesheets/administrate.scss
@@ -4,3 +4,11 @@
     color: white !important;
   }
 }
+
+/* override administrate theming; these aren't clickable */
+table.admin-educator-labels-table-styles {
+  tr:hover {
+    background-color: white;
+    cursor: default;
+  }
+}

--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -50,6 +50,19 @@ module Admin
       nil
     end
 
+    # Unrelated to adminstrate
+    def labels
+      @sorted_labels = EducatorLabel.all.sort_by(&:label_key)
+
+      @educators_by_label_key = {}
+      educators_with_includes = Educator.all.includes(:educator_labels, :school, :sections, {homeroom: [:school, :students]})
+      educators_with_includes.each do |educator|
+        educator.educator_labels.each do |label|
+          educators_by_label_key[label] = educators_by_label_key.fetch(label, []) + [educator]
+        end
+      end
+    end
+
     private
     # override
     def resource_params

--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -52,13 +52,13 @@ module Admin
 
     # Unrelated to adminstrate
     def labels
-      @sorted_labels = EducatorLabel.all.sort_by(&:label_key)
+      @sorted_label_keys = EducatorLabel.all.map(&:label_key).uniq
 
       @educators_by_label_key = {}
       educators_with_includes = Educator.all.includes(:educator_labels, :school, :sections, {homeroom: [:school, :students]})
       educators_with_includes.each do |educator|
-        educator.educator_labels.each do |label|
-          @educators_by_label_key[label] = @educators_by_label_key.fetch(label, []) + [educator]
+        educator.educator_labels.map(&:label_key).each do |label_key|
+          @educators_by_label_key[label_key] = @educators_by_label_key.fetch(label_key, []) + [educator]
         end
       end
     end

--- a/app/controllers/admin/educators_controller.rb
+++ b/app/controllers/admin/educators_controller.rb
@@ -58,7 +58,7 @@ module Admin
       educators_with_includes = Educator.all.includes(:educator_labels, :school, :sections, {homeroom: [:school, :students]})
       educators_with_includes.each do |educator|
         educator.educator_labels.each do |label|
-          educators_by_label_key[label] = educators_by_label_key.fetch(label, []) + [educator]
+          @educators_by_label_key[label] = @educators_by_label_key.fetch(label, []) + [educator]
         end
       end
     end

--- a/app/views/admin/educators/_navbar_for_admin_educator_permissions.html.erb
+++ b/app/views/admin/educators/_navbar_for_admin_educator_permissions.html.erb
@@ -17,6 +17,9 @@
       <%= link_to 'Adjust permissions', admin_root_url, {
         style: 'margin-left: 10px; vertical-align: middle;'
       } %>
+      <%= link_to 'Review labels', admin_labels_url, {
+        style: 'margin-left: 10px; vertical-align: middle;'
+      } %>
     </div>
 
     <div>

--- a/app/views/admin/educators/_navbar_for_admin_educator_permissions.html.erb
+++ b/app/views/admin/educators/_navbar_for_admin_educator_permissions.html.erb
@@ -11,8 +11,11 @@
       <%= link_to 'Home', '/', {
         style: 'margin-left: 30px; vertical-align: middle;'
       } %>
+      <%= link_to 'District', '/district', {
+        style: 'margin-left: 10px; vertical-align: middle;'
+      } %>
       <%= link_to 'Permissions overview', admin_authorization_url, {
-        style: 'margin-left: 30px; vertical-align: middle;'
+        style: 'margin-left: 50px; vertical-align: middle;'
       } %>
       <%= link_to 'Adjust permissions', admin_root_url, {
         style: 'margin-left: 10px; vertical-align: middle;'

--- a/app/views/admin/educators/labels.html.erb
+++ b/app/views/admin/educators/labels.html.erb
@@ -1,0 +1,38 @@
+<%= render 'navbar_for_admin_educator_permissions' %>
+
+<div style="margin: 20px;">
+  <h4 style="color: black; font-size: 24px; border-bottom: 1px solid #333; margin-bottom: 20px; padding-bottom: 10px;">
+    Review labels
+  </h4>
+  <p>Educator <b>'labels'</b> are controlled within Student Insights, and control access to particular features (eg, only 8th grade counselors can write transition notes for students, only principals can finalize class lists).
+  </p>
+  <div>
+    <div style="padding-top: 10px">
+      <table style="text-align: left; max-width: 1000px;">
+        <thead>
+          <tr>
+            <th style="padding: 5px; text-align: left; background: #eee;">Label key</th>
+            <th style="padding: 5px; text-align: left; background: #eee;">Logins</th>
+            <th style="padding: 5px; text-align: left; background: #eee;">Names</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @sorted_labels.map do |label| %>
+            <tr>
+              <td style="padding: 10px; padding-left: 5px;"><%= label.label_key %></td>
+              <td style="padding: 10px; padding-left: 5px;">
+                <% @educators_by_label_key.fetch(label.label_key, []).map do |educator| %>
+                  <div><%= educator.login_name %></div>
+                <% end %>
+              </td>
+              <td style="padding: 10px; padding-left: 5px;">
+                <% @educators_by_label_key.fetch(label.label_key, []).map do |educator| %>
+                  <div><%= link_to educator.full_name, "/educators/view/#{educator.id}" %></div>
+                <% end %>
+              </td>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/educators/labels.html.erb
+++ b/app/views/admin/educators/labels.html.erb
@@ -4,7 +4,7 @@
   <h4 style="color: black; font-size: 24px; border-bottom: 1px solid #333; margin-bottom: 20px; padding-bottom: 10px;">
     Review labels
   </h4>
-  <p>Educator <b>'labels'</b> are controlled within Student Insights, and control access to particular features (eg, only 8th grade counselors can write transition notes for students, only principals can finalize class lists).
+  <p>Educator "labels" are controlled within Student Insights, and control access to particular features (eg, only 8th grade counselors can write transition notes for students, only principals can finalize class lists).
   </p>
   <div>
     <div style="padding-top: 10px">
@@ -12,8 +12,8 @@
         <thead>
           <tr>
             <th style="padding: 5px; text-align: left; background: #eee;">Label key</th>
-            <th style="padding: 5px; text-align: left; background: #eee;">Logins</th>
-            <th style="padding: 5px; text-align: left; background: #eee;">Names</th>
+            <th style="padding: 5px; width: 300px; text-align: right; background: #eee;">Logins</th>
+            <th style="padding: 5px; width: 400px; text-align: left; background: #eee;">Names</th>
           </tr>
         </thead>
         <tbody>

--- a/app/views/admin/educators/labels.html.erb
+++ b/app/views/admin/educators/labels.html.erb
@@ -8,7 +8,7 @@
   </p>
   <div>
     <div style="padding-top: 10px">
-      <table style="text-align: left; max-width: 1000px;">
+      <table class="admin-educator-labels-table-styles" style="text-align: left; max-width: 1000px;">
         <thead>
           <tr>
             <th style="padding: 5px; text-align: left; background: #eee;">Label key</th>
@@ -17,16 +17,17 @@
           </tr>
         </thead>
         <tbody>
-          <% @sorted_labels.map do |label| %>
+          <% @sorted_label_keys.map do |label_key| %>
+            <% educators_for_label = @educators_by_label_key.fetch(label_key, []).sort_by(&:login_name) %>
             <tr>
-              <td style="padding: 10px; padding-left: 5px;"><%= label.label_key %></td>
-              <td style="padding: 10px; padding-left: 5px;">
-                <% @educators_by_label_key.fetch(label.label_key, []).map do |educator| %>
+              <td style="vertical-align: top; padding: 10px; padding-left: 5px;"><%= label_key %></td>
+              <td style="vertical-align: top; padding: 10px; padding-left: 5px;">
+                <% educators_for_label.map do |educator| %>
                   <div><%= educator.login_name %></div>
                 <% end %>
               </td>
-              <td style="padding: 10px; padding-left: 5px;">
-                <% @educators_by_label_key.fetch(label.label_key, []).map do |educator| %>
+              <td style="vertical-align: top; padding: 10px; padding-left: 5px;">
+                <% educators_for_label.map do |educator| %>
                   <div><%= link_to educator.full_name, "/educators/view/#{educator.id}" %></div>
                 <% end %>
               </td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :educators, only: [:index, :show, :edit, :update] # administrate
     get '/authorization' => 'educators#authorization'
+    get '/labels' => 'educators#labels'
     post '/masquerade/become' => 'masquerade#become'
     post '/masquerade/clear' => 'masquerade#clear'
     root to: "educators#index"


### PR DESCRIPTION
# Who is this PR for?
project leads

# What problem does this PR fix?
Within Student Insights "labels" are used as fine-grained feature switches for specific features, staged rollouts, etc.  Revising these often requires communication and collaboration, so it doesn't make sense to make this entirely self-serve for project leads.  But for seasonal or recurring kinds of changes, where updates are fairly well-understood, a first step towards self-serve is allowing project leads to review these settings directly.

# What does this PR do?
Adds a new admin page showing the list of labels, and which educators have them applied.  This information is visible in the existing admin pages, but this focuses on the labels as the concept (eg, "show me who has access to finalize class lists as a principal").

# Screenshot (if adding a client-side feature)
<img width="309" alt="Screen Shot 2020-05-28 at 11 33 05 AM" src="https://user-images.githubusercontent.com/1056957/83162493-d595d280-a0d7-11ea-88fb-a94d87714363.png">
<img width="1012" alt="Screen Shot 2020-05-28 at 12 11 14 PM" src="https://user-images.githubusercontent.com/1056957/83166076-5fe03580-a0dc-11ea-9e58-4094791eb971.png">


# Checklists
*Which features or pages does this PR touch?*
+ [x] Districtwide
+ [x] Educator: Labels review

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Included specs for changes
+ [x] Improved specs for existing code in need of better test coverage
+ [x] Manual testing made more sense here