### PR TITLE
Pausing New Bedford freshness checks

### DIFF
--- a/app/config_objects/per_district.rb
+++ b/app/config_objects/per_district.rb
@@ -75,7 +75,7 @@ class PerDistrict
     if @district_key == SOMERVILLE
       SftpClient.for_star # assuming daily updates
     elsif @district_key == NEW_BEDFORD
-      SftpClient.for_x2(modified_within_n_days: 90) # assuming regular quarterly updates
+      SftpClient.for_x2(modified_within_n_days: 180) # assuming regular quarterly updates - temporarily disabled for summer 2020
     else
       raise_not_handled!
     end


### PR DESCRIPTION
#Who is this PR for?

Developers

# What problem does this PR fix?

New Bedford has paused sftp transfers for the summer. Insights ordinarily tests the new bedford sftp data and sends an alert if it's more than 90 days old. This extends the check period so we don't continue getting these warnings all through the summer. 

# What does this PR do?

Changes the test for stale data from 90 to 180 days. We will change this back before school begins. 
