### PR TITLE
rolling back to previous highcharts version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chroma-js": "^2.1.0",
     "csv-stringify": "^5.3.6",
     "d3": "3.5.12",
-    "highcharts": "8.1.1",
+    "highcharts": "6.0.2",
     "jquery": "^3.5.0",
     "lodash": "^4.17.15",
     "lunr": "^2.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5977,10 +5977,10 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-highcharts@8.1.1:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-8.1.1.tgz#7dc011e260289ab64d775807df0d13b85ed88338"
-  integrity sha512-DSkI+fAqkqYDslOVLcEk8DX7W9itRIwzsdS0uVEOnVf0LF1hSKZtDINHP7ze/uBN9NdWQV9HydtiPTrkLx0lXg==
+highcharts@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-6.0.2.tgz#e3c4c998a21ce6bfa79458fa2c87d967e9234abe"
+  integrity sha1-48TJmKIc5r+nlFj6LIfZZ+kjSr4=
 
 highlight.js@~9.12.0:
   version "9.12.0"


### PR DESCRIPTION
# Who is this PR for?
All users

# What problem does this PR fix?
Student profile pdfs fail when the student has discipline incidents

# What does this PR do?
Rolls back to a previous version of Highcharts from the one set in #2826 . It's not immediately clear why upgrading Highcharts caused this problem, and we'll need to investigate and resolve that issue. Since the Highcharts upgrade wasn't necessary for any features, we can roll this back to make the pdf usable again. 

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile
+ [x] Student Report PDF
+ [x] Absences
+ [x] Tardies
+ [x] Discipline

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here