### PR TITLE
fixing rollbar error when only destroyed records present

### DIFF
--- a/app/importers/helpers/record_syncer.rb
+++ b/app/importers/helpers/record_syncer.rb
@@ -190,7 +190,8 @@ class RecordSyncer
       count = computed_stats[key]
       next if count == 0
 
-      percentage = (count.to_f / @total_sync_calls_count)
+      #percentage of record sync calls isn't meaningful for destroyed records
+      percentage = (key === "destroyed_records_count")? "N/A" : (count.to_f / @total_sync_calls_count)
       next unless @alert_tuning.should_alert?(key, count, percentage)
 
       alerts << {


### PR DESCRIPTION
We have been getting an error from rollbar when the record_syncer runs complaining of an infinite value in the JSON. Turns out that we had a number of deleted records with no other record changes, making the percentage in the rollbar log infinite. Since deleted records aren't related to other records processed by the syncer, percentage isn't meaningful in this case.