### PR TITLE
scoping reading benchmark sheets importer to current school year

### DIFF
--- a/spec/importers/file_importers/data_flows_fixture.json
+++ b/spec/importers/file_importers/data_flows_fixture.json
@@ -107,7 +107,7 @@
       "ReadingBenchmarkDataPoint"
     ],
     "options": [],
-    "description": "Import reading benchmark data for the specific school year 2019-2020, by reading all sheets within a Google Drive folder"
+    "description": "Import reading benchmark data for the current school year, by reading all sheets within a Google Drive folder"
   },
   {
     "importer": "StarMathImporter",


### PR DESCRIPTION
# Who is this PR for?

Educators

# What problem does this PR fix?

Originally the reading benchmark sheets importer was scoped to specific dates in 2019. This was to prevent previously entered data from being removed, but as a result the importer needs to be changed to run in other school years. 

# What does this PR do?

Scopes the reading benchmark sheets importer to the current school year. 

# Checklists
*Which features or pages does this PR touch?*
+ [ ] Imports