### PR TITLE
Enabling Ruby Language Metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'oj'
 gem 'oj_mimic_json'
 gem 'rack-attack'
 gem 'secure_headers'
+gem 'barnes' # heroku language metrics for ruby
 
 # services
 gem 'aws-sdk-s3', '~> 1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,9 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.1)
       aws-eventstream (~> 1.0, >= 1.0.2)
+    barnes (0.0.8)
+      multi_json (~> 1)
+      statsd-ruby (~> 1.1)
     bcrypt (3.1.13)
     better_errors (2.6.0)
       coderay (>= 1.0.0)
@@ -383,6 +386,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    statsd-ruby (1.4.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -419,6 +423,7 @@ DEPENDENCIES
   administrate (~> 0.13.0)
   authtrail
   aws-sdk-s3 (~> 1)
+  barnes
   better_errors
   bootsnap
   brakeman

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -35,10 +35,14 @@ workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 # If you are preloading your application and using Active Record, it's
 # recommended that you close any connections to the database before workers
 # are forked to prevent connection leakage.
-#
-# before_fork do
-#   ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
-# end
+
+# engabling barnes gem for language metrics in Heroku
+require 'barnes'
+
+before_fork do
+  # worker configuration
+  Barnes.start
+end
 
 # The code in the `on_worker_boot` will be called if you are using
 # clustered mode by specifying a number of `workers`. After each worker


### PR DESCRIPTION
In an ongoing effort to understand where performance becomes a problem, we'd like to know how much value we get when we scale up the Heroku Dynos. Heroku offers some ruby specific metrics that may help us see whether the app is over or under provisioned. See here: https://devcenter.heroku.com/articles/language-runtime-metrics-ruby#getting-started

This adds and configures the [barnes](https://github.com/heroku/barnes) gem to get this info from Heroku. We probably don't need to keep this permanently.