### PR TITLE
Upgrade to Node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "studentinsights",
   "version": "0.1.0",
   "engines": {
-    "node": "^12.18.0"
+    "node": "^14.15.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Node 14 is now in long term support. That triggers an error message on the build (cf #2675 ). It's a good reminder so we'll just upgrade. 