### PR TITLE
Disabling the school year check on benchmark sheets importer

### DIFF
--- a/app/importers/reading/reading_benchmark_sheets_importer.rb
+++ b/app/importers/reading/reading_benchmark_sheets_importer.rb
@@ -17,9 +17,6 @@ class ReadingBenchmarkSheetsImporter
   def initialize(options:)
     @explicit_folder_id = options.fetch(:folder_id, nil)
     @school_year = options.fetch(:school_year, SchoolYear.to_school_year(Time.now))
-    if @school_year != 2019
-      raise "aborting because of unexpected school_year; review the syncer scoping closely before running on another year"
-    end
     @log = options.fetch(:log, Rails.env.test? ? LogHelper::FakeLog.new : STDOUT)
     @dry_run = options.fetch(:dry_run, false)
     @fetcher = options.fetch(:fetcher, GoogleSheetsFetcher.new(log: @log))
@@ -126,9 +123,6 @@ class ReadingBenchmarkSheetsImporter
   # and the dates when this import process first started up, and other older ones were
   # stopped.
   def records_within_scope
-    if @school_year != 2019
-      raise "aborting because of unexpected school_year; review the syncer scoping closely before running on another year"
-    end
     ReadingBenchmarkDataPoint.all
       .where('created_at > ?', DateTime.new(@school_year, 9, 15))
       .where('created_at < ?', DateTime.new(@school_year+1, 8, 15))

--- a/app/importers/reading/reading_benchmark_sheets_importer.rb
+++ b/app/importers/reading/reading_benchmark_sheets_importer.rb
@@ -10,7 +10,7 @@ class ReadingBenchmarkSheetsImporter
       touches: [
         ReadingBenchmarkDataPoint.name
       ],
-      description: 'Import reading benchmark data for the specific school year 2019-2020, by reading all sheets within a Google Drive folder'
+      description: 'Import reading benchmark data, by reading all sheets within a Google Drive folder'
     })
   end
 

--- a/spec/importers/file_importers/data_flows_fixture.json
+++ b/spec/importers/file_importers/data_flows_fixture.json
@@ -107,7 +107,7 @@
       "ReadingBenchmarkDataPoint"
     ],
     "options": [],
-    "description": "Import reading benchmark data for the specific school year 2019-2020, by reading all sheets within a Google Drive folder"
+    "description": "Import reading benchmark data, by reading all sheets within a Google Drive folder"
   },
   {
     "importer": "StarMathImporter",


### PR DESCRIPTION
The original reading benchmark sheets importer was scoped to specific dates in 2019-2020 to avoid overwriting manually imported records from 2019. That won't be necessary going forward, and additionally this component will be reviewed before it is reenabled, as reading sheets are not being done in Fall 2020. This check causes noisy rollbar errors (correctly) so this disables the 2019-2020 school year check. 

This does not re-enable the importer, which will not be configured to run again until the sheets process has been reviewed and the sheets are being updated again. 