### PR TITLE
only check sections assigned to educator unless districtwide

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -5,7 +5,8 @@ class ProfileController < ApplicationController
 
   def json
     student = authorized { Student.find(params[:id]) }
-    authorized_sections = authorized { Section.all }
+    sections = current_educator.schoolwide_access? ? Section.all : current_educator.sections
+    authorized_sections = authorized { sections }
     chart_data = StudentProfileChart.new(student).chart_data
 
     render json: {

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -7,7 +7,7 @@ class ProfileController < ApplicationController
     student = authorized { Student.find(params[:id]) }
     #This unfortunately duplicates code in the authorizer, but it prevents us from having to
     #iterate through every section for users who can only view their assigned sections
-    special_access = current_educator.distictwide_access? || current_educator.schoolwide_access? || current_educator.is_admin?
+    special_access = current_educator.districtwide_access? || current_educator.schoolwide_access? || current_educator.admin?
     sections = special_access ? Section.all : current_educator.sections
     authorized_sections = authorized { sections }
     chart_data = StudentProfileChart.new(student).chart_data

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -5,7 +5,10 @@ class ProfileController < ApplicationController
 
   def json
     student = authorized { Student.find(params[:id]) }
-    sections = current_educator.schoolwide_access? ? Section.all : current_educator.sections
+    #This unfortunately duplicates code in the authorizer, but it prevents us from having to
+    #iterate through every section for users who can only view their assigned sections
+    special_access = current_educator.distictwide_access? || current_educator.schoolwide_access? || current_educator.is_admin?
+    sections = special_access ? Section.all : current_educator.sections
     authorized_sections = authorized { sections }
     chart_data = StudentProfileChart.new(student).chart_data
 


### PR DESCRIPTION
# Who is this PR for?

Educators

# What problem does this PR fix?

Certain users have been experience long load times when accessing the student profile. Perf testing indicates that the section authorization check is the major factor. Authorizing all sections takes 9-13 seconds on average when the user has no schoolwide access. 

# What does this PR do?

Introduces a check to limit the sections passed to the authorizer only to those sections belonging to the user.

# Checklists
*Which features or pages does this PR touch?*
+ [x] Student Profile

*Does this PR use tests to help verify we can deploy these changes quickly and confidently?*
+ [x] Manual testing made more sense here
The existing specs cover this change, as they already check for users with various permissions and this shouldn't functionally change the behavior. 