### PR TITLE
fix N+1 query in section auth

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -5,11 +5,7 @@ class ProfileController < ApplicationController
 
   def json
     student = authorized { Student.find(params[:id]) }
-    #This unfortunately duplicates code in the authorizer, but it prevents us from having to
-    #iterate through every section for users who can only view their assigned sections
-    special_access = current_educator.districtwide_access? || current_educator.schoolwide_access? || current_educator.admin?
-    sections = special_access ? Section.all : current_educator.sections
-    authorized_sections = authorized { sections }
+    authorized_sections = authorized { Section.all.includes(:course) }
     chart_data = StudentProfileChart.new(student).chart_data
 
     render json: {


### PR DESCRIPTION
Further investigation in the student profile shows we were getting N+1 queries in the Section assignments authorization. This passes sections to the authorizer with the associated models needed to avoid this problem. Perf tests show significant improvement with this:

**authorized {Section.all}**
**Current**
Median: 24 seconds
P95: 35 seconds

**authorized {Section.all.includes(:course)}**
Median: 3 seconds
P95: 14 seconds

This reverts #2853 as well, since that improvement is no longer needed and is more complex that the original behavior. 