### PR TITLE
Upgrade immer

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "prismjs": "^1.21.0",
     "serialize-javascript": "^3.1.0",
     "@storybook/react/**/lodash-es": "^4.17.15",
+    "@storybook/react/**/immer": "^8.0.1",
     "yargs": "^15.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8013,10 +8013,10 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-immer@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
-  integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
+immer@1.10.0, immer@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
+  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
 import-cwd@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Manually setting this resolution to resolve a security issue. This is used in Storybook/React via React-dev-tools. This version seems to work and the current storybook/react release doesn't resolve the security vulnerability. 