### PR TITLE
setting ruby ci build to ubuntu 18.04

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -63,7 +63,7 @@ jobs:
   # Based on Ruby starter action
   # Postgres setup based on https://help.github.com/en/actions/configuring-and-managing-workflows/creating-postgresql-service-containers
   ruby_build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     timeout-minutes: 10
 
     services:


### PR DESCRIPTION
In #2866 I missed that github actions lets you specify different OSs for the js and ruby tests. This sets them both to use ubuntu 18.04. This matches our production environment, and although almost everything runs on ubuntu 20.04 we use a trimmed wkhtmltopdf_binary_gem to cut down on the slug size. Because it doesn't contain binaries for ubuntu 20.04 this causes our CI tests to fail on ubuntu-latest. 