### PR TITLE
Sanitizing filenames when extracting archives

### DIFF
--- a/app/importers/iep_import/iep_pdf_import_job.rb
+++ b/app/importers/iep_import/iep_pdf_import_job.rb
@@ -105,7 +105,8 @@ class IepPdfImportJob
         log "  unzipping #{zip_basename}..."
         Zip::File.open(zip_file) do |zip_object|
           zip_object.each do |entry|
-            unzipped_pdf_filename = File.join(folder_for_unzipped_files, entry.name)
+            sanitized_name = File.basename(entry.name)
+            unzipped_pdf_filename = File.join(folder_for_unzipped_files, sanitized_name)
             entry.extract(unzipped_pdf_filename)
             unzipped_count_for_file += 1
             pdf_filenames << unzipped_pdf_filename

--- a/app/importers/photo_import/student_photo_importer.rb
+++ b/app/importers/photo_import/student_photo_importer.rb
@@ -32,7 +32,8 @@ class StudentPhotoImporter
 
     Zip::File.open(photos_zip_file) do |zip_file|
       zip_file.each do |entry|
-        entry.extract("tmp/data_download/photos/#{entry.name}") { true } # overwrite
+        sanitized_name = File.basename(entry.name)
+        entry.extract("tmp/data_download/photos/#{sanitized_name}") { true } # overwrite
         unzipped_count += 1
       end
     end


### PR DESCRIPTION
In the course of an internal review we found that rubyzip is vulnerable to [zip slip](https://snyk.io/research/zip-slip-vulnerability) even though our version (1.3.0) should not be [see here](https://snyk.io/vuln/SNYK-RUBY-RUBYZIP-20336).

This fixes the issue by ignoring everything but the base filename on extraction since the application determines the appropriate path. 