### PR TITLE
Webpack config fixes

### DIFF
--- a/ui/config/webpack.dev.js
+++ b/ui/config/webpack.dev.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 const path = require('path');
-const merge = require('webpack-merge');
+const {merge} = require('webpack-merge');
 const common = require('./webpack.common.js');
 const {CleanWebpackPlugin} = require('clean-webpack-plugin');
 

--- a/ui/config/webpack.prod.js
+++ b/ui/config/webpack.prod.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const common = require('./webpack.common.js');
-const merge = require('webpack-merge');
+const {merge} = require('webpack-merge');
 const {CleanWebpackPlugin} = require('clean-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
@@ -26,7 +26,6 @@ module.exports = merge(common, {
       dangerouslyAllowCleanPatternsOutsideProject: true,
       cleanOnceBeforeBuildPatterns: path.join(process.cwd(), '../../public/build')
     }),
-    new webpack.HashedModuleIdsPlugin(),
     new ManifestPlugin({fileName: 'manifest.json' }),
     new CompressionPlugin({
       filename: '[path].gz[query]'
@@ -34,6 +33,7 @@ module.exports = merge(common, {
   ],
 
   optimization: {
+    moduleIds: 'deterministic',
     minimizer: [
       new TerserPlugin({
         terserOptions: {


### PR DESCRIPTION
On the upgrade to webpack 5, these configuration files were left behind. I'm not sure how this wasn't caught until now, but this should bring them in line with what's expected in the new version of webpack. 