### PR TITLE
Webpack 5 config changes

### DIFF
--- a/ui/config/webpack.prod.js
+++ b/ui/config/webpack.prod.js
@@ -4,7 +4,7 @@ const webpack = require('webpack');
 const common = require('./webpack.common.js');
 const {merge} = require('webpack-merge');
 const {CleanWebpackPlugin} = require('clean-webpack-plugin');
-const {ManifestPlugin} = require('webpack-manifest-plugin');
+const {WebpackManifestPlugin} = require('webpack-manifest-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 
@@ -26,7 +26,7 @@ module.exports = merge(common, {
       dangerouslyAllowCleanPatternsOutsideProject: true,
       cleanOnceBeforeBuildPatterns: path.join(process.cwd(), '../../public/build')
     }),
-    new ManifestPlugin({fileName: 'manifest.json' }),
+    new WebpackManifestPlugin({fileName: 'manifest.json' }),
     new CompressionPlugin({
       filename: '[path].gz[query]'
     })

--- a/ui/config/webpack.prod.js
+++ b/ui/config/webpack.prod.js
@@ -4,7 +4,7 @@ const webpack = require('webpack');
 const common = require('./webpack.common.js');
 const {merge} = require('webpack-merge');
 const {CleanWebpackPlugin} = require('clean-webpack-plugin');
-const ManifestPlugin = require('webpack-manifest-plugin');
+const {ManifestPlugin} = require('webpack-manifest-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 


### PR DESCRIPTION
On the upgrade to webpack 5, these configuration files were left behind. I'm not sure how this wasn't caught until now, but this should bring them in line with what's expected in the new version of webpack.

This is a further pass as these are causing the production deployment to fail. 