### PR TITLE
Update nokogiri and disable sprockets concurrent compilation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'google-api-client', "~> 0.28.7"
 gem 'net-ldap'
 gem 'net-sftp'
 gem 'net-ssh'
-gem 'nokogiri', '~> 1.11.1' # https://github.com/sparklemotion/nokogiri/issues/1943
+gem 'nokogiri', '~> 1.11.4' # https://github.com/sparklemotion/nokogiri/issues/1943
 gem 'openssl'
 gem 'pg'
 gem 'puma', '~> 4.3.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (5.2.0)
     nio4r (2.5.7)
-    nokogiri (1.11.3)
+    nokogiri (1.11.5)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     oj (3.10.5)
@@ -443,7 +443,7 @@ DEPENDENCIES
   net-ldap
   net-sftp
   net-ssh
-  nokogiri (~> 1.11.1)
+  nokogiri (~> 1.11.4)
   oj
   oj_mimic_json
   openssl

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,3 +13,9 @@ Rails.application.config.assets.version = '1.0'
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+
+# We've run into errors in deployment related to sassc. The current workaround is to
+# disable concurrent compilation in sprockets. See: https://github.com/rails/sprockets/issues/581
+Rails.application.config.assets.configure do |env|
+  env.export_concurrent = false
+end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,9 +13,3 @@ Rails.application.config.assets.version = '1.0'
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-
-# We've run into errors in deployment related to sassc. The current workaround is to
-# disable concurrent compilation in sprockets. See: https://github.com/rails/sprockets/issues/581
-Rails.application.config.assets.configure do |env|
-  env.export_concurrent = false
-end


### PR DESCRIPTION
Updating nokogiri to 1.11.4 breaks the CI build. Looking around for an explanation it seems as though nokogiri was incidental and the issue stems from sprockets and sassc (See https://github.com/rails/sprockets/issues/581 and https://github.com/rails/sprockets/pull/469)

One recommended workaround is to disable concurrent asset compilation. That's what I'm trying here, and opening this PR to run a CI build as this doesn't fail locally. 