### PR TITLE
Update template for Administrate

### DIFF
--- a/app/views/admin/educators/_navigation.html.erb
+++ b/app/views/admin/educators/_navigation.html.erb
@@ -13,7 +13,7 @@ as defined by the routes in the `admin/` namespace
       <% next unless resource.name == :educators %>
       <%= link_to(
         display_resource_name(resource),
-        [namespace, resource.path],
+        resource_index_route(resource),
         class: "navigation__link navigation__link--#{nav_link_state(resource)}"
       ) %>
     <% end %>


### PR DESCRIPTION
Rails 6.0.3.7 introduced a [security fix](https://github.com/thoughtbot/administrate/pull/1972) which breaks Administrate making it impossible to reach the user permissions page. Administrate provides a new _application.html.erb template with a small change implemented in this PR which resolves the issue. 