### PR TITLE
Render all pdf chart labels as html

### DIFF
--- a/app/assets/javascripts/student_profile/pdf/generateReportGraph.js
+++ b/app/assets/javascripts/student_profile/pdf/generateReportGraph.js
@@ -47,6 +47,7 @@ export default function generateReportGraph(containerSelector, yAxisLabel, xAxis
       },
       stackLabels: {
         enabled: true,
+        useHTML: true,
         style: {
           fontWeight: 'bold',
           color: (Highcharts.theme && Highcharts.theme.textColor) || 'gray'

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chroma-js": "^2.1.0",
     "csv-stringify": "^5.3.6",
     "d3": "3.5.12",
-    "highcharts": "^9.0.0",
+    "highcharts": "^9.2.2",
     "hosted-git-info": "^2.8.9",
     "jquery": "^3.5.0",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7032,10 +7032,10 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-highcharts@^9.0.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-9.1.0.tgz#2cdb38e2e03530b4fde022bb05fbce5b34651e39"
-  integrity sha512-K7HUuKhEylZ1pMdzGR35kPgUmpp0MDNpaWhEMkGiC5Jfzg/endtTLHJN2lsFqEO+xoN7AykBK98XaJPEpsrLyA==
+highcharts@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-9.2.2.tgz#4ace4aa7c4d2b4051115d9be70bfd2038559d656"
+  integrity sha512-OMEdFCaG626ES1JEcKAvJTpxAOMuchy0XuAplmnOs0Yu7NMd2RMfTLFQ2fCJOxo3ubSdm/RVQwKAWC+5HYThnw==
 
 highlight.js@^10.1.1, highlight.js@~10.7.0:
   version "10.7.2"


### PR DESCRIPTION
When the highcharts rendering was fixed in #2834, only the data labels were changed. However, we're running into the same segfault with the Y axis stack labels. This just bumps highcharts and applies the same fix so the pdf will render appropriately. Right now it throws an error an many students who have a particular combination of incidents/absences. 

Ignoring the audit issues for now, as they are specific to storybook and don't affect production. 