### PR TITLE
Add Quantitative Reasoning to Levels page

### DIFF
--- a/app/assets/javascripts/levels/Courses.test.js
+++ b/app/assets/javascripts/levels/Courses.test.js
@@ -12,7 +12,7 @@ function testAssignments() {
     { grade_letter: 'B-', section: { course_description: 'ESL' } },
     { grade_letter: 'B+', section: { course_description: 'ESL - Semester SS' } },
     { grade_letter: 'A-', section: { course_description: 'SAFE - Pre-Algebra' } },
-    { grade_letter: 'B', section: { course_description: 'CHEMISTRY HONORS' } },
+    { grade_letter: 'B', section: { course_description: 'CHEMISTRY HONORS' } }
   ];
 }
 it('#firstMatchWithGrades', () => {


### PR DESCRIPTION
SHS has a new Quantitative Reasoning math course. This just adds it to the list of valid math courses for the levels page so it shows up. 