### PR TITLE
force thor to 1.2.2)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'jquery-rails'
 gem 'jquery-ui-rails', '~> 6.0.1'
 gem 'rails', '6.1.7.6'
 gem 'sprockets'
-gem 'thor'
+gem 'thor', '1.2.2'
 gem 'uglifier', '>= 1.3.0'
 
 # rails plugins or patches

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -420,7 +420,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
-    thor (1.3.0)
+    thor (1.2.2)
     tilt (2.2.0)
     timecop (0.9.6)
     timeout (0.4.1)
@@ -509,7 +509,7 @@ DEPENDENCIES
   simplecov
   spring
   sprockets
-  thor
+  thor (= 1.2.2)
   timecop
   twilio-ruby
   uglifier (>= 1.3.0)


### PR DESCRIPTION
Thor 1.3 seems to break the import task. I haven't been able to figure out why that is, but there's nothing we particularly need in that release so we'll stick with 1.2 for now.