### PR TITLE
do not initialize csvdownloader with a hash

### DIFF
--- a/app/importers/file_importers/student_section_assignments_importer.rb
+++ b/app/importers/file_importers/student_section_assignments_importer.rb
@@ -79,12 +79,12 @@ class StudentSectionAssignmentsImporter
   def download_csv
     client = SftpClient.for_x2
     data_transformer = StreamingCsvTransformer.new(@log)
-    CsvDownloader.new({
+    CsvDownloader.new(
       log: @log,
       remote_file_name: remote_file_name,
       client: client,
       transformer: data_transformer
-    }).get_data
+    ).get_data
   end
 
   def remote_file_name

--- a/app/importers/file_importers/student_section_grades_importer.rb
+++ b/app/importers/file_importers/student_section_grades_importer.rb
@@ -112,12 +112,12 @@ class StudentSectionGradesImporter
   def download_csv
     client = SftpClient.for_x2
     data_transformer = StreamingCsvTransformer.new(@log, headers: CSV_HEADERS)
-    CsvDownloader.new({
+    CsvDownloader.new(
       log: @log,
       remote_file_name: remote_file_name,
       client: client,
       transformer: data_transformer
-    }).get_data
+    ).get_data
   end
 
   def school_filter


### PR DESCRIPTION
This got missed somehow in an earlier upgrade